### PR TITLE
Separate timeouts for RO and RW transactions

### DIFF
--- a/.changeset/few-shrimps-count.md
+++ b/.changeset/few-shrimps-count.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-client': minor
+---
+
+Separate timeouts for RO and RW transactions. Default timeouts RO = 300s; RW = 20s.

--- a/.changeset/strong-bags-sin.md
+++ b/.changeset/strong-bags-sin.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-tree': patch
+---
+
+Now reports tree statistics even if initial loading failed.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -216,7 +216,7 @@ export class PlClient {
 
     while (true) {
       // opening low-level tx
-      const llTx = this.ll.createTx(ops);
+      const llTx = this.ll.createTx(writable, ops);
       // wrapping it into high-level tx (this also asynchronously sends initialization message)
       const tx = new PlTransaction(
         llTx,

--- a/lib/node/pl-client/src/core/config.test.ts
+++ b/lib/node/pl-client/src/core/config.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TX_TIMEOUT, plAddressToConfig } from './config';
+import { DEFAULT_RO_TX_TIMEOUT, DEFAULT_RW_TX_TIMEOUT, plAddressToConfig } from './config';
 
 test('config form url no auth', () => {
   const conf = plAddressToConfig('http://127.0.0.1:6345');
@@ -16,12 +16,22 @@ test('config form url with auth and special symbols', () => {
   const conf = plAddressToConfig('http://user1:password232$@127.0.0.1:6345');
   expect(conf.user).toEqual('user1');
   expect(conf.password).toEqual('password232$');
-  expect(conf.defaultTransactionTimeout).toEqual(DEFAULT_TX_TIMEOUT);
+  expect(conf.defaultROTransactionTimeout).toEqual(DEFAULT_RO_TX_TIMEOUT);
+  expect(conf.defaultRWTransactionTimeout).toEqual(DEFAULT_RW_TX_TIMEOUT);
 });
 
-test('config form url with auth and special symbols and request timeout', () => {
+test('config form url with auth and special symbols and tx timeout', () => {
   const conf = plAddressToConfig('http://user1:password232$@127.0.0.1:6345/?tx-timeout=11341');
   expect(conf.user).toEqual('user1');
   expect(conf.password).toEqual('password232$');
-  expect(conf.defaultTransactionTimeout).toEqual(11341);
+  expect(conf.defaultROTransactionTimeout).toEqual(11341);
+  expect(conf.defaultRWTransactionTimeout).toEqual(11341);
+});
+
+test('config form url with auth and special symbols and ro tx timeout', () => {
+  const conf = plAddressToConfig('http://user1:password232$@127.0.0.1:6345/?ro-tx-timeout=11341');
+  expect(conf.user).toEqual('user1');
+  expect(conf.password).toEqual('password232$');
+  expect(conf.defaultROTransactionTimeout).toEqual(11341);
+  expect(conf.defaultRWTransactionTimeout).toEqual(DEFAULT_RW_TX_TIMEOUT);
 });

--- a/lib/node/pl-client/src/core/config.ts
+++ b/lib/node/pl-client/src/core/config.ts
@@ -16,9 +16,13 @@ export interface PlClientConfig {
 
   /** Default timeout in milliseconds for unary calls, like ping and login. */
   defaultRequestTimeout: number;
-  /** Default timeout in milliseconds for transaction, should be adjusted for
-   * long round-trip connections. */
-  defaultTransactionTimeout: number;
+
+  /** Default timeout in milliseconds for read-write transaction, should be
+   * adjusted for long round-trip  or low bandwidth connections. */
+  defaultRWTransactionTimeout: number;
+  /** Default timeout in milliseconds for read-only transaction, should be
+   * adjusted for long round-trip or low bandwidth connections. */
+  defaultROTransactionTimeout: number;
 
   /** Controls what TTL will be requested from the server, when new JWT token
    * is requested. */
@@ -75,7 +79,8 @@ export interface PlClientConfig {
 }
 
 export const DEFAULT_REQUEST_TIMEOUT = 5_000;
-export const DEFAULT_TX_TIMEOUT = 30_000;
+export const DEFAULT_RO_TX_TIMEOUT = 300_000;
+export const DEFAULT_RW_TX_TIMEOUT = 20_000;
 export const DEFAULT_TOKEN_TTL_SECONDS = 31 * 24 * 60 * 60;
 export const DEFAULT_AUTH_MAX_REFRESH = 12 * 24 * 60 * 60;
 
@@ -91,7 +96,12 @@ export const DEFAULT_RETRY_JITTER = 0.3; // 30%
 type PlConfigOverrides = Partial<
   Pick<
     PlClientConfig,
-    'ssl' | 'defaultRequestTimeout' | 'defaultTransactionTimeout' | 'httpProxy' | 'grpcProxy'
+    | 'ssl'
+    | 'defaultRequestTimeout'
+    | 'defaultROTransactionTimeout'
+    | 'defaultRWTransactionTimeout'
+    | 'httpProxy'
+    | 'grpcProxy'
   >
 >;
 
@@ -114,7 +124,8 @@ export function plAddressToConfig(
       hostAndPort: address,
       ssl: false,
       defaultRequestTimeout: DEFAULT_REQUEST_TIMEOUT,
-      defaultTransactionTimeout: DEFAULT_TX_TIMEOUT,
+      defaultROTransactionTimeout: DEFAULT_RO_TX_TIMEOUT,
+      defaultRWTransactionTimeout: DEFAULT_RW_TX_TIMEOUT,
       authTTLSeconds: DEFAULT_TOKEN_TTL_SECONDS,
       authMaxRefreshSeconds: DEFAULT_AUTH_MAX_REFRESH,
       txDelay: 0,
@@ -151,7 +162,14 @@ export function plAddressToConfig(
     ssl: url.protocol === 'https:' || url.protocol === 'tls:',
     defaultRequestTimeout:
       parseInt(url.searchParams.get('request-timeout')) ?? DEFAULT_REQUEST_TIMEOUT,
-    defaultTransactionTimeout: parseInt(url.searchParams.get('tx-timeout')) ?? DEFAULT_TX_TIMEOUT,
+    defaultROTransactionTimeout:
+      parseInt(url.searchParams.get('ro-tx-timeout')) ??
+      parseInt(url.searchParams.get('tx-timeout')) ??
+      DEFAULT_RO_TX_TIMEOUT,
+    defaultRWTransactionTimeout:
+      parseInt(url.searchParams.get('rw-tx-timeout')) ??
+      parseInt(url.searchParams.get('tx-timeout')) ??
+      DEFAULT_RW_TX_TIMEOUT,
     authTTLSeconds: DEFAULT_TOKEN_TTL_SECONDS,
     authMaxRefreshSeconds: DEFAULT_AUTH_MAX_REFRESH,
     grpcProxy: url.searchParams.get('grpc-proxy') ?? undefined,

--- a/lib/node/pl-client/src/core/default_client.ts
+++ b/lib/node/pl-client/src/core/default_client.ts
@@ -29,7 +29,8 @@ type FileConfigOverrideFields =
   | 'user'
   | 'password'
   | 'alternativeRoot'
-  | 'defaultTransactionTimeout'
+  | 'defaultROTransactionTimeout'
+  | 'defaultRWTransactionTimeout'
   | 'defaultRequestTimeout'
   | 'authTTLSeconds'
   | 'authMaxRefreshSeconds';
@@ -39,7 +40,8 @@ const FILE_CONFIG_OVERRIDE_FIELDS: FileConfigOverrideFields[] = [
   'user',
   'password',
   'alternativeRoot',
-  'defaultTransactionTimeout',
+  'defaultROTransactionTimeout',
+  'defaultRWTransactionTimeout',
   'defaultRequestTimeout',
   'authTTLSeconds',
   'authMaxRefreshSeconds'

--- a/lib/node/pl-client/src/core/ll_client.test.ts
+++ b/lib/node/pl-client/src/core/ll_client.test.ts
@@ -8,7 +8,7 @@ import { UnauthenticatedError } from './errors';
 
 test('authenticated instance test', async () => {
   const client = await getTestLLClient();
-  const tx = client.createTx();
+  const tx = client.createTx(true);
   const response = await tx.send(
     {
       oneofKind: 'txOpen',
@@ -31,7 +31,7 @@ test('unauthenticated status change', async () => {
   const client = new LLPlClient(cfg.address);
   expect(client.status).toBe('OK');
 
-  const tx = client.createTx();
+  const tx = client.createTx(true);
 
   await expect(async () => {
     await tx.send(
@@ -67,7 +67,7 @@ test('automatic token update', async () => {
   });
 
   for (let i = 0; i < 6; i++) {
-    const tx = client.createTx();
+    const tx = client.createTx(true);
     const response = await tx.send(
       {
         oneofKind: 'txOpen',

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -229,17 +229,16 @@ export class LLPlClient {
     };
   }
 
-  createTx(ops: PlCallOps = {}): LLPlTransaction {
+  createTx(rw: boolean, ops: PlCallOps = {}): LLPlTransaction {
     return new LLPlTransaction((abortSignal) => {
       let totalAbortSignal = abortSignal;
       if (ops.abortSignal)
-        // this will be fixed in typescript 5.5.0
-        // see this https://github.com/microsoft/TypeScript/issues/58026
-        // and this https://github.com/microsoft/TypeScript/pull/58211
-        totalAbortSignal = (AbortSignal as any).any([totalAbortSignal, ops.abortSignal]);
+        totalAbortSignal = AbortSignal.any([totalAbortSignal, ops.abortSignal]);
       return this.grpcPl.tx({
         abort: totalAbortSignal,
-        timeout: ops.timeout ?? this.conf.defaultTransactionTimeout
+        timeout:
+          ops.timeout ??
+          (rw ? this.conf.defaultRWTransactionTimeout : this.conf.defaultROTransactionTimeout)
       });
     });
   }

--- a/lib/node/pl-client/src/core/ll_transaction.test.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.test.ts
@@ -7,7 +7,7 @@ import { Aborted } from '@milaboratories/ts-helpers';
 
 test('transaction timeout test', async () => {
   const client = await getTestLLClient();
-  const tx = client.createTx({ timeout: 500 });
+  const tx = client.createTx(true, { timeout: 500 });
 
   await expect(async () => {
     const response = await tx.send(
@@ -24,7 +24,7 @@ test('transaction timeout test', async () => {
 
 test('check timeout error type (passive)', async () => {
   const client = await getTestLLClient();
-  const tx = client.createTx({ timeout: 500 });
+  const tx = client.createTx(true, { timeout: 500 });
 
   try {
     const response = await tx.send(
@@ -43,7 +43,7 @@ test('check timeout error type (passive)', async () => {
 
 test('check timeout error type (active)', async () => {
   const client = await getTestLLClient();
-  const tx = client.createTx({ timeout: 500 });
+  const tx = client.createTx(true, { timeout: 500 });
 
   try {
     const openResponse = await tx.send(
@@ -98,7 +98,7 @@ test('check timeout error type (active)', async () => {
 
 test('check is abort error (active)', async () => {
   const client = await getTestLLClient();
-  const tx = client.createTx({ abortSignal: AbortSignal.timeout(100) });
+  const tx = client.createTx(true, { abortSignal: AbortSignal.timeout(100) });
 
   try {
     const openResponse = await tx.send(

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -225,10 +225,18 @@ export class SynchronizedTreeState {
 
     let stat = ops.logStat ? initialTreeLoadingStat() : undefined;
 
-    await tree.refresh(stat);
+    let ok = false;
 
-    // logging stats if we were asked to (even if error occured)
-    if (stat && logger) logger.info(`Tree stat (initial load): ${JSON.stringify(stat)}`);
+    try {
+      await tree.refresh(stat);
+      ok = true;
+    } finally {
+      // logging stats if we were asked to (even if error occured)
+      if (stat && logger)
+        logger.info(
+          `Tree stat (initial load, ${ok ? 'success' : 'failure'}): ${JSON.stringify(stat)}`
+        );
+    }
 
     return tree;
   }


### PR DESCRIPTION
…00s; RW = 20s. Now reports tree statistics even if initial loading failed.