### PR TITLE
increase default timeout for awaitStableState

### DIFF
--- a/.changeset/happy-ears-stare.md
+++ b/.changeset/happy-ears-stare.md
@@ -1,0 +1,5 @@
+---
+'@platforma-sdk/test': patch
+---
+
+Increase default timeout for awaitStableState

--- a/sdk/test/src/util.ts
+++ b/sdk/test/src/util.ts
@@ -16,7 +16,7 @@ export async function tryStat(path: string): Promise<BigIntStats | undefined> {
 
 export async function awaitStableState<S>(
   computable: Computable<unknown, S>,
-  timeout: number | AbortSignal = 2000
+  timeout: number | AbortSignal = 5000
 ): Promise<S> {
   try {
     return await computable.awaitStableValue(


### PR DESCRIPTION
This is normal until we improve overall productivity of the backend :(