### PR TITLE
Add deepTransform function for advanced map transformations

### DIFF
--- a/.changeset/bitter-parts-stop.md
+++ b/.changeset/bitter-parts-stop.md
@@ -1,0 +1,5 @@
+---
+'@platforma-sdk/workflow-tengo': patch
+---
+
+Add deepTransform function for advanced map transformations

--- a/sdk/workflow-tengo/src/maps.lib.tengo
+++ b/sdk/workflow-tengo/src/maps.lib.tengo
@@ -180,10 +180,39 @@ deepMerge = func(...maps) {
 	return res
 }
 
+/**
+ * Do deep transform of a map, the same as deepMerge but with ability to use functions to transform the values.
+ * Add {... key: undefined ...} to remove the "key" from the map collected from maps before.
+ */
+deepTransform := undefined
+deepTransform = func(...maps) {
+	res := {}
+	for map in maps {
+		for k, v in map {
+			if is_undefined(v) {
+				delete(res, k)
+			} else if is_callable(v) {
+				result := v(res[k])
+				if is_undefined(result) {
+					delete(res, k)
+				} else {
+					res[k] = result
+				}
+			} else if is_map(res[k]) && is_map(v) {
+				res[k] = deepTransform(res[k], v)
+			} else {
+				res[k] = v
+			}
+		}
+	}
+	return res
+}
+
 export ll.toStrict({
 	map : map,
 	merge: merge,
 	deepMerge: deepMerge,
+	deepTransform: deepTransform,
 	clone: clone,
 	mapKeys : mapKeys,
 	mapValues : mapValues,

--- a/sdk/workflow-tengo/src/maps.test.tengo
+++ b/sdk/workflow-tengo/src/maps.test.tengo
@@ -46,6 +46,35 @@ Test_map_Clone_3 := func() {
 	)
 }
 
+Test_map_DeepTransform := func() {
+	test.isEqual(
+		maps.deepTransform(
+			{a: {a: 1, b: 2}, c: 1, d: {a: {b: {c: 12}, d: 1}}},
+			{a: {b: func(val) { return val * 2 }}, d: {a: {b: {c: undefined}}}}
+		),
+		{a: {a: 1, b: 4}, c: 1, d: {a: {b: {}, d: 1}}},
+		"unexpected result from maps.deepTransform"
+	)
+
+	test.isEqual(
+		maps.deepTransform(
+			{user: {name: "John", age: 30}, settings: {theme: "dark"}},
+			{user: {age: func(val) { return val + 1 }}, settings: {theme: func(val) { return val + "-mode" }}}
+		),
+		{user: {name: "John", age: 31}, settings: {theme: "dark-mode"}},
+		"unexpected result from maps.deepTransform with simple transformations"
+	)
+
+	test.isEqual(
+		maps.deepTransform(
+			{data: {items: [1, 2, 3], meta: {count: 3}}},
+			{data: {meta: {count: func(val) { return undefined }}}}
+		),
+		{data: {items: [1, 2, 3], meta: {}}},
+		"unexpected result from maps.deepTransform with undefined return"
+	)
+}
+
 Test_map_ContainsKey := func() {
 	test.isTrue(maps.containsKey({a: undefined}, "a"), "map.containsKey() wrong result for regular map with existing key and undefined value")
 	test.isTrue(maps.containsKey({b: 1}, "b"), "map.containsKey() wrong result for regular map with existing key and truthful value")


### PR DESCRIPTION
Introduced a new deepTransform function that allows for deep transformations of maps, enabling the use of functions to modify values. This function also supports removing keys by passing undefined. Added corresponding unit tests to validate its functionality.