### PR TITLE
fix regex to remove pythonMessage line from UI

### DIFF
--- a/.changeset/tricky-poets-trade.md
+++ b/.changeset/tricky-poets-trade.md
@@ -1,0 +1,5 @@
+---
+'@platforma-sdk/bootstrap': patch
+---
+
+Fixes boilerplate failure to run block with no python software due to missing model output used in UI

--- a/tools/pl-bootstrap/src/block.ts
+++ b/tools/pl-bootstrap/src/block.ts
@@ -121,7 +121,7 @@ async function removePlatform(dir: string, platform: CreateBlockPlatform) {
   // https://regex101.com/r/oCTyHk/1
   await deleteRegexInFile(
     path.join(dir, 'ui', 'src', 'pages', 'MainPage.vue'),
-    new RegExp(`.*${p}Message.*\\n\\n`, 'g'),
+    new RegExp(`.*${p}Message.*\\n`, 'g'),
   );
 
   // Remove an output from the model.


### PR DESCRIPTION
eslint removes the empty line below pythonMessage which makes the regex fail to remove it.
Fixes boilerplate failure to run block with no python software due to missing model output used in UI.