### PR TITLE
Multiple fixes to anchored queries

### DIFF
--- a/.changeset/empty-tigers-smoke.md
+++ b/.changeset/empty-tigers-smoke.md
@@ -1,0 +1,11 @@
+---
+'@platforma-sdk/workflow-tengo': patch
+'@milaboratories/pl-model-common': patch
+'@platforma-sdk/test': patch
+---
+
+- Reverted wrong annotations field in anchored bquery schema (#722)
+- Fixed pColumn bundle.xsvTableBuilder for work with long file names
+- Fixed anchored axis spec in canonicalOptions
+- Allow optional domains in canonicalOptions
+- Removed do-pack from tests

--- a/lib/model/common/src/drivers/pframe/spec/anchored.ts
+++ b/lib/model/common/src/drivers/pframe/spec/anchored.ts
@@ -1,11 +1,11 @@
 import canonicalize from 'canonicalize';
-import type { AxisId, PColumnSpec } from './spec';
-import { getAxisId, matchAxisId } from './spec';
-import type { AAxisSelector, AnchorAxisRef, AnchorAxisRefByIdx, AnchoredPColumnId, AnchoredPColumnSelector, AxisSelector, PColumnSelector } from './selectors';
-import type { AxisFilter } from './filtered_column';
 import type { PValue } from '../data_types';
+import type { AxisFilter } from './filtered_column';
 import type { SUniversalPColumnId, UniversalPColumnId } from './ids';
 import { stringifyColumnId } from './ids';
+import type { AAxisSelector, AnchorAxisRef, AnchorAxisRefByIdx, AnchoredPColumnId, AnchoredPColumnSelector, AxisSelector, PColumnSelector } from './selectors';
+import type { AxisId, PColumnSpec } from './spec';
+import { getAxisId, matchAxisId } from './spec';
 
 //
 // Helper functions
@@ -121,7 +121,8 @@ export class AnchoredIdDeriver {
     result.axes = spec.axesSpec.map((axis) => {
       const key = axisKey(axis);
       const anchorAxisRef = this.axes.get(key);
-      return anchorAxisRef ?? axis;
+      if (anchorAxisRef === undefined) return getAxisId(axis);
+      else return anchorAxisRef;
     });
 
     // If no axis filters are provided, return the anchored ID as is
@@ -204,7 +205,8 @@ export function resolveAnchors(anchors: Record<string, PColumnSpec>, matcher: An
           throw new Error(`Anchor "${value.anchor}" not found for domain key "${key}"`);
 
         if (!anchorSpec.domain || anchorSpec.domain[key] === undefined)
-          throw new Error(`Domain key "${key}" not found in anchor "${value.anchor}"`);
+          continue;
+          // throw new Error(`Domain key "${key}" not found in anchor "${value.anchor}"`);
 
         resolvedDomain[key] = anchorSpec.domain[key];
       }

--- a/sdk/model/src/render/api.ts
+++ b/sdk/model/src/render/api.ts
@@ -18,6 +18,7 @@ import type {
   PTableRecordFilter,
   PTableSorting,
   PlRef,
+  ResolveAnchorsOptions,
   ResultCollection,
   SUniversalPColumnId,
   ValueOrError,
@@ -86,7 +87,7 @@ PColumn<PColumnValues | AccessorHandle | DataInfo<AccessorHandle>> {
 type UniversalPColumnOpts = {
   labelOps?: LabelDerivationOps;
   dontWaitAllData?: boolean;
-};
+} & ResolveAnchorsOptions;
 
 export class ResultPool implements ColumnProvider, AxisLabelProvider {
   private readonly ctx: GlobalCfgRenderCtx = getCfgRenderCtx();

--- a/sdk/model/src/render/util/column_collection.ts
+++ b/sdk/model/src/render/util/column_collection.ts
@@ -11,6 +11,7 @@ import type {
   AxisFilterByIdx,
   AnchoredPColumnSelector,
   PartitionedDataInfoEntries,
+  ResolveAnchorsOptions,
 } from '@milaboratories/pl-model-common';
 import {
   selectorsToPredicate,
@@ -161,7 +162,7 @@ type UniversalPColumnOptsNoDeriver = {
 
 type UniversalPColumnOpts = UniversalPColumnOptsNoDeriver & {
   anchorCtx: AnchoredIdDeriver;
-};
+} & ResolveAnchorsOptions;
 
 export class PColumnCollection {
   private readonly defaultProviderStore: PColumn<TreeNodeAccessor | DataInfo<TreeNodeAccessor> | undefined>[] = [];
@@ -231,7 +232,7 @@ export class PColumnCollection {
       if (usesAnchors) {
         if (!anchorCtx)
           throw new Error('Anchored selectors require an AnchoredIdDeriver to be provided in options.');
-        currentSelector = resolveAnchors(anchorCtx.anchors, rawSelector as AnchoredPColumnSelector);
+        currentSelector = resolveAnchors(anchorCtx.anchors, rawSelector as AnchoredPColumnSelector, opts);
       } else
         currentSelector = rawSelector as PColumnSelectorWithSplit | ((spec: PColumnSpec) => boolean);
 

--- a/sdk/test/package.json
+++ b/sdk/test/package.json
@@ -16,8 +16,7 @@
     "type-check": "tsc --noEmit --composite false",
     "build": "vite build",
     "test": "vitest",
-    "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "do-pack": "rm -f *.tgz && pnpm pack && mv *.tgz package.tgz"
+    "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write"
   },
   "files": [
     "dist/**/*"

--- a/sdk/workflow-tengo/src/pframes/bundle.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/bundle.lib.tengo
@@ -518,6 +518,7 @@ pColumnBundleUnmarshaller := func() {
 
 							pFrame := pBuilder.pFrameBuilder()
 
+							idx := 0
 							for request in requests {
 								col := pool[request.key]
 								colData := col.data
@@ -542,7 +543,13 @@ pColumnBundleUnmarshaller := func() {
 								}
 
 								// Use serializedId directly as the column identifier in the frame
-								pFrame.add(request.safeId, preparedSpec, colData)
+								//
+								// @TODO: once we have hash, use hash(request.safeId) to ensure stable column
+								// identifiers for deduplication as idx assignment may depend on the iteration order
+								// of the requests
+								//
+								pFrame.add(string(idx), preparedSpec, colData)
+								idx += 1
 							}
 
 							return xsv.exportFrame(pFrame.build(), format, exportParams)

--- a/sdk/workflow-tengo/src/workflow/model.lib.tengo
+++ b/sdk/workflow-tengo/src/workflow/model.lib.tengo
@@ -5,8 +5,7 @@ AXIS_SELECTOR_SCHEMA := {
     `__options__,closed`: true,
     `type,?`: ["or", "string", ["string"]],
     `name,?`: `string`,
-    `domain,?`: { any: `string` },
-    `annotations,?`: { any: `string` }
+    `domain,?`: { any: `string` }
 }
 
 // Anchor axis reference schemas for different reference types

--- a/tests/workflow-tengo/vitest.config.mts
+++ b/tests/workflow-tengo/vitest.config.mts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     watch: false,
     testTimeout: 15000,
-    maxWorkers: 3,
+    maxWorkers: 2,
     minWorkers: 1,
     // fileParallelism: false // is equal to minWorkers = 1, maxWorkwrs = 1
   }


### PR DESCRIPTION
- Reverted wrong annotations field in anchored bquery schema (#722)
- Fixed pColumn bundle.xsvTableBuilder for work with long file names
- Fixed anchored axis spec in canonicalOptions
- Allow optional domains in canonicalOptions
- Removed do-pack from tests