### PR TITLE
[sdk/ui-vue] MSA stability fixes

### DIFF
--- a/.changeset/beige-points-walk.md
+++ b/.changeset/beige-points-walk.md
@@ -1,0 +1,5 @@
+---
+'@platforma-sdk/ui-vue': minor
+---
+
+MSA: error handling improvements

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/PlMultiSequenceAlignment.vue
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/PlMultiSequenceAlignment.vue
@@ -42,11 +42,6 @@ const props = defineProps<{
    */
   readonly sequenceColumnPredicate: PColumnPredicate;
   /**
-   * Return true if column should be shown in label columns dropdown.
-   * By default, common axes of selected sequence columns are selected.
-   */
-  readonly labelColumnOptionPredicate?: PColumnPredicate;
-  /**
    * Sometimes sequence column and label column have disjoint axes.
    * In this case you have to define `linkerColumnPredicate` to select columns
    * connecting axes of sequence and label columns.
@@ -77,7 +72,6 @@ const selectedSequenceColumnIds = computed({
 const labelColumns = reactive(useLabelColumnsOptions(() => ({
   pFrame: props.pFrame,
   sequenceColumnIds: selectedSequenceColumnIds.value,
-  labelColumnOptionPredicate: props.labelColumnOptionPredicate,
 })));
 
 const selectedLabelColumnIds = computed({
@@ -104,10 +98,6 @@ const multipleAlignmentData = reactive(useMultipleAlignmentData(() => ({
 })));
 
 const formatNumber = new Intl.NumberFormat('en').format;
-
-const selectedTooManySequences = computed(
-  () => props.selection && props.selection.selectedKeys.length > sequenceLimit,
-);
 
 const colorSchemeOptions = computed<ListOptionNormalized<ColorSchemeOption>[]>(
   () => [
@@ -187,8 +177,11 @@ const error = computed(() =>
     :label-column-options="labelColumns.data.options"
     :color-scheme-options="colorSchemeOptions"
   />
+  <PlAlert v-if="error" type="error">
+    {{ error }}
+  </PlAlert>
   <PlAlert
-    v-if="
+    v-else-if="
       !multipleAlignmentData.loading
         && multipleAlignmentData.data.sequences.length < 2
     "
@@ -198,12 +191,9 @@ const error = computed(() =>
     Please select at least one sequence column and two or more rows to run
     alignment
   </PlAlert>
-  <PlAlert v-else-if="error" type="error">
-    {{ error }}
-  </PlAlert>
   <template v-else>
     <PlAlert
-      v-if="selectedTooManySequences"
+      v-if="multipleAlignmentData.data.exceedsLimit"
       type="warn"
       icon
       label="Visualization is limited"

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/data.ts
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/data.ts
@@ -18,6 +18,7 @@ import {
   type PlSelectionModel,
   type PObjectId,
   type PTableColumnId,
+  type PTableSorting,
   pTableValue,
 } from '@platforma-sdk/model';
 import { computedAsync } from '@vueuse/core';
@@ -55,9 +56,6 @@ export function useLabelColumnsOptions(
   params: MaybeRefOrGetter<{
     pFrame: PFrameHandle | undefined;
     sequenceColumnIds: PObjectId[];
-    labelColumnOptionPredicate:
-      | ((column: PColumnIdAndSpec) => boolean)
-      | undefined;
   }>,
 ) {
   const error = shallowRef<Error>();
@@ -67,6 +65,7 @@ export function useLabelColumnsOptions(
         error.value = undefined;
         return await getLabelColumnsOptions(toValue(params));
       } catch (err) {
+        console.error(err);
         error.value = ensureError(err);
         return { options: [], defaults: [] };
       }
@@ -89,6 +88,7 @@ export function useMarkupColumnsOptions(
         error.value = undefined;
         return await getMarkupColumnsOptions(toValue(params));
       } catch (err) {
+        console.error(err);
         error.value = ensureError(err);
         return [];
       }
@@ -116,11 +116,12 @@ export function useMultipleAlignmentData(
         error.value = undefined;
         return await getMultipleAlignmentData(toValue(params));
       } catch (err) {
+        console.error(err);
         error.value = ensureError(err);
-        return { sequences: [], labels: [] };
+        return { sequences: [], labels: [], exceedsLimit: false };
       }
     },
-    { sequences: [], labels: [] },
+    { sequences: [], labels: [], exceedsLimit: false },
     { evaluating: loading },
   );
   return { data, error, loading };
@@ -149,47 +150,61 @@ async function getSequenceColumnsOptions({
 async function getLabelColumnsOptions({
   pFrame,
   sequenceColumnIds,
-  labelColumnOptionPredicate,
 }: {
   pFrame: PFrameHandle | undefined;
   sequenceColumnIds: PObjectId[];
-  labelColumnOptionPredicate:
-    | ((column: PColumnIdAndSpec) => boolean)
-    | undefined;
 }): Promise<OptionsWithDefaults<PTableColumnId>> {
   if (!pFrame) return { options: [], defaults: [] };
   const pFrameDriver = getPFrameDriver();
   const columns = await pFrameDriver.listColumns(pFrame);
   const optionMap = new Map<CanonicalizedJson<PTableColumnId>, string>();
-  for (const column of columns) {
-    if (sequenceColumnIds.includes(column.columnId)) {
-      for (const axisSpec of column.spec.axesSpec) {
-        const axisId = getAxisId(axisSpec);
-        const axisIdJson = canonicalizeJson({ type: 'axis', id: axisId });
-        if (optionMap.has(axisIdJson)) continue;
-        const labelColumn = columns.find(
-          ({ spec }) =>
-            isLabelColumn(spec)
-            && matchAxisId(axisId, getAxisId(spec.axesSpec[0])),
-        );
-        optionMap.set(
-          labelColumn
-            ? canonicalizeJson({ type: 'column', id: labelColumn.columnId })
-            : axisIdJson,
-          axisSpec.annotations?.['pl7.app/label'] ?? 'Unlabelled axis',
-        );
-      }
+
+  const sequenceColumnsAxes = new Map(sequenceColumnIds.flatMap((id) => {
+    const column = columns.find(({ columnId }) => columnId === id);
+    if (!column) {
+      throw new Error(`Couldn't find sequence column (ID: \`${id}\`).`);
     }
-    if (labelColumnOptionPredicate?.(column)) {
-      optionMap.set(
-        canonicalizeJson({ type: 'column', id: column.columnId }),
-        column.spec.annotations?.['pl7.app/label'] ?? 'Unlabelled column',
-      );
-    }
+    return column.spec.axesSpec
+      .map((spec) => [canonicalizeJson(getAxisId(spec)), spec]);
+  }));
+
+  for (const [axisIdJson, axisSpec] of sequenceColumnsAxes.entries()) {
+    const axisId = parseJson(axisIdJson);
+    const labelColumn = columns.find(({ spec }) =>
+      isLabelColumn(spec) && matchAxisId(axisId, getAxisId(spec.axesSpec[0])),
+    );
+    optionMap.set(
+      labelColumn
+        ? canonicalizeJson({ type: 'column', id: labelColumn.columnId })
+        : canonicalizeJson({ type: 'axis', id: axisId }),
+      labelColumn?.spec.annotations?.['pl7.app/label']
+      ?? axisSpec.annotations?.['pl7.app/label']
+      ?? 'Unlabelled axis',
+    );
   }
+
+  const { hits: compatibleColumns } = await pFrameDriver.findColumns(pFrame, {
+    columnFilter: {},
+    compatibleWith: Array.from(
+      sequenceColumnsAxes.keys(),
+      (axisIdJson) => parseJson(axisIdJson),
+    ),
+    strictlyCompatible: false,
+  });
+
+  for (const { columnId, spec } of compatibleColumns) {
+    const columnIdJson = canonicalizeJson({ type: 'column', id: columnId });
+    if (optionMap.has(columnIdJson)) continue;
+    optionMap.set(
+      columnIdJson,
+      spec.annotations?.['pl7.app/label'] ?? 'Unlabelled column',
+    );
+  }
+
   const options = Array.from(optionMap).map(
     ([value, label]) => ({ label, value: parseJson(value) }),
   );
+
   const defaults = options
     .filter(({ value }) => {
       if (value.type === 'axis') return true;
@@ -215,7 +230,7 @@ async function getMarkupColumnsOptions({
   );
   if (!sequenceColumn) {
     throw new Error(
-      `Couldn't find sequence column (ID: ${sequenceColumnIds[0]})`,
+      `Couldn't find sequence column (ID: \`${sequenceColumnIds[0]}\`).`,
     );
   }
   return columns
@@ -247,7 +262,7 @@ async function getMultipleAlignmentData({
   selection: PlSelectionModel | undefined;
 }): Promise<MultipleAlignmentData> {
   if (!pframe || sequenceColumnIds.length === 0) {
-    return { sequences: [], labels: [] };
+    return { sequences: [], labels: [], exceedsLimit: false };
   }
 
   const pFrameDriver = getPFrameDriver();
@@ -305,6 +320,23 @@ async function getMultipleAlignmentData({
     secondaryEntry.push({ type: 'column', column: markupColumnId });
   }
 
+  const sorting: PTableSorting[] = Array.from(
+    new Set(sequenceColumnIds.flatMap((id) => {
+      const column = columns.find(({ columnId }) => columnId === id);
+      if (!column) {
+        throw new Error(`Couldn't find sequence column (ID: ${id})`);
+      }
+      return column.spec.axesSpec
+        .map((spec) => canonicalizeJson(getAxisId(spec)));
+    })),
+  )
+    .sort()
+    .map((id) => ({
+      column: { type: 'axis', id: parseJson(id) },
+      ascending: true,
+      naAndAbsentAreLeastValues: true,
+    }));
+
   const request: CalculateTableDataRequest<PObjectId> = {
     src: {
       type: 'outer',
@@ -312,14 +344,7 @@ async function getMultipleAlignmentData({
       secondary: secondaryEntry,
     },
     filters: [],
-    sorting: sequenceColumnIds.map((id) => ({
-      column: {
-        type: 'column',
-        id,
-      },
-      ascending: true,
-      naAndAbsentAreLeastValues: true,
-    })),
+    sorting,
   };
 
   const table = await pFrameDriver.calculateTableData(
@@ -327,18 +352,22 @@ async function getMultipleAlignmentData({
     JSON.parse(JSON.stringify(request)),
     {
       offset: 0,
-      length: sequenceLimit,
+      // +1 is a hack to check whether the selection is over the limit
+      length: sequenceLimit + 1,
     },
   );
 
-  const rowCount = table?.[0].data.data.length ?? 0;
+  let rowCount = table?.[0].data.data.length ?? 0;
+  let exceedsLimit = false;
+  if (rowCount > sequenceLimit) {
+    rowCount = sequenceLimit;
+    exceedsLimit = true;
+  }
 
   const sequenceColumns = sequenceColumnIds.map((columnId) => {
     const column = table.find(({ spec }) => spec.id === columnId);
     if (!column) {
-      throw new Error(
-        `Can't find a sequence column (ID: \`${columnId}\`) in the calculateTableData output.`,
-      );
+      throw new Error(`Couldn't find sequence column (ID: \`${columnId}\`).`);
     }
     return column;
   });
@@ -353,9 +382,7 @@ async function getMultipleAlignmentData({
       }
     });
     if (!column) {
-      throw new Error(
-        `Can't find a label column (ID: \`${labelColumn}\`) in the calculateTableData output.`,
-      );
+      throw new Error(`Couldn't find label column (ID: \`${labelColumn}\`).`);
     }
     return column;
   });
@@ -387,7 +414,7 @@ async function getMultipleAlignmentData({
       ),
   );
 
-  const result: MultipleAlignmentData = { sequences, labels };
+  const result: MultipleAlignmentData = { sequences, labels, exceedsLimit };
 
   if (markupColumn) {
     const labels = JSON.parse(
@@ -418,6 +445,7 @@ type MultipleAlignmentData = {
     labels: Record<string, string>;
     data: Markup[];
   };
+  exceedsLimit: boolean;
 };
 
 type OptionsWithDefaults<T> = {

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/multi-sequence-alignment.ts
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/multi-sequence-alignment.ts
@@ -5,6 +5,7 @@ const cache = new Map<string, string[]>();
 export async function multiSequenceAlignment(
   sequences: string[],
 ): Promise<string[]> {
+  if (sequences.length < 2) return sequences;
   const inputHash = await hash(sequences);
   let result = cache.get(inputHash);
   if (result) {


### PR DESCRIPTION
- `labelColumnOptionPredicate` property is removed. MSA now is smart enough to figure out the proper label options on its own.
- Errors during `multipleAlignmentData` and over 1000 sequences limit warning should now actually show up in the UI.
- MSA calculations resulting in errors now also dump errors in the console to help with debugging.
- Sequences order should now be stable.
- MSA algorithm no longer crashes on < 2 sequences.