### PR TITLE
[sdk/ui-vue] MSA: show multiple sequence columns separately

### DIFF
--- a/.changeset/rare-days-wonder.md
+++ b/.changeset/rare-days-wonder.md
@@ -1,0 +1,5 @@
+---
+'@platforma-sdk/ui-vue': patch
+---
+
+MSA: show multiple sequence columns separately

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/Consensus.vue
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/Consensus.vue
@@ -114,7 +114,7 @@ const data = computed<DataByColumns>(
     for (const [columnIndex, column] of residueCounts.entries()) {
       for (const [residue, count] of Object.entries(column)) {
         if (residue === '-') continue;
-        countKey.push(count);
+        countKey.push(residue === ' ' ? 0 : count);
         columnKey.push(columnIndex);
       }
     }

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/MultiSequenceAlignmentView.vue
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/MultiSequenceAlignmentView.vue
@@ -12,6 +12,7 @@ import SeqLogo from './SeqLogo.vue';
 import type { ColorScheme } from './types';
 
 const { sequenceRows, labelRows, markup, colorScheme } = defineProps<{
+  sequenceNames: string[];
   sequenceRows: string[][];
   labelRows: string[][];
   markup: {
@@ -24,7 +25,7 @@ const { sequenceRows, labelRows, markup, colorScheme } = defineProps<{
 }>();
 
 const concatenatedSequences = computed(() =>
-  sequenceRows.map((row) => row.join('')),
+  sequenceRows.map((row) => row.join(' ')),
 );
 
 const residueCounts = computed(
@@ -57,12 +58,22 @@ const objectUrl = useObjectUrl(highlightImageBlob);
 const highlightImage = computed(
   () => objectUrl.value ? `url('${objectUrl.value}')` : 'none',
 );
+
+function sequenceLength(index: number) {
+  return sequenceRows.at(0)?.at(index)?.length ?? 0;
+}
 </script>
 
 <template>
   <div :class="['pl-scrollable', $style.root]">
     <div :class="$style.corner" />
     <div :class="$style.header">
+      <div v-if="sequenceNames.length > 1" :class="$style['sequence-names']">
+        <span
+          v-for="(name, index) of sequenceNames"
+          :style="{ inlineSize: `calc(${sequenceLength(index)} * 20px)` }"
+        >{{ name }}</span>
+      </div>
       <Consensus v-if="consensus" :residueCounts />
       <SeqLogo v-if="seqLogo" :residueCounts />
     </div>
@@ -114,6 +125,14 @@ const highlightImage = computed(
   position: sticky;
   inset-block-start: 0;
   z-index: 1;
+}
+
+.sequence-names {
+  display: flex;
+  font-weight: 700;
+  line-height: 20px;
+  margin-block-end: 4px;
+  gap: 20px;
 }
 
 .labels {

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/PlMultiSequenceAlignment.vue
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/PlMultiSequenceAlignment.vue
@@ -209,6 +209,7 @@ const error = computed(() =>
     >
       <template v-if="multipleAlignmentData.data.sequences.length">
         <MultiSequenceAlignmentView
+          :sequence-names="multipleAlignmentData.data.sequenceNames"
           :sequence-rows="multipleAlignmentData.data.sequences"
           :label-rows="multipleAlignmentData.data.labels"
           :markup="multipleAlignmentData.data.markup"

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/SeqLogo.vue
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/SeqLogo.vue
@@ -4,6 +4,7 @@ import type {
   DataByColumns,
   Settings,
 } from '@milaboratories/miplots4';
+import { PlAlert } from '@milaboratories/uikit';
 import { useResizeObserver } from '@vueuse/core';
 import {
   computed,
@@ -15,7 +16,6 @@ import {
 } from 'vue';
 import type { ResidueCounts } from './types';
 import { useMiPlots } from './useMiPlots';
-import { PlAlert } from '@milaboratories/uikit';
 
 const { residueCounts } = defineProps<{
   residueCounts: ResidueCounts;

--- a/sdk/ui-vue/src/components/PlMultiSequenceAlignment/data.ts
+++ b/sdk/ui-vue/src/components/PlMultiSequenceAlignment/data.ts
@@ -37,17 +37,17 @@ export function useSequenceColumnsOptions(
   }>,
 ) {
   const error = shallowRef<Error>();
-  const data = computedAsync(
+  const data = computedAsync<OptionsWithDefaults<PObjectId>>(
     async () => {
       try {
         error.value = undefined;
         return await getSequenceColumnsOptions(toValue(params));
       } catch (err) {
         error.value = ensureError(err);
-        return { options: [], defaults: [] };
+        return getEmtpyOptions();
       }
     },
-    { options: [], defaults: [] },
+    getEmtpyOptions(),
   );
   return { data, error };
 }
@@ -59,7 +59,7 @@ export function useLabelColumnsOptions(
   }>,
 ) {
   const error = shallowRef<Error>();
-  const data = computedAsync(
+  const data = computedAsync<OptionsWithDefaults<PTableColumnId>>(
     async () => {
       try {
         error.value = undefined;
@@ -67,10 +67,10 @@ export function useLabelColumnsOptions(
       } catch (err) {
         console.error(err);
         error.value = ensureError(err);
-        return { options: [], defaults: [] };
+        return getEmtpyOptions();
       }
     },
-    { options: [], defaults: [] },
+    getEmtpyOptions(),
   );
   return { data, error };
 }
@@ -82,7 +82,7 @@ export function useMarkupColumnsOptions(
   }>,
 ) {
   const error = shallowRef<Error>();
-  const data = computedAsync(
+  const data = computedAsync<ListOptionNormalized<PObjectId>[]>(
     async () => {
       try {
         error.value = undefined;
@@ -110,7 +110,7 @@ export function useMultipleAlignmentData(
 ) {
   const loading = ref(true);
   const error = shallowRef<Error>();
-  const data = computedAsync(
+  const data = computedAsync<MultipleAlignmentData>(
     async () => {
       try {
         error.value = undefined;
@@ -118,10 +118,10 @@ export function useMultipleAlignmentData(
       } catch (err) {
         console.error(err);
         error.value = ensureError(err);
-        return { sequences: [], labels: [], exceedsLimit: false };
+        return getEmtpyMultipleAlignmentData();
       }
     },
-    { sequences: [], labels: [], exceedsLimit: false },
+    getEmtpyMultipleAlignmentData(),
     { evaluating: loading },
   );
   return { data, error, loading };
@@ -134,7 +134,7 @@ async function getSequenceColumnsOptions({
   pFrame: PFrameHandle | undefined;
   sequenceColumnPredicate: (column: PColumnIdAndSpec) => boolean;
 }): Promise<OptionsWithDefaults<PObjectId>> {
-  if (!pFrame) return { options: [], defaults: [] };
+  if (!pFrame) return getEmtpyOptions();
   const pFrameDriver = getPFrameDriver();
   const columns = await pFrameDriver.listColumns(pFrame);
   const options = columns
@@ -154,7 +154,7 @@ async function getLabelColumnsOptions({
   pFrame: PFrameHandle | undefined;
   sequenceColumnIds: PObjectId[];
 }): Promise<OptionsWithDefaults<PTableColumnId>> {
-  if (!pFrame) return { options: [], defaults: [] };
+  if (!pFrame) return getEmtpyOptions();
   const pFrameDriver = getPFrameDriver();
   const columns = await pFrameDriver.listColumns(pFrame);
   const optionMap = new Map<CanonicalizedJson<PTableColumnId>, string>();
@@ -262,7 +262,7 @@ async function getMultipleAlignmentData({
   selection: PlSelectionModel | undefined;
 }): Promise<MultipleAlignmentData> {
   if (!pframe || sequenceColumnIds.length === 0) {
-    return { sequences: [], labels: [], exceedsLimit: false };
+    return getEmtpyMultipleAlignmentData();
   }
 
   const pFrameDriver = getPFrameDriver();
@@ -406,6 +406,10 @@ async function getMultipleAlignmentData({
     (_, row) => alignedSequences.map((column) => column[row]),
   );
 
+  const sequenceNames = sequenceColumns.map((column) =>
+    column.spec.spec.annotations?.['pl7.app/label'] ?? 'Unlabelled column',
+  );
+
   const labels = Array.from(
     { length: rowCount },
     (_, row) =>
@@ -414,7 +418,12 @@ async function getMultipleAlignmentData({
       ),
   );
 
-  const result: MultipleAlignmentData = { sequences, labels, exceedsLimit };
+  const result: MultipleAlignmentData = {
+    sequences,
+    sequenceNames,
+    labels,
+    exceedsLimit,
+  };
 
   if (markupColumn) {
     const labels = JSON.parse(
@@ -438,8 +447,22 @@ async function getMultipleAlignmentData({
   return result;
 }
 
+function getEmtpyOptions<T>(): OptionsWithDefaults<T> {
+  return { options: [], defaults: [] };
+}
+
+function getEmtpyMultipleAlignmentData(): MultipleAlignmentData {
+  return {
+    sequences: [],
+    sequenceNames: [],
+    labels: [],
+    exceedsLimit: false,
+  };
+}
+
 type MultipleAlignmentData = {
   sequences: string[][];
+  sequenceNames: string[];
   labels: string[][];
   markup?: {
     labels: Record<string, string>;


### PR DESCRIPTION
Not my best solution, but it seems to be working fine (even text selection gestures work as expected). All the aligned sequences are still concatenated to generate the output, but a space is inserted between them now. What still needs to be implemented is being able have a markup highlight and multiple sequence columns simultaneously.