### PR TITLE
MILAB-3574: make pip to forget internet ever existed for deps

### DIFF
--- a/.changeset/fast-sites-cheer.md
+++ b/.changeset/fast-sites-cheer.md
@@ -2,4 +2,4 @@
 '@platforma-sdk/workflow-tengo': patch
 ---
 
-Make pip to forget internet ever existed :)
+Ensure pip installs Python dependencies from local sources only by adding the `--no-index` flag. This prevents any attempts to connect to the public PyPI repository, making dependency installation more secure and reliable in isolated environments.


### PR DESCRIPTION
When installing dependencies into venv prepared for software run, do not allow pip to go to the internet for the dependencies.