### PR TITLE
fix: force venv re-creation for all blocks that switch to new sdk

### DIFF
--- a/.changeset/icy-drinks-switch.md
+++ b/.changeset/icy-drinks-switch.md
@@ -1,0 +1,5 @@
+---
+'@platforma-sdk/workflow-tengo': patch
+---
+
+Make blocks to forcefully re-create venv when they update workflow-sdk dependency (ptabler polars dependencies issue)

--- a/sdk/workflow-tengo/src/exec/python/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/python/index.lib.tengo
@@ -139,7 +139,8 @@ pythonVenvBuilder := func() {
 				dependencies: depsMap,
 				// software: softwareRef,
 				pythonDescriptor: pythonDescriptor,
-				python: pythonPkg
+				python: pythonPkg,
+				forceRecreate: 1 // increment to force venv re-creation in blocks
 			}
 
 			validation.assertType(pyVenvInputs, internal.pythonVenvInputSchema, "incomplete python runenv configuration")

--- a/sdk/workflow-tengo/src/exec/python/internal.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/python/internal.lib.tengo
@@ -3,12 +3,14 @@ validation := import(":validation")
 desc := import(":exec.descriptor")
 
 pythonVenvInputSchema := {
-	toolset: "string",
-	dependencies: {"any": validation.reference},
+	"toolset": "string",
+	"dependencies": {"any": validation.reference},
 	// software: validation.reference,
 
-	pythonDescriptor: desc.runEnvScheme,
-	python: validation.reference
+	"pythonDescriptor": desc.runEnvScheme,
+	"python": validation.reference,
+
+	"forceRecreate,?": "number"
 }
 
 export ll.toStrict({


### PR DESCRIPTION
Because of polars dependency issue we happened to break several blocks on our user's side:
- transitive dependencies of python packages we use have 'latest' polars version reference in their requirements
- at some point polars for linux was built without a feature required for these packages
- this caused pip  to install this freshest broken version of polars from the internet during venv preparation process
- this venv was cached on clients side to prevent packages installation before each block workflow run

All this lead to cached venv to have broken packages that cannot work on linux.
This commit intentionally breaks cache and deduplication for block's venvs in all blocks to fix the problem in all blocks.