### PR TITLE
MILAB-3704: force stop pl process if it rejects to stop within timeout

### DIFF
--- a/.changeset/funny-regions-agree.md
+++ b/.changeset/funny-regions-agree.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-deployments': patch
+---
+
+Force stop backend process if it exceeeds timeout after gentle stop signal

--- a/.changeset/hot-files-beg.md
+++ b/.changeset/hot-files-beg.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-config': minor
+---
+
+Allow to control common timeouts for all controllers (init/stop/request)

--- a/lib/node/pl-config/src/common/config.ts
+++ b/lib/node/pl-config/src/common/config.ts
@@ -47,6 +47,11 @@ export function newDefaultPlConfig(
       db: { path: dbPath },
     },
     controllers: {
+      common: {
+        timeouts: {
+          stop: '10s',
+        },
+      },
       workflows: {},
       packageLoader: packageLoaderConfig,
       runner: {

--- a/lib/node/pl-config/src/common/types.ts
+++ b/lib/node/pl-config/src/common/types.ts
@@ -102,7 +102,7 @@ export type PlTlsAuthMode =
   | 'RequireValidCert';
 
 export type PlControllersSettings = {
-  common: PlControllerCommonSettings;
+  common?: PlControllerCommonSettings;
   data: PlControllerDataSettings;
   runner: PlControllerRunnerSettings;
   packageLoader: PlControllerPackageLoaderSettings;

--- a/lib/node/pl-config/src/common/types.ts
+++ b/lib/node/pl-config/src/common/types.ts
@@ -102,10 +102,19 @@ export type PlTlsAuthMode =
   | 'RequireValidCert';
 
 export type PlControllersSettings = {
+  common: PlControllerCommonSettings;
   data: PlControllerDataSettings;
   runner: PlControllerRunnerSettings;
   packageLoader: PlControllerPackageLoaderSettings;
   workflows: PlControllerWorkflowsSettings;
+};
+
+export type PlControllerCommonSettings = {
+  timeouts: {
+    init?: string;
+    stop?: string;
+    request?: string;
+  };
 };
 
 export type PlControllerDataSettings = {

--- a/lib/node/pl-config/src/local/config_test.yaml
+++ b/lib/node/pl-config/src/local/config_test.yaml
@@ -39,6 +39,9 @@ core:
     path: 'db'
 
 controllers:
+  common:
+    timeouts:
+      stop: '10s'
   data:
     main:
       storages:

--- a/lib/node/pl-config/src/ssh/config_test.yaml
+++ b/lib/node/pl-config/src/ssh/config_test.yaml
@@ -39,6 +39,10 @@ core:
     path: db
 
 controllers:
+  common:
+    timeouts:
+      stop: '10s'
+
   workflows: {}
 
   packageLoader:

--- a/lib/node/pl-deployments/src/local/pl.ts
+++ b/lib/node/pl-deployments/src/local/pl.ts
@@ -203,7 +203,12 @@ async function localPlatformaReadPidAndStop(
 
     if (oldPid !== undefined && alive) {
       trace('stopped', processStop(oldPid));
-      trace('waitStopped', await processWaitStopped(oldPid, 10_000));
+      try {
+        trace('waitStopped', await processWaitStopped(oldPid, 15_000)); // larger, that 10s we provide to backend in config.
+      } catch (_e) {
+        trace('forceStopped', processStop(oldPid, true));
+        trace('waitForceStopped', await processWaitStopped(oldPid, 5_000));
+      }
     }
 
     return t;

--- a/lib/node/pl-deployments/src/local/process.ts
+++ b/lib/node/pl-deployments/src/local/process.ts
@@ -1,5 +1,6 @@
 import type { SpawnOptions, ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import type { MiLogger } from '@milaboratories/ts-helpers';
 import { sleep } from '@milaboratories/ts-helpers';
 
@@ -22,14 +23,50 @@ wd: ${opts.opts.cwd}`);
 export async function isProcessAlive(pid: number) {
   try {
     process.kill(pid, 0);
-    return true;
+
+    // Check we look at 'platforma' to not kill wrong process.
+    const processName = getProcessName(pid);
+    if (process.platform === 'win32') {
+      return processName === 'platforma.exe'; // process name does not contain path to the file.
+    }
+
+    // Linux and Mac OS X behave differently (so can different Linux distributions).
+    // Process name can contain original path to the binary file or just its name.
+    return processName.endsWith('/platforma') || processName === 'platforma';
   } catch (_e) {
     return false;
   }
 }
 
-export function processStop(pid: number) {
-  return process.kill(pid, 'SIGINT');
+function getProcessName(pid: number): string {
+  try {
+    if (process.platform === 'win32') {
+      // Windows: use tasklist command
+      const output = execSync(`tasklist /FI "PID eq ${pid}" /FO CSV /NH`, { encoding: 'utf8' });
+      const lines = output.trim().split('\n');
+      if (lines.length > 0 && lines[0].includes(',')) {
+        const parts = lines[0].split(',');
+        if (parts.length >= 1) {
+          // Remove quotes and get the executable name
+          const exeName = parts[0].replace(/^"|"$/g, '').trim();
+          return exeName;
+        }
+      }
+    } else {
+      // Unix-like systems: use ps command
+      const output = execSync(`ps -p ${pid} -o comm=`, { encoding: 'utf8' });
+      const processName = output.trim();
+      return processName;
+    }
+  } catch (_error) {
+    // If we can't get the process name, return empty string
+    return '';
+  }
+  return '';
+}
+
+export function processStop(pid: number, force: boolean = false) {
+  return process.kill(pid, force ? 'SIGKILL' : 'SIGINT');
 }
 
 export async function processWaitStopped(pid: number, maxMs: number) {


### PR DESCRIPTION
When backend process started for builtin mode does not stop within timeout of 10 seconds - we just leave attempts to kill the process and then fail to start backend, showing the user a message about OS permissions.

Instead, we should do these things:
- set stop timeout on backend side to some controlled value (now backend has default of 30s when ML waits for 10s and constantly fails)
- make ML to control timout and force process to stop afterwards.
- to not kill unexpected process because of mistake - do simple process name validation for safety.