### PR TITLE
Make sure built-in backend has a log file

### DIFF
--- a/.changeset/clever-bags-fold.md
+++ b/.changeset/clever-bags-fold.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-config': patch
+---
+
+Make sure built-in backend has a log file

--- a/lib/node/pl-config/src/common/config.ts
+++ b/lib/node/pl-config/src/common/config.ts
@@ -20,7 +20,7 @@ export function newDefaultPlConfig(
     license: licenseForConfig(license),
     logging: {
       level: 'info',
-      destinations: [{ path: logPath }],
+      destinations: [{ type: 'file', path: logPath }],
     },
     monitoring: {
       enabled: true,

--- a/lib/node/pl-config/src/common/types.ts
+++ b/lib/node/pl-config/src/common/types.ts
@@ -21,9 +21,25 @@ export type PlLoggingSettings = {
 
 export type PlLogLevel = 'debug' | 'info' | 'error' | 'warn';
 
-export type PlLoggingDestination = {
+export type PlLoggingDestinationFile = {
+  type: 'file';
   path: string;
 };
+
+export type PlLoggingDestinationDir = {
+  type: 'dir';
+  path: string;
+};
+
+export type PlLoggingDestinationStream = {
+  type: 'stream';
+  name: 'stdout' | 'stderr';
+};
+
+export type PlLoggingDestination =
+  | PlLoggingDestinationFile
+  | PlLoggingDestinationDir
+  | PlLoggingDestinationStream;
 
 export type PlMonitoringSettings = {
   enabled: boolean;
@@ -131,7 +147,9 @@ export type PlControllerDataMainStoragesSettings = {
   downloadable: boolean;
 };
 
-export type PlControllerDataStoragesSettings = PlS3StorageSettings | PlFsStorageSettings;
+export type PlControllerDataStoragesSettings =
+  | PlS3StorageSettings
+  | PlFsStorageSettings;
 
 export type PlStorageID = { id: string };
 
@@ -139,10 +157,11 @@ export type PlCommonStorageSettings = {
   indexCachePeriod: string;
 };
 
-export type PlS3StorageSettings = PlStorageID &
-  PlS3StorageType &
-  PlCommonStorageSettings &
-  PlS3StorageTypeSettings;
+export type PlS3StorageSettings =
+  & PlStorageID
+  & PlS3StorageType
+  & PlCommonStorageSettings
+  & PlS3StorageTypeSettings;
 
 export type PlS3StorageType = { type: 'S3' };
 export type PlS3StorageTypeSettings = {
@@ -159,10 +178,11 @@ export type PlS3StorageTypeSettings = {
   uploadKeyPrefix: string;
 };
 
-export type PlFsStorageSettings = PlStorageID &
-  PlFsStorageType &
-  PlCommonStorageSettings &
-  PlFsStorageTypeSettings;
+export type PlFsStorageSettings =
+  & PlStorageID
+  & PlFsStorageType
+  & PlCommonStorageSettings
+  & PlFsStorageTypeSettings;
 
 type PlFsStorageType = { type: 'FS' };
 

--- a/lib/node/pl-config/src/local/config_test.yaml
+++ b/lib/node/pl-config/src/local/config_test.yaml
@@ -7,7 +7,8 @@ license:
 logging:
   level: 'info'
   destinations:
-  - path: 'platforma.log'
+    - type: 'file'
+      path: 'platforma.log'
 
 monitoring:
   enabled: true
@@ -31,10 +32,10 @@ core:
 
   authEnabled: true
   auth:
-  - driver: jwt
-    key: jwtkey
-  - driver: htpasswd
-    path: 'users.htpasswd'
+    - driver: jwt
+      key: jwtkey
+    - driver: htpasswd
+      path: 'users.htpasswd'
   db:
     path: 'db'
 
@@ -58,26 +59,26 @@ controllers:
           downloadable: false
 
     storages:
-    - id: 'root'
-      type: 'FS'
-      indexCachePeriod: '1m'
-      rootPath: ''
-      allowRemoteAccess: false
-      externalURL: ''
+      - id: 'root'
+        type: 'FS'
+        indexCachePeriod: '1m'
+        rootPath: ''
+        allowRemoteAccess: false
+        externalURL: ''
 
-    - id: 'work'
-      type: 'FS'
-      indexCachePeriod: '1m'
-      rootPath: 'storages/work'
-      allowRemoteAccess: false
-      externalURL: ''
+      - id: 'work'
+        type: 'FS'
+        indexCachePeriod: '1m'
+        rootPath: 'storages/work'
+        allowRemoteAccess: false
+        externalURL: ''
 
-    - id: 'main'
-      type: 'FS'
-      indexCachePeriod: '0m'
-      rootPath: 'storages/main'
-      allowRemoteAccess: false
-      externalURL: 'http://127.0.0.1:11237'
+      - id: 'main'
+        type: 'FS'
+        indexCachePeriod: '0m'
+        rootPath: 'storages/main'
+        allowRemoteAccess: false
+        externalURL: 'http://127.0.0.1:11237'
 
   runner:
     type: local
@@ -86,8 +87,8 @@ controllers:
     workdirCacheOnFailure: '1h'
     storageRoot: 'storages/work'
     secrets:
-    - map:
-        MI_LICENSE: 'abc'
+      - map:
+          MI_LICENSE: 'abc'
 
   packageLoader:
     packagesRoot: 'packages'

--- a/lib/node/pl-config/src/ssh/config_test.yaml
+++ b/lib/node/pl-config/src/ssh/config_test.yaml
@@ -6,7 +6,8 @@ license:
 logging:
   level: info
   destinations:
-  - path: platforma.log
+    - type: 'file'
+      path: platforma.log
 
 monitoring:
   enabled: true
@@ -31,10 +32,10 @@ core:
 
   authEnabled: true
   auth:
-  - driver: jwt
-    key: jwtkey
-  - driver: htpasswd
-    path: /home/pl-doctor/platforma_backend/users.htpasswd
+    - driver: jwt
+      key: jwtkey
+    - driver: htpasswd
+      path: /home/pl-doctor/platforma_backend/users.htpasswd
   db:
     path: db
 
@@ -53,8 +54,8 @@ controllers:
     storageRoot: /home/pl-doctor/platforma_backend/storages/work
     workdirCacheOnFailure: 1h
     secrets:
-    - map:
-        MI_LICENSE: 'abc'
+      - map:
+          MI_LICENSE: 'abc'
 
   data:
     main:
@@ -70,18 +71,18 @@ controllers:
           downloadable: true
 
     storages:
-    - id: remoteRoot
-      type: FS
-      indexCachePeriod: 1m
-      rootPath: ""
-    - id: work
-      type: FS
-      indexCachePeriod: 1m
-      rootPath: /home/pl-doctor/platforma_backend/storages/work
+      - id: remoteRoot
+        type: FS
+        indexCachePeriod: 1m
+        rootPath: ''
+      - id: work
+        type: FS
+        indexCachePeriod: 1m
+        rootPath: /home/pl-doctor/platforma_backend/storages/work
 
-    - id: main
-      type: FS
-      indexCachePeriod: "0s"
-      rootPath: /home/pl-doctor/platforma_backend/storages/main
-      allowRemoteAccess: true
-      externalURL: "http://localhost:11112"
+      - id: main
+        type: FS
+        indexCachePeriod: '0s'
+        rootPath: /home/pl-doctor/platforma_backend/storages/main
+        allowRemoteAccess: true
+        externalURL: 'http://localhost:11112'


### PR DESCRIPTION
Currently, setting up backend via built-in and ssh modes produces a config that results in backend not logging anything. Just one line was missing: `type: "file"`. I added this line and updated the config type.