### PR TITLE
fix: improve file upload resilience

### DIFF
--- a/lib/node/pl-drivers/src/clients/upload.ts
+++ b/lib/node/pl-drivers/src/clients/upload.ts
@@ -316,24 +316,33 @@ async function checkExpectedMTime(path: string, expectedMTimeUnix: bigint) {
   }
 }
 
+function isExpiredTokenError(body: string): boolean {
+  return body.includes("<Code>ExpiredToken</Code>");
+}
+
 function checkStatusCodeOk(
   statusCode: number,
   body: string,
   headers: IncomingHttpHeaders,
   info: UploadAPI_GetPartURL_Response,
 ) {
+  const message =
+    `response is not ok, status code: ${statusCode},` +
+    ` body: ${body}, headers: ${JSON.stringify(headers)}, url: ${info.uploadUrl}`;
+
   if (statusCode == 400) {
-    throw new BadRequestError(
-      `response is not ok, status code: ${statusCode},` +
-        ` body: ${body}, headers: ${JSON.stringify(headers)}, url: ${info.uploadUrl}`,
-    );
+    // S3 may return 400 with ExpiredToken when the STS session credentials
+    // used to sign the pre-signed URL have expired. This is recoverable:
+    // a retry will request a fresh pre-signed URL from the backend.
+    if (isExpiredTokenError(body)) {
+      throw new NetworkError(message);
+    }
+
+    throw new BadRequestError(message);
   }
 
   if (statusCode != 200) {
-    throw new NetworkError(
-      `response is not ok, status code: ${statusCode},` +
-        ` body: ${body}, headers: ${JSON.stringify(headers)}, url: ${info.uploadUrl}`,
-    );
+    throw new NetworkError(message);
   }
 }
 


### PR DESCRIPTION
## Summary

- Treat S3 `ExpiredToken` errors as recoverable during file uploads. When STS session credentials expire during long multipart uploads (800+ chunks), S3 returns HTTP 400 with `ExpiredToken`. Previously classified as non-recoverable `BadRequestError`, permanently killing the upload. Now classified as recoverable `NetworkError`, allowing the retry loop to request a fresh pre-signed URL.

## Context

Large file uploads that exceed the STS token lifetime (1-12h depending on AWS config) would fail terminally at an arbitrary chunk with no way to recover. The fix parses the S3 error XML body to distinguish `ExpiredToken` from other 400 errors.

## Test plan

- [ ] Upload a large file (800+ chunks) and verify upload completes successfully
- [ ] Verify that genuine 400 errors (malformed requests) still fail as non-recoverable
- [ ] Verify retry behavior: after `ExpiredToken`, the next attempt gets a fresh pre-signed URL from the backend