### PR TITLE
fix: stop infinite polling when BlobImport progress returns NOT_FOUND

### DIFF
--- a/.changeset/fix-upload-progress-polling.md
+++ b/.changeset/fix-upload-progress-polling.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-drivers": patch
+---
+
+fix: stop infinite polling when BlobImport progress returns NOT_FOUND (PLATFORM-ELECTRON-KC2)

--- a/lib/model/common/src/drivers/upload.ts
+++ b/lib/model/common/src/drivers/upload.ts
@@ -1,5 +1,8 @@
 export interface ImportProgress {
   done: boolean;
+  /** True if the import was terminated because the resource
+   * was deleted or aborted on the server (e.g. NOT_FOUND / ABORTED). */
+  aborted?: boolean;
   /** Status of indexing/uploading got from platforma gRPC. */
   status?: ImportStatus;
   /** True if BlobUpload, false if BlobIndex. */

--- a/lib/node/pl-drivers/src/drivers/upload.ts
+++ b/lib/node/pl-drivers/src/drivers/upload.ts
@@ -227,7 +227,7 @@ export class UploadDriver {
 }
 
 function isProgressDone(p: sdk.ImportProgress) {
-  return p.done && (p.status?.progress ?? 0.0) >= 1.0;
+  return p.done;
 }
 
 type ScheduledRefresh = {

--- a/lib/node/pl-drivers/src/drivers/upload_task.ts
+++ b/lib/node/pl-drivers/src/drivers/upload_task.ts
@@ -135,8 +135,8 @@ export class UploadTask {
       }
 
       if (isTerminalUploadError(e)) {
-        this.logger.warn(
-          `terminal error while updating BlobImport status: ${e}, ${stringifyWithResourceId(this.res)}`,
+        this.logger.info(
+          `BlobImport terminated (resource deleted or aborted): ${e}, ${stringifyWithResourceId(this.res)}`,
         );
         this.change.markChanged(
           `upload status for ${resourceIdToString(this.res.id)} aborted: ${e.code}`,

--- a/lib/node/pl-drivers/src/drivers/upload_task.ts
+++ b/lib/node/pl-drivers/src/drivers/upload_task.ts
@@ -89,7 +89,7 @@ export class UploadTask {
         this.change.markChanged(
           `blob upload for ${resourceIdToString(this.res.id)} aborted: ${e.code}`,
         );
-        this.setDone(true);
+        this.setAborted();
 
         return;
       }
@@ -141,7 +141,7 @@ export class UploadTask {
         this.change.markChanged(
           `upload status for ${resourceIdToString(this.res.id)} aborted: ${e.code}`,
         );
-        this.setDone(true);
+        this.setAborted();
         return;
       }
 
@@ -176,6 +176,11 @@ export class UploadTask {
   private setDone(done: boolean) {
     this.progress.done = done;
     if (done) this.progress.lastError = undefined;
+  }
+
+  private setAborted() {
+    this.progress.done = true;
+    this.progress.aborted = true;
   }
 
   public incCounter(w: Watcher, callerId: string) {
@@ -259,6 +264,7 @@ function newProgress(res: ImportResourceSnapshot, signer: Signer) {
     uploadData: uploadData,
     progress: {
       done: false,
+      aborted: undefined,
       status: undefined,
       isUpload: isUpload(res),
       isUploadSignMatch: isUploadSignMatch,
@@ -280,6 +286,7 @@ export function isMyUpload(p: sdk.ImportProgress): boolean {
 function cloneProgress(progress: sdk.ImportProgress): sdk.ImportProgress {
   const cloned: sdk.ImportProgress = {
     done: progress.done,
+    aborted: progress.aborted,
     isUpload: progress.isUpload,
     isUploadSignMatch: progress.isUploadSignMatch,
     lastError: progress.lastError,

--- a/lib/node/pl-drivers/src/drivers/upload_task.ts
+++ b/lib/node/pl-drivers/src/drivers/upload_task.ts
@@ -136,7 +136,7 @@ export class UploadTask {
 
       if (isTerminalUploadError(e)) {
         this.logger.info(
-          `BlobImport terminated (resource deleted or aborted): ${e}, ${stringifyWithResourceId(this.res)}`,
+          `terminal error while updating BlobImport status: ${e}, ${stringifyWithResourceId(this.res)}`,
         );
         this.change.markChanged(
           `upload status for ${resourceIdToString(this.res.id)} aborted: ${e.code}`,

--- a/lib/node/pl-drivers/src/drivers/upload_task_notfound.test.ts
+++ b/lib/node/pl-drivers/src/drivers/upload_task_notfound.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { UploadTask } from "./upload_task";
+import type { ImportResourceSnapshot } from "./types";
+import type { ClientProgress } from "../clients/progress";
+import type { ClientUpload } from "../clients/upload";
+import { ConsoleLoggerAdapter, HmacSha256Signer } from "@milaboratories/ts-helpers";
+import type { ResourceId, ResourceType } from "@milaboratories/pl-client";
+
+function makeNotFoundError() {
+  const err: any = new Error("NOT_FOUND: resource not found");
+  err.name = "RpcError";
+  err.code = "NOT_FOUND";
+  return err;
+}
+
+function makeMockResourceSnapshot(): ImportResourceSnapshot {
+  return {
+    id: 123456n as unknown as ResourceId,
+    type: { name: "BlobIndex", version: "1" } as ResourceType,
+    fields: { incarnation: undefined },
+  } as unknown as ImportResourceSnapshot;
+}
+
+function createUploadTask(getStatusFn: (...args: any[]) => Promise<any>) {
+  const logger = new ConsoleLoggerAdapter();
+  const signer = new HmacSha256Signer(HmacSha256Signer.generateSecret());
+
+  const mockClientUpload = {} as ClientUpload;
+  const mockClientProgress = {
+    getStatus: getStatusFn,
+  } as unknown as ClientProgress;
+
+  return new UploadTask(
+    logger,
+    mockClientUpload,
+    mockClientProgress,
+    10,
+    signer,
+    makeMockResourceSnapshot(),
+  );
+}
+
+describe("UploadTask NOT_FOUND handling", () => {
+  it("sets aborted when resource returns NOT_FOUND after partial progress", async () => {
+    let callCount = 0;
+    const task = createUploadTask(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { done: false, progress: 0.5, bytesProcessed: "50", bytesTotal: "100" };
+      }
+      throw makeNotFoundError();
+    });
+
+    // First poll: partial progress
+    await task.updateStatus();
+    expect(task.progress.done).toBe(false);
+    expect(task.progress.aborted).toBeFalsy();
+    expect(task.progress.status?.progress).toBe(0.5);
+
+    // Second poll: NOT_FOUND
+    await task.updateStatus();
+    expect(task.progress.done).toBe(true);
+    expect(task.progress.aborted).toBe(true);
+    expect(task.progress.lastError).toContain("NOT_FOUND");
+  });
+
+  it("sets aborted when first poll returns NOT_FOUND", async () => {
+    const task = createUploadTask(async () => {
+      throw makeNotFoundError();
+    });
+
+    await task.updateStatus();
+    expect(task.progress.done).toBe(true);
+    expect(task.progress.aborted).toBe(true);
+    expect(task.progress.status).toBeUndefined();
+    expect(task.progress.lastError).toContain("NOT_FOUND");
+  });
+
+  it("does not set aborted on normal completion", async () => {
+    const task = createUploadTask(async () => {
+      return { done: true, progress: 1.0, bytesProcessed: "100", bytesTotal: "100" };
+    });
+
+    await task.updateStatus();
+    expect(task.progress.done).toBe(true);
+    expect(task.progress.aborted).toBeFalsy();
+    expect(task.progress.status?.progress).toBe(1.0);
+  });
+});

--- a/lib/ui/uikit/src/components/PlFileInput/PlFileInput.vue
+++ b/lib/ui/uikit/src/components/PlFileInput/PlFileInput.vue
@@ -111,11 +111,16 @@ const fileName = computed(() => tryValue(props.modelValue, getFileNameFromHandle
 
 const filePath = computed(() => tryValue(props.modelValue, getFilePathFromHandle));
 
+const isAborted = computed(() => props.progress?.aborted);
+
 const isUploading = computed(() => props.progress && !props.progress.done);
 
-const isUploaded = computed(() => props.progress && props.progress.done);
+const isUploaded = computed(() => props.progress && props.progress.done && !props.progress.aborted);
 
-const computedErrorMessage = computed(() => getErrorMessage(data.error, props.error));
+const computedErrorMessage = computed(() => {
+  if (isAborted.value) return props.progress?.lastError ?? "Import cancelled";
+  return getErrorMessage(data.error, props.error);
+});
 
 const hasErrors = computed(() => typeof computedErrorMessage.value === "string");
 
@@ -136,13 +141,13 @@ const uploadStats = computed(() => {
 const progressStyle = computed(() => {
   const { progress } = props;
 
-  if (!progress) {
+  if (!progress || progress.aborted) {
     return {};
   }
 
-  return {
-    width: progress.done ? "100%" : Math.round((progress.status?.progress ?? 0) * 100) + "%",
-  };
+  const pct = progress.done ? 100 : Math.round((progress.status?.progress ?? 0) * 100);
+
+  return { width: pct + "%" };
 });
 
 const openFileDialog = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1820,7 +1820,7 @@ importers:
         version: 1.1.13(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.13(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.25.2)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.13(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.25.3)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-middle-layer':
         specifier: workspace:*
         version: link:../../model/middle-layer
@@ -4674,8 +4674,8 @@ packages:
   '@milaboratories/pl-model-common@1.25.1':
     resolution: {integrity: sha512-U3nwSU7FPhpSWyjrz47w/T1MmyS3sR66bzmvQw3FxXVV1fblNkTqSo/okuH1gJLRdaKnF6SZfxH9pTDa7vhHNg==}
 
-  '@milaboratories/pl-model-common@1.25.2':
-    resolution: {integrity: sha512-Pl8Dq6yXihVCjUi9gYmSoCOPCs619x4dz9EcB6zGfIJEPZiAsKu03qmC5F297wgJukeQ5yEUcETebE4sh7DiJw==}
+  '@milaboratories/pl-model-common@1.25.3':
+    resolution: {integrity: sha512-2NuQr9F+KSimxVd/LEUsyWh+d+1oP3RceR/X/SITWZ1tCgDr1dJD0D5wmLUlnCFgBXvDesJ+gKfnICpl/uZBXw==}
 
   '@milaboratories/pl-model-middle-layer@1.12.8':
     resolution: {integrity: sha512-0StiAyYcnYxiwY+8bkXx9n1R63NB3SaV2rRkZXKYDyx2on440Ftlrh3arKmCmEAHA9oiA/KpBoVAe5VXLDJC+g==}
@@ -10581,10 +10581,10 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.13(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.25.2)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.13(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.25.3)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.25.2
+      '@milaboratories/pl-model-common': 1.25.3
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
   '@milaboratories/pl-error-like@1.12.8':
@@ -10603,7 +10603,7 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.25.2':
+  '@milaboratories/pl-model-common@1.25.3':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0


### PR DESCRIPTION
## Summary
- Fixed infinite polling loop in `UploadDriver` when `getStatus` returns `NOT_FOUND` for deleted/aborted resources
- `isProgressDone()` required both `p.done` AND `p.status.progress >= 1.0`, but terminal errors only set `done=true` without updating `status` — causing the task to be re-polled indefinitely
- Downgraded log from `warn` to `info` since resource deletion/abort is expected behavior, not an error

## Root cause
When `Progress/GetStatus` returns `NOT_FOUND` (resource deleted or aborted), `updateStatus()` calls `setDone(true)` which sets `progress.done = true`. However, `isProgressDone()` also checked `status.progress >= 1.0`. Since `status` was never set in the error path (or was still at a partial value), `isProgressDone()` returned `false`, keeping the task in the polling loop. Each poll produced another `NOT_FOUND` → another Sentry warning → 70K+ events.

## Test plan
- [x] Build passes (`pnpm turbo run build --filter=@milaboratories/pl-drivers`)
- [x] Existing integration tests in `upload.test.ts` cover the normal upload/index flows
- [ ] Manual: trigger a BlobImport, then delete the resource mid-import — verify no repeated warnings in logs

Fixes [PLATFORM-ELECTRON-KC2](https://sn.pl-open.science/organizations/sentry/issues/20104/events/de0d9d4e12974f84b10bb2b7f8998dab/?project=3&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=previous-event&stream_index=0)