### PR TITLE
fix: pre-commit hook fails when committing only deletions

### DIFF
--- a/.changeset/loud-taxis-hug.md
+++ b/.changeset/loud-taxis-hug.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: pre-commit hook fails when committing only deletions

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 [ -n "$CI" ] && exit 0
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 pnpm fmt
-[ -n "$STAGED" ] && echo "$STAGED" | xargs git add
+if [ -n "$STAGED" ]; then echo "$STAGED" | xargs git add; fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
 [ -n "$CI" ] && exit 0
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 pnpm fmt
-if [ -n "$STAGED" ]; then echo "$STAGED" | xargs git add; fi
+if [ -n "$STAGED" ]; then
+  echo "$STAGED" | while IFS= read -r file; do
+    git add "$file"
+  done
+fi


### PR DESCRIPTION
## Summary

- Pre-commit hook exits with code 1 when committing only file deletions
- Root cause: `[ -n "$STAGED" ] && ...` is the last line of the hook. `--diff-filter=ACMR` excludes deletions, so `STAGED` is empty, `[ -n "" ]` returns 1, and `&&` short-circuit makes that the hook's exit code
- Fix: replaced `&&` chain with `if/then/fi` which exits 0 when the condition is false

## Test plan
- [ ] Verify `git rm <file> && git commit` works without `--no-verify`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a pre-commit hook bug where committing only deletions caused the hook to exit with code 1. The root cause was that `[ -n "$STAGED" ] && echo "$STAGED" | xargs git add` as the last line returns exit code 1 when `STAGED` is empty, since `--diff-filter=ACMR` excludes deletions. Replacing it with `if/then/fi` ensures the hook exits 0 in that case.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted fix with no side effects.

Single-line change that correctly addresses the root cause. The if/then/fi construct exits 0 when the condition is false, which is the desired behavior. No other issues found.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .husky/pre-commit | Replaces `[ -n "$STAGED" ] && ...` with `if/then/fi` to ensure the hook exits 0 when no staged non-deleted files exist — correct fix for the described bug. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pre-commit hook fails when committi..."](https://github.com/milaboratory/platforma/commit/c0fdc11e84f675a360757881724fb29514262267) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27843833)</sub>

<!-- /greptile_comment -->