### PR TITLE
feat: add splitAxes and coreColumnPredicate to createPlDataTableV3

### DIFF
--- a/sdk/model/src/columns/index.ts
+++ b/sdk/model/src/columns/index.ts
@@ -3,3 +3,4 @@ export * from "./column_snapshot_provider";
 export * from "./column_selector";
 export * from "./column_collection_builder";
 export * from "./ctx_column_sources";
+export * from "./expand_by_partition";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalizedJson,
   DiscoverColumnsStepInfo,
   PColumn,
+  PColumnIdAndSpec,
   PObjectId,
   PTableColumnId,
   PTableColumnIdAxis,
@@ -25,7 +26,8 @@ import { isEmpty } from "es-toolkit/compat";
 import type { PlDataTableFilters, PlDataTableModel } from "../typesV5";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
-import type { ColumnSnapshot, MatchingMode } from "../../../columns";
+import type { ColumnSnapshot, MatchingMode, SplitAxis } from "../../../columns";
+import { expandByPartition } from "../../../columns";
 import { Services, type RequireServices } from "@milaboratories/pl-model-common";
 import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
@@ -35,6 +37,7 @@ import {
   isColumnOptional,
   withLabelAnnotations,
   withTableVisualAnnotations,
+  type LabelableColumn,
 } from "./utils";
 import { createPTableDefV3 } from "./createPTableDefV3";
 import { discoverColumns, type DiscoveredColumnOptions } from "./discoverColumns";
@@ -44,6 +47,25 @@ export type createPlDataTableOptionsV3 = DiscoveredColumnOptions & {
   filters?: PlDataTableFilters;
   sorting?: PTableSorting[];
   coreJoinType?: "inner" | "full";
+
+  /**
+   * Custom predicate to select core columns. Core columns are joined together
+   * (inner or full, controlled by coreJoinType) and define the row universe.
+   * Non-core columns are left-joined onto the core result.
+   *
+   * When omitted, anchor columns (isAnchor flag from discovery) are used as core.
+   * Overrides `splitAxes.asCore` when both are provided.
+   */
+  coreColumnPredicate?: (spec: PColumnIdAndSpec) => boolean;
+
+  /**
+   * Split matching columns along partition axes (e.g. split abundance by sampleId).
+   * Matched columns are expanded by partition — one output per key combination —
+   * with split axes removed from spec and trace annotations added.
+   * Expanded columns replace originals in the table.
+   * When `asCore` is true, expanded columns become core (defining the row universe).
+   */
+  splitAxes?: SplitAxesConfig;
 
   tableState?: PlDataTableStateV2;
   labelsOptions?: DeriveLabelsOptions;
@@ -78,20 +100,76 @@ export type ColumnVisibilityRule = {
 
 export type ColumnMatcher = (spec: PColumnSpec) => boolean;
 
+/**
+ * Axis splitting config for columns matching a predicate.
+ * Matched columns are expanded by partition (one output per key combination),
+ * with split axes removed from their spec and trace annotations added.
+ */
+export type SplitAxesConfig = {
+  /** Which columns to split. */
+  match: ColumnMatcher;
+  /** Axis indices to split on. */
+  axes: SplitAxis[];
+  /** Whether expanded columns should be core (defining the row universe). Default: false. */
+  asCore?: boolean;
+};
+
 // Main Function
 
 export function createPlDataTableV3<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
   ctx: RenderCtxBase<A, U, S>,
   options: createPlDataTableOptionsV3,
 ): PlDataTableModel | undefined {
-  const state = upgradePlDataTableStateV2(options.tableState);
-  const coreJoinType = options.coreJoinType ?? "full";
+  const input = resolveColumns(ctx, options);
+  if (!input) return undefined;
 
-  const discovered = discoverColumns(ctx, options);
+  return buildTable(ctx, input, options);
+}
+
+/** Discover columns, optionally split by partition axes, and prepare for the table pipeline. */
+function resolveColumns<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
+  ctx: RenderCtxBase<A, U, S>,
+  options: createPlDataTableOptionsV3,
+): ResolvedTableInput | undefined {
+  let discovered = discoverColumns(ctx, options);
   if (discovered === undefined || discovered.length === 0) return undefined;
 
-  const splited = splitDiscoveredColumns(discovered);
-  const resolved = resolveDiscoveredColumns(splited, discovered);
+  // Apply axis splitting: expand matched columns, replace originals
+  let expandedIds: Set<PObjectId> | undefined;
+  if (options.splitAxes) {
+    const result = applyAxisSplitting(discovered, options.splitAxes);
+    if (!result) return undefined; // partition data not ready
+    discovered = result.columns;
+    expandedIds = result.expandedIds;
+  }
+
+  const split = splitDiscoveredColumns(discovered);
+  const resolved = resolveDiscoveredColumns(split, discovered);
+
+  // Core columns: expanded split columns (if asCore) or anchor columns
+  const anchorColumnIds =
+    expandedIds && options.splitAxes?.asCore
+      ? expandedIds
+      : new Set<PObjectId>(discovered.filter((dc) => dc.isAnchor).map((dc) => dc.id));
+
+  const labelableColumns: LabelableColumn[] = discovered.map((dc) => ({
+    id: dc.id as PObjectId,
+    spec: dc.spec,
+    linkerPath: dc.linkerPath,
+  }));
+
+  return { labelableColumns, resolved, anchorColumnIds };
+}
+
+/** Shared pipeline: labels → annotate → core/non-core → table defs → handles. */
+function buildTable<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
+  ctx: RenderCtxBase<A, U, S>,
+  input: ResolvedTableInput,
+  options: createPlDataTableOptionsV3,
+): PlDataTableModel | undefined {
+  const state = upgradePlDataTableStateV2(options.tableState);
+  const coreJoinType = options.coreJoinType ?? "full";
+  const { labelableColumns, resolved, anchorColumnIds } = input;
 
   const labelColumns = getMatchingLabelColumns(
     resolved.all,
@@ -99,7 +177,7 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
   );
 
   const derivedLabels = deriveAllLabels({
-    columns: discovered,
+    columns: labelableColumns,
     labelColumns,
     deriveLabelsOptions: {
       includeNativeLabel: true,
@@ -126,11 +204,15 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
   const sorting = resolveSorting(state.pTableParams.sorting, options.sorting);
   validateSorting(sorting, columnIsAvailable);
 
-  const anchorColumnIds = new Set<PObjectId>(
-    discovered.filter((dc) => dc.isAnchor).map((dc) => dc.id),
-  );
-  const coreColumns = annotated.direct.filter((c) => anchorColumnIds.has(c.id));
-  const nonCoreDirectColumns = annotated.direct.filter((c) => !anchorColumnIds.has(c.id));
+  let isCoreColumn: (c: TableColumn) => boolean;
+  if (options.coreColumnPredicate) {
+    const predicate = options.coreColumnPredicate;
+    isCoreColumn = (c) => predicate(getColumnIdAndSpec(c));
+  } else {
+    isCoreColumn = (c) => anchorColumnIds.has(c.id);
+  }
+  const coreColumns = annotated.direct.filter(isCoreColumn);
+  const nonCoreDirectColumns = annotated.direct.filter((c) => !isCoreColumn(c));
 
   if (coreColumns.length === 0) return undefined;
 
@@ -187,7 +269,17 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
   } satisfies PlDataTableModel;
 }
 
-// Helpers
+// Types
+
+/** Resolved input for the shared table-building pipeline. */
+type ResolvedTableInput = {
+  /** Columns with optional linkerPath for label derivation. */
+  readonly labelableColumns: LabelableColumn[];
+  /** Column groups for table construction. */
+  readonly resolved: ResolvedColumns;
+  /** IDs of anchor columns (empty for direct mode). */
+  readonly anchorColumnIds: Set<PObjectId>;
+};
 
 /** A linker step with its resolved column data. */
 export type ResolvedLinkerStep = {
@@ -398,6 +490,33 @@ function buildVisibleColumns(
   const all: TableColumn[] = [...direct, ...linked];
   const labels = getMatchingLabelColumns(all.map(getColumnIdAndSpec), originalLabelColumns);
   return { direct, linked, linkers, all, labels };
+}
+
+/** Apply axis splitting: expand matched columns by partition, replace originals. */
+function applyAxisSplitting(
+  discovered: DiscoveredColumn<SUniversalPColumnId>[],
+  config: SplitAxesConfig,
+): { columns: DiscoveredColumn<SUniversalPColumnId>[]; expandedIds: Set<PObjectId> } | undefined {
+  const toSplit = discovered.filter((dc) => config.match(dc.spec));
+  const toKeep = discovered.filter((dc) => !config.match(dc.spec));
+
+  // SUniversalPColumnId extends PObjectId, so this is safe
+  const { items, complete } = expandByPartition(toSplit, config.axes);
+  if (!complete) return undefined;
+
+  const expanded: DiscoveredColumn<SUniversalPColumnId>[] = items.map((snap) => ({
+    id: snap.id as SUniversalPColumnId,
+    spec: snap.spec,
+    dataStatus: snap.dataStatus,
+    data: snap.data,
+    isAnchor: false,
+    linkerPath: [],
+  }));
+
+  return {
+    columns: [...expanded, ...toKeep],
+    expandedIds: new Set(items.map((s) => s.id)),
+  };
 }
 
 /** Resolve a ColumnSnapshot to a PColumn with lazily-evaluated data. */


### PR DESCRIPTION
- Export expandByPartition from columns/index.ts (was defined but not public)
- Add splitAxes option: post-discovery axis splitting for columns matching a predicate (e.g. split abundance by sampleId). Expanded columns replace originals; asCore flag makes them define the row universe.
- Add coreColumnPredicate option: custom core column selection overriding the default anchor-based logic.
- Refactor createPlDataTableV3 into resolveColumns + buildTable for clarity. deriveAllLabels now receives LabelableColumn[] directly.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR exports `expandByPartition` from `columns/index.ts` and extends `createPlDataTableV3` with two new options: `splitAxes` (post-discovery per-partition column expansion) and `coreColumnPredicate` (custom core-column selection). The refactor into `resolveColumns` + `buildTable` is clean and the overall architecture is sound.

One P1 issue: `expandByPartition` preserves the original `id` on every expanded snapshot, so after splitting a single column into *N* partitions there are *N* entries in `labelableColumns` all with the same `id`. The `reduce` inside `deriveAllLabels` writes labels keyed by `id`, meaning only the last partition's derived label survives, and `withLabelAnnotations` then stamps that one label on every partition column.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after the label-derivation bug for shared-ID expanded columns is resolved.

One P1 finding: when a column is split into multiple partitions they all share the same id, causing deriveAllLabels to overwrite earlier partition labels in the reduce. Everything else — the refactor, coreColumnPredicate, export addition — is correct. Score is 4 rather than 5 because this P1 could produce silently wrong column labels in the UI when splitAxes is used.

sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts — labelableColumns construction and downstream deriveAllLabels usage.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The new options accept developer-provided predicates and config objects (not user-supplied data), and no external input reaches sensitive APIs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/columns/index.ts | Adds `export * from "./expand_by_partition"` to make expandByPartition, SplitAxis, and related types public — straightforward and correct. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Adds splitAxes and coreColumnPredicate; refactors into resolveColumns + buildTable. A label-derivation bug exists: the reduce in deriveAllLabels overwrites labels by id, so when multiple expanded columns share the same id (one per partition), all end up with the last partition's label. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
Line: 155-161

Comment:
**Label derivation overwrites labels for expanded partition columns**

`expandByPartition` produces multiple snapshots that all keep the same original `id` (one per partition). Those snapshots are mapped 1-to-1 into `labelableColumns`, so the array contains e.g. three entries with `id: "colA"` but different `spec` (different trace annotations). Inside `deriveAllLabels`, the `reduce` writes labels back by `columns[index].id`:

```ts
.reduce(
  (acc, label, index) => ((acc[columns[index].id] = label), acc),
  {} as Record<string, string>,
)
```

Later iterations overwrite earlier ones, so only the label derived from the **last** partition's spec survives under `"colA"`. `withLabelAnnotations` then stamps that single label on every partition column with `id === "colA"`. If `deriveDistinctLabels` generates partition-specific labels (e.g. using the `pl7.app/trace` annotation), all but the last partition will carry the wrong label.

Consider keying `labelableColumns` (and the resulting `derivedLabels` map) by a per-partition synthetic ID (e.g. an index or the trace value) instead of the raw `dc.id`, or deduplicate earlier so each entry has a unique identifier before being passed to `deriveAllLabels`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
Line: 207-213

Comment:
**`anchorColumnIds` computed unconditionally but unused when `coreColumnPredicate` is set**

When `coreColumnPredicate` is provided, `isCoreColumn` is set to `(c) => predicate(getColumnIdAndSpec(c))` and `anchorColumnIds` is never consulted. The set is still built (filtering `discovered`, potentially calling `expandedIds` logic), which is wasted work. Consider guarding the computation:

```suggestion
  let isCoreColumn: (c: TableColumn) => boolean;
  if (options.coreColumnPredicate) {
    const predicate = options.coreColumnPredicate;
    isCoreColumn = (c) => predicate(getColumnIdAndSpec(c));
  } else {
    const anchorColumnIds =
      expandedIds && options.splitAxes?.asCore
        ? expandedIds
        : new Set<PObjectId>(discovered.filter((dc) => dc.isAnchor).map((dc) => dc.id));
    isCoreColumn = (c) => anchorColumnIds.has(c.id);
  }
```

(This also removes the now-unnecessary `anchorColumnIds` field from `ResolvedTableInput` if it is only used here.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
Line: 496-519

Comment:
**Linked columns silently lose their `linkerPath` after splitting**

Any `DiscoveredColumn` with a non-empty `linkerPath` that matches `config.match` will be included in `toSplit`. After expansion the resulting `DiscoveredColumn` has `linkerPath: []`, so those columns are moved from the "linked" group to the "direct" group — their linker relationships are silently dropped. This could produce incorrect join/group behaviour for linked columns that happen to match the split predicate.

If splitting linked columns is intentional (i.e. expanded columns are always "direct"), a comment or a guard that throws/warns when a linked column is about to be split would prevent surprising bugs for callers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add splitAxes and coreColumnPredic..."](https://github.com/milaboratory/platforma/commit/031b1591f55aac77e201b241deef0552fb3d23e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27858141)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->