### PR TITLE
chore: bump pl-model-common to publish isAnyLogHandle

### DIFF
--- a/.changeset/bump-pl-model-common.md
+++ b/.changeset/bump-pl-model-common.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-common": patch
+---
+
+Export isAnyLogHandle type guard and branded log handle types added in the MCP server PR.


### PR DESCRIPTION
## Summary

- The MCP server PR added `isAnyLogHandle` to `pl-model-common` source but no changeset was included
- `pl-mcp-server@0.2.0` imports it at runtime, causing `MISSING_EXPORT` in the desktop app CI
- This changeset triggers a patch release of `pl-model-common` with the new export

## Test plan
- [ ] CI passes
- [ ] After merge + publish, re-run desktop app PR checks