### PR TITLE
Pass secrets to platform binary

### DIFF
--- a/.changeset/neat-parents-do.md
+++ b/.changeset/neat-parents-do.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": patch
+---
+
+test trigger

--- a/.changeset/neat-parents-do.md
+++ b/.changeset/neat-parents-do.md
@@ -1,5 +1,2 @@
 ---
-"@platforma-sdk/workflow-tengo": patch
 ---
-
-test trigger

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Start Platforma Docker
         if: steps.dry-run.outputs.skip != 'true'
         uses: milaboratory/github-ci/actions/docker/pl-compose@v4
+        env:
+          PL_LICENSE: ${{ secrets.MI_LICENSE }}
+          MI_LICENSE: ${{ secrets.MI_LICENSE }}
         with:
           pl-docker-registry: ${{ format('{0}/{1}', steps.ecr-login.outputs.registry, 'pl') }}
           pl-docker-tag: main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -82,6 +82,9 @@ jobs:
 
       - name: Start Platforma Docker
         uses: milaboratory/github-ci/actions/docker/pl-compose@v4
+        env:
+          PL_LICENSE: ${{ secrets.MI_LICENSE }}
+          MI_LICENSE: ${{ secrets.MI_LICENSE }}
         with:
           pl-docker-registry: ${{ format('{0}/{1}', steps.ecr-login.outputs.registry, 'pl') }}
           pl-docker-tag: main


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR passes `MI_LICENSE` as both `PL_LICENSE` and `MI_LICENSE` environment variables to the `milaboratory/github-ci/actions/docker/pl-compose` action in both the reusable test workflow and the nightly workflow, so the Platforma binary receives its license secret at startup (the downstream test-run steps already had these variables). The only concern is the changeset, which bumps `@platforma-sdk/workflow-tengo` with a placeholder description ("test trigger") and no accompanying source change to that package.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — workflow changes are correct and the only remaining finding is a cosmetic changeset message.
- Both workflow changes are straightforward and consistent: the same license secret pattern already used in the test-run steps is now also passed to the Docker compose action. No logic errors or security concerns. The sole P2 finding is the placeholder changeset description, which doesn't affect runtime behavior.
- .changeset/neat-parents-do.md — the "test trigger" description should be updated or the changeset removed if it was only meant to trigger CI.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_test.yaml | Adds PL_LICENSE and MI_LICENSE env vars (both from secrets.MI_LICENSE) to the "Start Platforma Docker" action so the platform binary receives the license secret at startup. |
| .github/workflows/nightly.yaml | Same license secret injection as _test.yaml, applied to the nightly workflow's "Start Platforma Docker" step. |
| .changeset/neat-parents-do.md | Changeset for @platforma-sdk/workflow-tengo with description "test trigger" — no corresponding source change to that package, and the description will land in the public changelog as-is. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .changeset/neat-parents-do.md
Line: 5

Comment:
**Placeholder changeset message**

The description `test trigger` will be published verbatim in the `@platforma-sdk/workflow-tengo` changelog. There is also no corresponding source change to that package in this PR — was this changeset intended to trigger a CI pipeline, or should it either be removed or replaced with a real description of what changed?

```suggestion
Pass license secret to Platforma binary in CI
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add test trigger for workflow-tengo patc..."](https://github.com/milaboratory/platforma/commit/a40dd19dc385bbfc4af899e2d71f0f7918f8d85e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28352980)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->