### PR TITLE
fix(pl-cli): allow pframes-rs-node native install under pnpm 10

### DIFF
--- a/.changeset/pl-cli-allow-pframes-native-build.md
+++ b/.changeset/pl-cli-allow-pframes-native-build.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/pl-cli": patch
+---
+
+Allow `@milaboratories/pframes-rs-node` install script to run under pnpm 10 via `pnpm.onlyBuiltDependencies`. Without this, `pnpm dlx @platforma-sdk/pl-cli` fails at runtime with `MODULE_NOT_FOUND` for the `pframes_rs_node.node` native binary because pnpm 10 blocks dependency install scripts by default.

--- a/tools/pl-cli/package.json
+++ b/tools/pl-cli/package.json
@@ -66,5 +66,10 @@
         "description": "Manage projects"
       }
     }
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@milaboratories/pframes-rs-node"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Running \`pnpm dlx @platforma-sdk/pl-cli\` on pnpm 10 fails at runtime with:

\`\`\`
ModuleLoadError: Cannot find module '.../@milaboratories/pframes-rs-node/dist/napi-v8/pframes_rs_node.node'
\`\`\`

pnpm 10 blocks dependency lifecycle scripts by default. Without an entry
in \`pnpm.onlyBuiltDependencies\`, the \`install\` script of
\`@milaboratories/pframes-rs-node\` never runs, so \`node-pre-gyp\` does
not download the native \`pframes_rs_node.node\` binary from the CDN.

This adds the package to \`pnpm.onlyBuiltDependencies\` in
\`tools/pl-cli/package.json\`, so consumers installing pl-cli as a
regular dependency (\`pnpm add\`) on pnpm 10 get a working install out of
the box.

## Note for \`pnpm dlx\` users

\`pnpm dlx\` does not inherit \`onlyBuiltDependencies\` from the target
package. For dlx invocations, the flag \`--allow-build\` (pnpm 10.2+) must
still be passed explicitly:

\`\`\`
pnpm dlx --allow-build=@milaboratories/pframes-rs-node @platforma-sdk/pl-cli ...
\`\`\`

This PR does not change dlx behavior — only the packaged config.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR attempts to fix a pnpm 10 runtime failure (`MODULE_NOT_FOUND` for `pframes_rs_node.node`) by adding `pnpm.onlyBuiltDependencies` to `tools/pl-cli/package.json`. However, pnpm v10 only reads `onlyBuiltDependencies` from the **root** `package.json` of the installing project — it does not respect this field when it appears inside a published dependency's own manifest, so consumers doing `pnpm add @platforma-sdk/pl-cli` on pnpm 10 will still hit the same error.

- The stated fix for `pnpm add` consumers will not work; users need to add `@milaboratories/pframes-rs-node` to their own project root's `pnpm.onlyBuiltDependencies`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: the fix does not achieve its stated goal for published package consumers on pnpm 10.

There is a P1 logic issue: `pnpm.onlyBuiltDependencies` in a published (non-root) `package.json` is not respected by pnpm v10 in the consuming project, so the core promise of the PR — fixing `pnpm add` for end users — is not delivered. The fix only has an effect within the monorepo workspace, which already runs pnpm 9 where lifecycle scripts are unrestricted by default.

tools/pl-cli/package.json — the `pnpm.onlyBuiltDependencies` addition will be silently ignored by consumers' pnpm 10 installs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/pl-cli/package.json | Adds `pnpm.onlyBuiltDependencies` for `@milaboratories/pframes-rs-node`, but pnpm v10 ignores this field in non-root published packages, so the fix does not achieve its stated goal for consumers. |
| .changeset/pl-cli-allow-pframes-native-build.md | Patch changeset for `@platforma-sdk/pl-cli` describing the intent; the description is accurate about the problem but the implementation it documents won't work as claimed for `pnpm add` consumers. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tools/pl-cli/package.json
Line: 70-74

Comment:
**`onlyBuiltDependencies` not respected from published packages**

pnpm v10 only reads `pnpm.onlyBuiltDependencies` from the **root** `package.json` of the consuming project — it does not propagate this setting from a published dependency's own `package.json`. This means consumers who run `pnpm add @platforma-sdk/pl-cli` on pnpm 10 will still not have the `pframes-rs-node` install script run, and the runtime `MODULE_NOT_FOUND` error will persist. This field is effectively a no-op once the package is published and installed elsewhere.

To actually fix the issue for consumers, the install instructions (README or docs) should tell pnpm-10 users to add the following to their own project root `package.json`:

```json
"pnpm": {
  "onlyBuiltDependencies": ["@milaboratories/pframes-rs-node"]
}
```

The `--allow-build` flag for `pnpm dlx` (already documented in the PR) remains the correct workaround for dlx.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pl-cli): allow pframes-rs-node insta..."](https://github.com/milaboratory/platforma/commit/909dca996e349231c0c8cd570ebecbe7b8abffe4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28515426)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->