### PR TITLE
docs(pl-cli): document required --allow-build flag for pnpm dlx

### DIFF
--- a/.changeset/pl-cli-dlx-docs.md
+++ b/.changeset/pl-cli-dlx-docs.md
@@ -1,0 +1,5 @@
+---
+---
+
+Docs-only: add README to `@platforma-sdk/pl-cli` documenting required
+`--allow-build=@milaboratories/pframes-rs-node` flag for `pnpm dlx`.

--- a/tools/pl-cli/README.md
+++ b/tools/pl-cli/README.md
@@ -1,0 +1,28 @@
+# @platforma-sdk/pl-cli
+
+CLI for Platforma server state manipulation.
+
+## Usage
+
+```bash
+pnpm dlx --allow-build=@milaboratories/pframes-rs-node \
+  @platforma-sdk/pl-cli <command> [args...]
+```
+
+The `--allow-build=@milaboratories/pframes-rs-node` flag is **required**.
+Without it you will get:
+
+```
+ModuleLoadError: Cannot find module '.../pframes_rs_node.node'
+```
+
+## Commands
+
+- `admin copy-project` — copy a project between users (requires admin credentials)
+- `project list` — list projects for a user
+- `project info` — show project metadata
+- `project duplicate` — duplicate a project
+- `project rename` — rename a project
+- `project delete` — delete a project
+
+Run `pl-cli <command> --help` for per-command flags.

--- a/tools/pl-cli/README.md
+++ b/tools/pl-cli/README.md
@@ -21,8 +21,8 @@ ModuleLoadError: Cannot find module '.../pframes_rs_node.node'
 - `admin copy-project` — copy a project between users (requires admin credentials)
 - `project list` — list projects for a user
 - `project info` — show project metadata
-- `project duplicate` — duplicate a project
-- `project rename` — rename a project
-- `project delete` — delete a project
+- `project duplicate` — Create a copy of an existing project
+- `project rename` — Change the name of a project
+- `project delete` — Permanently remove a project
 
 Run `pl-cli <command> --help` for per-command flags.


### PR DESCRIPTION
## Summary

Adds a README to `@platforma-sdk/pl-cli` showing the correct `pnpm dlx`
invocation. `@milaboratories/pframes-rs-node` needs its install script to
run (`node-pre-gyp` downloads the native `.node` binary); on pnpm 10 the
only way to allow that in a dlx context is the `--allow-build` CLI flag.
Without it, the CLI fails at runtime with `MODULE_NOT_FOUND` for
`pframes_rs_node.node`.

Empty changeset — no publish impact; `files` already includes the README
so it ships on the next release.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `README.md` to `@platforma-sdk/pl-cli` documenting the `pnpm dlx --allow-build=@milaboratories/pframes-rs-node` invocation required on pnpm 10, along with a brief command reference. The README is already listed in `package.json`'s `files` field and all documented commands match actual source files under `src/cmd/`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — docs-only change with no code modifications.

Both files are purely additive documentation. The README accurately reflects the codebase (all commands verified against source), the package.json already includes README.md in `files`, and the empty changeset format is correct for a non-versioning change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/pl-cli/README.md | New README documenting pnpm dlx usage with --allow-build flag; all listed commands match actual source files |
| .changeset/pl-cli-dlx-docs.md | Empty changeset (no version bumps) for docs-only change — correct format for non-versioning PRs |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(pl-cli): document required --allow-..."](https://github.com/milaboratory/platforma/commit/acc1dc1b9e027c9e73617a32816a713c3b8117ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28519335)</sub>

<!-- /greptile_comment -->