### PR TITLE
fix(ts-builder): gate external on unresolved specifier to fix Windows…

### DIFF
--- a/.changeset/grumpy-symbols-speak.md
+++ b/.changeset/grumpy-symbols-speak.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/ts-builder": patch
+---
+
+Fix windows builds

--- a/.changeset/ts-builder-windows-external-resolved.md
+++ b/.changeset/ts-builder-windows-external-resolved.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/ts-builder": patch
+---
+
+Fix Windows build output with `preserveModules`: the default `external` callback now only runs its classification for unresolved specifiers (`isResolved=false`). Previously, when Rolldown called `external` again with a resolved absolute path, the regex `/^[^./]/` matched Windows drive letters (`D:\...`), flagging local files as external. This caused Rolldown to emit imports with source `.ts` extensions (e.g. `import from "./helper.ts"`), producing bundles that fail at runtime with `ERR_MODULE_NOT_FOUND`. POSIX was unaffected because its absolute paths start with `/`.

--- a/tools/ts-builder/src/configs/utils/commonRolldown.ts
+++ b/tools/ts-builder/src/configs/utils/commonRolldown.ts
@@ -27,8 +27,9 @@ export function createBuildEntry(input: string[], output: string, format: Format
   return {
     input,
     plugins,
-    external: (id: string) =>
-      id.startsWith("node:") || (/^[^./]/.test(id) && !id.startsWith("@oxc-project/runtime")),
+    external: (id: string, _importer: string | undefined, isResolved: boolean) =>
+      !isResolved &&
+      (id.startsWith("node:") || (/^[^./]/.test(id) && !id.startsWith("@oxc-project/runtime"))),
     ...(useSources && {
       resolve: { conditionNames: ["sources"] },
     }),


### PR DESCRIPTION
… preserveModules output
https://github.com/vadimpiven/rolldown-windows-ts-extension-bug

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Gates the `external` callback in `commonRolldown.ts` on `isResolved=false`, preventing Windows drive-letter paths (`D:\...`) from matching the bare-specifier regex `/^[^./]/` and being incorrectly marked as external during `preserveModules` builds. The fix is minimal, correctly scoped, and the changeset description accurately explains the root cause.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line logic fix with no side-effects on POSIX builds and a clear test-case described in the changeset.

All findings are at P2 or lower; the change is a narrowly-targeted guard on the `isResolved` flag with correct behaviour for node: built-ins, bare npm specifiers, and local relative/absolute paths on both platforms.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/ts-builder/src/configs/utils/commonRolldown.ts | Adds `isResolved` guard to the `external` callback so Windows absolute paths (e.g. `D:\...`) are no longer misclassified as external by the bare-specifier regex. |
| .changeset/ts-builder-windows-external-resolved.md | Accurate patch-level changeset entry with a clear root-cause description of the Windows `preserveModules` bug. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ts-builder): gate external on unreso..."](https://github.com/milaboratory/platforma/commit/dd79785d182121488d0285f62499dc9077a70f5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28667743)</sub>

<!-- /greptile_comment -->