### PR TITLE
Update built-in backend version to 3.2.1

### DIFF
--- a/.changeset/shy-cities-move.md
+++ b/.changeset/shy-cities-move.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-deployments": minor
+---
+
+Update built-in backend to version 3.2.1

--- a/lib/node/pl-deployments/package.json
+++ b/lib/node/pl-deployments/package.json
@@ -66,5 +66,5 @@
   "engines": {
     "node": ">=22.19.0"
   },
-  "pl-version": "1.46.0"
+  "pl-version": "3.2.1"
 }

--- a/lib/node/pl-deployments/src/local/config.test.yaml
+++ b/lib/node/pl-deployments/src/local/config.test.yaml
@@ -5,7 +5,8 @@ license:
 logging:
   level: "info"
   destinations:
-    - path: "platforma.log"
+    - type: "file"
+      path: "platforma.log"
 
 monitoring:
   listen: "127.0.0.1:11235"
@@ -18,15 +19,19 @@ core:
     extendedInfo: true
     dumpResourceData: true
 
+  tls:
+    enabled: false
   grpc:
     listen: "127.0.0.1:11234"
-    tlsEnabled: false
-
   http:
     listen: "127.0.0.1:11233"
 
-  authEnabled: false
-  auth: []
+  authEnabled: true
+  auth:
+    - driver: jwt
+      key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    - driver: htpasswd
+      path: "users.htpasswd"
   db:
     path: "./db"
 

--- a/lib/node/pl-deployments/src/local/pl.test.ts
+++ b/lib/node/pl-deployments/src/local/pl.test.ts
@@ -133,6 +133,7 @@ async function prepareDirForTestConfig() {
   await fs.mkdir(upath.join(dir, "storages", "work"), { recursive: true });
   await fs.mkdir(upath.join(dir, "storages", "main"), { recursive: true });
   await fs.mkdir(upath.join(dir, "packages"), { recursive: true });
+  await fs.writeFile(upath.join(dir, "users.htpasswd"), "testuser:testpassword");
 
   return dir;
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the built-in backend (`pl-version`) in `@milaboratories/pl-deployments` from `1.46.0` to `3.2.1`, and adds the corresponding changeset entry marking it as a minor release.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, well-scoped version bump with a matching changeset entry.

The change is a single-field update to a version string consumed by `getDefaultPlVersion()`, with no logic changes. The changeset is correctly categorised as `minor`. No issues found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/shy-cities-move.md | Adds changeset for a minor version bump of `@milaboratories/pl-deployments` describing the backend version update. |
| lib/node/pl-deployments/package.json | Updates `pl-version` from `1.46.0` to `3.2.1`; this field is read by `pl_version.ts` to provide the default backend version at runtime. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Update built-in backend version to 3.2.1"](https://github.com/milaboratory/platforma/commit/42feb480da1d502cb0deb512f58401f7343b6171) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28756108)</sub>

<!-- /greptile_comment -->