### PR TITLE
Update Built-In backend version to 3.2.1

### DIFF
--- a/.changeset/great-mammals-eat.md
+++ b/.changeset/great-mammals-eat.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-deployments": minor
+---
+
+Update Built-In version to 3.2.1

--- a/lib/node/pl-deployments/package.json
+++ b/lib/node/pl-deployments/package.json
@@ -66,5 +66,5 @@
   "engines": {
     "node": ">=22.19.0"
   },
-  "pl-version": "1.46.0"
+  "pl-version": "3.2.1"
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Bumps the built-in backend `pl-version` from `1.46.0` to `3.2.1` in `@milaboratories/pl-deployments`, accompanied by a minor changeset entry. The change is straightforward and isolated to a single field.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, isolated version field update with no logic changes.

Only two files changed: a version field in package.json and a changeset descriptor. No logic, no API surface, no migrations involved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/great-mammals-eat.md | New changeset file documenting the pl-deployments version bump as a "minor" change |
| lib/node/pl-deployments/package.json | Updates `pl-version` field from 1.46.0 to 3.2.1 — the only change in this file |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Update Built-In backend version to 3.2.1"](https://github.com/milaboratory/platforma/commit/aeee6f97e13f8e79370142b0f670090c41159621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28776876)</sub>

<!-- /greptile_comment -->