### PR TITLE
fix(pl-drivers): await cleanup in download_url driver test

### DIFF
--- a/.changeset/fix-download-url-test-teardown.md
+++ b/.changeset/fix-download-url-test-teardown.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-drivers": patch
+---
+
+Fix flaky test teardown error in download_url driver test

--- a/lib/node/pl-drivers/src/drivers/download_url/driver.test.ts
+++ b/lib/node/pl-drivers/src/drivers/download_url/driver.test.ts
@@ -41,6 +41,7 @@ test("should download a tar archive and extracts its content and then deleted", 
     expect(indexJsCode).toContain("use strict");
 
     c.resetState();
+    await c.awaitChange();
   });
 }, 45000);
 


### PR DESCRIPTION
## Summary
- Fix `EnvironmentTeardownError` ("Closing rpc while onUserConsoleLog was pending") in `download_url/driver.test.ts`
- Added missing `await c.awaitChange()` after `c.resetState()` in the first test so async cleanup completes before Vitest tears down the worker

## Test plan
- [ ] CI passes (the fix eliminates the unhandled error that was causing CI noise)
- [ ] All 56 tests in pl-drivers still pass

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a missing `await c.awaitChange()` after `c.resetState()` in the first test of `download_url/driver.test.ts`. Without it, Vitest tears down the worker before the async cleanup triggered by `resetState()` completes, causing a spurious `EnvironmentTeardownError`. The fix mirrors the pattern already used in the third test and is accompanied by an appropriate patch-level changeset.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line fix that resolves a known flaky teardown error with no functional risk.

The change is minimal, correct, and consistent with the existing pattern in the same file. No logic, API, or data-flow changes; only a missing `await` is added in a test helper call.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-drivers/src/drivers/download_url/driver.test.ts | Added `await c.awaitChange()` after `c.resetState()` in the first test to let async cleanup finish before teardown; matches the pattern already present in the third test. |
| .changeset/fix-download-url-test-teardown.md | Correct patch-level changeset entry for the @milaboratories/pl-drivers package. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["changeset for download\_url test fix"](https://github.com/milaboratory/platforma/commit/41782d12067e38ec381e034d40f5be65fe358a73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28802187)</sub>

<!-- /greptile_comment -->