### PR TITLE
feat(pframe): add LinkerJoin query node to spec and data layers

### DIFF
--- a/.changeset/linker-join-query.md
+++ b/.changeset/linker-join-query.md
@@ -1,0 +1,12 @@
+---
+"@milaboratories/pl-model-common": minor
+"@milaboratories/pl-model-middle-layer": minor
+---
+
+Add LinkerJoin query node (spec + data layers) mirroring OuterJoin's shape,
+with a specialized linker sub-struct and a non-empty array of secondary join
+entries. Introduces `PFrameWasmV3` whose `discoverColumns` returns
+`DiscoverColumnsResponseV2` — each hit carries a ready-to-execute `SpecQuery`
+that materializes the traversal path (plain column for direct hits, nested
+`linkerJoin` chain for linker-path hits). V2 interfaces remain as legacy
+shims pointing to V3 and will be removed in a future PFrames update.

--- a/.changeset/linker-join-query.md
+++ b/.changeset/linker-join-query.md
@@ -5,8 +5,10 @@
 
 Add LinkerJoin query node (spec + data layers) mirroring OuterJoin's shape,
 with a specialized linker sub-struct and a non-empty array of secondary join
-entries. Introduces `PFrameWasmV3` whose `discoverColumns` returns
-`DiscoverColumnsResponseV2` — each hit carries a ready-to-execute `SpecQuery`
-that materializes the traversal path (plain column for direct hits, nested
-`linkerJoin` chain for linker-path hits). V2 interfaces remain as legacy
-shims pointing to V3 and will be removed in a future PFrames update.
+entries. Introduces `PFrameWasmV3` adding `buildQuery`: a pure spec-layer
+assembler that turns a terminal column plus an ordered path of wrapping
+steps (linker hops, filter joins) into a ready-to-compose
+`SpecQueryJoinEntry`. Extends `DiscoverColumnsStepInfo` with a `filter`
+variant and adds `BuildQueryInput` in `pl-model-common`. V2 interfaces
+remain as legacy shims pointing to V3 and will be removed in a future
+PFrames update.

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -881,3 +881,39 @@ export interface QueryJoinEntry<Q> {
   /** The query to be joined */
   entry: Q;
 }
+
+/**
+ * Linker-join query operation.
+ *
+ * Inner-joins a linker column (`linker`) with a secondary subquery, then projects
+ * out the linker's one-side axes from the joined result. Used to traverse a linker
+ * relationship: rows on the secondary side are "lifted" onto the linker's many-side
+ * axes, with one-side axes collapsed away.
+ *
+ * Structurally mirrors {@link QueryOuterJoin}'s `{ primary, secondary }` shape,
+ * but the linker side is a specialized sub-struct (a plain column reference — never
+ * an arbitrary subquery) rather than a full join entry.
+ *
+ * **Join behavior**:
+ * - The linker column is inner-joined with the `secondary` subquery
+ * - After the join, the linker's one-side axes are projected out
+ * - Result axes = joined axes minus the linker's one-side axes
+ *
+ * @template L - Linker sub-struct type (layer-specific)
+ * @template JE - Join entry type for the secondary side
+ *
+ * @example
+ * // Traverse linker l1 and read rest data lifted onto l1's many-side
+ * {
+ *   type: 'linkerJoin',
+ *   linker: { column: 'l1' },
+ *   secondary: { entry: restQuery, ... }
+ * }
+ */
+export interface QueryLinkerJoin<L, JE extends QueryJoinEntry<unknown>> {
+  type: "linkerJoin";
+  /** Linker side — column reference plus layer-specific integration data. */
+  linker: L;
+  /** Rest side — the subquery joined with the linker. */
+  secondary: JE;
+}

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -885,19 +885,22 @@ export interface QueryJoinEntry<Q> {
 /**
  * Linker-join query operation.
  *
- * Inner-joins a linker column (`linker`) with a secondary subquery, then projects
- * out the linker's one-side axes from the joined result. Used to traverse a linker
- * relationship: rows on the secondary side are "lifted" onto the linker's many-side
- * axes, with one-side axes collapsed away.
+ * Inner-joins a linker column (`linker`) with one or more secondary subqueries,
+ * then projects out the linker's one-side axes from the joined result. Used to
+ * traverse a linker relationship: rows on the secondary side are "lifted" onto
+ * the linker's many-side axes, with one-side axes collapsed away.
  *
- * Structurally mirrors {@link QueryOuterJoin}'s `{ primary, secondary }` shape,
- * but the linker side is a specialized sub-struct (a plain column reference — never
- * an arbitrary subquery) rather than a full join entry.
+ * Mirrors {@link QueryOuterJoin}'s `{ primary, secondary }` shape (with
+ * `secondary` as an array), but the linker side is a specialized sub-struct —
+ * a plain column reference rather than a full join entry.
  *
  * **Join behavior**:
- * - The linker column is inner-joined with the `secondary` subquery
+ * - The linker column is inner-joined with all `secondary` entries
  * - After the join, the linker's one-side axes are projected out
  * - Result axes = joined axes minus the linker's one-side axes
+ *
+ * **Note**: `secondary` must contain at least one entry (empty has no
+ * well-defined meaning for linker-join).
  *
  * @template L - Linker sub-struct type (layer-specific)
  * @template JE - Join entry type for the secondary side
@@ -907,13 +910,13 @@ export interface QueryJoinEntry<Q> {
  * {
  *   type: 'linkerJoin',
  *   linker: { column: 'l1' },
- *   secondary: { entry: restQuery, ... }
+ *   secondary: [{ entry: restQuery, ... }]
  * }
  */
 export interface QueryLinkerJoin<L, JE extends QueryJoinEntry<unknown>> {
   type: "linkerJoin";
   /** Linker side — column reference plus layer-specific integration data. */
   linker: L;
-  /** Rest side — the subquery joined with the linker. */
-  secondary: JE;
+  /** Rest side — one or more subqueries joined with the linker (at least one). */
+  secondary: JE[];
 }

--- a/lib/model/common/src/drivers/pframe/query/query_data.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_data.ts
@@ -21,6 +21,7 @@ import type {
   QueryFilter,
   QueryInlineColumn,
   QueryJoinEntry,
+  QueryLinkerJoin,
   QueryOuterJoin,
   QuerySliceAxes,
   QuerySort,
@@ -69,6 +70,24 @@ export type DataQuerySparseToDenseColumn = QuerySparseToDenseColumn<PObjectId, C
 export type DataQuerySymmetricJoin = QuerySymmetricJoin<DataQueryJoinEntry>;
 /** @see QueryOuterJoin */
 export type DataQueryOuterJoin = QueryOuterJoin<DataQueryJoinEntry>;
+/**
+ * Linker side of a data-layer linker-join.
+ *
+ * Carries the linker column id along with integration-derived artifacts needed
+ * for execution:
+ * - `axesMapping` — how the linker's axes map into the joined result
+ * - `oneSideAxesIndices` — which axis indices in the joined result to project out
+ */
+export type DataQueryLinkerJoinLinker = {
+  /** Linker column reference. */
+  column: PObjectId;
+  /** Linker's axes mapped into the joined result. */
+  axesMapping: number[];
+  /** Axis indices (in the joined result) to project out — the linker's one-side axes. */
+  oneSideAxesIndices: number[];
+};
+/** @see QueryLinkerJoin */
+export type DataQueryLinkerJoin = QueryLinkerJoin<DataQueryLinkerJoinLinker, DataQueryJoinEntry>;
 /** @see QuerySliceAxes */
 export type DataQuerySliceAxes = QuerySliceAxes<DataQuery, QueryAxisSelector<number>>;
 /** @see QuerySort */
@@ -93,6 +112,7 @@ export type DataQuery =
   | DataQuerySparseToDenseColumn
   | DataQuerySymmetricJoin
   | DataQueryOuterJoin
+  | DataQueryLinkerJoin
   | DataQuerySliceAxes
   | DataQuerySort
   | DataQueryFilter;

--- a/lib/model/common/src/drivers/pframe/query/query_spec.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_spec.ts
@@ -21,6 +21,7 @@ import type {
   QueryFilter,
   QueryInlineColumn,
   QueryJoinEntry,
+  QueryLinkerJoin,
   QueryOuterJoin,
   QuerySliceAxes,
   QuerySort,
@@ -81,6 +82,21 @@ export type SpecQuerySparseToDenseColumn<C = PObjectId> = QuerySparseToDenseColu
 export type SpecQuerySymmetricJoin<C = PObjectId> = QuerySymmetricJoin<SpecQueryJoinEntry<C>>;
 /** @see QueryOuterJoin */
 export type SpecQueryOuterJoin<C = PObjectId> = QueryOuterJoin<SpecQueryJoinEntry<C>>;
+/**
+ * Linker side of a spec-layer linker-join.
+ *
+ * At the spec layer the linker is just a column reference — integration artifacts
+ * (axes mapping, one-side indices) are derived during spec→data conversion.
+ */
+export type SpecQueryLinkerJoinLinker<C = PObjectId> = {
+  /** Linker column reference. */
+  column: C;
+};
+/** @see QueryLinkerJoin */
+export type SpecQueryLinkerJoin<C = PObjectId> = QueryLinkerJoin<
+  SpecQueryLinkerJoinLinker<C>,
+  SpecQueryJoinEntry<C>
+>;
 /** @see QuerySliceAxes */
 export type SpecQuerySliceAxes<C = PObjectId> = QuerySliceAxes<
   SpecQuery<C>,
@@ -112,6 +128,7 @@ export type SpecQuery<C = PObjectId> =
   | SpecQuerySparseToDenseColumn<C>
   | SpecQuerySymmetricJoin<C>
   | SpecQueryOuterJoin<C>
+  | SpecQueryLinkerJoin<C>
   | SpecQuerySliceAxes<C>
   | SpecQuerySort<C>
   | SpecQueryFilter<C>;

--- a/lib/model/common/src/drivers/pframe/query/utils.test.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.test.ts
@@ -78,13 +78,13 @@ describe("traverseQuerySpec", () => {
     const q: Q = {
       type: "linkerJoin",
       linker: { column: "l" },
-      secondary: entry(col("a")),
+      secondary: [entry(col("a")), entry(col("b"))],
     };
     const result = traverseQuerySpec(q, { column: (c) => c.toUpperCase() });
     expect(result).toEqual({
       type: "linkerJoin",
       linker: { column: "L" },
-      secondary: entry({ type: "column", column: "A" }),
+      secondary: [entry({ type: "column", column: "A" }), entry({ type: "column", column: "B" })],
     });
   });
 

--- a/lib/model/common/src/drivers/pframe/query/utils.test.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.test.ts
@@ -209,6 +209,15 @@ describe("collectSpecQueryColumns", () => {
     } as unknown as Q;
     expect(collectSpecQueryColumns(q)).toEqual([]);
   });
+
+  it("collects linker and secondary columns from linkerJoin", () => {
+    const q: Q = {
+      type: "linkerJoin",
+      linker: { column: "l" },
+      secondary: [entry(col("a")), entry(col("b"))],
+    };
+    expect(collectSpecQueryColumns(q)).toEqual(["l", "a", "b"]);
+  });
 });
 
 describe("sortSpecQuery", () => {
@@ -231,6 +240,20 @@ describe("sortSpecQuery", () => {
     expect(result).toEqual({
       type: "outerJoin",
       primary: pentry(pcol("p")),
+      secondary: [pentry(pcol("a")), pentry(pcol("b")), pentry(pcol("c"))],
+    });
+  });
+
+  it("sorts linkerJoin secondary entries (linker column unchanged)", () => {
+    const q: SpecQuery = {
+      type: "linkerJoin",
+      linker: { column: pid("l") },
+      secondary: [pentry(pcol("c")), pentry(pcol("a")), pentry(pcol("b"))],
+    };
+    const result = sortSpecQuery(q);
+    expect(result).toEqual({
+      type: "linkerJoin",
+      linker: { column: "l" },
       secondary: [pentry(pcol("a")), pentry(pcol("b")), pentry(pcol("c"))],
     });
   });

--- a/lib/model/common/src/drivers/pframe/query/utils.test.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.test.ts
@@ -74,6 +74,20 @@ describe("traverseQuerySpec", () => {
     });
   });
 
+  it("transforms columns inside linkerJoin", () => {
+    const q: Q = {
+      type: "linkerJoin",
+      linker: { column: "l" },
+      secondary: entry(col("a")),
+    };
+    const result = traverseQuerySpec(q, { column: (c) => c.toUpperCase() });
+    expect(result).toEqual({
+      type: "linkerJoin",
+      linker: { column: "L" },
+      secondary: entry({ type: "column", column: "A" }),
+    });
+  });
+
   it("transforms columns inside filter", () => {
     const q: Q = {
       type: "filter",

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -82,7 +82,7 @@ export function traverseQuerySpec<C1, C2>(
       result = {
         ...query,
         linker: { ...query.linker, column: visitor.column(query.linker.column) },
-        secondary: traverseEntry(query.secondary),
+        secondary: query.secondary.map(traverseEntry),
       };
       break;
     case "filter":
@@ -133,10 +133,10 @@ export function sortSpecQuery(query: SpecQuery): SpecQuery {
           const sorted = [...node.secondary].sort(cmpQueryJoinEntrySpec);
           return { ...node, secondary: sorted };
         }
-        case "linkerJoin":
-          // `linker` is a bare column reference and `secondary` is a single entry —
-          // nothing to reorder here.
-          return node;
+        case "linkerJoin": {
+          const sorted = [...node.secondary].sort(cmpQueryJoinEntrySpec);
+          return { ...node, secondary: sorted };
+        }
         case "sliceAxes":
           return {
             ...node,
@@ -214,7 +214,14 @@ function cmpQuerySpec(lhs: SpecQuery, rhs: SpecQuery): number {
       if (lhs.linker.column !== rhsLinker.linker.column) {
         return lhs.linker.column < rhsLinker.linker.column ? -1 : 1;
       }
-      return cmpQueryJoinEntrySpec(lhs.secondary, rhsLinker.secondary);
+      if (lhs.secondary.length !== rhsLinker.secondary.length) {
+        return lhs.secondary.length - rhsLinker.secondary.length;
+      }
+      for (let i = 0; i < lhs.secondary.length; i++) {
+        const cmp = cmpQueryJoinEntrySpec(lhs.secondary[i], rhsLinker.secondary[i]);
+        if (cmp !== 0) return cmp;
+      }
+      return 0;
     }
     case "sliceAxes":
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -78,6 +78,13 @@ export function traverseQuerySpec<C1, C2>(
         secondary: query.secondary.map(traverseEntry),
       };
       break;
+    case "linkerJoin":
+      result = {
+        ...query,
+        linker: { ...query.linker, column: visitor.column(query.linker.column) },
+        secondary: traverseEntry(query.secondary),
+      };
+      break;
     case "filter":
     case "sort":
     case "sliceAxes":
@@ -126,6 +133,10 @@ export function sortSpecQuery(query: SpecQuery): SpecQuery {
           const sorted = [...node.secondary].sort(cmpQueryJoinEntrySpec);
           return { ...node, secondary: sorted };
         }
+        case "linkerJoin":
+          // `linker` is a bare column reference and `secondary` is a single entry —
+          // nothing to reorder here.
+          return node;
         case "sliceAxes":
           return {
             ...node,
@@ -197,6 +208,13 @@ function cmpQuerySpec(lhs: SpecQuery, rhs: SpecQuery): number {
         if (cmp !== 0) return cmp;
       }
       return 0;
+    }
+    case "linkerJoin": {
+      const rhsLinker = rhs as typeof lhs;
+      if (lhs.linker.column !== rhsLinker.linker.column) {
+        return lhs.linker.column < rhsLinker.linker.column ? -1 : 1;
+      }
+      return cmpQueryJoinEntrySpec(lhs.secondary, rhsLinker.secondary);
     }
     case "sliceAxes":
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -1,5 +1,6 @@
 import type { Branded } from "@milaboratories/helpers";
 import type { PoolEntry } from "../../pool_entry";
+import type { PObjectId } from "../../pool";
 import type {
   AxisSpec,
   AxesSpec,
@@ -103,7 +104,6 @@ export interface DiscoverColumnsRequest {
 }
 
 /** Linker step: traversal through a linker column */
-/** A step traversed during path-based column discovery. Discriminated by `type`. */
 export interface DiscoverColumnsLinkerStep {
   type: "linker";
   /** The linker column traversed in this step */
@@ -112,8 +112,48 @@ export interface DiscoverColumnsLinkerStep {
   qualifications: AxisQualification[];
 }
 
+/**
+ * Filter step: intersects the current subquery with a filter column on shared
+ * axes. Filter columns carry `pl7.app/isSubset: "true"` with axes ⊆ dataset
+ * axes, so the inner-join narrows the key space to rows where the filter is
+ * present.
+ */
+export interface DiscoverColumnsFilterStep {
+  type: "filter";
+  /** The filter column applied in this step */
+  filter: PColumnIdAndSpec;
+}
+
 /** A step traversed during path-based column discovery. Discriminated by `type`. */
-export type DiscoverColumnsStepInfo = DiscoverColumnsLinkerStep;
+export type DiscoverColumnsStepInfo = DiscoverColumnsLinkerStep | DiscoverColumnsFilterStep;
+
+/**
+ * Input to {@link PFrameWasmV4.buildQuery}: a terminal column plus an ordered
+ * path of wrapping steps (linker hops, filter joins). Produces a
+ * {@link SpecQueryJoinEntry} ready to be plugged into an
+ * `innerJoin`/`fullJoin`/`outerJoin` entry list.
+ *
+ * Path ordering: `path[0]` is outermost (first applied), `path[N-1]` is
+ * closest to `column`. Omit or pass `[]` for a direct column with no
+ * wrapping.
+ *
+ * Columns are referenced by id — specs are resolved later at
+ * {@link PFrameWasmV4.evaluateQuery} against the registered specs of the
+ * PFrame, so the caller cannot disagree with the frame about spec content.
+ *
+ * Qualifications annotate the resulting outermost entry; they do not
+ * propagate into the inner query.
+ */
+export type BuildQueryInput = {
+  /** Shape version marker — bumped only on breaking structural changes. */
+  readonly version: "v1";
+  /** Terminal column id — the column actually returning data. */
+  readonly column: PObjectId;
+  /** Ordered path from source integration to `column`. Outermost first. */
+  readonly path?: DiscoverColumnsStepInfo[];
+  /** Axis qualifications attached to the resulting join entry. */
+  readonly qualifications?: AxisQualification[];
+};
 
 /** Qualifications info for a discover columns response mapping variant */
 export interface DiscoverColumnsResponseQualifications {

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -16,24 +16,34 @@ import type {
   DeleteColumnFromColumnsRequest,
   DeleteColumnFromColumnsResponse,
 } from "./delete_column";
-import type { DiscoverColumnsRequestV2, DiscoverColumnsResponse } from "./discover_columns";
+import type {
+  DiscoverColumnsRequestV2,
+  DiscoverColumnsResponse,
+  DiscoverColumnsResponseV2,
+} from "./discover_columns";
 import type { FindColumnsRequest, FindColumnsResponse } from "./find_columns";
 
 /**
- * V2 PFrame interface with include/exclude column filtering in discoverColumns.
+ * V3 PFrame interface: same surface as V2 except `discoverColumns` returns
+ * {@link DiscoverColumnsResponseV2}, which includes a per-hit ready-to-execute
+ * {@link SpecQuery} alongside the existing fields.
  */
-export interface PFrameWasmV2 extends Disposable {
+export interface PFrameWasmV3 extends Disposable {
   /**
    * Deletes columns from a columns specification.
    */
   deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
 
   /**
-   * Discovers columns compatible with a given axes integration,
-   * with separate include and exclude filters.
-   * Exclude filter is applied after include, removing matching columns from results.
+   * Discovers columns compatible with a given axes integration, with separate
+   * include and exclude filters. Exclude filter is applied after include,
+   * removing matching columns from results.
+   *
+   * Each hit also carries a {@link SpecQuery} materializing its traversal
+   * path — direct hits produce a plain column reference; linker-path hits
+   * produce a nested `linkerJoin` chain ready to be evaluated.
    */
-  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
+  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponseV2;
 
   /**
    * Finds columns in the PFrame matching the given filter criteria.
@@ -52,13 +62,13 @@ export interface PFrameWasmV2 extends Disposable {
 }
 
 /**
- * V2 PFrame API factory with createPFrame returning PFrameWasmV2.
+ * V3 PFrame API factory with createPFrame returning {@link PFrameWasmV3}.
  */
-export interface PFrameWasmAPIV2 {
+export interface PFrameWasmAPIV3 {
   /**
-   * Creates a new V2 PFrame from a map of column IDs to column specifications.
+   * Creates a new V3 PFrame from a map of column IDs to column specifications.
    */
-  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV2;
+  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV3;
 
   /**
    * Expands an {@link AxesSpec} into {@link AxesId}s with parent information
@@ -85,6 +95,49 @@ export interface PFrameWasmAPIV2 {
 }
 
 /**
+ * V2 PFrame interface. Superseded by {@link PFrameWasmV3}, which adds a per-hit
+ * {@link SpecQuery} to `discoverColumns` responses. Will be removed in a future
+ * PFrames update.
+ */
+export interface PFrameWasmV2 extends Disposable {
+  /** @see PFrameWasmV3.deleteColumns */
+  deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
+
+  /** @see PFrameWasmV3.discoverColumns — V2 response lacks the per-hit `query` field. */
+  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
+
+  /** @see PFrameWasmV3.findColumns */
+  findColumns(request: FindColumnsRequest): FindColumnsResponse;
+
+  /** @see PFrameWasmV3.evaluateQuery */
+  evaluateQuery(request: SpecQuery): EvaluateQueryResponse;
+
+  /** @see PFrameWasmV3.rewriteLegacyQuery */
+  rewriteLegacyQuery(request: LegacyQuery): SpecQuery;
+}
+
+/**
+ * V2 PFrame API factory. Superseded by {@link PFrameWasmAPIV3}; will be removed
+ * in a future PFrames update.
+ */
+export interface PFrameWasmAPIV2 {
+  /** @see PFrameWasmAPIV3.createPFrame */
+  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV2;
+
+  /** @see PFrameWasmAPIV3.expandAxes */
+  expandAxes(spec: AxesSpec): AxesId;
+
+  /** @see PFrameWasmAPIV3.collapseAxes */
+  collapseAxes(ids: AxesId): AxesSpec;
+
+  /** @see PFrameWasmAPIV3.findAxis */
+  findAxis(spec: AxesSpec, selector: SingleAxisSelector): number;
+
+  /** @see PFrameWasmAPIV3.findTableColumn */
+  findTableColumn(tableSpec: PTableColumnSpec[], selector: PTableColumnId): number;
+}
+
+/**
  * Response from evaluating a query against a PFrame.
  */
 export type EvaluateQueryResponse = {
@@ -103,7 +156,7 @@ export type EvaluateQueryResponse = {
 /**
  * Represents a legacy (V4) query format used before the unified SpecQuery.
  *
- * This type is used with {@link PFrameWasmV2.rewriteLegacyQuery} to upgrade
+ * This type is used with {@link PFrameWasmV3.rewriteLegacyQuery} to upgrade
  * older query structures to the current {@link SpecQuery} format.
  */
 export type LegacyQuery = {

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -1,6 +1,7 @@
 import type {
   AxesId,
   AxesSpec,
+  BuildQueryInput,
   JoinEntry,
   PColumnSpec,
   PObjectId,
@@ -10,23 +11,18 @@ import type {
   PTableSorting,
   DataQuery,
   SpecQuery,
+  SpecQueryJoinEntry,
   SingleAxisSelector,
 } from "@milaboratories/pl-model-common";
 import type {
   DeleteColumnFromColumnsRequest,
   DeleteColumnFromColumnsResponse,
 } from "./delete_column";
-import type {
-  DiscoverColumnsRequestV2,
-  DiscoverColumnsResponse,
-  DiscoverColumnsResponseV2,
-} from "./discover_columns";
+import type { DiscoverColumnsRequestV2, DiscoverColumnsResponse } from "./discover_columns";
 import type { FindColumnsRequest, FindColumnsResponse } from "./find_columns";
 
 /**
- * V3 PFrame interface: same surface as V2 except `discoverColumns` returns
- * {@link DiscoverColumnsResponseV2}, which includes a per-hit ready-to-execute
- * {@link SpecQuery} alongside the existing fields.
+ * V3 PFrame interface: adds {@link PFrameWasmV3.buildQuery} on top of V2.
  */
 export interface PFrameWasmV3 extends Disposable {
   /**
@@ -35,15 +31,13 @@ export interface PFrameWasmV3 extends Disposable {
   deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
 
   /**
-   * Discovers columns compatible with a given axes integration, with separate
-   * include and exclude filters. Exclude filter is applied after include,
-   * removing matching columns from results.
-   *
-   * Each hit also carries a {@link SpecQuery} materializing its traversal
-   * path — direct hits produce a plain column reference; linker-path hits
-   * produce a nested `linkerJoin` chain ready to be evaluated.
+   * Discovers columns compatible with a given axes integration. Include and
+   * exclude filters are applied in order (exclude removes matches from the
+   * include set). Each hit carries its traversal `path`; feed the hit's
+   * column id and `path` into {@link buildQuery} to materialize it as a
+   * {@link SpecQueryJoinEntry}.
    */
-  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponseV2;
+  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
 
   /**
    * Finds columns in the PFrame matching the given filter criteria.
@@ -59,6 +53,22 @@ export interface PFrameWasmV3 extends Disposable {
    * Rewrites a legacy query format (V4) to the current SpecQuery format.
    */
   rewriteLegacyQuery(request: LegacyQuery): SpecQuery;
+
+  /**
+   * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
+   * ordered path of wrapping steps (linker hops, filter joins).
+   *
+   * Right-fold over `path` starting from `Column(column)`: each `linker` step
+   * wraps the current subquery as `linkerJoin`, each `filter` step as
+   * `innerJoin` with the filter column. `qualifications` annotate the
+   * outermost entry only.
+   *
+   * Pure over its input — column ids are resolved later in
+   * {@link evaluateQuery}. Throws only on malformed input: shape violations
+   * and unknown step tags (so v1 callers are shielded from step variants
+   * added in later versions).
+   */
+  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
 }
 
 /**
@@ -95,15 +105,14 @@ export interface PFrameWasmAPIV3 {
 }
 
 /**
- * V2 PFrame interface. Superseded by {@link PFrameWasmV3}, which adds a per-hit
- * {@link SpecQuery} to `discoverColumns` responses. Will be removed in a future
- * PFrames update.
+ * V2 PFrame interface. Superseded by {@link PFrameWasmV3}, which adds
+ * {@link PFrameWasmV3.buildQuery}. Will be removed in a future PFrames update.
  */
 export interface PFrameWasmV2 extends Disposable {
   /** @see PFrameWasmV3.deleteColumns */
   deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
 
-  /** @see PFrameWasmV3.discoverColumns — V2 response lacks the per-hit `query` field. */
+  /** @see PFrameWasmV3.discoverColumns */
   discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
 
   /** @see PFrameWasmV3.findColumns */

--- a/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
@@ -3,6 +3,7 @@ import type {
   ColumnValueType,
   DiscoverColumnsStepInfo,
   PColumnIdAndSpec,
+  SpecQuery,
 } from "@milaboratories/pl-model-common";
 import type { AxisQualification, ColumnAxesWithQualifications } from "./common";
 
@@ -89,18 +90,51 @@ export interface DiscoverColumnsMappingVariant {
   distinctiveQualifications: DiscoverColumnsResponseQualifications;
 }
 
-/** A single hit in the discover columns response */
-export interface DiscoverColumnsResponseHit {
+/**
+ * A single hit in the discover columns response. Carries the matched column
+ * along with its integration metadata, the linker path traversed to reach it,
+ * and a ready-to-execute {@link SpecQuery}: for direct hits a plain column
+ * reference, for linker-path hits a nested `linkerJoin` chain that joins the
+ * linker(s) with the hit column and projects out the one-side axes.
+ */
+export interface DiscoverColumnsResponseHitV2 {
   /** The column that was found compatible */
   hit: PColumnIdAndSpec;
   /** Possible ways to integrate this column with the existing set */
   mappingVariants: DiscoverColumnsMappingVariant[];
   /** Linker steps traversed to reach this hit; empty for direct matches */
   path: DiscoverColumnsStepInfo[];
+  /** Query that materializes this hit's traversal path and the hit itself. */
+  query: SpecQuery;
 }
 
-/** Response from discover columns */
-export interface DiscoverColumnsResponse {
+/**
+ * Response from discover columns — each hit carries a per-hit {@link SpecQuery}
+ * alongside its match metadata.
+ */
+export interface DiscoverColumnsResponseV2 {
   /** Columns that could be integrated and possible ways to integrate them */
+  hits: DiscoverColumnsResponseHitV2[];
+}
+
+/**
+ * Legacy hit shape without the per-hit query. Superseded by
+ * {@link DiscoverColumnsResponseHitV2}; will be removed in a future PFrames update.
+ */
+export interface DiscoverColumnsResponseHit {
+  /** @see DiscoverColumnsResponseHitV2.hit */
+  hit: PColumnIdAndSpec;
+  /** @see DiscoverColumnsResponseHitV2.mappingVariants */
+  mappingVariants: DiscoverColumnsMappingVariant[];
+  /** @see DiscoverColumnsResponseHitV2.path */
+  path: DiscoverColumnsStepInfo[];
+}
+
+/**
+ * Legacy response shape. Superseded by {@link DiscoverColumnsResponseV2}; will
+ * be removed in a future PFrames update.
+ */
+export interface DiscoverColumnsResponse {
+  /** @see DiscoverColumnsResponseV2.hits */
   hits: DiscoverColumnsResponseHit[];
 }

--- a/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
@@ -3,7 +3,6 @@ import type {
   ColumnValueType,
   DiscoverColumnsStepInfo,
   PColumnIdAndSpec,
-  SpecQuery,
 } from "@milaboratories/pl-model-common";
 import type { AxisQualification, ColumnAxesWithQualifications } from "./common";
 
@@ -92,49 +91,21 @@ export interface DiscoverColumnsMappingVariant {
 
 /**
  * A single hit in the discover columns response. Carries the matched column
- * along with its integration metadata, the linker path traversed to reach it,
- * and a ready-to-execute {@link SpecQuery}: for direct hits a plain column
- * reference, for linker-path hits a nested `linkerJoin` chain that joins the
- * linker(s) with the hit column and projects out the one-side axes.
+ * along with its integration metadata and the path traversed to reach it.
+ * To materialize the hit as an executable query, feed `hit.columnId` and
+ * `path` into the PFrame's `buildQuery`.
  */
-export interface DiscoverColumnsResponseHitV2 {
+export interface DiscoverColumnsResponseHit {
   /** The column that was found compatible */
   hit: PColumnIdAndSpec;
   /** Possible ways to integrate this column with the existing set */
   mappingVariants: DiscoverColumnsMappingVariant[];
-  /** Linker steps traversed to reach this hit; empty for direct matches */
-  path: DiscoverColumnsStepInfo[];
-  /** Query that materializes this hit's traversal path and the hit itself. */
-  query: SpecQuery;
-}
-
-/**
- * Response from discover columns — each hit carries a per-hit {@link SpecQuery}
- * alongside its match metadata.
- */
-export interface DiscoverColumnsResponseV2 {
-  /** Columns that could be integrated and possible ways to integrate them */
-  hits: DiscoverColumnsResponseHitV2[];
-}
-
-/**
- * Legacy hit shape without the per-hit query. Superseded by
- * {@link DiscoverColumnsResponseHitV2}; will be removed in a future PFrames update.
- */
-export interface DiscoverColumnsResponseHit {
-  /** @see DiscoverColumnsResponseHitV2.hit */
-  hit: PColumnIdAndSpec;
-  /** @see DiscoverColumnsResponseHitV2.mappingVariants */
-  mappingVariants: DiscoverColumnsMappingVariant[];
-  /** @see DiscoverColumnsResponseHitV2.path */
+  /** Steps traversed to reach this hit; empty for direct matches */
   path: DiscoverColumnsStepInfo[];
 }
 
-/**
- * Legacy response shape. Superseded by {@link DiscoverColumnsResponseV2}; will
- * be removed in a future PFrames update.
- */
+/** Response from discover columns. */
 export interface DiscoverColumnsResponse {
-  /** @see DiscoverColumnsResponseV2.hits */
+  /** Columns that could be integrated and possible ways to integrate them */
   hits: DiscoverColumnsResponseHit[];
 }

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -357,14 +357,18 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
       const associatedId = this.idDeriver.deriveS(col.spec);
 
       results.push({
-        path: hit.path.map((step) => ({
-          linker: remapSnapshot(
-            this.idDeriver.deriveS(step.linker.spec),
-            this.columnsMap.get(step.linker.columnId) ??
-              throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
-          ),
-          qualifications: step.qualifications,
-        })),
+        path: hit.path.map((step) => {
+          if (step.type !== "linker")
+            throw new Error(`Unexpected discover-columns step type: ${step.type}`);
+          return {
+            linker: remapSnapshot(
+              this.idDeriver.deriveS(step.linker.spec),
+              this.columnsMap.get(step.linker.columnId) ??
+                throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
+            ),
+            qualifications: step.qualifications,
+          };
+        }),
         column: remapSnapshot(associatedId, col),
         variants: hit.mappingVariants,
         originalId: origId,


### PR DESCRIPTION
Mirrors QueryOuterJoin's { primary, secondary } shape with linker specialization: the linker side is a column reference sub-struct (plain column at spec; column + axes mapping + one-side indices at data), and secondary is a full join entry. Semantics: inner-join the linker with secondary, then project out the linker's one-side axes.

Extends traverseQuerySpec, sortSpecQuery, and cmpQuerySpec in utils with the new variant; covers traversal via a test case.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `QueryLinkerJoin` across the spec and data layers, mirroring the existing `QueryOuterJoin` shape but with a specialized linker side (plain column reference at spec; column + `axesMapping` + `oneSideAxesIndices` at data). `traverseQuerySpec`, `sortSpecQuery`, and `cmpQuerySpec` in `utils.ts` are all extended to handle the new variant consistently with existing join types, and a traversal test is added.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are additive and consistent with existing patterns, with no correctness issues found.

All findings are P2 style/test-coverage suggestions. The implementation correctly handles the new node type across traversal, sorting, and comparison utilities, and the type definitions are well-structured at both spec and data layers.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/drivers/pframe/query/query_common.ts | Adds `QueryLinkerJoin<L, JE>` generic interface; well-documented with JSDoc and a usage example. |
| lib/model/common/src/drivers/pframe/query/query_data.ts | Adds `DataQueryLinkerJoinLinker` (column + axesMapping + oneSideAxesIndices) and `DataQueryLinkerJoin` to the `DataQuery` union; consistent with existing patterns. |
| lib/model/common/src/drivers/pframe/query/query_spec.ts | Adds `SpecQueryLinkerJoinLinker<C>` (column only) and `SpecQueryLinkerJoin<C>` to the `SpecQuery<C>` union; correctly omits the integration artifacts that are spec→data derived. |
| lib/model/common/src/drivers/pframe/query/utils.ts | Extends `traverseQuerySpec`, `sortSpecQuery`, and `cmpQuerySpec` to handle `linkerJoin`; implementation is consistent with existing join variants and the `node` visitor is correctly applied. |
| lib/model/common/src/drivers/pframe/query/utils.test.ts | Adds a `traverseQuerySpec` test for `linkerJoin`; missing explicit tests for `collectSpecQueryColumns` and `sortSpecQuery` with the new node type. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/model/common/src/drivers/pframe/query/utils.test.ts
Line: 77-89

Comment:
**Missing tests for `sortSpecQuery` and `collectSpecQueryColumns` with `linkerJoin`**

The new test case only covers `traverseQuerySpec`. `collectSpecQueryColumns` on a `linkerJoin` will include the linker column (because `traverseQuerySpec` calls `visitor.column` on it), but there is no explicit test verifying this. Similarly, `sortSpecQuery` is intentionally a no-op for `linkerJoin`, but there is no test that confirms the node is returned unchanged. Given the other node types each have dedicated `sortSpecQuery` tests, adding these would help catch regressions if the linker branch ever gets sorting logic.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframe): add LinkerJoin query node ..."](https://github.com/milaboratory/platforma/commit/b3b784e5b2b7d0e99b7ca62dbae48c46e00943f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29110357)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->