### PR TITLE
Slice operation support for ptabler

### DIFF
--- a/.changeset/green-fans-tickle.md
+++ b/.changeset/green-fans-tickle.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+"@platforma-open/milaboratories.software-ptabler.schema": patch
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Slice operation support

--- a/lib/ptabler/schema/src/basic_steps.ts
+++ b/lib/ptabler/schema/src/basic_steps.ts
@@ -222,3 +222,38 @@ export interface LimitStep {
    */
   n: number;
 }
+
+/**
+ * Defines a step that extracts a contiguous row range from a table
+ * and outputs the result to a new table in the tablespace.
+ * This operation is similar to Polars' `slice` method.
+ * Rows that extend past the end of the frame are silently omitted.
+ */
+export interface SliceStep {
+  /**
+   * The type identifier for this step.
+   * Must be 'slice'.
+   */
+  type: "slice";
+
+  /**
+   * The name of the input table in the tablespace from which rows will be sliced.
+   */
+  inputTable: string;
+
+  /**
+   * The name for the resulting sliced table that will be added to the tablespace.
+   */
+  outputTable: string;
+
+  /**
+   * The starting row index (0-based, non-negative).
+   */
+  offset: number;
+
+  /**
+   * The number of rows to extract starting from offset.
+   * If offset + length exceeds the input row count, only the available tail rows are returned.
+   */
+  length: number;
+}

--- a/lib/ptabler/schema/src/basic_steps.ts
+++ b/lib/ptabler/schema/src/basic_steps.ts
@@ -252,7 +252,8 @@ export interface SliceStep {
   offset: number;
 
   /**
-   * The number of rows to extract starting from offset.
+   * The number of rows to extract starting from offset. Must be non-negative.
+   * A length of 0 yields an empty table with the input schema preserved.
    * If offset + length exceeds the input row count, only the available tail rows are returned.
    */
   length: number;

--- a/lib/ptabler/schema/src/index.ts
+++ b/lib/ptabler/schema/src/index.ts
@@ -13,6 +13,7 @@ import type {
   FilterStep,
   LimitStep,
   SelectStep,
+  SliceStep,
   UniqueKeepStrategy,
   UniqueStep,
   WithColumnsStep,
@@ -35,6 +36,7 @@ export type PTablerStep =
   | AddColumnsStep
   | FilterStep
   | LimitStep
+  | SliceStep
   | AggregateStep
   | AnyJoinStep
   | ConcatenateStep
@@ -59,9 +61,11 @@ export type {
   BaseFileWriteStep,
   ConcatenateStep,
   FilterStep,
+  LimitStep,
   ReadCsvStep,
   ReadNdjsonStep,
   SelectStep,
+  SliceStep,
   SortStep,
   UniqueKeepStrategy,
   UniqueStep,

--- a/lib/ptabler/software/src/ptabler/steps/__init__.py
+++ b/lib/ptabler/software/src/ptabler/steps/__init__.py
@@ -11,6 +11,7 @@ from .io import (
 from .basics import AddColumns, Select, Unique, WithColumns, WithoutColumns
 from .filter import Filter
 from .limit import Limit
+from .slice import Slice
 from .join import Join
 from .aggregate import Aggregate
 from .concatenate import Concatenate
@@ -34,6 +35,7 @@ type AnyPStep = Union[
     WithoutColumns,
     Filter,
     Limit,
+    Slice,
     Join,
     Aggregate,
     Concatenate,
@@ -57,6 +59,7 @@ __all__ = [
     "WithoutColumns",
     "Filter",
     "Limit",
+    "Slice",
     "Join",
     "Aggregate",
     "Concatenate",

--- a/lib/ptabler/software/src/ptabler/steps/slice.py
+++ b/lib/ptabler/software/src/ptabler/steps/slice.py
@@ -1,0 +1,21 @@
+from .base import PStep, StepContext
+
+
+class Slice(PStep, tag="slice"):
+    """
+    PStep to extract a contiguous row range from a table.
+
+    Retrieves a table (LazyFrame) from the tablespace, extracts rows
+    [offset, offset + length), and stores the result under a new name.
+    Ranges that extend past the end of the frame are silently clipped.
+    Corresponds to the SliceStep defined in the TypeScript type definitions.
+    """
+    input_table: str
+    output_table: str
+    offset: int
+    length: int
+
+    def execute(self, ctx: StepContext):
+        lf = ctx.get_table(self.input_table)
+        sliced_lf = lf.slice(self.offset, self.length)
+        ctx.put_table(self.output_table, sliced_lf)

--- a/lib/ptabler/software/src/test/slice_test.py
+++ b/lib/ptabler/software/src/test/slice_test.py
@@ -50,3 +50,8 @@ class SliceTests(unittest.TestCase):
         result = self._run_slice(offset=0, length=5)
         expected = self._make_test_df().collect()
         assert_frame_equal(result, expected)
+
+    def test_length_zero_returns_empty_with_schema(self):
+        result = self._run_slice(offset=0, length=0)
+        self.assertEqual(result.height, 0)
+        self.assertEqual(result.columns, ["id", "value"])

--- a/lib/ptabler/software/src/test/slice_test.py
+++ b/lib/ptabler/software/src/test/slice_test.py
@@ -1,0 +1,52 @@
+import unittest
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from ptabler.workflow import PWorkflow
+from ptabler.steps import GlobalSettings, TableSpace, Slice
+
+global_settings = GlobalSettings(root_folder=".")
+
+
+class SliceTests(unittest.TestCase):
+    def _make_test_df(self) -> pl.LazyFrame:
+        return pl.DataFrame({
+            "id": [1, 2, 3, 4, 5],
+            "value": [10, 20, 30, 40, 50],
+        }).lazy()
+
+    def _run_slice(self, offset: int, length: int) -> pl.DataFrame:
+        initial_table_space: TableSpace = {"input_data": self._make_test_df()}
+        step = Slice(
+            input_table="input_data",
+            output_table="sliced_data",
+            offset=offset,
+            length=length,
+        )
+        workflow = PWorkflow(workflow=[step])
+        ctx = workflow.execute(
+            global_settings=global_settings,
+            lazy=True,
+            initial_table_space=initial_table_space.copy(),
+        )
+        return ctx.get_table("sliced_data").collect()
+
+    def test_basic_range(self):
+        result = self._run_slice(offset=1, length=2)
+        expected = pl.DataFrame({"id": [2, 3], "value": [20, 30]})
+        assert_frame_equal(result, expected)
+
+    def test_offset_past_end_returns_empty(self):
+        result = self._run_slice(offset=10, length=5)
+        self.assertEqual(result.height, 0)
+        self.assertEqual(result.columns, ["id", "value"])
+
+    def test_length_exceeds_row_count_returns_tail(self):
+        result = self._run_slice(offset=3, length=10)
+        expected = pl.DataFrame({"id": [4, 5], "value": [40, 50]})
+        assert_frame_equal(result, expected)
+
+    def test_offset_zero_full_length(self):
+        result = self._run_slice(offset=0, length=5)
+        expected = self._make_test_df().collect()
+        assert_frame_equal(result, expected)

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -1441,6 +1441,32 @@ _newDataFrame = func(parentWorkflow, dfName) {
 		},
 
 		/**
+		 * Returns rows [offset, offset+length) of the DataFrame.
+		 * Mirrors Polars `slice`. Ranges that extend past end-of-frame are clipped.
+		 *
+		 * @param offset {number} - Non-negative, 0-based starting row index.
+		 * @param length {number} - Positive number of rows to extract.
+		 * @returns {object} - A new DataFrame object.
+		 * @example
+		 *   batch0 := df.slice(0, 100)
+		 *   batch1 := df.slice(100, 100)
+		 */
+		slice: func(offset, length) {
+			ll.assert(is_int(offset) && offset >= 0, "slice offset must be a non-negative integer.")
+			ll.assert(is_int(length) && length > 0, "slice length must be a positive integer.")
+
+			outputDfName := parentWorkflow._newAnonymousDataFrameId()
+			parentWorkflow.addRawStep({
+				type: "slice",
+				inputTable: dfName,
+				outputTable: outputDfName,
+				offset: offset,
+				length: length
+			})
+			return _newDataFrame(parentWorkflow, outputDfName)
+		},
+
+		/**
 		 * Sorts the DataFrame by one or more columns or expressions.
 		 * Sorting is always stable (maintains relative order of equivalent rows).
 		 *

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -1442,18 +1442,21 @@ _newDataFrame = func(parentWorkflow, dfName) {
 
 		/**
 		 * Returns rows [offset, offset+length) of the DataFrame.
-		 * Mirrors Polars `slice`. Ranges that extend past end-of-frame are clipped.
+		 * Mirrors Polars `slice`. Ranges that extend past end-of-frame are clipped;
+		 * length=0 yields an empty frame (useful for dynamic chunk sizing / empty
+		 * partition handling).
 		 *
 		 * @param offset {number} - Non-negative, 0-based starting row index.
-		 * @param length {number} - Positive number of rows to extract.
+		 * @param length {number} - Non-negative number of rows to extract.
 		 * @returns {object} - A new DataFrame object.
 		 * @example
 		 *   batch0 := df.slice(0, 100)
 		 *   batch1 := df.slice(100, 100)
+		 *   empty  := df.slice(0, 0)   // empty frame, same schema as df
 		 */
 		slice: func(offset, length) {
 			ll.assert(is_int(offset) && offset >= 0, "slice offset must be a non-negative integer.")
-			ll.assert(is_int(length) && length > 0, "slice length must be a positive integer.")
+			ll.assert(is_int(length) && length >= 0, "slice length must be a non-negative integer.")
 
 			outputDfName := parentWorkflow._newAnonymousDataFrameId()
 			parentWorkflow.addRawStep({

--- a/tests/workflow-tengo/src/pt/pt.test.ts
+++ b/tests/workflow-tengo/src/pt/pt.test.ts
@@ -299,6 +299,61 @@ tplTest.concurrent(
   },
 );
 
+tplTest.concurrent(
+  "pt slice test - offset+length, tail clipping, past-end and zero-length",
+  async ({ helper, expect, driverKit }) => {
+    const inputTsvData = dedent`
+      id	value
+      1	A
+      2	B
+      3	C
+      4	D
+      5	E
+    `;
+
+    // slice(1, 2) → rows [1, 3): id 2 and 3.
+    const expectedBasic = dedent`
+      id	value
+      2	B
+      3	C
+    `;
+
+    // slice(3, 10) on a 5-row frame → rows [3, 5), only 2 rows available.
+    const expectedTail = dedent`
+      id	value
+      4	D
+      5	E
+    `;
+
+    // Past-end and zero-length slices must both produce header-only frames
+    // preserving the input schema.
+    const expectedEmptyWithHeader = dedent`
+      id	value
+    `;
+
+    const result = await helper.renderTemplate(
+      false,
+      "pt.slice",
+      ["out_basic", "out_tail", "out_past_end", "out_zero_length"],
+      (tx) => ({
+        inputTsv: tx.createValue(Pl.JsonObject, JSON.stringify(inputTsvData)),
+      }),
+    );
+
+    const [basic, tail, pastEnd, zeroLength] = await Promise.all([
+      getFileContent(result, "out_basic", driverKit),
+      getFileContent(result, "out_tail", driverKit),
+      getFileContent(result, "out_past_end", driverKit),
+      getFileContent(result, "out_zero_length", driverKit),
+    ]);
+
+    expect(normalizeTsv(basic)).toEqual(normalizeTsv(expectedBasic));
+    expect(normalizeTsv(tail)).toEqual(normalizeTsv(expectedTail));
+    expect(normalizeTsv(pastEnd)).toEqual(normalizeTsv(expectedEmptyWithHeader));
+    expect(normalizeTsv(zeroLength)).toEqual(normalizeTsv(expectedEmptyWithHeader));
+  },
+);
+
 tplTest.concurrent("pt ex3 test - join operations", async ({ helper, expect, driverKit }) => {
   // No input files needed as data is defined in the template as strings
 

--- a/tests/workflow-tengo/src/pt/slice.tpl.tengo
+++ b/tests/workflow-tengo/src/pt/slice.tpl.tengo
@@ -1,0 +1,42 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+file := import("@platforma-sdk/workflow-tengo:file")
+
+self.defineOutputs(
+	"out_basic",
+	"out_tail",
+	"out_past_end",
+	"out_zero_length"
+)
+
+self.body(func(inputs){
+	tsvInput := inputs.inputTsv
+
+	wf := pt.workflow()
+
+	df := wf.frame(tsvInput, {
+		xsvType: "tsv"
+	})
+
+	// Basic slice: rows [1, 3)
+	df.slice(1, 2).save("out_basic.tsv")
+
+	// Past end of frame is clipped — offset=3 with length=10 on a 5-row frame
+	// returns rows [3, 5) (the last two).
+	df.slice(3, 10).save("out_tail.tsv")
+
+	// Offset past the end returns an empty frame (schema preserved).
+	df.slice(100, 5).save("out_past_end.tsv")
+
+	// length=0 must be accepted and yield an empty frame with the input schema.
+	df.slice(0, 0).save("out_zero_length.tsv")
+
+	ptablerResult := wf.run()
+
+	return {
+		out_basic: file.exportFile(ptablerResult.getFile("out_basic.tsv")),
+		out_tail: file.exportFile(ptablerResult.getFile("out_tail.tsv")),
+		out_past_end: file.exportFile(ptablerResult.getFile("out_past_end.tsv")),
+		out_zero_length: file.exportFile(ptablerResult.getFile("out_zero_length.tsv"))
+	}
+})


### PR DESCRIPTION
Required for MILAB-6013 batch processing API. Adds slice operation support to ptabler.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `slice` operation to ptabler, exposing Polars' `LazyFrame.slice` as a first-class step across the TypeScript schema, Python executor, and Tengo SDK. The implementation is consistent and well-tested. As a minor aside, `LimitStep` was also added to the `index.ts` re-exports, which looks like a small pre-existing omission fixed alongside this work.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; only finding is a P2 style suggestion about adding input validation to the Python model

All findings are P2 (style/best-practices). The core implementation is correct, tests cover the main edge cases, and the Tengo SDK already enforces the constraints at the call site.

lib/ptabler/software/src/ptabler/steps/slice.py — consider adding msgspec field validators for offset/length
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ptabler/software/src/ptabler/steps/slice.py | New PStep implementing Polars LazyFrame.slice; functionally correct but lacks input validation (offset ≥ 0, length > 0) enforced by the Tengo SDK layer |
| lib/ptabler/schema/src/basic_steps.ts | Adds well-documented SliceStep interface; constraints on offset/length are documented in JSDoc but not type-enforced (TypeScript limitation) |
| lib/ptabler/schema/src/index.ts | Adds SliceStep to PTablerStep union and re-exports; also adds the previously-missing LimitStep re-export |
| lib/ptabler/software/src/ptabler/steps/__init__.py | Correctly imports and exports Slice in both AnyPStep union and __all__ |
| lib/ptabler/software/src/test/slice_test.py | Good test coverage for basic range, out-of-range offset, length overflow, and zero-offset full-length cases |
| sdk/workflow-tengo/src/pt/index.lib.tengo | Adds slice() to the DataFrame fluent API with correct assertions (offset ≥ 0, length > 0) and step delegation |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/ptabler/software/src/ptabler/steps/slice.py
Line: 14-16

Comment:
**Missing input validation on `offset` and `length`**

The schema docs say `offset` is non-negative and the Tengo SDK explicitly asserts `length > 0`, but `Slice` has no corresponding guards. `msgspec.Struct` accepts any `int`, so a caller passing `offset=-1` would silently invoke Polars' from-end semantics (not what the contract describes), and `length=0` or a negative length could produce unexpected empty frames or a Polars runtime error. Other `PStep` implementations that carry semantic constraints (e.g. `Limit`) share this pattern; adding validators here would make the Python layer consistent with the Tengo layer.

```suggestion
    offset: Annotated[int, msgspec.Meta(ge=0)]
    length: Annotated[int, msgspec.Meta(gt=0)]
```
(requires `from typing import Annotated` at the top)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6013 slice operation support for p..."](https://github.com/milaboratory/platforma/commit/1d33c79ce50f66e0b9dfe187622f05c093386d82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29119108)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->