### PR TITLE
pl-mcp-server: target a block's webview from execute_js

### DIFF
--- a/.changeset/mcp-execute-js-block-target.md
+++ b/.changeset/mcp-execute-js-block-target.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-mcp-server': minor
+---
+
+Add optional `projectId` and `blockId` to the `execute_js` MCP tool. When both are provided, the JS runs inside the cached block webview, where `window.platforma` is accessible. Errors with "has no loaded webview" if the block isn't loaded — callers should `select_block` first. Behavior without those args is unchanged.

--- a/lib/node/pl-mcp-server/src/server.ts
+++ b/lib/node/pl-mcp-server/src/server.ts
@@ -25,8 +25,16 @@ export interface PlMcpServerCallbacks {
   captureScreenshot?: () => Promise<string>;
   /** Send an input event to the application window. */
   sendInputEvent?: (event: unknown) => Promise<void>;
-  /** Execute JavaScript in the renderer and return the result. */
-  executeJavaScript?: (code: string) => Promise<unknown>;
+  /**
+   * Execute JavaScript in a renderer and return the result.
+   * With no `target`, runs in the topmost webContents (usually the main app).
+   * With `target`, runs in the specified block's webview (where `window.platforma` is
+   * exposed) — the block must already be loaded (e.g. via `select_block`).
+   */
+  executeJavaScript?: (
+    code: string,
+    target?: { projectId: string; blockId: string },
+  ) => Promise<unknown>;
   /** List available blocks from all configured registries. */
   listAvailableBlocks?: (query?: string) => Promise<unknown[]>;
   /** Navigate the desktop UI to show a specific block. */

--- a/lib/node/pl-mcp-server/src/tools/ui-interaction.ts
+++ b/lib/node/pl-mcp-server/src/tools/ui-interaction.ts
@@ -137,19 +137,37 @@ export function registerUIInteractionTools(server: McpServer, ctx: ToolContext):
     "execute_js",
     {
       description:
-        "Execute JavaScript in the renderer process and return the result. Useful for querying DOM, reading text, or complex interactions.",
+        "Execute JavaScript in a renderer and return the result. By default runs in the topmost webContents (main app / topmost modal). Pass projectId + blockId to run inside that block's webview, where `window.platforma` is exposed and the driverKit (e.g. `window.platforma.lsDriver.getLocalFileHandle`) is callable. The block must already be open — call `select_block` first if needed.",
       inputSchema: {
         code: z.string().describe("JavaScript code to execute"),
+        projectId: z
+          .string()
+          .optional()
+          .describe("Target project ID. Must be paired with blockId."),
+        blockId: z
+          .string()
+          .optional()
+          .describe(
+            "Target block ID. When provided with projectId, JS runs in that block's webview (where `window.platforma` is available).",
+          ),
       },
     },
-    async ({ code }) => {
+    async ({ code, projectId, blockId }) => {
       if (!ctx.callbacks.executeJavaScript) {
         return errorResult(
           "JS execution is not available.",
           "Make sure the MCP server is running inside Platforma Desktop and MCP connected properly. If everything is fine check Electron logs with get_app_log",
         );
       }
-      const result = await ctx.callbacks.executeJavaScript(code);
+      if ((projectId === undefined) !== (blockId === undefined)) {
+        return errorResult(
+          "projectId and blockId must be provided together.",
+          "Either pass both to target a specific block's webview, or pass neither to run in the topmost webContents.",
+        );
+      }
+      const target =
+        projectId !== undefined && blockId !== undefined ? { projectId, blockId } : undefined;
+      const result = await ctx.callbacks.executeJavaScript(code, target);
       return textResult(result);
     },
   );


### PR DESCRIPTION
## Summary
- Add optional `projectId` + `blockId` to the `execute_js` MCP tool. When both
  are set, JS runs inside the target block's webview, where `window.platforma`
  is exposed — the driverKit is directly reachable from MCP.
- Extend the `executeJavaScript` callback on `PlMcpServerCallbacks` to
  `(code, target?)`. Backward compatible: 1-arg implementations still satisfy
  the slot.
- Minor bump on `@milaboratories/pl-mcp-server`.

## Test plan
- [x] `pnpm --filter @milaboratories/pl-mcp-server run check` clean
- [x] Tool returns actionable error when only one of projectId/blockId is passed
- [x] End-to-end verified with companion desktop-app change: select_block →
      execute_js({projectId, blockId, code}) returns `window.platforma.*` for
      Titeseq and Samples & Data blocks. Full MCP-only scaffold
      (create_project → add S&D → in-webview listFiles + setBlockArgs →
      run_block) runs green.
- [ ] Companion PR in the consumer side: milaboratory/platforma-desktop-app#463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the `execute_js` MCP tool with optional `projectId` + `blockId` parameters that route JavaScript execution into a specific block's webview (where `window.platforma` is exposed), falling back to the existing topmost-webContents behavior when omitted. The `executeJavaScript` callback on `PlMcpServerCallbacks` is updated with an optional `target` argument in a backward-compatible way.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a P2 style suggestion on empty-string validation that does not block functionality.

All changes are small and focused. The XOR pairing guard is correct, the callback signature change is backward-compatible, and the changeset bump is appropriate. The sole finding (empty strings bypassing the guard) is a minor DX improvement, not a correctness defect.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/mcp-execute-js-block-target.md | New changeset file for a minor version bump of `@milaboratories/pl-mcp-server`; content accurately describes the feature addition. |
| lib/node/pl-mcp-server/src/server.ts | Updated `executeJavaScript` callback signature to accept an optional `target` parameter; backward-compatible per TypeScript's function parameter assignability rules. |
| lib/node/pl-mcp-server/src/tools/ui-interaction.ts | Adds optional `projectId`/`blockId` to `execute_js` with XOR pairing validation; minor gap: empty strings pass the guard but reach the callback with invalid IDs. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/node/pl-mcp-server/src/tools/ui-interaction.ts
Line: 143-152

Comment:
**Empty-string IDs bypass validation**

`z.string().optional()` accepts empty strings (`""`). If an LLM passes `projectId: ""` and `blockId: ""` (or one empty + one valid), the XOR check won't catch it because `"" !== undefined`. The callback will then receive `{ projectId: "", blockId: "" }`, likely producing a cryptic "has no loaded webview" error from deep in the implementation instead of the clear paired-args error here.

```suggestion
        projectId: z
          .string()
          .min(1)
          .optional()
          .describe("Target project ID. Must be paired with blockId."),
        blockId: z
          .string()
          .min(1)
          .optional()
          .describe(
            "Target block ID. When provided with projectId, JS runs in that block's webview (where `window.platforma` is available).",
          ),
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pl-mcp-server: target block webview in e..."](https://github.com/milaboratory/platforma/commit/eb96c6d0ebfb0ff5a774be08a3075df9d14db9bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29164141)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->