### PR TITLE
pl-errors: publish ModelAPIVersionMismatchError export

### DIFF
--- a/.changeset/pl-errors-model-api-version-mismatch-export.md
+++ b/.changeset/pl-errors-model-api-version-mismatch-export.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-errors": minor
+"@milaboratories/pl-mcp-server": patch
+---
+
+Publish the `ModelAPIVersionMismatchError` class from `pl-errors`, which was added in #1563 but missed in that PR's changeset. `pl-mcp-server@2.1.0` imports the class (`src/tools/block-state.ts`), so downstream bundling against `pl-errors@1.2.8` (the version pinned by the current release) fails with `MISSING_EXPORT`. Bumping `pl-errors` publishes the class; the `pl-mcp-server` patch bump re-resolves its `workspace:*` dep so the next release pins the fixed `pl-errors`.


### PR DESCRIPTION
## Summary
- Catch-up changeset for `pl-errors` and `pl-mcp-server`. The `ModelAPIVersionMismatchError` class was added to `pl-errors` in #1563, but that PR's changeset only bumped `pl-mcp-server`. As a result, `pl-errors@1.2.8` on npm doesn't export the symbol, and `pl-mcp-server@2.1.0` imports it.
- Downstream fallout: consumers that bundle `pl-mcp-server` (e.g. `platforma-desktop-app` once it catalog-bumps to 2.1.0) fail with `MISSING_EXPORT: "ModelAPIVersionMismatchError" is not exported by "@milaboratories/pl-errors@1.2.8"`. Repro: milaboratory/platforma-desktop-app#463 CI.
- This changeset bumps `pl-errors` (minor — new exported class) and `pl-mcp-server` (patch — re-resolve `workspace:*` pin on the next release).

## Test plan
- [x] Changeset validated locally (`.changeset/pl-errors-model-api-version-mismatch-export.md` parses).
- [ ] After merge: `pl-errors@1.2.9` and `pl-mcp-server@2.1.1` published; `pl-mcp-server@2.1.1` manifest pins `pl-errors: 1.2.9`.
- [ ] Consumer verification in milaboratory/platforma-desktop-app#463 (catalog bump + CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)