### PR TITLE
feat(pl-middle-layer): use server-side LoadSubtree for tree refreshes when available

### DIFF
--- a/.changeset/load-subtree-rpc.md
+++ b/.changeset/load-subtree-rpc.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-client": minor
+"@milaboratories/pl-tree": minor
+"@milaboratories/pl-middle-layer": minor
+---
+
+Use server-side `ResourceAPI.LoadSubtree` for tree synchronization when the backend advertises the `loadSubtree:v1` capability. This collapses a multi-round-trip client-driven BFS into a single RPC, making project open and post-mutation refresh roughly proportional to one RTT regardless of graph depth. Falls back transparently to the existing client-driven loader on older backends.

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -391,6 +391,7 @@ message TxAPI {
       ResourceAPI.Name.Delete.Request resource_name_delete = 69; // detach name from resource
       ResourceAPI.Tree.Request resource_tree = 70; // load tree rooted at given resource
       ResourceAPI.TreeSize.Request resource_tree_size = 71; // calculate size for all resources in tree
+      ResourceAPI.LoadSubtree.Request resource_load_subtree = 72; // server-side pruned subtree walk with known-finals skip
 
       FieldAPI.Create.Request field_create = 101; // add field to resource
       FieldAPI.Exists.Request field_exists = 107; // check if field exists
@@ -490,6 +491,7 @@ message TxAPI {
       ResourceAPI.Name.Delete.Response resource_name_delete = 69;
       ResourceAPI.Tree.Response resource_tree = 70;
       ResourceAPI.TreeSize.Response resource_tree_size = 71;
+      ResourceAPI.LoadSubtree.Response resource_load_subtree = 72;
 
       FieldAPI.Create.Response field_create = 101;
       FieldAPI.Exists.Response field_exists = 107;
@@ -868,6 +870,79 @@ message ResourceAPI {
       // could change between calls depending on compression algorithm
       uint64 size = 1;
       uint64 resource_count = 2;
+    }
+  }
+
+  // Server-side tree walk rooted at a given resource.
+  //
+  // The client declares which resources it already holds up-to-date
+  // (known_finals) and a set of pruning rules; the server performs the walk
+  // locally against the open read transaction and streams visited resources
+  // back without per-layer client round-trips.
+  //
+  // Used by the middle layer to synchronize project state efficiently on
+  // high-latency connections.
+  message LoadSubtree {
+    message Request {
+      // Root of the server-side walk.
+      uint64 resource_id = 1;
+      bytes resource_signature = 2;
+
+      // Resources the client already holds with up-to-date, final state.
+      // The server returns no data for these resources and does not descend
+      // past them. Each entry must carry a signature obtained from a prior
+      // response.
+      repeated KnownFinal known_finals = 3;
+
+      // Declarative pruning rules evaluated per visited resource.
+      // Rules are tried in order; the first matching rule wins.
+      // If no rule matches, all fields are kept and traversal continues
+      // into them.
+      repeated PruningRule pruning = 4;
+
+      // If true, the response carries per-resource key-values alongside each
+      // visited resource. Defaults to false.
+      bool include_kv = 5;
+
+      // Safety limit: aborts traversal with ResourceExhausted if more than N
+      // resources would be visited. Zero means unlimited.
+      uint32 max_resources = 6;
+    }
+
+    message KnownFinal {
+      uint64 resource_id = 1;
+      bytes resource_signature = 2;
+    }
+
+    message PruningRule {
+      enum TypeMatch {
+        EXACT = 0;  // resource type name equals type_pattern
+        PREFIX = 1; // resource type name starts with type_pattern
+      }
+      TypeMatch type_match = 1;
+      string type_pattern = 2;
+
+      enum Action {
+        INCLUDE_ALL = 0;    // keep all fields and descend into them
+        DROP_ALL = 1;       // drop all fields and do not descend
+        EXCLUDE_FIELDS = 2; // drop fields matching field_names or any field_name_prefixes
+      }
+      Action action = 3;
+      repeated string field_names = 4;
+      repeated string field_name_prefixes = 5;
+    }
+
+    // Multi-message.
+    message Response {
+      Resource resource = 1;
+
+      message KV {
+        string key = 1;
+        bytes value = 2;
+      }
+
+      // Populated only when include_kv=true in the request.
+      repeated KV kv = 2;
     }
   }
 }
@@ -1610,7 +1685,17 @@ message MaintenanceAPI {
       string os = 7; // linux / windows / macosx
       string arch = 8; // x64 / aarch64
 
-      // next free: 9
+      // Opt-in capabilities advertised by this server instance, used by
+      // clients to pick between fast and fallback code paths without waiting
+      // for a failed RPC.
+      //
+      // Each entry is an opaque token "<feature>:<version>" (e.g.
+      // "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
+      // The field is unset on servers predating this mechanism, which the
+      // client treats as "no optional capabilities advertised".
+      repeated string capabilities = 9;
+
+      // next free: 10
     }
   }
 

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -209,6 +209,16 @@ export class PlClient {
     return this._serverInfo!;
   }
 
+  /** Returns true if the connected server advertises the given capability
+   * (see MaintenanceAPI.Ping.Response.capabilities). Unknown / old servers
+   * return false. Capability tokens use the form "<feature>:<version>",
+   * e.g. "loadSubtree:v1". */
+  public hasServerCapability(capability: string): boolean {
+    const caps = this._serverInfo?.capabilities;
+    if (!caps || caps.length === 0) return false;
+    return caps.includes(capability);
+  }
+
   /** Discovers or creates the user's root resource.
    *  Tries ListUserResources RPC first (new backend), falls back to
    *  legacy named-resource lookup for older backends. */

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -495,7 +495,17 @@ export class LLPlClient implements WireClientProviderFactory {
     if (cl instanceof GrpcPlApiClient) {
       return (await cl.ping({})).response;
     } else {
-      return notEmpty((await cl.GET("/v1/ping")).data, "REST: empty response for ping request");
+      const restResponse = notEmpty(
+        (await cl.GET("/v1/ping")).data,
+        "REST: empty response for ping request",
+      );
+      // The REST schema (openapi.yaml, synced from pl) may lag behind the
+      // gRPC schema when new optional fields are added; default them here so
+      // REST callers see the same shape as gRPC callers.
+      return {
+        ...restResponse,
+        capabilities: (restResponse as { capabilities?: string[] }).capabilities ?? [],
+      } as grpcTypes.MaintenanceAPI_Ping_Response;
     }
   }
 

--- a/lib/node/pl-client/src/core/load_subtree.ts
+++ b/lib/node/pl-client/src/core/load_subtree.ts
@@ -1,0 +1,85 @@
+// Wire-level types for the LoadSubtree transaction method.
+//
+// These mirror MiLaboratories.PL.API.ResourceAPI.LoadSubtree in the proto but
+// use TypeScript-idiomatic string unions instead of generated enums so
+// middle-layer callers can describe pruning rules declaratively without
+// importing proto-generated identifiers.
+
+import {
+  ResourceAPI_LoadSubtree_PruningRule_Action,
+  ResourceAPI_LoadSubtree_PruningRule_TypeMatch,
+  type ResourceAPI_LoadSubtree_PruningRule,
+} from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
+import type { ResourceData } from "./types";
+import type { AnyResourceRef, KeyValue } from "./transaction";
+
+export type PruningRuleTypeMatch = "exact" | "prefix";
+export type PruningRuleAction = "includeAll" | "dropAll" | "excludeFields";
+
+/** A single pruning rule. Rules are evaluated in order when executing a
+ *  LoadSubtree call; the first matching rule wins. A resource with no
+ *  matching rule keeps all its fields and is descended into. */
+export interface PruningRule {
+  /** How type_pattern is matched against the resource type name. */
+  typeMatch: PruningRuleTypeMatch;
+  /** Pattern compared with the resource's type.name. */
+  typePattern: string;
+  /** Action applied to the matched resource. */
+  action: PruningRuleAction;
+  /** For action="excludeFields": exact field names to drop. */
+  fieldNames?: string[];
+  /** For action="excludeFields": drop fields whose name starts with any of
+   *  these prefixes. */
+  fieldNamePrefixes?: string[];
+}
+
+/** Declarative spec for server-side subtree pruning. Equivalent to the
+ *  classic in-memory PruningFunction but transmissible over the wire. */
+export type PruningSpec = readonly PruningRule[];
+
+export interface LoadSubtreeOptions {
+  /** Root of the server-side walk. */
+  root: AnyResourceRef;
+  /** Resources the client already holds in its up-to-date state; the server
+   *  returns no data for these and does not descend past them. */
+  knownFinals?: Iterable<AnyResourceRef>;
+  /** Pruning rules — see {@link PruningSpec}. */
+  pruning?: PruningSpec;
+  /** If true, per-resource key-values are returned alongside each resource.
+   *  Defaults to false. */
+  includeKv?: boolean;
+  /** Safety limit for the total number of visited resources. Zero = server
+   *  default. */
+  maxResources?: number;
+}
+
+/** Single entry produced by {@link PlTransaction.loadSubtree}. */
+export interface LoadedSubtreeNode {
+  resource: ResourceData;
+  /** Empty unless the request was made with includeKv=true. */
+  kv: KeyValue[];
+}
+
+export function encodePruningRule(rule: PruningRule): ResourceAPI_LoadSubtree_PruningRule {
+  return {
+    typeMatch:
+      rule.typeMatch === "prefix"
+        ? ResourceAPI_LoadSubtree_PruningRule_TypeMatch.PREFIX
+        : ResourceAPI_LoadSubtree_PruningRule_TypeMatch.EXACT,
+    typePattern: rule.typePattern,
+    action: encodeAction(rule.action),
+    fieldNames: rule.fieldNames ?? [],
+    fieldNamePrefixes: rule.fieldNamePrefixes ?? [],
+  };
+}
+
+function encodeAction(a: PruningRuleAction): ResourceAPI_LoadSubtree_PruningRule_Action {
+  switch (a) {
+    case "includeAll":
+      return ResourceAPI_LoadSubtree_PruningRule_Action.INCLUDE_ALL;
+    case "dropAll":
+      return ResourceAPI_LoadSubtree_PruningRule_Action.DROP_ALL;
+    case "excludeFields":
+      return ResourceAPI_LoadSubtree_PruningRule_Action.EXCLUDE_FIELDS;
+  }
+}

--- a/lib/node/pl-client/src/core/stat.ts
+++ b/lib/node/pl-client/src/core/stat.ts
@@ -32,6 +32,11 @@ export type TxStat = {
 
   kvGetRequests: number;
   kvGetBytes: number;
+
+  loadSubtreeRequests: number;
+  loadSubtreeNodes: number;
+  loadSubtreeFields: number;
+  loadSubtreeBytes: number;
 };
 
 export type TxStatWithoutTime = Omit<TxStat, "timeMs">;
@@ -64,6 +69,10 @@ export function initialTxStatWithoutTime(): TxStatWithoutTime {
     kvListBytes: 0,
     kvGetRequests: 0,
     kvGetBytes: 0,
+    loadSubtreeRequests: 0,
+    loadSubtreeNodes: 0,
+    loadSubtreeFields: 0,
+    loadSubtreeBytes: 0,
   };
 }
 export function initialTxStat(): TxStat {
@@ -102,6 +111,10 @@ export function addStat(a: TxStat, b: TxStat): TxStat {
     kvListBytes: a.kvListBytes + b.kvListBytes,
     kvGetRequests: a.kvGetRequests + b.kvGetRequests,
     kvGetBytes: a.kvGetBytes + b.kvGetBytes,
+    loadSubtreeRequests: a.loadSubtreeRequests + b.loadSubtreeRequests,
+    loadSubtreeNodes: a.loadSubtreeNodes + b.loadSubtreeNodes,
+    loadSubtreeFields: a.loadSubtreeFields + b.loadSubtreeFields,
+    loadSubtreeBytes: a.loadSubtreeBytes + b.loadSubtreeBytes,
   };
 }
 

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -37,6 +37,7 @@ import {
   notEmpty,
 } from "@milaboratories/ts-helpers";
 import { isNotFoundError } from "./errors";
+import { encodePruningRule, type LoadSubtreeOptions, type LoadedSubtreeNode } from "./load_subtree";
 import type { FinalResourceDataPredicate } from "./final";
 import type { LRUCache } from "lru-cache";
 import type { ResourceDataCacheRecord } from "./cache";
@@ -829,6 +830,63 @@ export class PlTransaction {
     rId: AnyResourceRef,
   ): Promise<KeyValueString[] | undefined> {
     return this.track(notFoundToUndefined(async () => await this.listKeyValuesString(rId)));
+  }
+
+  //
+  // Server-side subtree walk
+  //
+
+  /** Executes a server-side BFS walk rooted at the given resource and
+   *  returns each visited resource alongside its (optional) key-values.
+   *
+   *  Callers must check server capability ("loadSubtree:v1") before using
+   *  this method; on servers predating the RPC it will fail with
+   *  UNIMPLEMENTED. Use {@link PlClient.hasServerCapability} to gate calls. */
+  public async loadSubtree(opts: LoadSubtreeOptions): Promise<LoadedSubtreeNode[]> {
+    return this.track(async () => {
+      const knownFinals = opts.knownFinals
+        ? [...opts.knownFinals].map((rid) => ({
+            resourceId: toResourceId(rid),
+            resourceSignature: new Uint8Array(0),
+          }))
+        : [];
+
+      const pruning = (opts.pruning ?? []).map(encodePruningRule);
+
+      const result = await this.sendMultiAndParse(
+        {
+          oneofKind: "resourceLoadSubtree",
+          resourceLoadSubtree: {
+            resourceId: toResourceId(opts.root),
+            resourceSignature: new Uint8Array(0),
+            knownFinals,
+            pruning,
+            includeKv: opts.includeKv ?? false,
+            maxResources: opts.maxResources ?? 0,
+          },
+        },
+        (r) =>
+          r.map((e) => ({
+            resource: protoToResource(notEmpty(e.resourceLoadSubtree.resource)),
+            kv: e.resourceLoadSubtree.kv.map((kv) => ({
+              key: kv.key,
+              value: kv.value,
+            })),
+          })),
+      );
+
+      this._stat.loadSubtreeRequests++;
+      this._stat.loadSubtreeNodes += result.length;
+      for (const n of result) {
+        this._stat.loadSubtreeBytes += n.resource.data?.length ?? 0;
+        this._stat.loadSubtreeFields += n.resource.fields.length;
+        for (const kv of n.kv) {
+          this._stat.loadSubtreeBytes += kv.key.length + kv.value.length;
+        }
+      }
+
+      return result;
+    });
   }
 
   public setKValue(rId: AnyResourceRef, key: string, value: Uint8Array | string): void {

--- a/lib/node/pl-client/src/index.ts
+++ b/lib/node/pl-client/src/index.ts
@@ -4,6 +4,7 @@ export * from "./core/config";
 export * from "./core/client";
 export * from "./core/driver";
 export * from "./core/transaction";
+export * from "./core/load_subtree";
 export * from "./core/errors";
 export * from "./core/default_client";
 export * from "./core/unauth_client";

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -322,6 +322,12 @@ export interface TxAPI_ClientMessage {
          */
         resourceTreeSize: ResourceAPI_TreeSize_Request; // calculate size for all resources in tree
     } | {
+        oneofKind: "resourceLoadSubtree";
+        /**
+         * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Request resource_load_subtree = 72
+         */
+        resourceLoadSubtree: ResourceAPI_LoadSubtree_Request; // server-side pruned subtree walk with known-finals skip
+    } | {
         oneofKind: "fieldCreate";
         /**
          * @generated from protobuf field: MiLaboratories.PL.API.FieldAPI.Create.Request field_create = 101
@@ -698,6 +704,12 @@ export interface TxAPI_ServerMessage {
          * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.TreeSize.Response resource_tree_size = 71
          */
         resourceTreeSize: ResourceAPI_TreeSize_Response;
+    } | {
+        oneofKind: "resourceLoadSubtree";
+        /**
+         * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response resource_load_subtree = 72
+         */
+        resourceLoadSubtree: ResourceAPI_LoadSubtree_Response;
     } | {
         oneofKind: "fieldCreate";
         /**
@@ -1762,6 +1774,176 @@ export interface ResourceAPI_TreeSize_Response {
      * @generated from protobuf field: uint64 resource_count = 2
      */
     resourceCount: bigint;
+}
+/**
+ * Server-side tree walk rooted at a given resource.
+ *
+ * The client declares which resources it already holds up-to-date
+ * (known_finals) and a set of pruning rules; the server performs the walk
+ * locally against the open read transaction and streams visited resources
+ * back without per-layer client round-trips.
+ *
+ * Used by the middle layer to synchronize project state efficiently on
+ * high-latency connections.
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree
+ */
+export interface ResourceAPI_LoadSubtree {
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Request
+ */
+export interface ResourceAPI_LoadSubtree_Request {
+    /**
+     * Root of the server-side walk.
+     *
+     * @generated from protobuf field: uint64 resource_id = 1
+     */
+    resourceId: bigint;
+    /**
+     * @generated from protobuf field: bytes resource_signature = 2
+     */
+    resourceSignature: Uint8Array;
+    /**
+     * Resources the client already holds with up-to-date, final state.
+     * The server returns no data for these resources and does not descend
+     * past them. Each entry must carry a signature obtained from a prior
+     * response.
+     *
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.KnownFinal known_finals = 3
+     */
+    knownFinals: ResourceAPI_LoadSubtree_KnownFinal[];
+    /**
+     * Declarative pruning rules evaluated per visited resource.
+     * Rules are tried in order; the first matching rule wins.
+     * If no rule matches, all fields are kept and traversal continues
+     * into them.
+     *
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule pruning = 4
+     */
+    pruning: ResourceAPI_LoadSubtree_PruningRule[];
+    /**
+     * If true, the response carries per-resource key-values alongside each
+     * visited resource. Defaults to false.
+     *
+     * @generated from protobuf field: bool include_kv = 5
+     */
+    includeKv: boolean;
+    /**
+     * Safety limit: aborts traversal with ResourceExhausted if more than N
+     * resources would be visited. Zero means unlimited.
+     *
+     * @generated from protobuf field: uint32 max_resources = 6
+     */
+    maxResources: number;
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.KnownFinal
+ */
+export interface ResourceAPI_LoadSubtree_KnownFinal {
+    /**
+     * @generated from protobuf field: uint64 resource_id = 1
+     */
+    resourceId: bigint;
+    /**
+     * @generated from protobuf field: bytes resource_signature = 2
+     */
+    resourceSignature: Uint8Array;
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule
+ */
+export interface ResourceAPI_LoadSubtree_PruningRule {
+    /**
+     * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.TypeMatch type_match = 1
+     */
+    typeMatch: ResourceAPI_LoadSubtree_PruningRule_TypeMatch;
+    /**
+     * @generated from protobuf field: string type_pattern = 2
+     */
+    typePattern: string;
+    /**
+     * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.Action action = 3
+     */
+    action: ResourceAPI_LoadSubtree_PruningRule_Action;
+    /**
+     * @generated from protobuf field: repeated string field_names = 4
+     */
+    fieldNames: string[];
+    /**
+     * @generated from protobuf field: repeated string field_name_prefixes = 5
+     */
+    fieldNamePrefixes: string[];
+}
+/**
+ * @generated from protobuf enum MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.TypeMatch
+ */
+export enum ResourceAPI_LoadSubtree_PruningRule_TypeMatch {
+    /**
+     * resource type name equals type_pattern
+     *
+     * @generated from protobuf enum value: EXACT = 0;
+     */
+    EXACT = 0,
+    /**
+     * resource type name starts with type_pattern
+     *
+     * @generated from protobuf enum value: PREFIX = 1;
+     */
+    PREFIX = 1
+}
+/**
+ * @generated from protobuf enum MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.Action
+ */
+export enum ResourceAPI_LoadSubtree_PruningRule_Action {
+    /**
+     * keep all fields and descend into them
+     *
+     * @generated from protobuf enum value: INCLUDE_ALL = 0;
+     */
+    INCLUDE_ALL = 0,
+    /**
+     * drop all fields and do not descend
+     *
+     * @generated from protobuf enum value: DROP_ALL = 1;
+     */
+    DROP_ALL = 1,
+    /**
+     * drop fields matching field_names or any field_name_prefixes
+     *
+     * @generated from protobuf enum value: EXCLUDE_FIELDS = 2;
+     */
+    EXCLUDE_FIELDS = 2
+}
+/**
+ * Multi-message.
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response
+ */
+export interface ResourceAPI_LoadSubtree_Response {
+    /**
+     * @generated from protobuf field: MiLaboratories.PL.API.Resource resource = 1
+     */
+    resource?: Resource;
+    /**
+     * Populated only when include_kv=true in the request.
+     *
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response.KV kv = 2
+     */
+    kv: ResourceAPI_LoadSubtree_Response_KV[];
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response.KV
+ */
+export interface ResourceAPI_LoadSubtree_Response_KV {
+    /**
+     * @generated from protobuf field: string key = 1
+     */
+    key: string;
+    /**
+     * @generated from protobuf field: bytes value = 2
+     */
+    value: Uint8Array;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.FieldAPI
@@ -3581,6 +3763,19 @@ export interface MaintenanceAPI_Ping_Response {
      * @generated from protobuf field: string arch = 8
      */
     arch: string; // x64 / aarch64
+    /**
+     * Opt-in capabilities advertised by this server instance, used by
+     * clients to pick between fast and fallback code paths without waiting
+     * for a failed RPC.
+     *
+     * Each entry is an opaque token "<feature>:<version>" (e.g.
+     * "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
+     * The field is unset on servers predating this mechanism, which the
+     * client treats as "no optional capabilities advertised".
+     *
+     * @generated from protobuf field: repeated string capabilities = 9
+     */
+    capabilities: string[];
 }
 /**
  * @generated from protobuf enum MiLaboratories.PL.API.MaintenanceAPI.Ping.Response.Compression
@@ -3702,6 +3897,7 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
             { no: 69, name: "resource_name_delete", kind: "message", oneof: "request", T: () => ResourceAPI_Name_Delete_Request },
             { no: 70, name: "resource_tree", kind: "message", oneof: "request", T: () => ResourceAPI_Tree_Request },
             { no: 71, name: "resource_tree_size", kind: "message", oneof: "request", T: () => ResourceAPI_TreeSize_Request },
+            { no: 72, name: "resource_load_subtree", kind: "message", oneof: "request", T: () => ResourceAPI_LoadSubtree_Request },
             { no: 101, name: "field_create", kind: "message", oneof: "request", T: () => FieldAPI_Create_Request },
             { no: 107, name: "field_exists", kind: "message", oneof: "request", T: () => FieldAPI_Exists_Request },
             { no: 102, name: "field_set", kind: "message", oneof: "request", T: () => FieldAPI_Set_Request },
@@ -3902,6 +4098,12 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
                     message.request = {
                         oneofKind: "resourceTreeSize",
                         resourceTreeSize: ResourceAPI_TreeSize_Request.internalBinaryRead(reader, reader.uint32(), options, (message.request as any).resourceTreeSize)
+                    };
+                    break;
+                case /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Request resource_load_subtree */ 72:
+                    message.request = {
+                        oneofKind: "resourceLoadSubtree",
+                        resourceLoadSubtree: ResourceAPI_LoadSubtree_Request.internalBinaryRead(reader, reader.uint32(), options, (message.request as any).resourceLoadSubtree)
                     };
                     break;
                 case /* MiLaboratories.PL.API.FieldAPI.Create.Request field_create */ 101:
@@ -4198,6 +4400,9 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
         /* MiLaboratories.PL.API.ResourceAPI.TreeSize.Request resource_tree_size = 71; */
         if (message.request.oneofKind === "resourceTreeSize")
             ResourceAPI_TreeSize_Request.internalBinaryWrite(message.request.resourceTreeSize, writer.tag(71, WireType.LengthDelimited).fork(), options).join();
+        /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Request resource_load_subtree = 72; */
+        if (message.request.oneofKind === "resourceLoadSubtree")
+            ResourceAPI_LoadSubtree_Request.internalBinaryWrite(message.request.resourceLoadSubtree, writer.tag(72, WireType.LengthDelimited).fork(), options).join();
         /* MiLaboratories.PL.API.FieldAPI.Create.Request field_create = 101; */
         if (message.request.oneofKind === "fieldCreate")
             FieldAPI_Create_Request.internalBinaryWrite(message.request.fieldCreate, writer.tag(101, WireType.LengthDelimited).fork(), options).join();
@@ -4341,6 +4546,7 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
             { no: 69, name: "resource_name_delete", kind: "message", oneof: "response", T: () => ResourceAPI_Name_Delete_Response },
             { no: 70, name: "resource_tree", kind: "message", oneof: "response", T: () => ResourceAPI_Tree_Response },
             { no: 71, name: "resource_tree_size", kind: "message", oneof: "response", T: () => ResourceAPI_TreeSize_Response },
+            { no: 72, name: "resource_load_subtree", kind: "message", oneof: "response", T: () => ResourceAPI_LoadSubtree_Response },
             { no: 101, name: "field_create", kind: "message", oneof: "response", T: () => FieldAPI_Create_Response },
             { no: 107, name: "field_exists", kind: "message", oneof: "response", T: () => FieldAPI_Exists_Response },
             { no: 102, name: "field_set", kind: "message", oneof: "response", T: () => FieldAPI_Set_Response },
@@ -4545,6 +4751,12 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
                     message.response = {
                         oneofKind: "resourceTreeSize",
                         resourceTreeSize: ResourceAPI_TreeSize_Response.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).resourceTreeSize)
+                    };
+                    break;
+                case /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response resource_load_subtree */ 72:
+                    message.response = {
+                        oneofKind: "resourceLoadSubtree",
+                        resourceLoadSubtree: ResourceAPI_LoadSubtree_Response.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).resourceLoadSubtree)
                     };
                     break;
                 case /* MiLaboratories.PL.API.FieldAPI.Create.Response field_create */ 101:
@@ -4850,6 +5062,9 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
         /* MiLaboratories.PL.API.ResourceAPI.TreeSize.Response resource_tree_size = 71; */
         if (message.response.oneofKind === "resourceTreeSize")
             ResourceAPI_TreeSize_Response.internalBinaryWrite(message.response.resourceTreeSize, writer.tag(71, WireType.LengthDelimited).fork(), options).join();
+        /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response resource_load_subtree = 72; */
+        if (message.response.oneofKind === "resourceLoadSubtree")
+            ResourceAPI_LoadSubtree_Response.internalBinaryWrite(message.response.resourceLoadSubtree, writer.tag(72, WireType.LengthDelimited).fork(), options).join();
         /* MiLaboratories.PL.API.FieldAPI.Create.Response field_create = 101; */
         if (message.response.oneofKind === "fieldCreate")
             FieldAPI_Create_Response.internalBinaryWrite(message.response.fieldCreate, writer.tag(101, WireType.LengthDelimited).fork(), options).join();
@@ -5857,7 +6072,6 @@ class ResourceAPI_CreateStruct_Request$Type extends MessageType<ResourceAPI_Crea
     create(value?: PartialMessage<ResourceAPI_CreateStruct_Request>): ResourceAPI_CreateStruct_Request {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.id = 0n;
-        message.colorProof = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_CreateStruct_Request>(this, message, value);
         return message;
@@ -6018,7 +6232,6 @@ class ResourceAPI_CreateEphemeral_Request$Type extends MessageType<ResourceAPI_C
     create(value?: PartialMessage<ResourceAPI_CreateEphemeral_Request>): ResourceAPI_CreateEphemeral_Request {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.id = 0n;
-        message.colorProof = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_CreateEphemeral_Request>(this, message, value);
         return message;
@@ -6328,7 +6541,6 @@ class ResourceAPI_CreateValue_Request$Type extends MessageType<ResourceAPI_Creat
         message.id = 0n;
         message.data = new Uint8Array(0);
         message.errorIfExists = false;
-        message.colorProof = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_CreateValue_Request>(this, message, value);
         return message;
@@ -6644,7 +6856,6 @@ class ResourceAPI_CreateSingleton_Request$Type extends MessageType<ResourceAPI_C
         message.id = 0n;
         message.data = new Uint8Array(0);
         message.errorIfExists = false;
-        message.colorProof = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_CreateSingleton_Request>(this, message, value);
         return message;
@@ -8934,6 +9145,374 @@ class ResourceAPI_TreeSize_Response$Type extends MessageType<ResourceAPI_TreeSiz
  * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.TreeSize.Response
  */
 export const ResourceAPI_TreeSize_Response = new ResourceAPI_TreeSize_Response$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_LoadSubtree$Type extends MessageType<ResourceAPI_LoadSubtree> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.LoadSubtree", []);
+    }
+    create(value?: PartialMessage<ResourceAPI_LoadSubtree>): ResourceAPI_LoadSubtree {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_LoadSubtree>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_LoadSubtree): ResourceAPI_LoadSubtree {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_LoadSubtree, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree
+ */
+export const ResourceAPI_LoadSubtree = new ResourceAPI_LoadSubtree$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_LoadSubtree_Request$Type extends MessageType<ResourceAPI_LoadSubtree_Request> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Request", [
+            { no: 1, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "known_finals", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_LoadSubtree_KnownFinal },
+            { no: 4, name: "pruning", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_LoadSubtree_PruningRule },
+            { no: 5, name: "include_kv", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 6, name: "max_resources", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_LoadSubtree_Request>): ResourceAPI_LoadSubtree_Request {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.resourceId = 0n;
+        message.resourceSignature = new Uint8Array(0);
+        message.knownFinals = [];
+        message.pruning = [];
+        message.includeKv = false;
+        message.maxResources = 0;
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_LoadSubtree_Request>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_LoadSubtree_Request): ResourceAPI_LoadSubtree_Request {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 resource_id */ 1:
+                    message.resourceId = reader.uint64().toBigInt();
+                    break;
+                case /* bytes resource_signature */ 2:
+                    message.resourceSignature = reader.bytes();
+                    break;
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.KnownFinal known_finals */ 3:
+                    message.knownFinals.push(ResourceAPI_LoadSubtree_KnownFinal.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule pruning */ 4:
+                    message.pruning.push(ResourceAPI_LoadSubtree_PruningRule.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* bool include_kv */ 5:
+                    message.includeKv = reader.bool();
+                    break;
+                case /* uint32 max_resources */ 6:
+                    message.maxResources = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_LoadSubtree_Request, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 resource_id = 1; */
+        if (message.resourceId !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.resourceId);
+        /* bytes resource_signature = 2; */
+        if (message.resourceSignature.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.resourceSignature);
+        /* repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.KnownFinal known_finals = 3; */
+        for (let i = 0; i < message.knownFinals.length; i++)
+            ResourceAPI_LoadSubtree_KnownFinal.internalBinaryWrite(message.knownFinals[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule pruning = 4; */
+        for (let i = 0; i < message.pruning.length; i++)
+            ResourceAPI_LoadSubtree_PruningRule.internalBinaryWrite(message.pruning[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        /* bool include_kv = 5; */
+        if (message.includeKv !== false)
+            writer.tag(5, WireType.Varint).bool(message.includeKv);
+        /* uint32 max_resources = 6; */
+        if (message.maxResources !== 0)
+            writer.tag(6, WireType.Varint).uint32(message.maxResources);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Request
+ */
+export const ResourceAPI_LoadSubtree_Request = new ResourceAPI_LoadSubtree_Request$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_LoadSubtree_KnownFinal$Type extends MessageType<ResourceAPI_LoadSubtree_KnownFinal> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.LoadSubtree.KnownFinal", [
+            { no: 1, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_LoadSubtree_KnownFinal>): ResourceAPI_LoadSubtree_KnownFinal {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.resourceId = 0n;
+        message.resourceSignature = new Uint8Array(0);
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_LoadSubtree_KnownFinal>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_LoadSubtree_KnownFinal): ResourceAPI_LoadSubtree_KnownFinal {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 resource_id */ 1:
+                    message.resourceId = reader.uint64().toBigInt();
+                    break;
+                case /* bytes resource_signature */ 2:
+                    message.resourceSignature = reader.bytes();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_LoadSubtree_KnownFinal, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 resource_id = 1; */
+        if (message.resourceId !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.resourceId);
+        /* bytes resource_signature = 2; */
+        if (message.resourceSignature.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.resourceSignature);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.KnownFinal
+ */
+export const ResourceAPI_LoadSubtree_KnownFinal = new ResourceAPI_LoadSubtree_KnownFinal$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_LoadSubtree_PruningRule$Type extends MessageType<ResourceAPI_LoadSubtree_PruningRule> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule", [
+            { no: 1, name: "type_match", kind: "enum", T: () => ["MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.TypeMatch", ResourceAPI_LoadSubtree_PruningRule_TypeMatch] },
+            { no: 2, name: "type_pattern", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "action", kind: "enum", T: () => ["MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.Action", ResourceAPI_LoadSubtree_PruningRule_Action] },
+            { no: 4, name: "field_names", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "field_name_prefixes", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_LoadSubtree_PruningRule>): ResourceAPI_LoadSubtree_PruningRule {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.typeMatch = 0;
+        message.typePattern = "";
+        message.action = 0;
+        message.fieldNames = [];
+        message.fieldNamePrefixes = [];
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_LoadSubtree_PruningRule>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_LoadSubtree_PruningRule): ResourceAPI_LoadSubtree_PruningRule {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.TypeMatch type_match */ 1:
+                    message.typeMatch = reader.int32();
+                    break;
+                case /* string type_pattern */ 2:
+                    message.typePattern = reader.string();
+                    break;
+                case /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.Action action */ 3:
+                    message.action = reader.int32();
+                    break;
+                case /* repeated string field_names */ 4:
+                    message.fieldNames.push(reader.string());
+                    break;
+                case /* repeated string field_name_prefixes */ 5:
+                    message.fieldNamePrefixes.push(reader.string());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_LoadSubtree_PruningRule, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.TypeMatch type_match = 1; */
+        if (message.typeMatch !== 0)
+            writer.tag(1, WireType.Varint).int32(message.typeMatch);
+        /* string type_pattern = 2; */
+        if (message.typePattern !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.typePattern);
+        /* MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule.Action action = 3; */
+        if (message.action !== 0)
+            writer.tag(3, WireType.Varint).int32(message.action);
+        /* repeated string field_names = 4; */
+        for (let i = 0; i < message.fieldNames.length; i++)
+            writer.tag(4, WireType.LengthDelimited).string(message.fieldNames[i]);
+        /* repeated string field_name_prefixes = 5; */
+        for (let i = 0; i < message.fieldNamePrefixes.length; i++)
+            writer.tag(5, WireType.LengthDelimited).string(message.fieldNamePrefixes[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.PruningRule
+ */
+export const ResourceAPI_LoadSubtree_PruningRule = new ResourceAPI_LoadSubtree_PruningRule$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_LoadSubtree_Response$Type extends MessageType<ResourceAPI_LoadSubtree_Response> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response", [
+            { no: 1, name: "resource", kind: "message", T: () => Resource },
+            { no: 2, name: "kv", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_LoadSubtree_Response_KV }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_LoadSubtree_Response>): ResourceAPI_LoadSubtree_Response {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.kv = [];
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_LoadSubtree_Response>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_LoadSubtree_Response): ResourceAPI_LoadSubtree_Response {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* MiLaboratories.PL.API.Resource resource */ 1:
+                    message.resource = Resource.internalBinaryRead(reader, reader.uint32(), options, message.resource);
+                    break;
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response.KV kv */ 2:
+                    message.kv.push(ResourceAPI_LoadSubtree_Response_KV.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_LoadSubtree_Response, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* MiLaboratories.PL.API.Resource resource = 1; */
+        if (message.resource)
+            Resource.internalBinaryWrite(message.resource, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* repeated MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response.KV kv = 2; */
+        for (let i = 0; i < message.kv.length; i++)
+            ResourceAPI_LoadSubtree_Response_KV.internalBinaryWrite(message.kv[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response
+ */
+export const ResourceAPI_LoadSubtree_Response = new ResourceAPI_LoadSubtree_Response$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_LoadSubtree_Response_KV$Type extends MessageType<ResourceAPI_LoadSubtree_Response_KV> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response.KV", [
+            { no: 1, name: "key", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "value", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_LoadSubtree_Response_KV>): ResourceAPI_LoadSubtree_Response_KV {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.key = "";
+        message.value = new Uint8Array(0);
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_LoadSubtree_Response_KV>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_LoadSubtree_Response_KV): ResourceAPI_LoadSubtree_Response_KV {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string key */ 1:
+                    message.key = reader.string();
+                    break;
+                case /* bytes value */ 2:
+                    message.value = reader.bytes();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_LoadSubtree_Response_KV, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string key = 1; */
+        if (message.key !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.key);
+        /* bytes value = 2; */
+        if (message.value.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.value);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.LoadSubtree.Response.KV
+ */
+export const ResourceAPI_LoadSubtree_Response_KV = new ResourceAPI_LoadSubtree_Response_KV$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class FieldAPI$Type extends MessageType<FieldAPI> {
     constructor() {
@@ -17591,7 +18170,8 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
             { no: 5, name: "instance_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "platform", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "os", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 8, name: "arch", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 8, name: "arch", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "capabilities", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<MaintenanceAPI_Ping_Response>): MaintenanceAPI_Ping_Response {
@@ -17603,6 +18183,7 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
         message.platform = "";
         message.os = "";
         message.arch = "";
+        message.capabilities = [];
         if (value !== undefined)
             reflectionMergePartial<MaintenanceAPI_Ping_Response>(this, message, value);
         return message;
@@ -17632,6 +18213,9 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
                     break;
                 case /* string arch */ 8:
                     message.arch = reader.string();
+                    break;
+                case /* repeated string capabilities */ 9:
+                    message.capabilities.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -17666,6 +18250,9 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
         /* string arch = 8; */
         if (message.arch !== "")
             writer.tag(8, WireType.LengthDelimited).string(message.arch);
+        /* repeated string capabilities = 9; */
+        for (let i = 0; i < message.capabilities.length; i++)
+            writer.tag(9, WireType.LengthDelimited).string(message.capabilities[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -1,5 +1,10 @@
 import type { MiddleLayerEnvironment } from "./middle_layer";
-import type { FieldData, OptionalAnyResourceId, ResourceId } from "@milaboratories/pl-client";
+import type {
+  FieldData,
+  OptionalAnyResourceId,
+  PruningSpec,
+  ResourceId,
+} from "@milaboratories/pl-client";
 import {
   DefaultRetryOptions,
   ensureResourceIdNotNull,
@@ -722,6 +727,7 @@ export class Project {
       {
         ...env.ops.defaultTreeOptions,
         pruning: projectTreePruning(env.logger),
+        pruningSpec: projectTreePruningSpec,
       },
       env.logger,
     );
@@ -737,6 +743,28 @@ export class Project {
     return new Project(env, rid, projectTree);
   }
 }
+
+/** Declarative pruning spec for the project resource tree. Sent to the
+ *  server when it advertises the `loadSubtree:v1` capability, letting the
+ *  walk happen locally on the backend. Kept in lock-step with
+ *  {@link projectTreePruning}: any change here must be reflected there and
+ *  vice versa. */
+const projectTreePruningSpec: PruningSpec = [
+  { typeMatch: "prefix", typePattern: "StreamWorkdir/", action: "dropAll" },
+  {
+    typeMatch: "exact",
+    typePattern: "BlockPackCustom",
+    action: "excludeFields",
+    fieldNames: ["template"],
+  },
+  {
+    typeMatch: "exact",
+    typePattern: "UserProject",
+    action: "excludeFields",
+    fieldNamePrefixes: ["__serviceTemplate"],
+  },
+  { typeMatch: "exact", typePattern: "Blob", action: "dropAll" },
+];
 
 function projectTreePruning(logger: MiLogger): PruningFunction {
   return (r: ExtendedResourceData): FieldData[] => {

--- a/lib/node/pl-middle-layer/src/middle_layer/project_list.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_list.ts
@@ -1,6 +1,6 @@
 import type { PruningFunction } from "@milaboratories/pl-tree";
 import { SynchronizedTreeState } from "@milaboratories/pl-tree";
-import type { PlClient, ResourceId, ResourceType } from "@milaboratories/pl-client";
+import type { PlClient, PruningSpec, ResourceId, ResourceType } from "@milaboratories/pl-client";
 import { resourceTypesEqual } from "@milaboratories/pl-client";
 import type { TreeAndComputableU } from "./types";
 import type { WatchableValue } from "@milaboratories/computable";
@@ -23,6 +23,19 @@ export const ProjectsListTreePruningFunction: PruningFunction = (resource) => {
   return resource.fields;
 };
 
+/** Server-side pruning spec mirroring {@link ProjectsListTreePruningFunction}:
+ *  keep all fields on the Projects root, drop fields on every other resource
+ *  so the walk bottoms out at one level below the root. */
+export const ProjectsListTreePruningSpec: PruningSpec = [
+  {
+    typeMatch: "exact",
+    typePattern: ProjectsResourceType.name,
+    action: "includeAll",
+  },
+  // Catch-all: drop fields on any other resource and stop descending.
+  { typeMatch: "prefix", typePattern: "", action: "dropAll" },
+];
+
 export async function createProjectList(
   pl: PlClient,
   rid: ResourceId,
@@ -35,6 +48,7 @@ export async function createProjectList(
     {
       ...env.ops.defaultTreeOptions,
       pruning: ProjectsListTreePruningFunction,
+      pruningSpec: ProjectsListTreePruningSpec,
     },
     env.logger,
   );

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -2,6 +2,7 @@ import type {
   FieldData,
   OptionalResourceId,
   PlTransaction,
+  PruningSpec,
   ResourceId,
 } from "@milaboratories/pl-client";
 import Denque from "denque";
@@ -29,6 +30,15 @@ export interface TreeLoadingRequest {
    * all referenced resources, this is required to be able to pass it to tree
    * to update the state. */
   readonly pruningFunction?: PruningFunction;
+
+  /** Tree root, used as the sole seed when the server-side loader is active
+   * (see {@link loadTreeStateServerSide}). */
+  readonly root: ResourceId;
+
+  /** Wire-level pruning spec, mirroring {@link pruningFunction} but in a
+   * declarative shape transmissible to the server. Populated by callers that
+   * wish to opt into server-side loading. */
+  readonly pruningSpec?: PruningSpec;
 }
 
 /** Given the current tree state, build the request object to pass to
@@ -36,6 +46,7 @@ export interface TreeLoadingRequest {
 export function constructTreeLoadingRequest(
   tree: PlTreeState,
   pruningFunction?: PruningFunction,
+  pruningSpec?: PruningSpec,
 ): TreeLoadingRequest {
   const seedResources: ResourceId[] = [];
   const finalResources = new Set<ResourceId>();
@@ -47,7 +58,13 @@ export function constructTreeLoadingRequest(
   // if tree is empty, seeding tree reconstruction from the specified root
   if (seedResources.length === 0 && finalResources.size === 0) seedResources.push(tree.root);
 
-  return { seedResources, finalResources, pruningFunction };
+  return {
+    seedResources,
+    finalResources,
+    pruningFunction,
+    root: tree.root,
+    pruningSpec,
+  };
 }
 
 export type TreeLoadingStat = {
@@ -207,3 +224,48 @@ export async function loadTreeState(
 
   return result;
 }
+
+/** Server-side equivalent of {@link loadTreeState}: fetches the pruned
+ * subtree rooted at the tree's root in a single gRPC call, skipping any
+ * resources the client already knows are final. Requires the server to
+ * advertise the "loadSubtree:v1" capability. */
+export async function loadTreeStateServerSide(
+  tx: PlTransaction,
+  loadingRequest: TreeLoadingRequest,
+  stats?: TreeLoadingStat,
+): Promise<ExtendedResourceData[]> {
+  const startTimestamp = Date.now();
+
+  if (stats) {
+    stats.requests++;
+    // One network round-trip for the whole subtree, regardless of graph depth.
+    stats.roundTrips++;
+  }
+
+  const nodes = await tx.loadSubtree({
+    root: loadingRequest.root,
+    knownFinals: loadingRequest.finalResources,
+    pruning: loadingRequest.pruningSpec,
+    includeKv: true,
+  });
+
+  const result: ExtendedResourceData[] = nodes.map((n) => ({ ...n.resource, kv: n.kv }));
+
+  if (stats) {
+    for (const r of result) {
+      stats.retrievedResources++;
+      stats.retrievedFields += r.fields.length;
+      stats.retrievedKeyValues += r.kv.length;
+      stats.retrievedResourceDataBytes += r.data?.length ?? 0;
+      for (const kv of r.kv) stats.retrievedKeyValueBytes += kv.value.length;
+    }
+    stats.millisSpent += Date.now() - startTimestamp;
+  }
+
+  return result;
+}
+
+/** Capability token a server must advertise (via
+ * {@link PlClient.hasServerCapability}) before {@link loadTreeStateServerSide}
+ * may be used. */
+export const LoadSubtreeCapability = "loadSubtree:v1" as const;

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -10,7 +10,14 @@ import { isTimeoutOrCancelError } from "@milaboratories/pl-client";
 import type { ExtendedResourceData } from "./state";
 import { PlTreeState, TreeStateUpdateError } from "./state";
 import type { PruningFunction, TreeLoadingStat } from "./sync";
-import { constructTreeLoadingRequest, initialTreeLoadingStat, loadTreeState } from "./sync";
+import type { PruningSpec } from "@milaboratories/pl-client";
+import {
+  constructTreeLoadingRequest,
+  initialTreeLoadingStat,
+  loadTreeState,
+  loadTreeStateServerSide,
+  LoadSubtreeCapability,
+} from "./sync";
 import * as tp from "node:timers/promises";
 import type { MiLogger } from "@milaboratories/ts-helpers";
 
@@ -23,6 +30,14 @@ export type SynchronizedTreeOps = {
   /** Pruning function to limit set of fields through which tree will
    * traverse during state synchronization */
   pruning?: PruningFunction;
+
+  /** Declarative pruning spec mirroring {@link pruning}. When both are
+   * provided and the server advertises {@link LoadSubtreeCapability},
+   * {@link loadTreeStateServerSide} is used and `pruningSpec` is authoritative.
+   * Otherwise the loader falls back to the client-driven BFS and
+   * {@link pruning} is used. Callers migrating to the new loader should
+   * provide both to keep parity across old and new backends. */
+  pruningSpec?: PruningSpec;
 
   /** Interval after last sync to sleep before the next one */
   pollingInterval: number;
@@ -46,6 +61,7 @@ export class SynchronizedTreeState {
   private state: PlTreeState;
   private readonly pollingInterval: number;
   private readonly pruning?: PruningFunction;
+  private readonly pruningSpec?: PruningSpec;
   private readonly logStat?: StatLoggingMode;
   private readonly hooks: PollingComputableHooks;
   private readonly abortController = new AbortController();
@@ -56,8 +72,16 @@ export class SynchronizedTreeState {
     ops: SynchronizedTreeOps,
     private readonly logger?: MiLogger,
   ) {
-    const { finalPredicateOverride, pruning, pollingInterval, stopPollingDelay, logStat } = ops;
+    const {
+      finalPredicateOverride,
+      pruning,
+      pruningSpec,
+      pollingInterval,
+      stopPollingDelay,
+      logStat,
+    } = ops;
     this.pruning = pruning;
+    this.pruningSpec = pruningSpec;
     this.pollingInterval = pollingInterval;
     this.finalPredicate = finalPredicateOverride ?? pl.finalPredicate;
     this.logStat = logStat;
@@ -123,11 +147,21 @@ export class SynchronizedTreeState {
   /** Executed from the main loop, and initialization procedure. */
   private async refresh(stats?: TreeLoadingStat, txOps?: TxOps): Promise<void> {
     if (this.terminated) throw new Error("tree synchronization is terminated");
-    const request = constructTreeLoadingRequest(this.state, this.pruning);
+    const request = constructTreeLoadingRequest(this.state, this.pruning, this.pruningSpec);
+
+    // Pick server-side walker when the backend advertises the capability and
+    // a declarative pruning spec was supplied; fall back to the classic
+    // client-driven BFS otherwise. Both paths produce the same
+    // ExtendedResourceData[] shape and feed the same tree state.
+    const useServerSide =
+      this.pruningSpec !== undefined && this.pl.hasServerCapability(LoadSubtreeCapability);
+
     const data = await this.pl.withReadTx(
       "ReadingTree",
       async (tx) => {
-        return await loadTreeState(tx, request, stats);
+        return useServerSide
+          ? await loadTreeStateServerSide(tx, request, stats)
+          : await loadTreeState(tx, request, stats);
       },
       txOps,
     );


### PR DESCRIPTION
## Problem

Opening a project and applying block mutations (reorder/delete) walk the resource graph client-side: one gRPC round-trip per graph layer. On LAN this is invisible; on high-latency/lossy connections it compounds into multi-second hangs and `network` timeout errors. The bottleneck is architectural — not bandwidth, not payload size — so a browser app loading a heavy page over the same connection is unaffected.

See the paired pl PR for the full problem framing.

## Change

When the backend advertises the `loadSubtree:v1` capability (via `MaintenanceAPI.Ping.Response.capabilities`), tree synchronization uses the new server-side `ResourceAPI.LoadSubtree` RPC instead of the client-driven BFS. The walk happens locally on the backend against the open read transaction and streams results back in a single RPC regardless of graph depth.

Fallback is transparent — when the capability is absent, the loader uses the existing client-driven BFS with no behavior change.

### Packages touched

**`@milaboratories/pl-client`**
- `PlClient.hasServerCapability(capability: string): boolean` — reads the new `capabilities` field from Ping.
- `PlTransaction.loadSubtree(opts: LoadSubtreeOptions): Promise<LoadedSubtreeNode[]>` — wire wrapper over the new RPC.
- `PruningRule` / `PruningSpec` / `LoadSubtreeOptions` / `LoadedSubtreeNode` — declarative wire types exported publicly so pl-tree and middle-layer can describe pruning without touching proto-generated identifiers.
- TxStat gains `loadSubtreeRequests`, `loadSubtreeNodes`, `loadSubtreeFields`, `loadSubtreeBytes`.
- Proto regen is minimal — only our additions in the generated `api.ts`. Unrelated proto messages are unchanged.
- REST Ping wrapper in `ll_client.ts` defaults `capabilities` to `[]` so the REST path tolerates older openapi schemas.

**`@milaboratories/pl-tree`**
- New `loadTreeStateServerSide(tx, request, stats)` peer to existing `loadTreeState`. Same signature, same return type.
- `TreeLoadingRequest` gains `root` and optional `pruningSpec` fields.
- `SynchronizedTreeOps` gains an optional `pruningSpec`.
- `SynchronizedTreeState.refresh()` chooses the loader: if a spec is supplied **and** the client reports the capability, it calls `loadTreeStateServerSide`; otherwise it falls back to the classic loader.
- `LoadSubtreeCapability = "loadSubtree:v1"` constant exported for symmetry with the backend token.

**`@milaboratories/pl-middle-layer`**
- `projectTreePruningSpec` (in `project.ts`) — declarative equivalent of `projectTreePruning`, covering `StreamWorkdir/*`, `BlockPackCustom.template`, `UserProject.__serviceTemplate*`, `Blob`.
- `ProjectsListTreePruningSpec` (in `project_list.ts`) — declarative equivalent of `ProjectsListTreePruningFunction`.
- Both `SynchronizedTreeState.init` call sites now pass both `pruning` (function, for fallback) and `pruningSpec` (declarative, for server-side path).
- The "resource with excessive field count" warning stays in `projectTreePruning`; it fires only on the fallback path. Parity-logging on the server-side path is out of scope for this PR.

### Why both `PruningFunction` and `PruningSpec`?

The two are maintained in lock-step: the function is the authoritative filter on the classic loader, the spec is the authoritative filter on the server-side path. Unit tests in the paired pl PR cover the exact translation, so regressing one and not the other is detectable.

Keeping both avoids a breaking change for any external consumer still wiring a `PruningFunction` directly, and lets new/old backends coexist without the middle layer having to branch.

## Compatibility

Zero-impact on old backends: the switch inside `refresh()` keys on the explicit capability, so a backend that doesn't advertise it keeps using the client-driven BFS just like today. No wasted round-trip, no `UNIMPLEMENTED` probes.

Also forward-compatible: if a future feature needs similar gating, `hasServerCapability` is reusable with a different token.

## Test plan

- [x] `pnpm types:check` green in pl-client, pl-tree.
- [x] `pnpm build` green in pl-client, pl-tree, pl-middle-layer, and the desktop app (via pnpm overrides).
- [x] `pnpm fmt` applied to all three packages.
- [ ] Manual test vs a local backend built from the paired pl PR:
  - [ ] `curl /v1/ping` shows `capabilities: ["loadSubtree:v1"]`.
  - [ ] Opening a project with the new desktop + new backend uses the server-side path (one RTT per refresh in tree stats).
  - [ ] Opening a project with the new desktop + old backend (capability removed from backend) falls back to the client-driven BFS with identical UI behavior.
  - [ ] Block delete and reorder complete faster under simulated latency (`tc qdisc` or equivalent).

## Changeset

`.changeset/load-subtree-rpc.md` — minor bumps for pl-client, pl-tree, pl-middle-layer.

## Depends on

milaboratory/pl#1776 — the backend change adding `ResourceAPI.LoadSubtree` and the `capabilities` Ping field. This PR is safe to merge and ship against older pl releases (fallback kicks in); the fast path only activates once a pl with the new RPC is deployed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces server-side subtree loading (`ResourceAPI.LoadSubtree`) as a capability-gated fast path for tree synchronization, collapsing a multi-round-trip client-driven BFS into a single RPC. The fallback to the existing client-driven path is transparent and the dual `pruning`/`pruningSpec` strategy is well-designed for old/new backend coexistence. Three P2 items worth confirming before or after merging: the server's handling of empty `resourceSignature` bytes in `knownFinals`, the server's prefix-matching behaviour for an empty `typePattern` (catch-all in `ProjectsListTreePruningSpec`), and the missing `prunedFields`/`finalResourcesSkipped` stat increments on the server-side code path.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 clarifications that do not block correctness or fallback behavior.

All three comments are P2: empty signatures are a potential optimization gap (not a functional bug), the catch-all prefix is a protocol question rather than a current failure, and missing stat counters are a monitoring gap. The fallback to the client-driven BFS is fully preserved, so the worst-case scenario on a new backend is a slightly less efficient tree walk.

`lib/node/pl-client/src/core/transaction.ts` (empty signatures in knownFinals) and `lib/node/pl-middle-layer/src/middle_layer/project_list.ts` (empty-string prefix catch-all) deserve a cross-check against the paired backend PR.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/transaction.ts | Adds `loadSubtree` method wiring the new RPC; knownFinals always sent with empty signatures which may silently bypass the skip optimization |
| lib/node/pl-client/src/core/load_subtree.ts | New file: clean TypeScript-idiomatic wire types and encoder for PruningRule/PruningSpec, correctly mapping string unions to proto enums |
| lib/node/pl-client/src/core/client.ts | Adds `hasServerCapability` helper that safely reads `capabilities` from ping response; handles null/undefined server info correctly |
| lib/node/pl-client/src/core/ll_client.ts | REST ping path now defaults missing `capabilities` to `[]` so older openapi schemas don't break the capability check |
| lib/node/pl-tree/src/sync.ts | Adds `loadTreeStateServerSide` and `LoadSubtreeCapability`; prunedFields and finalResourcesSkipped stats are not populated on the server-side path |
| lib/node/pl-tree/src/synchronized_tree.ts | Capability-gated dispatch between server-side and client-driven BFS paths is clean and correct; fallback is transparent |
| lib/node/pl-middle-layer/src/middle_layer/project.ts | Adds `projectTreePruningSpec` in lock-step with `projectTreePruning`; all four pruning rules match their function equivalents |
| lib/node/pl-middle-layer/src/middle_layer/project_list.ts | Adds `ProjectsListTreePruningSpec`; catch-all rule uses empty-string prefix which needs server confirmation that `""` matches all type names |
| lib/node/pl-client/src/core/stat.ts | Four new loadSubtree stat fields added consistently across type definition, initializer, and addStat aggregator |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pl-tree/src/sync.ts`, line 1281-1315 ([link](https://github.com/milaboratory/platforma/blob/91ad225d0afab074e899757549449e944aa12072/lib/node/pl-tree/src/sync.ts#L1281-L1315)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`stats.prunedFields` and `stats.finalResourcesSkipped` silently stay at 0**

   `loadTreeStateServerSide` never updates `stats.prunedFields` or `stats.finalResourcesSkipped`. When the server-side path is active, any log or dashboard that watches these counters will always read 0, making it impossible to tell how much pruning or known-final skipping actually happened on the server. The classic `loadTreeState` increments both. This doesn't affect correctness, but monitoring parity between the two paths is already called out in the PR as a future concern for the "excessive field count" warning — the stat gap compounds that blind spot.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-tree/src/sync.ts
   Line: 1281-1315

   Comment:
   **`stats.prunedFields` and `stats.finalResourcesSkipped` silently stay at 0**

   `loadTreeStateServerSide` never updates `stats.prunedFields` or `stats.finalResourcesSkipped`. When the server-side path is active, any log or dashboard that watches these counters will always read 0, making it impossible to tell how much pruning or known-final skipping actually happened on the server. The classic `loadTreeState` increments both. This doesn't affect correctness, but monitoring parity between the two paths is already called out in the PR as a future concern for the "excessive field count" warning — the stat gap compounds that blind spot.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/node/pl-client/src/core/transaction.ts
Line: 847-852

Comment:
**Empty `resourceSignature` in `knownFinals` may silently defeat the optimization**

All `knownFinals` entries are sent with `resourceSignature: new Uint8Array(0)`. The proto doc says "Each entry must carry a signature obtained from a prior response." If the backend validates the signature and rejects empty bytes (treating the entry as a cache-miss rather than a known-final), the server will re-fetch and re-descend through every supposedly-skipped resource on every refresh — reducing the server-side path to a full tree walk rather than the incremental walk that justifies the feature. The same empty signature is sent for the root resource itself. Worth cross-checking against the paired backend PR to confirm the server accepts `Uint8Array(0)` as "no signature / skip check".

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/node/pl-tree/src/sync.ts
Line: 1281-1315

Comment:
**`stats.prunedFields` and `stats.finalResourcesSkipped` silently stay at 0**

`loadTreeStateServerSide` never updates `stats.prunedFields` or `stats.finalResourcesSkipped`. When the server-side path is active, any log or dashboard that watches these counters will always read 0, making it impossible to tell how much pruning or known-final skipping actually happened on the server. The classic `loadTreeState` increments both. This doesn't affect correctness, but monitoring parity between the two paths is already called out in the PR as a future concern for the "excessive field count" warning — the stat gap compounds that blind spot.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/node/pl-middle-layer/src/middle_layer/project_list.ts
Line: 36

Comment:
**Catch-all rule relies on empty-string prefix behavior being well-defined**

`{ typeMatch: "prefix", typePattern: "", action: "dropAll" }` is intended as a catch-all that drops every non-Projects resource. An empty prefix matches every string, so this works in standard string semantics — but the backend's prefix-matching logic should explicitly handle `""` as "match all". If the server treats an empty `type_pattern` as "no match" or as a no-op, the catch-all silently stops firing and the walk continues unbound into all subtrees. Worth a one-line comment (or a companion integration test) confirming the server treats `""` as the "match any type" wildcard.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pl-middle-layer): use server-side L..."](https://github.com/milaboratory/platforma/commit/91ad225d0afab074e899757549449e944aa12072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29368378)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->