### PR TITLE
feat(pframe): expose buildQuery on PFrameSpecDriver

### DIFF
--- a/.changeset/spec-driver-build-query-list-columns.md
+++ b/.changeset/spec-driver-build-query-list-columns.md
@@ -1,0 +1,24 @@
+---
+"@milaboratories/pl-model-common": minor
+"@milaboratories/pf-spec-driver": minor
+"@milaboratories/pl-middle-layer": patch
+---
+
+Expose `buildQuery` and `listColumns` on `PFrameSpecDriver`:
+
+- `buildQuery(input: BuildQueryInput): SpecQueryJoinEntry` — pure
+  spec-layer assembler that turns a terminal column plus an ordered
+  path of wrapping steps (linker hops, filter joins) into a
+  ready-to-compose `SpecQueryJoinEntry`. No frame handle is required
+  (wires directly to the top-level export from `pframes-rs-wasm`).
+- `listColumns(handle: SpecFrameHandle): PColumnInfo[]` — enumerates
+  every column registered in the spec frame. `hasData` is always
+  `false` for spec-only frames.
+
+Both are also routed through the QuickJS service injector, so block
+models can call `ctx.services.pframeSpec.buildQuery(...)` and
+`ctx.services.pframeSpec.listColumns(handle)`.
+
+Bumps `@milaboratories/pframes-rs-wasm` to 1.1.26 (corrected V3:
+`buildQuery` at top level, `listColumns` on the frame resource). The
+pool type switches from `PFrameWasmV2` to `PFrameWasmV3`.

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -6,13 +6,14 @@ import type {
   AxesSpec,
   AxesId,
   PColumnIdAndSpec,
+  PColumnInfo,
   PColumnSpec,
   SingleAxisSelector,
   AxisValueType,
   ColumnValueType,
 } from "./spec";
 import type { PTableColumnId, PTableColumnSpec } from "./table_common";
-import { DataQuery, SpecQuery } from "./query";
+import { DataQuery, SpecQuery, SpecQueryJoinEntry } from "./query";
 
 /** Matches a string value either exactly or by regex pattern */
 export type StringMatcher =
@@ -228,6 +229,9 @@ export interface PFrameSpecDriver {
   /** Create a spec-only PFrame from column specs. Returns a pool entry with handle and unref. */
   createSpecFrame(specs: Record<string, PColumnSpec>): PoolEntry<SpecFrameHandle>;
 
+  /** List all columns currently registered in the frame. */
+  listColumns(handle: SpecFrameHandle): PColumnInfo[];
+
   /** Discover columns compatible with given axes integration. */
   discoverColumns(
     handle: SpecFrameHandle,
@@ -239,6 +243,15 @@ export interface PFrameSpecDriver {
 
   /** Evaluates a query specification against this PFrame */
   evaluateQuery(handle: SpecFrameHandle, request: SpecQuery): EvaluateQueryResponse;
+
+  /**
+   * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
+   * ordered path of wrapping steps (linker hops, filter joins).
+   *
+   * Pure over its input — no frame handle is needed. Column ids are resolved
+   * later at {@link evaluateQuery} against the registered specs.
+   */
+  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
 
   /** Expand index-based parentAxes in AxesSpec to resolved AxisId parents in AxesId. */
   expandAxes(spec: AxesSpec): AxesId;

--- a/lib/model/pf-spec-driver/src/pframe_pool.ts
+++ b/lib/model/pf-spec-driver/src/pframe_pool.ts
@@ -15,7 +15,7 @@ import { bytesToHex } from "@noble/hashes/utils.js";
 export class PFramePool extends RefCountPoolBase<
   Record<string, PColumnSpec>,
   SpecFrameHandle,
-  PFrameInternal.PFrameWasmV2
+  PFrameInternal.PFrameWasmV3
 > {
   constructor(private readonly logger: MiLogger) {
     super();
@@ -30,14 +30,14 @@ export class PFramePool extends RefCountPoolBase<
   protected createNewResource(
     params: Record<string, PColumnSpec>,
     key: SpecFrameHandle,
-  ): PFrameInternal.PFrameWasmV2 {
+  ): PFrameInternal.PFrameWasmV3 {
     if (logPFrames()) {
       this.logger.info(`Creating SpecFrame for handle = ${key}, columns: ` + stringifyJson(params));
     }
     return createPFrame(params);
   }
 
-  public getByKey(key: SpecFrameHandle): PFrameInternal.PFrameWasmV2 {
+  public getByKey(key: SpecFrameHandle): PFrameInternal.PFrameWasmV3 {
     const resource = super.tryGetByKey(key);
     if (!resource) {
       const error = new PFrameDriverError(`Invalid SpecFrame handle`);

--- a/lib/model/pf-spec-driver/src/spec_driver.test.ts
+++ b/lib/model/pf-spec-driver/src/spec_driver.test.ts
@@ -1,4 +1,4 @@
-import type { AxisSpec, PColumnSpec } from "@milaboratories/pl-model-common";
+import type { AxisSpec, PColumnSpec, PObjectId } from "@milaboratories/pl-model-common";
 import { describe, expect, test } from "vitest";
 import { SpecDriver } from "./spec_driver";
 
@@ -198,5 +198,111 @@ describe("SpecDriver", () => {
     const linkedNames = linkedHits.map((h) => h.hit.spec.name);
     expect(linkedNames).toContain("description");
     expect(linkedNames).toContain("priority");
+  });
+
+  test("listColumns returns all registered columns", async () => {
+    await using driver = new SpecDriver();
+    const { key: handle } = driver.createSpecFrame({
+      col1: createSpec("col1"),
+      col2: createSpec("col2"),
+    });
+
+    const columns = driver.listColumns(handle);
+
+    const ids = columns.map((c) => c.columnId).sort();
+    expect(ids).toEqual(["col1", "col2"]);
+    for (const c of columns) {
+      expect(c.hasData).toBe(false);
+    }
+  });
+
+  test("buildQuery wraps a bare column with no path (no handle needed)", async () => {
+    await using driver = new SpecDriver();
+    const columnId = "c1" as PObjectId;
+
+    const entry = driver.buildQuery({ version: "v1", column: columnId });
+
+    expect(entry.entry).toEqual({ type: "column", column: columnId });
+  });
+
+  test("discoverColumns: parallel linkers with cd-disambiguated one-side axes yield 4 variants", async () => {
+    // Port of pframes-rs-spec case 42: trunk [a1] reaches hit [a3, a2] through
+    // each of two parallel linkers whose one-side exposes a2[cd=d:1] and
+    // a2[cd=d:2]. Expected: 2 path entries x 2 cd variants = 4 total variants.
+    await using driver = new SpecDriver();
+
+    const linkerAxes: AxisSpec[] = [
+      { type: "Int", name: "a3" } as AxisSpec,
+      {
+        type: "Int",
+        name: "a2",
+        parentAxes: [0],
+        contextDomain: { d: "1" },
+      } as AxisSpec,
+      {
+        type: "Int",
+        name: "a2",
+        parentAxes: [0],
+        contextDomain: { d: "2" },
+      } as AxisSpec,
+      { type: "Int", name: "a1" } as AxisSpec,
+    ];
+    const lClosest: PColumnSpec = {
+      kind: "PColumn",
+      name: "linker",
+      valueType: "Int",
+      axesSpec: linkerAxes,
+      domain: { algo: "closest" },
+      annotations: { "pl7.app/isLinkerColumn": "true" },
+    } as PColumnSpec;
+    const lFuel: PColumnSpec = {
+      kind: "PColumn",
+      name: "linker",
+      valueType: "Int",
+      axesSpec: linkerAxes,
+      domain: { algo: "fuelOpt" },
+      annotations: { "pl7.app/isLinkerColumn": "true" },
+    } as PColumnSpec;
+    const hitSpec: PColumnSpec = {
+      kind: "PColumn",
+      name: "hit",
+      valueType: "Int",
+      axesSpec: [
+        { type: "Int", name: "a3" } as AxisSpec,
+        { type: "Int", name: "a2", parentAxes: [0] } as AxisSpec,
+      ],
+      annotations: {},
+    } as PColumnSpec;
+
+    const { key: handle } = driver.createSpecFrame({
+      l_closest: lClosest,
+      l_fuel: lFuel,
+      hit: hitSpec,
+    });
+
+    const response = driver.discoverColumns(handle, {
+      axes: [{ axesSpec: [{ type: "Int", name: "a1" } as AxisSpec], qualifications: [] }],
+      maxHops: 1,
+      constraints: {
+        allowFloatingSourceAxes: true,
+        allowFloatingHitAxes: false,
+        allowSourceQualifications: false,
+        allowHitQualifications: true,
+      },
+    });
+
+    expect(response.hits).toHaveLength(2);
+    const paths = response.hits
+      .map((h) => h.path.map((s) => (s.type === "linker" ? s.linker.columnId : s.filter.columnId)))
+      .sort();
+    expect(paths).toEqual([["l_closest"], ["l_fuel"]]);
+    for (const hit of response.hits) {
+      expect(hit.hit.spec.name).toBe("hit");
+      expect(hit.mappingVariants).toHaveLength(2);
+      const cdValues = hit.mappingVariants
+        .map((v) => v.qualifications.forHit[0]?.contextDomain?.d)
+        .sort();
+      expect(cdValues).toEqual(["1", "2"]);
+    }
   });
 });

--- a/lib/model/pf-spec-driver/src/spec_driver.ts
+++ b/lib/model/pf-spec-driver/src/spec_driver.ts
@@ -1,4 +1,5 @@
 import {
+  buildQuery,
   expandAxes,
   collapseAxes,
   findAxis,
@@ -7,12 +8,15 @@ import {
 import type {
   AxesId,
   AxesSpec,
+  BuildQueryInput,
+  PColumnInfo,
   PColumnSpec,
   PFrameSpecDriver,
   PTableColumnId,
   PTableColumnSpec,
   SingleAxisSelector,
   SpecFrameHandle,
+  SpecQueryJoinEntry,
   PoolEntry,
   DiscoverColumnsRequest,
   DiscoverColumnsResponse,
@@ -60,6 +64,33 @@ export class SpecDriver implements PFrameSpecDriver, AsyncDisposable {
     } catch (err: unknown) {
       const error = new PFrameSpecDriverError(`createSpecFrame failed`);
       error.cause = ensureError(err);
+      throw error;
+    }
+  }
+
+  listColumns(handle: SpecFrameHandle): PColumnInfo[] {
+    const pframe = this.frames.getByKey(handle);
+    try {
+      if (logPFrames()) {
+        this.logger.info(`listColumns: handle = ${handle}`);
+      }
+      return pframe.listColumns();
+    } catch (err: unknown) {
+      const error = new PFrameSpecDriverError(`listColumns failed`);
+      error.cause = new Error(`handle: ${handle}, ` + `error:\n${ensureError(err)}`);
+      throw error;
+    }
+  }
+
+  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry {
+    try {
+      if (logPFrames()) {
+        this.logger.info(`buildQuery: input: ${JSON.stringify(input)}`);
+      }
+      return buildQuery(input);
+    } catch (err: unknown) {
+      const error = new PFrameSpecDriverError(`buildQuery failed`);
+      error.cause = new Error(`input: ${JSON.stringify(input)}, ` + `error:\n${ensureError(err)}`);
       throw error;
     }
   }

--- a/lib/node/pl-middle-layer/src/js_render/service_injectors.ts
+++ b/lib/node/pl-middle-layer/src/js_render/service_injectors.ts
@@ -11,6 +11,7 @@ import type {
   PTableColumnId,
   PTableColumnSpec,
   SingleAxisSelector,
+  BuildQueryInput,
   DeleteColumnRequest,
   DiscoverColumnsRequest,
   PFrameDef,
@@ -73,12 +74,20 @@ export function getServiceInjectors(): ServiceInjectorMap {
           return obj;
         },
 
+        listColumns: (handle: QuickJSHandle) =>
+          vm.exportObjectViaJson(driver.listColumns(vm.vm.getString(handle) as SpecFrameHandle)),
+
         discoverColumns: (handle: QuickJSHandle, request: QuickJSHandle) =>
           vm.exportObjectViaJson(
             driver.discoverColumns(
               vm.vm.getString(handle) as SpecFrameHandle,
               vm.importObjectViaJson(request) as DiscoverColumnsRequest,
             ),
+          ),
+
+        buildQuery: (input: QuickJSHandle) =>
+          vm.exportObjectViaJson(
+            driver.buildQuery(vm.importObjectViaJson(input) as BuildQueryInput),
           ),
 
         deleteColumn: (handle: QuickJSHandle, request: QuickJSHandle) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.25
-      version: 1.1.25
+      specifier: 1.1.26
+      version: 1.1.26
     '@milaboratories/pframes-rs-wasm':
       specifier: 1.1.26
       version: 1.1.26
@@ -1854,7 +1854,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.25(encoding@0.1.13)
+        version: 1.1.26(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
         version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
@@ -2288,7 +2288,7 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.25(encoding@0.1.13)
+        version: 1.1.26(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
         version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
@@ -4849,11 +4849,11 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.25':
-    resolution: {integrity: sha512-Vn9ua04n3cJcpRk54HnFHg0rD9mRjFkbmwEHtTfeVPH2U8YdNZyXBsG+Uy86Ml7gRxb2suR3Zv2wQ049H9bISw==}
+  '@milaboratories/pframes-rs-node@1.1.26':
+    resolution: {integrity: sha512-RAsTcdPGLDz9h3NKu/VH1gdCZnEUvq+8cNrnjsuwOPHSXjvrd2XpjcOrHlmGZPvsGze6tX9MZ8i+Qrqo/r92cA==}
 
-  '@milaboratories/pframes-rs-serv@1.1.25':
-    resolution: {integrity: sha512-sdVswwrFLle0CgXMRhHGORWWILKLpg/xQEB/hg9+kk7Hze17JWYLD6Ax4HTn8ac2ZA6n5Rk1vSeWL2u+fbN1Xw==}
+  '@milaboratories/pframes-rs-serv@1.1.26':
+    resolution: {integrity: sha512-bDh2Oj5642wicI66ZAZs8GtqmvuY0U/X0+zmBkfgNOXPfAsJ2At9LwuqfdeKROcv/A3rRzUkLH4xUAOzqNV1Bg==}
     hasBin: true
 
   '@milaboratories/pframes-rs-wasm@1.1.26':
@@ -4866,11 +4866,11 @@ packages:
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-model-common@1.32.0':
-    resolution: {integrity: sha512-S3kM5/4evfbkT058sBf5KHKmgEF+LbhiyPd/ylaFplk1clgmMSBUxOcMTi7y3iwxZrrBdZ0Nf/a+IOhVyaSryQ==}
+  '@milaboratories/pl-model-common@1.32.1':
+    resolution: {integrity: sha512-XFAJw2Re+YZ4rsgIupcNX8MlnsjU0kj53RA1LLBKps/9a5GmNadsN+vXuCaHv7TffGNweyba5gatih0Ek2AbsQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.17.0':
-    resolution: {integrity: sha512-0hmGdfIX19aQFpF1zWFUJv1z6V6G9N2YL6+F93Ls+THB3VeMXq1IHU1Jnmd5qmk3tqH6k9KZSGsMSK25HZ8z6g==}
+  '@milaboratories/pl-model-middle-layer@1.18.0':
+    resolution: {integrity: sha512-jtCXFydSA6W37a5TvJGe6UL3lrWDN9VwPx2ILqCS2ZBClypm5kqBbPiDs7Xz9zAglL5+K3XOI5opX+HmlB8CzA==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -10973,22 +10973,22 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/pframes-rs-node@1.1.25(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.26(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pframes-rs-serv': 1.1.25
-      '@milaboratories/pl-model-common': 1.32.0
+      '@milaboratories/pframes-rs-serv': 1.1.26
+      '@milaboratories/pl-model-common': 1.32.1
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.25':
+  '@milaboratories/pframes-rs-serv@1.1.26':
     dependencies:
       '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pl-model-common': 1.32.0
-      '@milaboratories/pl-model-middle-layer': 1.17.0
+      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/pl-model-middle-layer': 1.18.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
@@ -11003,17 +11003,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.32.0':
+  '@milaboratories/pl-model-common@1.32.1':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.17.0':
+  '@milaboratories/pl-model-middle-layer@1.18.0':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.32.0
+      '@milaboratories/pl-model-common': 1.32.1
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,11 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.18
-      version: 1.1.18
+      specifier: 1.1.25
+      version: 1.1.25
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.18
-      version: 1.1.18
+      specifier: 1.1.26
+      version: 1.1.26
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1734,7 +1734,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1854,10 +1854,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.18(encoding@0.1.13)
+        version: 1.1.25(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2288,10 +2288,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.18(encoding@0.1.13)
+        version: 1.1.25(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -4845,32 +4845,32 @@ packages:
     resolution: {integrity: sha512-BgwkcYrppMZzHyRpq6CgWZrns9zJr9ppSu+TIeJgozHQV+ufIujziyPttonWz2UmTVUEJh3/Q2TLp1bbbWKyNQ==}
     engines: {node: '>=22'}
 
-  '@milaboratories/helpers@1.14.0':
-    resolution: {integrity: sha512-lKzbuUJHBiGEVxqS9+EaYkuMAQt0iAohQUiIviu+2rNZHrTIvJGLBIiLBHC7fmjJM45xCKzyLG6c0tPjDUi2kQ==}
+  '@milaboratories/helpers@1.14.1':
+    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.18':
-    resolution: {integrity: sha512-zK0pq5MzbRw0ihDpUJ68+yPb/xd7fbyf7HWwazMa0bB4hFZKn8Pn1LAAfJ5GV7OdwZHG6vckB46mK5m7nOlOhg==}
+  '@milaboratories/pframes-rs-node@1.1.25':
+    resolution: {integrity: sha512-Vn9ua04n3cJcpRk54HnFHg0rD9mRjFkbmwEHtTfeVPH2U8YdNZyXBsG+Uy86Ml7gRxb2suR3Zv2wQ049H9bISw==}
 
-  '@milaboratories/pframes-rs-serv@1.1.18':
-    resolution: {integrity: sha512-1kqvvfkoC0gFl17IUdtBlRoQJzYYYJl6iMiOnFHcvHwbRUskJRw77c+r54kZW8BQ/VFY8Pgry6yY+mZk2JVrGQ==}
+  '@milaboratories/pframes-rs-serv@1.1.25':
+    resolution: {integrity: sha512-sdVswwrFLle0CgXMRhHGORWWILKLpg/xQEB/hg9+kk7Hze17JWYLD6Ax4HTn8ac2ZA6n5Rk1vSeWL2u+fbN1Xw==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasm@1.1.18':
-    resolution: {integrity: sha512-K/Th/EGE5CBtCa1+w6ikYai/LHMi71eE5y+tObSxsHrZeOUP+J704xPaDbIV4CW2XOzS3VStY9AZCrOX4GrBWA==}
+  '@milaboratories/pframes-rs-wasm@1.1.26':
+    resolution: {integrity: sha512-lP56AHUj96WWlcEoKwMn0TIS/EVAOMkXVVS42G9fypV26tGbxrxSgOlcIgRpCpdR+s1r6yoy7/hx9u97Gxvorg==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.28.0
-      '@milaboratories/pl-model-middle-layer': 1.15.0
+      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/pl-model-middle-layer': 1.18.0
 
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-model-common@1.28.0':
-    resolution: {integrity: sha512-VGfXSzep5LR8vnj7El0ksDiZEmELhT8jB7EeXv3VIOmYZj4cPYbkNsb+54wrBloMzyIc1iG1H13ucR44qbv/bw==}
+  '@milaboratories/pl-model-common@1.32.0':
+    resolution: {integrity: sha512-S3kM5/4evfbkT058sBf5KHKmgEF+LbhiyPd/ylaFplk1clgmMSBUxOcMTi7y3iwxZrrBdZ0Nf/a+IOhVyaSryQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.15.0':
-    resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
+  '@milaboratories/pl-model-middle-layer@1.17.0':
+    resolution: {integrity: sha512-0hmGdfIX19aQFpF1zWFUJv1z6V6G9N2YL6+F93Ls+THB3VeMXq1IHU1Jnmd5qmk3tqH6k9KZSGsMSK25HZ8z6g==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -10971,28 +10971,28 @@ snapshots:
 
   '@milaboratories/helpers@1.13.5': {}
 
-  '@milaboratories/helpers@1.14.0': {}
+  '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/pframes-rs-node@1.1.18(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.25(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pframes-rs-serv': 1.1.18
-      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/pframes-rs-serv': 1.1.25
+      '@milaboratories/pl-model-common': 1.32.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.18':
+  '@milaboratories/pframes-rs-serv@1.1.25':
     dependencies:
       '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pl-model-common': 1.28.0
-      '@milaboratories/pl-model-middle-layer': 1.15.0
+      '@milaboratories/pl-model-common': 1.32.0
+      '@milaboratories/pl-model-middle-layer': 1.17.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pl-model-common': link:lib/model/common
@@ -11003,20 +11003,20 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.28.0':
+  '@milaboratories/pl-model-common@1.32.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.0
+      '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.15.0':
+  '@milaboratories/pl-model-middle-layer@1.17.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.0
-      '@milaboratories/pl-model-common': 1.28.0
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-model-common': 1.32.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@milaboratories/software-pframes-conv@2.2.9': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -242,7 +242,7 @@ catalog:
   "winston": ^3.17.0
 
   "@milaboratories/tengo-tester": ^1.6.4
-  "@milaboratories/pframes-rs-node": 1.1.25
+  "@milaboratories/pframes-rs-node": 1.1.26
   "@milaboratories/pframes-rs-wasm": 1.1.26
 
   "quickjs-emscripten": 0.31.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -242,8 +242,8 @@ catalog:
   "winston": ^3.17.0
 
   "@milaboratories/tengo-tester": ^1.6.4
-  "@milaboratories/pframes-rs-node": 1.1.18
-  "@milaboratories/pframes-rs-wasm": 1.1.18
+  "@milaboratories/pframes-rs-node": 1.1.25
+  "@milaboratories/pframes-rs-wasm": 1.1.26
 
   "quickjs-emscripten": 0.31.0
 


### PR DESCRIPTION
## Summary
- Surfaces the `buildQuery` method (added in pframes-rs-wasm 1.1.25) on `PFrameSpecDriver`: a pure spec-layer assembler that turns a terminal column plus an ordered path of wrapping steps (linker hops, filter joins) into a ready-to-compose `SpecQueryJoinEntry`.
- Wires the method through the QuickJS service injector so block models can call it via `ctx.services.pframeSpec.buildQuery(...)`.
- Drops the standalone `PFrameWasmV2` interface: the name stays as a deprecated alias of `PFrameWasmV3` so type references in shipped `pframes-rs-wasm` declarations still resolve.
- Bumps `@milaboratories/pframes-rs-wasm` / `@milaboratories/pframes-rs-node` to 1.1.25.

Design reference: `docs/text/work/projects/pframes-api/05-build-query.md`.

## Test plan
- [x] `pnpm -C lib/model/pf-spec-driver test` — covers bare column and linker+filter path.
- [x] `pnpm check` — full monorepo tsc + lint + format passes.
- [ ] Block integration smoke — verify `createPlDataTable` / enrichment path continues to work against the updated driver.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR surfaces `buildQuery` on `PFrameSpecDriver`, wiring the new WASM 1.1.25 method through a lazily-created scratch frame (empty-column `PFrameWasmV3`) so the operation stays stateless and frame-handle-free. `PFrameWasmV2`/`PFrameWasmAPIV2` are collapsed to deprecated type aliases of their V3 counterparts, and the new method is exposed to block models via the QuickJS service injector.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all remaining findings are P2 style/test-coverage suggestions with no correctness impact.

The implementation is clean: scratch frame lifecycle (lazy init, disposal, post-dispose reset) is handled correctly, error wrapping is consistent with other driver methods, and the QuickJS wiring follows the established pattern. Both new tests pass; the only gap is that the fold-path test checks the outermost entry type but not the full nested structure. No P0/P1 issues found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/pf-spec-driver/src/spec_driver.ts | Adds lazy-initialized scratchFrame for stateless buildQuery calls; disposal and error handling are correct. |
| lib/model/common/src/drivers/pframe/spec_driver.ts | Adds buildQuery to PFrameSpecDriver interface and fixes JSDoc refs from PFrameWasmV4 to PFrameSpecDriver; no issues. |
| lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts | PFrameWasmV2/APIV2 collapsed to deprecated type aliases of V3/APIV3; backward-compatible since V3 is a structural superset. |
| lib/node/pl-middle-layer/src/js_render/service_injectors.ts | Wires buildQuery into the QuickJS service injector following the same pattern as other driver methods; P2 note on unvalidated input cast. |
| lib/model/pf-spec-driver/src/spec_driver.test.ts | Adds two new tests for buildQuery; bare-column test is thorough, but the path-fold test only validates the outermost entry type. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/model/pf-spec-driver/src/spec_driver.test.ts
Line: 246-254

Comment:
**Shallow assertion on fold structure**

The test only checks that the outermost entry type is `"linkerJoin"` but doesn't verify the fold is correct: that the inner `innerJoin` wraps the terminal column and that the filter column id is wired correctly. A single mis-ordering (filter → linker instead of linker → filter) or wrong column id in the inner entry would pass this test silently. Consider also asserting on `result.entry.linker`, the inner entry type, and the terminal column.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/node/pl-middle-layer/src/js_render/service_injectors.ts
Line: 99-102

Comment:
**Unvalidated `as` cast for QuickJS input**

`vm.importObjectViaJson(input) as BuildQueryInput` performs no runtime schema check before passing the deserialized object into the WASM layer. A block model that sends a malformed payload (e.g. wrong `version`, missing `column`) will hit the WASM throw path rather than a friendly validation error. This is consistent with other injectors in this file (e.g. `expandAxes`), but since `buildQuery` is brand-new surface exposed to user-authored block models it may be worth adding a zod/guard check here or in `SpecDriver.buildQuery` itself.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframe): expose buildQuery on PFram..."](https://github.com/milaboratory/platforma/commit/01cd52570f25c6ae999b287f9a223ae8ed0e2014) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29428261)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->