### PR TITLE
Column collection builder reimplementing

### DIFF
--- a/.changeset/empty-pandas-happen.md
+++ b/.changeset/empty-pandas-happen.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-model-common": patch
+"@platforma-sdk/ui-vue": patch
+"@platforma-sdk/model": patch
+---
+
+refactoring column_collection_builder

--- a/etc/blocks/model-test/model/src/index.ts
+++ b/etc/blocks/model-test/model/src/index.ts
@@ -9,7 +9,6 @@ import {
   type InferHrefType,
   type InferOutputsType,
   type InferPluginNames,
-  getService,
 } from "@platforma-sdk/model";
 
 // =============================================================================
@@ -79,13 +78,13 @@ export const counterPlugin = PluginModel.define({
   .output("isEven", (ctx) => {
     return ctx.data.count % 2 === 0;
   })
-  .output("specFrameTest", () => {
-    const entry = getService("pframeSpec").createSpecFrame({});
+  .output("specFrameTest", (ctx) => {
+    const entry = ctx.getService("pframeSpec").createSpecFrame({});
     entry.unref();
     return `specFrame: created and manually disposed`;
   })
-  .output("pframeTest", () => {
-    const handle = getService("pframe").createPFrame([]);
+  .output("pframeTest", (ctx) => {
+    const handle = ctx.getService("pframe").createPFrame([]);
     return `pframe: created handle ${handle}`;
   })
   .build();
@@ -137,8 +136,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
     ctx.outputs?.resolve("delayedContent")?.getDataAsString(),
   )
 
-  .output("blockSpecFrameTest", () => {
-    getService("pframeSpec").createSpecFrame({});
+  .output("blockSpecFrameTest", (ctx) => {
+    ctx.getService("pframeSpec").createSpecFrame({});
     return `blockSpecFrame: created (auto-disposed)`;
   })
 

--- a/etc/blocks/model-test/model/src/index.ts
+++ b/etc/blocks/model-test/model/src/index.ts
@@ -9,6 +9,7 @@ import {
   type InferHrefType,
   type InferOutputsType,
   type InferPluginNames,
+  getService,
 } from "@platforma-sdk/model";
 
 // =============================================================================
@@ -78,13 +79,13 @@ export const counterPlugin = PluginModel.define({
   .output("isEven", (ctx) => {
     return ctx.data.count % 2 === 0;
   })
-  .output("specFrameTest", (ctx) => {
-    const entry = ctx.services.pframeSpec.createSpecFrame({});
+  .output("specFrameTest", () => {
+    const entry = getService("pframeSpec").createSpecFrame({});
     entry.unref();
     return `specFrame: created and manually disposed`;
   })
-  .output("pframeTest", (ctx) => {
-    const handle = ctx.services.pframe.createPFrame([]);
+  .output("pframeTest", () => {
+    const handle = getService("pframe").createPFrame([]);
     return `pframe: created handle ${handle}`;
   })
   .build();
@@ -136,8 +137,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
     ctx.outputs?.resolve("delayedContent")?.getDataAsString(),
   )
 
-  .output("blockSpecFrameTest", (ctx) => {
-    ctx.services.pframeSpec.createSpecFrame({});
+  .output("blockSpecFrameTest", () => {
+    getService("pframeSpec").createSpecFrame({});
     return `blockSpecFrame: created (auto-disposed)`;
   })
 

--- a/etc/blocks/model-test/model/src/index.ts
+++ b/etc/blocks/model-test/model/src/index.ts
@@ -144,7 +144,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   .outputWithStatus("blockTableTest", (ctx) => {
     return createPlDataTable(ctx, {
       tableState: ctx.data.tableState,
-      discoverColumnOptions: {
+      columns: {
         anchors: {
           main: {
             kind: "PColumn",
@@ -153,7 +153,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
             axesSpec: [{ type: "String", name: "item" }],
           },
         },
-        columnsSelector: {
+        selector: {
           include: [{ name: [{ type: "exact", value: "mock_score" }] }],
         },
       },

--- a/etc/blocks/model-test/test/src/wf.test.ts
+++ b/etc/blocks/model-test/test/src/wf.test.ts
@@ -67,7 +67,7 @@ blockTest(
     await project.runBlock(blockId);
     const blockState = await helpers.awaitBlockDoneAndGetStableBlockState(blockId);
 
-    // Block-level pframeSpec service (via ctx.services.pframeSpec)
+    // Block-level pframeSpec service
     expect(blockState.outputs?.blockSpecFrameTest).toStrictEqual({
       ok: true,
       value: "blockSpecFrame: created (auto-disposed)",
@@ -83,14 +83,14 @@ blockTest(
     // Plugin outputs are keyed with a prefix — access via plain record
     const outputs = blockState.outputs as Record<string, unknown> | undefined;
 
-    // Plugin-level pframeSpec service (via plugin ctx.services.pframeSpec)
+    // Plugin-level pframeSpec service
     expect(outputs?.[pluginOutputKey("counter" as any, "specFrameTest")]).toStrictEqual({
       ok: true,
       value: "specFrame: created and manually disposed",
       stable: true,
     });
 
-    // Plugin-level pframe service (via plugin ctx.services.pframe)
+    // Plugin-level pframe service
     const pframeOutput = outputs?.[pluginOutputKey("counter" as any, "pframeTest")] as any;
     expect(pframeOutput).toMatchObject({ ok: true, stable: true });
     expect(pframeOutput?.value).toMatch(/^pframe: created handle/);

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -41,6 +41,19 @@ export const platforma = BlockModelV3.create(blockDataModel)
     return createPlDataTableV3(ctx, {
       tableState: ctx.data.tableState,
 
+      columns: {
+        anchors: {
+          main: {
+            name: "value",
+            axes: [{ name: "name" }],
+          },
+        },
+        selector: {
+          mode: "related",
+          maxHops: 4,
+        },
+      },
+
       sorting: [
         {
           column: {
@@ -63,25 +76,12 @@ export const platforma = BlockModelV3.create(blockDataModel)
         ],
       } as PlDataTableFilters,
 
-      discoverColumnOptions: {
-        anchors: {
-          main: {
-            name: "value",
-            axes: [{ name: "name" }],
-          },
-        },
-        columnsSelector: {
-          mode: "related",
-          maxHops: 4,
-        },
-      },
-
       labelsOptions: {
         // Custom linker label formatter to verify linker path labels in the UI.
         // Default would produce "via L1 > L2"; this makes it "[L1 > L2]" for easy visual identification.
         linkerLabelFormatter: (linkerLabels) => `[${linkerLabels.join(" > ")}]`,
       },
-      columnsDisplayOptions: {
+      displayOptions: {
         ordering: [
           // "category" leftmost (highest priority)
           { match: (spec) => spec.name === "category", priority: 20 },

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -49,7 +49,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
           },
         },
         selector: {
-          mode: "related",
+          mode: "enrichment",
           maxHops: 4,
         },
       },

--- a/etc/blocks/table-test/workflow/src/main.tpl.tengo
+++ b/etc/blocks/table-test/workflow/src/main.tpl.tengo
@@ -27,6 +27,20 @@ wf.body(func(args) {
 		"D\tG2\t1\n" +
 		"E\tG1\t1\n"
 
+	// --- Alternate linker: second path "name" -> "group" ---
+	// Exercises multi-variant discovery for group-axis columns (createPlDataTableV3.ts
+	// → deriveAllTooltips → withInfoAnnotations at utils.ts#L192-208).
+	// Two linker columns with same axes pair (name, group) produce two MatchVariants
+	// per hit column on the group axis — each variant gets its own distinctiveQualifications
+	// and linkerPath, so deriveDistinctTooltips emits a distinct tooltip per variant and
+	// withInfoAnnotations writes Annotation.Table.Info for each.
+	linkerAltTsv := "name\tgroup\tlinkAlt\n" +
+		"A\tG1\t1\n" +
+		"B\tG1\t1\n" +
+		"C\tG2\t1\n" +
+		"D\tG2\t1\n" +
+		"E\tG1\t1\n"
+
 	// --- Second-hop linked data: columns on "region" axis ---
 	regionTsv := "region\tregionName\tpopulation\n" +
 		"R1\tNorth\t1000\n" +
@@ -61,6 +75,7 @@ wf.body(func(args) {
 		writeFile("main.tsv", mainTsv).
 		writeFile("group.tsv", groupTsv).
 		writeFile("linker.tsv", linkerTsv).
+		writeFile("linkerAlt.tsv", linkerAltTsv).
 		writeFile("region.tsv", regionTsv).
 		writeFile("linker2.tsv", linker2Tsv).
 		writeFile("nameLabel.tsv", nameLabelTsv).
@@ -69,6 +84,7 @@ wf.body(func(args) {
 		saveFile("main.tsv").
 		saveFile("group.tsv").
 		saveFile("linker.tsv").
+		saveFile("linkerAlt.tsv").
 		saveFile("region.tsv").
 		saveFile("linker2.tsv").
 		saveFile("nameLabel.tsv").
@@ -79,6 +95,7 @@ wf.body(func(args) {
 	mainFile := e.getFile("main.tsv")
 	groupFile := e.getFile("group.tsv")
 	linkerFile := e.getFile("linker.tsv")
+	linkerAltFile := e.getFile("linkerAlt.tsv")
 	regionFile := e.getFile("region.tsv")
 	linker2File := e.getFile("linker2.tsv")
 	nameLabelFile := e.getFile("nameLabel.tsv")
@@ -213,6 +230,34 @@ wf.body(func(args) {
 		partitionKeyLength: 0
 	}
 
+	// Second linker over the same (name, group) axes pair. Distinct native id
+	// ensures it survives dedup in collectColumns. During discoverColumns this
+	// yields a second MatchVariant for each group-axis hit column, producing
+	// `distinctiveQualifications` and variantCount=2 in deriveAllTooltips.
+	linkerAltSpec := {
+		axes: [{
+			column: "group",
+			spec: groupAxisSpec
+		}, {
+			column: "name",
+			spec: nameAxisSpec
+		}],
+		columns: [{
+			column: "linkAlt",
+			id: "linker_name_group_alt",
+			spec: {
+				name: "linker_name_group_alt",
+				valueType: "Int",
+				annotations: {
+					"pl7.app/linkLabel": "Name-Group Linker (Alt)",
+					"pl7.app/isLinkerColumn": "true"
+				}
+			}
+		}],
+		storageFormat: "Binary",
+		partitionKeyLength: 0
+	}
+
 	regionSpec := {
 		axes: [{
 			column: "region",
@@ -331,6 +376,7 @@ wf.body(func(args) {
 	mainPf := xsv.importFile(mainFile, "tsv", mainSpec, importOps)
 	groupPf := xsv.importFile(groupFile, "tsv", groupSpec, importOps)
 	linkerPf := xsv.importFile(linkerFile, "tsv", linkerSpec, importOps)
+	linkerAltPf := xsv.importFile(linkerAltFile, "tsv", linkerAltSpec, importOps)
 	regionPf := xsv.importFile(regionFile, "tsv", regionSpec, importOps)
 	linker2Pf := xsv.importFile(linker2File, "tsv", linker2Spec, importOps)
 	nameLabelPf := xsv.importFile(nameLabelFile, "tsv", nameLabelSpec, importOps)
@@ -346,6 +392,9 @@ wf.body(func(args) {
 		pf.add(k, v.spec, v.data)
 	}
 	for k, v in linkerPf {
+		pf.add(k, v.spec, v.data)
+	}
+	for k, v in linkerAltPf {
 		pf.add(k, v.spec, v.data)
 	}
 	for k, v in regionPf {

--- a/etc/blocks/table-test/workflow/src/main.tpl.tengo
+++ b/etc/blocks/table-test/workflow/src/main.tpl.tengo
@@ -19,24 +19,21 @@ wf.body(func(args) {
 		"G1\tFirst group\t1\n" +
 		"G2\tSecond group\t2\n"
 
-	// --- Linker: maps "name" -> "group" ---
+	// --- Linker A: maps "name" -> "group" (group axis domain: source=primary) ---
+	// Partial coverage — maps A,B,C only.
 	linkerTsv := "name\tgroup\tlink\n" +
 		"A\tG1\t1\n" +
 		"B\tG1\t1\n" +
-		"C\tG2\t1\n" +
-		"D\tG2\t1\n" +
-		"E\tG1\t1\n"
+		"C\tG2\t1\n"
 
-	// --- Alternate linker: second path "name" -> "group" ---
-	// Exercises multi-variant discovery for group-axis columns (createPlDataTableV3.ts
-	// → deriveAllTooltips → withInfoAnnotations at utils.ts#L192-208).
-	// Two linker columns with same axes pair (name, group) produce two MatchVariants
-	// per hit column on the group axis — each variant gets its own distinctiveQualifications
-	// and linkerPath, so deriveDistinctTooltips emits a distinct tooltip per variant and
-	// withInfoAnnotations writes Annotation.Table.Info for each.
+	// --- Linker B: second path "name" -> "group" (group axis domain: source=secondary) ---
+	// Partial coverage — maps C,D,E only. Different group-axis domain than linker A.
+	// Two linkers over the same (name, group) axis pair but with DIFFERENT group-axis
+	// domains produce MatchVariants whose qualifications on the hit's group axis carry
+	// distinct contextDomain values — populating `distinctiveQualifications` (non-empty
+	// forHit) for each group-axis hit column. Feeds formatDistinctive in
+	// deriveDistinctTooltips and withInfoAnnotations per-variant records.
 	linkerAltTsv := "name\tgroup\tlinkAlt\n" +
-		"A\tG1\t1\n" +
-		"B\tG1\t1\n" +
 		"C\tG2\t1\n" +
 		"D\tG2\t1\n" +
 		"E\tG1\t1\n"
@@ -110,12 +107,67 @@ wf.body(func(args) {
 		}
 	}
 
+	nameAxisSpecPrimary := {
+		name: "name",
+		type: "String",
+		annotations: {
+			"pl7.app/label": "Name"
+		},
+		domain: {
+			"pl7.app/source": "primary"
+		}
+	}
+
+	nameAxisSpecSecondary := {
+		name: "name",
+		type: "String",
+		annotations: {
+			"pl7.app/label": "Name"
+		},
+		domain: {
+			"pl7.app/source": "secondary"
+		}
+	}
+
 	groupAxisSpec := {
 		name: "group",
 		type: "String",
 		annotations: {
 			"pl7.app/label": "Group"
 		}
+	}
+
+	groupAxisSpecHit := {
+		name: "group",
+		type: "String",
+		annotations: {
+			"pl7.app/label": "Group hit"
+		},
+		parentAxes: [0]
+	}
+
+	groupAxisSpecPrimary := {
+		name: "group",
+		type: "String",
+		annotations: {
+			"pl7.app/label": "Group primary"
+		},
+		domain: {
+			"pl7.app/source": "primary"
+		},
+		parentAxes: [0]
+	}
+
+	groupAxisSpecSecondary := {
+		name: "group",
+		type: "String",
+		annotations: {
+			"pl7.app/label": "Group secondary"
+		},
+		domain: {
+			"pl7.app/source": "secondary"
+		},
+		parentAxes: [0]
 	}
 
 	regionAxisSpec := {
@@ -180,6 +232,9 @@ wf.body(func(args) {
 		axes: [{
 			column: "group",
 			spec: groupAxisSpec
+		}, {
+			column: "group",
+			spec: groupAxisSpecHit
 		}],
 		columns: [{
 			column: "description",
@@ -206,10 +261,17 @@ wf.body(func(args) {
 		partitionKeyLength: 0
 	}
 
+	// Linker A: group axis domain=source:primary. Carries rows A,B,C only.
 	linkerSpec := {
 		axes: [{
 			column: "group",
 			spec: groupAxisSpec
+		}, {
+			column: "group",
+			spec: groupAxisSpecPrimary
+		}, {
+			column: "group",
+			spec: groupAxisSpecSecondary
 		}, {
 			column: "name",
 			spec: nameAxisSpec
@@ -221,7 +283,7 @@ wf.body(func(args) {
 				name: "linker_name_group",
 				valueType: "Int",
 				annotations: {
-					"pl7.app/linkLabel": "Name-Group Linker",
+					"pl7.app/linkLabel": "Name-Group Linker (primary)",
 					"pl7.app/isLinkerColumn": "true"
 				}
 			}
@@ -230,10 +292,12 @@ wf.body(func(args) {
 		partitionKeyLength: 0
 	}
 
-	// Second linker over the same (name, group) axes pair. Distinct native id
-	// ensures it survives dedup in collectColumns. During discoverColumns this
-	// yields a second MatchVariant for each group-axis hit column, producing
-	// `distinctiveQualifications` and variantCount=2 in deriveAllTooltips.
+	// Linker B: group axis domain=source:secondary. Carries rows C,D,E only.
+	// Same (name, group) axis pair as linker A by name/type but with a distinct
+	// axis `domain` — discoverColumns emits a MatchVariant whose hit-axis
+	// qualification carries contextDomain={pl7.app/source: secondary}, which
+	// differs from linker A's variant. That delta populates
+	// `distinctiveQualifications.forHit` on both variants.
 	linkerAltSpec := {
 		axes: [{
 			column: "group",
@@ -249,7 +313,7 @@ wf.body(func(args) {
 				name: "linker_name_group_alt",
 				valueType: "Int",
 				annotations: {
-					"pl7.app/linkLabel": "Name-Group Linker (Alt)",
+					"pl7.app/linkLabel": "Name-Group Linker (secondary)",
 					"pl7.app/isLinkerColumn": "true"
 				}
 			}
@@ -394,9 +458,9 @@ wf.body(func(args) {
 	for k, v in linkerPf {
 		pf.add(k, v.spec, v.data)
 	}
-	for k, v in linkerAltPf {
-		pf.add(k, v.spec, v.data)
-	}
+	// for k, v in linkerAltPf {
+	// 	pf.add(k, v.spec, v.data)
+	// }
 	for k, v in regionPf {
 		pf.add(k, v.spec, v.data)
 	}

--- a/etc/blocks/table-test/workflow/src/main.tpl.tengo
+++ b/etc/blocks/table-test/workflow/src/main.tpl.tengo
@@ -458,9 +458,9 @@ wf.body(func(args) {
 	for k, v in linkerPf {
 		pf.add(k, v.spec, v.data)
 	}
-	// for k, v in linkerAltPf {
-	// 	pf.add(k, v.spec, v.data)
-	// }
+	for k, v in linkerAltPf {
+		pf.add(k, v.spec, v.data)
+	}
 	for k, v in regionPf {
 		pf.add(k, v.spec, v.data)
 	}

--- a/lib/model/common/src/drivers/pframe/spec/anchored.ts
+++ b/lib/model/common/src/drivers/pframe/spec/anchored.ts
@@ -31,9 +31,9 @@ function domainKey(key: string, value: string): string {
  * Maintains maps of known domain values and axes that can be referenced by anchors
  */
 export class AnchoredIdDeriver {
+  private readonly axes = new Map<string, AnchorAxisRefByIdx>();
   private readonly domains = new Map<string, string>();
   private readonly contextDomains = new Map<string, string>();
-  private readonly axes = new Map<string, AnchorAxisRefByIdx>();
   /**
    * Domain packs are used to group domain keys that can be anchored to the same anchor
    * This is used to optimize the lookup of domain anchors
@@ -244,6 +244,7 @@ export type ResolveAnchorsOptions = {
  * @param matcher - An anchored column matcher (or id, which is subtype of it) containing references that need to be resolved
  * @param options - Options for resolving anchors
  * @returns A non-anchored column matcher with all references resolved to actual values
+ * @deprecated - This function by parent PColumnCollection
  */
 export function resolveAnchors(
   anchors: Record<string, Pick<PColumnSpec, "axesSpec" | "domain" | "contextDomain">>,

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -35,7 +35,7 @@ export function createDiscoveredPColumn(props: {
   columnQualifications: AxisQualification[];
   queriesQualifications: Record<PObjectId, AxisQualification[]>;
 }): DiscoveredPColumn {
-  return structuredClone(props);
+  return JSON.parse(JSON.stringify(props));
 }
 
 export function createDiscoveredPColumnId(props: {

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -1,0 +1,72 @@
+import { Branded, throwError } from "@milaboratories/helpers";
+import { PObjectId } from "../../../pool";
+import { AxisQualification } from "../spec_driver";
+import canonicalize from "canonicalize";
+
+export type DiscoveredPColumn = {
+  path: PathItem[];
+  column: PObjectId;
+  columnQualifications: AxisQualification[];
+  // queriesAxes???
+  queriesQualifications: AxisQualification[][];
+};
+
+export type DiscoveredPColumnId = Branded<PObjectId, DiscoveredPColumn>;
+
+type PathItem = {
+  column: PObjectId;
+  qualifications: AxisQualification[];
+};
+
+export function isDiscoveredPColumn(obj: unknown): obj is DiscoveredPColumn {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "path" in obj &&
+    "column" in obj &&
+    "columnQualifications" in obj &&
+    "queriesQualifications" in obj
+  );
+}
+
+export function createDiscoveredPColumn(
+  column: PObjectId,
+  path: PathItem[],
+  columnQualifications: AxisQualification[],
+  queriesQualifications: AxisQualification[][],
+): DiscoveredPColumn {
+  return {
+    column,
+    path,
+    columnQualifications,
+    queriesQualifications,
+  };
+}
+
+export function createDiscoveredPColumnId(
+  column: PObjectId,
+  path: PathItem[],
+  columnQualifications: AxisQualification[],
+  queriesQualifications: AxisQualification[][],
+): DiscoveredPColumnId {
+  return stringifyDiscoveredPColumnId(
+    createDiscoveredPColumn(column, path, columnQualifications, queriesQualifications),
+  );
+}
+
+export function parseDiscoveredPColumnId(id: DiscoveredPColumnId): DiscoveredPColumn {
+  try {
+    const parsed = JSON.parse(id);
+    return isDiscoveredPColumn(parsed)
+      ? parsed
+      : throwError("Parsed object is not a valid DiscoveredPColumn");
+  } catch {
+    throw new Error(
+      "Invalid DiscoveredPColumnId: not a valid JSON or does not conform to DiscoveredPColumn structure",
+    );
+  }
+}
+
+export function stringifyDiscoveredPColumnId(id: DiscoveredPColumn): DiscoveredPColumnId {
+  return canonicalize(id) as DiscoveredPColumnId;
+}

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -7,7 +7,6 @@ export type DiscoveredPColumn = {
   path: PathItem[];
   column: PObjectId;
   columnQualifications: AxisQualification[];
-  // queriesAxes???
   queriesQualifications: Record<PObjectId, AxisQualification[]>;
 };
 

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -1,19 +1,20 @@
 import { Branded, throwError } from "@milaboratories/helpers";
 import { PObjectId } from "../../../pool";
 import { AxisQualification } from "../spec_driver";
-import canonicalize from "canonicalize";
+import { canonicalizeJson } from "../../../json";
 
 export type DiscoveredPColumn = {
   path: PathItem[];
   column: PObjectId;
   columnQualifications: AxisQualification[];
   // queriesAxes???
-  queriesQualifications: AxisQualification[][];
+  queriesQualifications: Record<PObjectId, AxisQualification[]>;
 };
 
-export type DiscoveredPColumnId = Branded<PObjectId, DiscoveredPColumn>;
+export type DiscoveredPColumnId = Branded<PObjectId, "DiscoveredPColumnId">; // CanonicalizedJson<DiscoveredPColumn>;
 
 type PathItem = {
+  type: "linker";
   column: PObjectId;
   qualifications: AxisQualification[];
 };
@@ -29,29 +30,22 @@ export function isDiscoveredPColumn(obj: unknown): obj is DiscoveredPColumn {
   );
 }
 
-export function createDiscoveredPColumn(
-  column: PObjectId,
-  path: PathItem[],
-  columnQualifications: AxisQualification[],
-  queriesQualifications: AxisQualification[][],
-): DiscoveredPColumn {
-  return {
-    column,
-    path,
-    columnQualifications,
-    queriesQualifications,
-  };
+export function createDiscoveredPColumn(props: {
+  column: PObjectId;
+  path: PathItem[];
+  columnQualifications: AxisQualification[];
+  queriesQualifications: Record<PObjectId, AxisQualification[]>;
+}): DiscoveredPColumn {
+  return structuredClone(props);
 }
 
-export function createDiscoveredPColumnId(
-  column: PObjectId,
-  path: PathItem[],
-  columnQualifications: AxisQualification[],
-  queriesQualifications: AxisQualification[][],
-): DiscoveredPColumnId {
-  return stringifyDiscoveredPColumnId(
-    createDiscoveredPColumn(column, path, columnQualifications, queriesQualifications),
-  );
+export function createDiscoveredPColumnId(props: {
+  column: PObjectId;
+  path: PathItem[];
+  columnQualifications: AxisQualification[];
+  queriesQualifications: Record<PObjectId, AxisQualification[]>;
+}): DiscoveredPColumnId {
+  return stringifyDiscoveredPColumnId(createDiscoveredPColumn(props));
 }
 
 export function parseDiscoveredPColumnId(id: DiscoveredPColumnId): DiscoveredPColumn {
@@ -67,9 +61,6 @@ export function parseDiscoveredPColumnId(id: DiscoveredPColumnId): DiscoveredPCo
   }
 }
 
-export function stringifyDiscoveredPColumnId(id: DiscoveredPColumn): DiscoveredPColumnId {
-  return (
-    (canonicalize(id) as undefined | DiscoveredPColumnId) ??
-    throwError("Failed to stringify DiscoveredPColumnId")
-  );
+export function stringifyDiscoveredPColumnId(id: DiscoveredPColumn) {
+  return canonicalizeJson<DiscoveredPColumn>(id) as string as DiscoveredPColumnId;
 }

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -68,5 +68,8 @@ export function parseDiscoveredPColumnId(id: DiscoveredPColumnId): DiscoveredPCo
 }
 
 export function stringifyDiscoveredPColumnId(id: DiscoveredPColumn): DiscoveredPColumnId {
-  return canonicalize(id) as DiscoveredPColumnId;
+  return (
+    (canonicalize(id) as undefined | DiscoveredPColumnId) ??
+    throwError("Failed to stringify DiscoveredPColumnId")
+  );
 }

--- a/lib/model/common/src/drivers/pframe/spec/ids.ts
+++ b/lib/model/common/src/drivers/pframe/spec/ids.ts
@@ -3,10 +3,12 @@ import type { AnchoredPColumnId } from "./selectors";
 import type { FilteredPColumnId } from "./filtered_column";
 import canonicalize from "canonicalize";
 import type { PObjectId } from "../../../pool";
+import { DiscoveredPColumn } from "./discovered_column";
+
 /**
  * Universal column identifier optionally anchored and optionally filtered.
  */
-export type UniversalPColumnId = AnchoredPColumnId | FilteredPColumnId;
+export type UniversalPColumnId = AnchoredPColumnId | FilteredPColumnId | DiscoveredPColumn;
 
 /**
  * Canonically serialized {@link UniversalPColumnId}.

--- a/lib/model/common/src/drivers/pframe/spec/index.ts
+++ b/lib/model/common/src/drivers/pframe/spec/index.ts
@@ -4,3 +4,4 @@ export * from "./filtered_column";
 export * from "./spec";
 export * from "./selectors";
 export * from "./native_id";
+export * from "./discovered_column";

--- a/lib/model/common/src/drivers/pframe/spec/spec.ts
+++ b/lib/model/common/src/drivers/pframe/spec/spec.ts
@@ -164,6 +164,7 @@ export const Annotation = {
     FontFamily: "pl7.app/table/fontFamily",
     OrderPriority: "pl7.app/table/orderPriority",
     Visibility: "pl7.app/table/visibility",
+    Info: "pl7.app/table/info",
   },
   Trace: "pl7.app/trace",
   VDJ: {
@@ -205,6 +206,7 @@ export type Annotation = Metadata &
     [Annotation.Table.FontFamily]: string;
     [Annotation.Table.OrderPriority]: StringifiedJson<number>;
     [Annotation.Table.Visibility]: "hidden" | "optional" | (string & {});
+    [Annotation.Table.Info]: string;
     [Annotation.Trace]: StringifiedJson<Trace>;
     [Annotation.VDJ.IsAssemblingFeature]: StringifiedJson<boolean>;
   }>;

--- a/lib/model/common/src/services/service_types.ts
+++ b/lib/model/common/src/services/service_types.ts
@@ -78,28 +78,32 @@ export interface ServiceDispatch {
 // Auto-derived types from the Services const in service_declarations.ts.
 // Adding a service to Services automatically updates all of these.
 
-type SMap = typeof Services;
+type TServices = typeof Services;
 
 type ExtractServiceName<T> = T extends Branded<infer N extends string, any> ? N : never;
 
 /** Model-side service interfaces keyed by service name literal. */
 export type ModelServices = {
-  [K in keyof SMap as ExtractServiceName<SMap[K]>]: InferServiceModel<ServiceBrand<SMap[K]>>;
+  [K in keyof TServices as ExtractServiceName<TServices[K]>]: InferServiceModel<
+    ServiceBrand<TServices[K]>
+  >;
 };
 
 /** UI-side service interfaces keyed by service name literal. */
 export type UiServices = {
-  [K in keyof SMap as ExtractServiceName<SMap[K]>]: InferServiceUi<ServiceBrand<SMap[K]>>;
+  [K in keyof TServices as ExtractServiceName<TServices[K]>]: InferServiceUi<
+    ServiceBrand<TServices[K]>
+  >;
 };
 
 /** Map from Services keys to their unbranded string name literals. */
 export type ServiceNameLiterals = {
-  [K in keyof SMap]: ExtractServiceName<SMap[K]>;
+  [K in keyof TServices]: ExtractServiceName<TServices[K]>;
 };
 
 /** Auto-derived requires* feature flags from Services keys. */
 export type ServiceRequireFlags = {
-  [K in keyof SMap as `requires${K & string}`]?: boolean;
+  [K in keyof TServices as `requires${K & string}`]?: boolean;
 };
 
 export type RequireServices<T extends ServiceName> = UnionToIntersection<

--- a/sdk/model/src/block_model.ts
+++ b/sdk/model/src/block_model.ts
@@ -6,12 +6,11 @@ import type {
   BlockCodeKnownFeatureFlags,
   BlockConfigContainer,
 } from "@milaboratories/pl-model-common";
-import { resolveRequiredServices } from "@milaboratories/pl-model-common";
 import { getPlatformaInstance, isInUI, createAndRegisterRenderLambda } from "./internal";
 import type { DataModel } from "./block_migrations";
 import type { PlatformaV3 } from "./platforma";
 import type { BlockDefaultUiServices } from "./services/service_resolve";
-import { blockServiceNames, BLOCK_SERVICE_FLAGS } from "./services/block_services";
+import { BLOCK_SERVICE_FLAGS } from "./services/block_services";
 import type { InferRenderFunctionReturn, RenderFunction } from "./render";
 import { BlockRenderCtx, PluginRenderCtx } from "./render";
 import type { PluginData, PluginModel, PluginOutputs, PluginParams } from "./plugin_model";
@@ -237,7 +236,7 @@ export class BlockModelV3<
         ...this.config.outputs,
         [key]: createAndRegisterRenderLambda({
           handle: `block-output#${key}`,
-          lambda: () => cfgOrRf(new BlockRenderCtx<Args, Data>(blockServiceNames)),
+          lambda: () => cfgOrRf(new BlockRenderCtx<Args, Data>()),
           ...flags,
         }),
       },
@@ -335,7 +334,7 @@ export class BlockModelV3<
         sections: createAndRegisterRenderLambda(
           {
             handle: "sections",
-            lambda: () => rf(new BlockRenderCtx<Args, Data>(blockServiceNames)),
+            lambda: () => rf(new BlockRenderCtx<Args, Data>()),
           },
           true,
         ),
@@ -351,7 +350,7 @@ export class BlockModelV3<
       ...this.config,
       title: createAndRegisterRenderLambda({
         handle: "title",
-        lambda: () => rf(new BlockRenderCtx<Args, Data>(blockServiceNames)),
+        lambda: () => rf(new BlockRenderCtx<Args, Data>()),
       }),
     });
   }
@@ -363,7 +362,7 @@ export class BlockModelV3<
       ...this.config,
       subtitle: createAndRegisterRenderLambda({
         handle: "subtitle",
-        lambda: () => rf(new BlockRenderCtx<Args, Data>(blockServiceNames)),
+        lambda: () => rf(new BlockRenderCtx<Args, Data>()),
       }),
     });
   }
@@ -375,7 +374,7 @@ export class BlockModelV3<
       ...this.config,
       tags: createAndRegisterRenderLambda({
         handle: "tags",
-        lambda: () => rf(new BlockRenderCtx<Args, Data>(blockServiceNames)),
+        lambda: () => rf(new BlockRenderCtx<Args, Data>()),
       }),
     });
   }
@@ -536,8 +535,6 @@ export class BlockModelV3<
 
     const { dataModel, argsFunction, prerunArgsFunction } = this.config;
 
-    const mergedServiceNames = resolveRequiredServices(this.config.featureFlags);
-
     function getPlugin(handle: PluginHandle): PluginRecord {
       const plugin = plugins[handle];
       if (!plugin) throw new Error(`Plugin model not found for '${handle}'`);
@@ -577,7 +574,7 @@ export class BlockModelV3<
       // Wrap plugin param lambdas: close over BlockRenderCtx creation
       const wrappedInputs: Record<string, () => unknown> = {};
       for (const [paramKey, paramFn] of Object.entries(inputs)) {
-        wrappedInputs[paramKey] = () => paramFn(new BlockRenderCtx(mergedServiceNames));
+        wrappedInputs[paramKey] = () => paramFn(new BlockRenderCtx());
       }
 
       // Register plugin outputs (in config pack, evaluated by middle layer)
@@ -587,7 +584,7 @@ export class BlockModelV3<
         const key = pluginOutputKey(handle, outputKey);
         pluginOutputs[key] = createAndRegisterRenderLambda({
           handle: key,
-          lambda: () => outputFn(new PluginRenderCtx(handle, wrappedInputs, mergedServiceNames)),
+          lambda: () => outputFn(new PluginRenderCtx(handle, wrappedInputs)),
           withStatus: outputFlags[outputKey]?.withStatus,
         });
       }

--- a/sdk/model/src/columns/column_collection_builder.test.ts
+++ b/sdk/model/src/columns/column_collection_builder.test.ts
@@ -395,6 +395,57 @@ describe("AnchoredColumnCollection", () => {
     expect(col1Match.variants).toBeDefined();
   });
 
+  test("variants carry forAnchors keyed by anchor name", () => {
+    const spec = createSpec("col1", { axesSpec: [sampleAxis("sample")] });
+    const snap = createSnapshot("id1", spec);
+    const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
+    builder.addSource([snap, anchorSnap]);
+
+    const collection = builder.build({ anchors: { main: anchorSpec } })!;
+    const matches = collection.findColumns();
+    const col1Match = matches.find((m) => m.column.spec.name === "col1")!;
+
+    expect(col1Match.variants.length).toBeGreaterThan(0);
+    for (const v of col1Match.variants) {
+      expect(v.qualifications.forAnchors).toBeDefined();
+      expect(v.qualifications.forHit).toBeDefined();
+      expect(v.distinctiveQualifications.forAnchors).toBeDefined();
+      expect(v.distinctiveQualifications.forHit).toBeDefined();
+      // forAnchors keys are a subset of anchor names
+      for (const key of Object.keys(v.qualifications.forAnchors)) {
+        expect(["main"]).toContain(key);
+      }
+    }
+  });
+
+  test("anchors sharing same axes group produce forAnchors entries pointing to same array", () => {
+    // Two anchors with identical axesSpec share an axes-group bucket in the reverse index.
+    const sharedAxes = [sampleAxis("sample"), sampleAxis("gene")];
+    const anchorA = createSpec("anchor-a", { axesSpec: sharedAxes });
+    const anchorB = createSpec("anchor-b", { axesSpec: sharedAxes });
+    const anchorASnap = createSnapshot("anchor-a-id", anchorA);
+    const anchorBSnap = createSnapshot("anchor-b-id", anchorB);
+
+    const colSpec = createSpec("c1", { axesSpec: [sampleAxis("sample")] });
+    const colSnap = createSnapshot("c1-id", colSpec);
+
+    const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
+    builder.addSource([colSnap, anchorASnap, anchorBSnap]);
+
+    const collection = builder.build({ anchors: { a: anchorA, b: anchorB } })!;
+    const matches = collection.findColumns();
+    const c1 = matches.find((m) => m.column.spec.name === "c1")!;
+    expect(c1).toBeDefined();
+
+    for (const v of c1.variants) {
+      const forAnchors = v.qualifications.forAnchors;
+      if ("a" in forAnchors && "b" in forAnchors) {
+        // Shared axes group → same reference for both anchor keys.
+        expect(forAnchors.a).toBe(forAnchors.b);
+      }
+    }
+  });
+
   test("findColumns exclude filters out matching columns", () => {
     const snap1 = createSnapshot("id1", createSpec("col1", { axesSpec: [sampleAxis("sample")] }));
     const snap2 = createSnapshot("id2", createSpec("col2", { axesSpec: [sampleAxis("sample")] }));

--- a/sdk/model/src/columns/column_collection_builder.test.ts
+++ b/sdk/model/src/columns/column_collection_builder.test.ts
@@ -1,10 +1,4 @@
-import type {
-  AxisSpec,
-  PColumnSpec,
-  PObjectId,
-  SUniversalPColumnId,
-} from "@milaboratories/pl-model-common";
-import { AnchoredIdDeriver } from "@milaboratories/pl-model-common";
+import type { AxisSpec, PColumnSpec, PObjectId } from "@milaboratories/pl-model-common";
 import { SpecDriver } from "@milaboratories/pf-spec-driver";
 
 import { afterEach, describe, expect, test } from "vitest";
@@ -122,25 +116,26 @@ describe("ColumnCollectionBuilder", () => {
   });
 });
 
-describe("ColumnCollection.getColumn", () => {
-  test("returns snapshot for existing id", () => {
+describe("ColumnCollection lookup by id", () => {
+  test("findColumns includes snapshot with existing id", () => {
     const spec = createSpec("col1");
     const snap = createSnapshot("id1", spec);
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
     builder.addSource([snap]);
 
     const collection = builder.build()!;
-    const found = collection.getColumn("id1" as PObjectId);
+    const found = collection.findColumns().find((c) => c.id === ("id1" as PObjectId));
     expect(found).toBeDefined();
     expect(found!.spec.name).toBe("col1");
   });
 
-  test("returns undefined for missing id", () => {
+  test("findColumns does not include missing id", () => {
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
     builder.addSource([createSnapshot("id1", createSpec("col1"))]);
 
     const collection = builder.build()!;
-    expect(collection.getColumn("missing" as PObjectId)).toBeUndefined();
+    const found = collection.findColumns().find((c) => c.id === ("missing" as PObjectId));
+    expect(found).toBeUndefined();
   });
 });
 
@@ -232,7 +227,7 @@ describe("data status handling", () => {
     builder.addSource([snap]);
     const collection = builder.build()!;
 
-    const found = collection.getColumn("id1" as PObjectId)!;
+    const found = collection.findColumns().find((c) => c.id === ("id1" as PObjectId))!;
     expect(found.dataStatus).toBe("ready");
     expect(found.data).toBeDefined();
     expect(found.data!.get()).toBe(data);
@@ -245,7 +240,7 @@ describe("data status handling", () => {
     builder.addSource([snap]);
     const collection = builder.build()!;
 
-    const found = collection.getColumn("id1" as PObjectId)!;
+    const found = collection.findColumns().find((c) => c.id === ("id1" as PObjectId))!;
     expect(found.dataStatus).toBe("computing");
     expect(found.data).toBeDefined();
 
@@ -260,7 +255,7 @@ describe("data status handling", () => {
     builder.addSource([snap]);
     const collection = builder.build()!;
 
-    const found = collection.getColumn("id1" as PObjectId)!;
+    const found = collection.findColumns().find((c) => c.id === ("id1" as PObjectId))!;
     expect(found.dataStatus).toBe("absent");
     expect(found.data).toBeUndefined();
   });
@@ -338,7 +333,7 @@ describe("AnchoredColumnCollection", () => {
     );
   });
 
-  test("getColumn returns snapshot by SUniversalPColumnId", () => {
+  test("findColumns surfaces column by original PObjectId", () => {
     const spec = createSpec("col1", { axesSpec: [sampleAxis("sample")] });
     const snap = createSnapshot("id1", spec);
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
@@ -346,22 +341,22 @@ describe("AnchoredColumnCollection", () => {
 
     const collection = builder.build({ anchors: { main: anchorSpec } })!;
 
-    const idDeriver = new AnchoredIdDeriver({ main: anchorSpec });
-    const expectedId = idDeriver.deriveS(spec);
-
-    const found = collection.getColumn(expectedId);
+    const matches = collection.findColumns();
+    const found = matches.find((m) => m.column.id === ("id1" as PObjectId));
     expect(found).toBeDefined();
-    expect(found!.spec.name).toBe("col1");
-    expect(found!.id).toBe(expectedId);
+    expect(found!.column.spec.name).toBe("col1");
   });
 
-  test("getColumn returns undefined for unknown id", () => {
+  test("findColumns does not include unknown id", () => {
     const snap = createSnapshot("id1", createSpec("col1", { axesSpec: [sampleAxis("sample")] }));
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
     builder.addSource([snap, anchorSnap]);
 
     const collection = builder.build({ anchors: { main: anchorSpec } })!;
-    expect(collection.getColumn("not-a-real-id" as SUniversalPColumnId)).toBeUndefined();
+    const found = collection
+      .findColumns()
+      .find((m) => m.column.id === ("not-a-real-id" as PObjectId));
+    expect(found).toBeUndefined();
   });
 
   test("getAnchors returns resolved anchor map", () => {
@@ -377,7 +372,7 @@ describe("AnchoredColumnCollection", () => {
     expect(anchors.get("main")!.spec.name).toBe("anchor-col");
   });
 
-  test("findColumns returns ColumnMatch with originalId and variants", () => {
+  test("findColumns returns ColumnMatch with column id and variants", () => {
     const spec = createSpec("col1", { axesSpec: [sampleAxis("sample")] });
     const snap = createSnapshot("id1", spec);
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
@@ -391,11 +386,11 @@ describe("AnchoredColumnCollection", () => {
     expect(matches.length).toBeGreaterThanOrEqual(1);
     const col1Match = matches.find((m) => m.column.spec.name === "col1")!;
     expect(col1Match).toBeDefined();
-    expect(col1Match.originalId).toBe("id1");
+    expect(col1Match.column.id).toBe("id1");
     expect(col1Match.variants).toBeDefined();
   });
 
-  test("variants carry forAnchors keyed by anchor name", () => {
+  test("variants carry forQueries keyed by anchor PObjectId", () => {
     const spec = createSpec("col1", { axesSpec: [sampleAxis("sample")] });
     const snap = createSnapshot("id1", spec);
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
@@ -407,18 +402,18 @@ describe("AnchoredColumnCollection", () => {
 
     expect(col1Match.variants.length).toBeGreaterThan(0);
     for (const v of col1Match.variants) {
-      expect(v.qualifications.forAnchors).toBeDefined();
+      expect(v.qualifications.forQueries).toBeDefined();
       expect(v.qualifications.forHit).toBeDefined();
-      expect(v.distinctiveQualifications.forAnchors).toBeDefined();
+      expect(v.distinctiveQualifications.forQueries).toBeDefined();
       expect(v.distinctiveQualifications.forHit).toBeDefined();
-      // forAnchors keys are a subset of anchor names
-      for (const key of Object.keys(v.qualifications.forAnchors)) {
-        expect(["main"]).toContain(key);
+      // forQueries keys are a subset of anchor ids
+      for (const key of Object.keys(v.qualifications.forQueries)) {
+        expect([anchorSnap.id]).toContain(key);
       }
     }
   });
 
-  test("anchors sharing same axes group produce forAnchors entries pointing to same array", () => {
+  test("anchors sharing same axes group produce forQueries entries pointing to same array", () => {
     // Two anchors with identical axesSpec share an axes-group bucket in the reverse index.
     const sharedAxes = [sampleAxis("sample"), sampleAxis("gene")];
     const anchorA = createSpec("anchor-a", { axesSpec: sharedAxes });
@@ -438,10 +433,10 @@ describe("AnchoredColumnCollection", () => {
     expect(c1).toBeDefined();
 
     for (const v of c1.variants) {
-      const forAnchors = v.qualifications.forAnchors;
-      if ("a" in forAnchors && "b" in forAnchors) {
-        // Shared axes group → same reference for both anchor keys.
-        expect(forAnchors.a).toBe(forAnchors.b);
+      const forQueries = v.qualifications.forQueries;
+      if (anchorASnap.id in forQueries && anchorBSnap.id in forQueries) {
+        // Shared axes group → equal qualifications for both anchor keys.
+        expect(forQueries[anchorASnap.id]).toStrictEqual(forQueries[anchorBSnap.id]);
       }
     }
   });
@@ -488,9 +483,8 @@ describe("AnchoredColumnCollection", () => {
 
     const collection = builder.build({ anchors: { main: anchorSpec } })!;
 
-    const idDeriver = new AnchoredIdDeriver({ main: anchorSpec });
-    const found = collection.getColumn(idDeriver.deriveS(spec))!;
-    expect(found.dataStatus).toBe("computing");
-    expect(found.data!.get()).toBeUndefined();
+    const found = collection.findColumns().find((m) => m.column.id === ("id1" as PObjectId))!;
+    expect(found.column.dataStatus).toBe("computing");
+    expect(found.column.data!.get()).toBeUndefined();
   });
 });

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -4,6 +4,7 @@ import type {
   DiscoverColumnsConstraints,
   DiscoverColumnsRequest,
   DiscoverColumnsResponse,
+  DiscoverColumnsResponseQualifications,
   MultiColumnSelector,
   NativePObjectId,
   PColumnIdAndSpec,
@@ -108,10 +109,11 @@ export interface MatchVariant {
   }[];
 }
 
-/** Qualifications needed for both query (already-integrated) columns and the hit column. */
+/** Qualifications needed for both already-integrated anchor columns and the hit column. */
 export interface MatchQualifications {
-  /** Qualifications for each query (already-integrated) column set. */
-  readonly forQueries: AxisQualification[][];
+  /** Qualifications for already-integrated anchor columns, keyed by anchor key.
+   *  Anchors sharing the same axes group reference the same `AxisQualification[]` array. */
+  readonly forAnchors: Record<string, AxisQualification[]>;
   /** Qualifications for the hit column. */
   readonly forHit: AxisQualification[];
 }
@@ -277,6 +279,8 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
 
   private readonly idDeriver: AnchoredIdDeriver;
   private readonly uniqAnchorAxes: ColumnAxesWithQualifications[];
+  /** axesGroupIdx (position in uniqAnchorAxes) → anchor keys resolving to that group. */
+  private readonly anchorsByAxesGroup: Map<number, string[]>;
   private readonly idToOriginalIdMap: Map<SUniversalPColumnId, PObjectId>;
   private readonly specFrameEntry: PoolEntry<SpecFrameHandle>;
 
@@ -299,16 +303,44 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
         Array.from(this.anchorsMap.entries()).map(([k, v]) => [k, v.spec] as const),
       ),
     );
+    const axesGroupKey = (axis: ColumnAxesWithQualifications) =>
+      canonicalizeJson(getAxesId(axis.axesSpec)) + canonicalizeJson(axis.qualifications);
     this.uniqAnchorAxes = uniqBy(
       Array.from(this.anchorsMap.values(), ({ spec }) => ({
         axesSpec: spec.axesSpec,
         qualifications: [],
       })),
-      (axis) => canonicalizeJson(getAxesId(axis.axesSpec)) + canonicalizeJson(axis.qualifications),
+      axesGroupKey,
+    );
+    const axesGroupIdxByKey = new Map(
+      this.uniqAnchorAxes.map((axis, i) => [axesGroupKey(axis), i]),
+    );
+    this.anchorsByAxesGroup = Array.from(this.anchorsMap.entries()).reduce<Map<number, string[]>>(
+      (acc, [anchorKey, { spec }]) => {
+        const idx =
+          axesGroupIdxByKey.get(axesGroupKey({ axesSpec: spec.axesSpec, qualifications: [] })) ??
+          throwError(`Anchor "${anchorKey}": axes group missing from uniqAnchorAxes index`);
+        const bucket = acc.get(idx);
+        if (bucket === undefined) acc.set(idx, [anchorKey]);
+        else bucket.push(anchorKey);
+        return acc;
+      },
+      new Map(),
     );
     this.idToOriginalIdMap = new Map(
       options.columns.map((col) => [this.idDeriver.deriveS(col.spec), col.id] as const),
     );
+  }
+
+  private toForAnchors(q: DiscoverColumnsResponseQualifications): MatchQualifications {
+    const forAnchors = q.forQueries.reduce<Record<string, AxisQualification[]>>(
+      (acc, qs, groupIdx) => {
+        for (const key of this.anchorsByAxesGroup.get(groupIdx) ?? []) acc[key] = qs;
+        return acc;
+      },
+      {},
+    );
+    return { forAnchors, forHit: q.forHit };
   }
 
   dispose(): void {
@@ -362,7 +394,11 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
         ),
         qualifications: step.qualifications,
       }));
-      const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({ ...v, path }));
+      const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({
+        path,
+        qualifications: this.toForAnchors(v.qualifications),
+        distinctiveQualifications: this.toForAnchors(v.distinctiveQualifications),
+      }));
       const existing = acc.get(associatedId);
       return acc.set(
         associatedId,

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -303,22 +303,20 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
         Array.from(this.anchorsMap.entries()).map(([k, v]) => [k, v.spec] as const),
       ),
     );
-    const axesGroupKey = (axis: ColumnAxesWithQualifications) =>
-      canonicalizeJson(getAxesId(axis.axesSpec)) + canonicalizeJson(axis.qualifications);
     this.uniqAnchorAxes = uniqBy(
       Array.from(this.anchorsMap.values(), ({ spec }) => ({
         axesSpec: spec.axesSpec,
         qualifications: [],
       })),
-      axesGroupKey,
+      getAxesGroupKey,
     );
     const axesGroupIdxByKey = new Map(
-      this.uniqAnchorAxes.map((axis, i) => [axesGroupKey(axis), i]),
+      this.uniqAnchorAxes.map((axis, i) => [getAxesGroupKey(axis), i]),
     );
     this.anchorsByAxesGroup = Array.from(this.anchorsMap.entries()).reduce<Map<number, string[]>>(
       (acc, [anchorKey, { spec }]) => {
         const idx =
-          axesGroupIdxByKey.get(axesGroupKey({ axesSpec: spec.axesSpec, qualifications: [] })) ??
+          axesGroupIdxByKey.get(getAxesGroupKey({ axesSpec: spec.axesSpec, qualifications: [] })) ??
           throwError(`Anchor "${anchorKey}": axes group missing from uniqAnchorAxes index`);
         const bucket = acc.get(idx);
         if (bucket === undefined) acc.set(idx, [anchorKey]);
@@ -412,6 +410,10 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
   }
 }
 
+function getAxesGroupKey(axis: ColumnAxesWithQualifications) {
+  return canonicalizeJson(getAxesId(axis.axesSpec)) + canonicalizeJson(axis.qualifications);
+}
+
 /**
  * Collect all columns from all providers, dedup by NativePObjectId.
  * First source wins.
@@ -494,6 +496,7 @@ function resolveAnchorMap(
         maxHops: 0,
         constraints: matchingModeToConstraints("exact"),
       });
+
       if (matched.hits.length === 0) {
         throwError(`Anchor "${key}": no columns matched selector`);
       }

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -29,6 +29,7 @@ import { ArrayColumnProvider, toColumnSnapshotProvider } from "./column_snapshot
 import type { PFrameSpecDriver, PoolEntry, SpecFrameHandle } from "@milaboratories/pl-model-common";
 import { throwError } from "@milaboratories/helpers";
 import { uniqBy } from "es-toolkit";
+import { getService } from "../services";
 
 // --- FindColumnsOptions ---
 
@@ -139,7 +140,7 @@ export interface AnchoredBuildOptions extends BuildOptions {
 export class ColumnCollectionBuilder {
   private readonly providers: ColumnSnapshotProvider[] = [];
 
-  constructor(private readonly specDriver: PFrameSpecDriver) {}
+  constructor(private readonly specDriver: PFrameSpecDriver = getService("pframeSpec")) {}
 
   /**
    * Register a column source. Sources added first take precedence for dedup.

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -1,35 +1,23 @@
 import type {
   AxisQualification,
-  ColumnAxesWithQualifications,
   DiscoverColumnsConstraints,
   DiscoverColumnsRequest,
   DiscoverColumnsResponse,
-  DiscoverColumnsResponseQualifications,
   MultiColumnSelector,
   NativePObjectId,
-  PColumnIdAndSpec,
   PColumnSpec,
   PObjectId,
-  SUniversalPColumnId,
 } from "@milaboratories/pl-model-common";
-import {
-  AnchoredIdDeriver,
-  canonicalizeJson,
-  deriveNativeId,
-  getAxesId,
-  isPColumnSpec,
-} from "@milaboratories/pl-model-common";
+import { deriveNativeId, isPColumnSpec } from "@milaboratories/pl-model-common";
 import type { ColumnSelector, RelaxedColumnSelector } from "./column_selector";
 import { convertColumnSelectorToMultiColumnSelector } from "./column_selector";
 import { TreeNodeAccessor } from "../render/accessor";
 import type { ColumnSnapshot } from "./column_snapshot";
-import { createColumnSnapshot } from "./column_snapshot";
 import type { ColumnSnapshotProvider, ColumnSource } from "./column_snapshot_provider";
 import { ArrayColumnProvider, toColumnSnapshotProvider } from "./column_snapshot_provider";
 
 import type { PFrameSpecDriver, PoolEntry, SpecFrameHandle } from "@milaboratories/pl-model-common";
 import { throwError } from "@milaboratories/helpers";
-import { uniqBy } from "es-toolkit";
 import { getService } from "../services";
 
 // --- FindColumnsOptions ---
@@ -49,9 +37,6 @@ export interface ColumnCollection extends Disposable {
   /** Release the underlying spec frame WASM resource. */
   dispose(): void;
 
-  /** Point lookup by provider-native ID. */
-  getColumn(id: PObjectId): undefined | ColumnSnapshot<PObjectId>;
-
   /** Find columns matching selectors. Returns flat list of snapshots.
    *  No axis compatibility matching, no linker traversal.
    *  Never returns undefined — the "not ready" state was absorbed by the builder. */
@@ -66,10 +51,7 @@ export interface AnchoredColumnCollection extends Disposable {
   dispose(): void;
 
   /** List of anchors used for discovery, with their resolved specs. */
-  getAnchors(): Map<string, PColumnIdAndSpec>;
-
-  /** Point lookup by anchored ID. */
-  getColumn(id: SUniversalPColumnId): undefined | ColumnSnapshot<SUniversalPColumnId>;
+  getAnchors(): Map<string, ColumnSnapshot<PObjectId>>;
 
   /** Axis-aware column discovery. */
   findColumns(options?: AnchoredFindColumnsOptions): ColumnMatch[];
@@ -89,9 +71,7 @@ export interface AnchoredFindColumnsOptions extends FindColumnsOptions {
 /** Result of anchored discovery — column snapshot + routing info. */
 export interface ColumnMatch {
   /** Column snapshot with anchored SUniversalPColumnId. */
-  readonly column: ColumnSnapshot<SUniversalPColumnId>;
-  /** Provider-native ID — for lookups back to the source provider. */
-  readonly originalId: PObjectId;
+  readonly column: ColumnSnapshot<PObjectId>;
   /** Match variants — different ways (paths/qualifications) to reach this column. */
   readonly variants: MatchVariant[];
 }
@@ -104,16 +84,15 @@ export interface MatchVariant {
   readonly distinctiveQualifications: MatchQualifications;
   /** Linker steps traversed to reach this hit; empty for direct matches. */
   readonly path: {
-    linker: ColumnSnapshot<SUniversalPColumnId>;
+    linker: ColumnSnapshot<PObjectId>;
     qualifications: AxisQualification[];
   }[];
 }
 
 /** Qualifications needed for both already-integrated anchor columns and the hit column. */
 export interface MatchQualifications {
-  /** Qualifications for already-integrated anchor columns, keyed by anchor key.
-   *  Anchors sharing the same axes group reference the same `AxisQualification[]` array. */
-  readonly forAnchors: Record<string, AxisQualification[]>;
+  /** Qualifications for already-integrated anchor columns */
+  readonly forQueries: Record<PObjectId, AxisQualification[]>;
   /** Qualifications for the hit column. */
   readonly forHit: AxisQualification[];
 }
@@ -235,12 +214,6 @@ class ColumnCollectionImpl implements ColumnCollection, Disposable {
     this.dispose();
   }
 
-  getColumn(id: PObjectId): undefined | ColumnSnapshot<PObjectId> {
-    const col = this.columns.get(id);
-    if (col === undefined) return undefined;
-    return this.toSnapshot(col);
-  }
-
   findColumns(options?: FindColumnsOptions): ColumnSnapshot<PObjectId>[] {
     const includeColumns = options?.include ? toMultiColumnSelectors(options.include) : undefined;
     const excludeColumns = options?.exclude ? toMultiColumnSelectors(options.exclude) : undefined;
@@ -256,14 +229,9 @@ class ColumnCollectionImpl implements ColumnCollection, Disposable {
     // Map hits back to snapshots
     const results = response.hits
       .map((hit) => this.columns.get(hit.hit.columnId as PObjectId))
-      .filter((col): col is ColumnSnapshot<PObjectId> => col !== undefined)
-      .map((col) => this.toSnapshot(col));
+      .filter((col): col is ColumnSnapshot<PObjectId> => col !== undefined);
 
     return results;
-  }
-
-  private toSnapshot(col: ColumnSnapshot<PObjectId>): ColumnSnapshot<PObjectId> {
-    return remapSnapshot(col.id, col);
   }
 }
 
@@ -274,14 +242,8 @@ interface AnchoredColumnCollectionImplOptions extends ColumnCollectionImplOption
 }
 
 class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposable {
-  private readonly anchorsMap: Map<string, PColumnIdAndSpec>;
+  private readonly anchorsMap: Map<string, ColumnSnapshot<PObjectId>>;
   private readonly columnsMap: Map<PObjectId, ColumnSnapshot<PObjectId>>;
-
-  private readonly idDeriver: AnchoredIdDeriver;
-  private readonly uniqAnchorAxes: ColumnAxesWithQualifications[];
-  /** axesGroupIdx (position in uniqAnchorAxes) → anchor keys resolving to that group. */
-  private readonly anchorsByAxesGroup: Map<number, string[]>;
-  private readonly idToOriginalIdMap: Map<SUniversalPColumnId, PObjectId>;
   private readonly specFrameEntry: PoolEntry<SpecFrameHandle>;
 
   constructor(
@@ -298,47 +260,6 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
       options.columns,
       this.specDriver.discoverColumns.bind(this.specDriver, this.specFrameEntry.key),
     );
-    this.idDeriver = new AnchoredIdDeriver(
-      Object.fromEntries(
-        Array.from(this.anchorsMap.entries()).map(([k, v]) => [k, v.spec] as const),
-      ),
-    );
-    this.uniqAnchorAxes = uniqBy(
-      Array.from(this.anchorsMap.values(), ({ spec }) => ({
-        axesSpec: spec.axesSpec,
-        qualifications: [],
-      })),
-      getAxesGroupKey,
-    );
-    const axesGroupIdxByKey = new Map(
-      this.uniqAnchorAxes.map((axis, i) => [getAxesGroupKey(axis), i]),
-    );
-    this.anchorsByAxesGroup = Array.from(this.anchorsMap.entries()).reduce<Map<number, string[]>>(
-      (acc, [anchorKey, { spec }]) => {
-        const idx =
-          axesGroupIdxByKey.get(getAxesGroupKey({ axesSpec: spec.axesSpec, qualifications: [] })) ??
-          throwError(`Anchor "${anchorKey}": axes group missing from uniqAnchorAxes index`);
-        const bucket = acc.get(idx);
-        if (bucket === undefined) acc.set(idx, [anchorKey]);
-        else bucket.push(anchorKey);
-        return acc;
-      },
-      new Map(),
-    );
-    this.idToOriginalIdMap = new Map(
-      options.columns.map((col) => [this.idDeriver.deriveS(col.spec), col.id] as const),
-    );
-  }
-
-  private toForAnchors(q: DiscoverColumnsResponseQualifications): MatchQualifications {
-    const forAnchors = q.forQueries.reduce<Record<string, AxisQualification[]>>(
-      (acc, qs, groupIdx) => {
-        for (const key of this.anchorsByAxesGroup.get(groupIdx) ?? []) acc[key] = qs;
-        return acc;
-      },
-      {},
-    );
-    return { forAnchors, forHit: q.forHit };
   }
 
   dispose(): void {
@@ -349,16 +270,8 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
     this.dispose();
   }
 
-  getAnchors(): Map<string, PColumnIdAndSpec> {
+  getAnchors(): Map<string, ColumnSnapshot<PObjectId>> {
     return this.anchorsMap;
-  }
-
-  getColumn(id: SUniversalPColumnId): undefined | ColumnSnapshot<SUniversalPColumnId> {
-    const origId = this.idToOriginalIdMap.get(id);
-    if (origId === undefined) return undefined;
-    const col = this.columnsMap.get(origId);
-    if (col === undefined) return undefined;
-    return remapSnapshot(id, col);
   }
 
   findColumns(options?: AnchoredFindColumnsOptions): ColumnMatch[] {
@@ -366,52 +279,45 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
     const constraints = matchingModeToConstraints(mode);
     const includeColumns = options?.include ? toMultiColumnSelectors(options.include) : undefined;
     const excludeColumns = options?.exclude ? toMultiColumnSelectors(options.exclude) : undefined;
-
+    const anchors = Array.from(this.anchorsMap.values());
     const response = this.specDriver.discoverColumns(this.specFrameEntry.key, {
       includeColumns,
       excludeColumns,
       constraints,
       maxHops: options?.maxHops ?? 4,
-      axes: this.uniqAnchorAxes,
+      axes: anchors.map((anchor) => ({
+        axesSpec: anchor.spec.axesSpec,
+        qualifications: [],
+      })),
     });
 
-    // Group WASM hits by anchored column id — each physical column appears once;
-    // alternative linker paths become extra entries in `variants`, each carrying
-    // its own `path`. Callers expand variants into distinct table columns.
-    const byColumn = response.hits.reduce<Map<SUniversalPColumnId, ColumnMatch>>((acc, hit) => {
+    const byColumn = response.hits.reduce<Map<PObjectId, ColumnMatch>>((acc, hit) => {
       const origId = hit.hit.columnId as PObjectId;
       const col =
         this.columnsMap.get(origId) ??
         throwError(`Column with id ${origId} not found in collection`);
-      const associatedId = this.idDeriver.deriveS(col.spec);
       const path = hit.path.map((step) => ({
-        linker: remapSnapshot(
-          this.idDeriver.deriveS(step.linker.spec),
+        linker:
           this.columnsMap.get(step.linker.columnId) ??
-            throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
-        ),
+          throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
         qualifications: step.qualifications,
       }));
       const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({
         path,
-        qualifications: this.toForAnchors(v.qualifications),
-        distinctiveQualifications: this.toForAnchors(v.distinctiveQualifications),
+        qualifications: remapFromIdxToId(v.qualifications, anchors),
+        distinctiveQualifications: remapFromIdxToId(v.distinctiveQualifications, anchors),
       }));
-      const existing = acc.get(associatedId);
+      const existing = acc.get(origId);
       return acc.set(
-        associatedId,
+        origId,
         existing === undefined
-          ? { column: remapSnapshot(associatedId, col), originalId: origId, variants }
+          ? { column: col, variants }
           : { ...existing, variants: [...existing.variants, ...variants] },
       );
     }, new Map());
 
     return Array.from(byColumn.values());
   }
-}
-
-function getAxesGroupKey(axis: ColumnAxesWithQualifications) {
-  return canonicalizeJson(getAxesId(axis.axesSpec)) + canonicalizeJson(axis.qualifications);
 }
 
 /**
@@ -437,14 +343,6 @@ function collectColumns(providers: ColumnSnapshotProvider[]): ColumnSnapshot<POb
 
 // --- Shared snapshot helpers ---
 
-/** Create a new snapshot with a different ID, preserving data accessors. */
-function remapSnapshot<Id extends PObjectId>(
-  id: Id,
-  col: ColumnSnapshot<PObjectId>,
-): ColumnSnapshot<Id> {
-  return createColumnSnapshot(id, col.spec, col.data, col.dataStatus);
-}
-
 /** Normalize SDK ColumnSelectorInput to MultiColumnSelector[]. */
 function toMultiColumnSelectors(input: ColumnSelector): MultiColumnSelector[] {
   return convertColumnSelectorToMultiColumnSelector(input);
@@ -461,32 +359,32 @@ function resolveAnchorMap(
   anchors: Record<string, AnchorEntry>,
   columns: ColumnSnapshot<PObjectId>[],
   discoverColumns: (request: DiscoverColumnsRequest) => DiscoverColumnsResponse,
-): Map<string, PColumnIdAndSpec> {
-  const result = new Map<string, PColumnIdAndSpec>();
+): Map<string, ColumnSnapshot<PObjectId>> {
+  const result = new Map<string, ColumnSnapshot<PObjectId>>();
   const resovedIds = new Set<PObjectId>();
   const getDuplicateError = (key: string) =>
     `Anchor "${key}": selector matched a column that was already matched by another anchor; please refine the selector to match a different column`;
 
-  for (const [key, anchor] of Object.entries(anchors)) {
+  for (const [name, anchor] of Object.entries(anchors)) {
     if (typeof anchor === "string") {
       const found =
         columns.find((col) => col.id === anchor) ??
-        throwError(`Anchor "${key}": column with id "${anchor}" not found in sources`);
+        throwError(`Anchor "${name}": column with id "${anchor}" not found in sources`);
       if (resovedIds.has(found.id)) {
-        throwError(getDuplicateError(key));
+        throwError(getDuplicateError(name));
       }
-      result.set(key, { columnId: found.id, spec: found.spec });
+      result.set(name, found);
       resovedIds.add(found.id);
     } else if ("kind" in anchor) {
-      if (!isPColumnSpec(anchor)) throwError(`Anchor "${key}": invalid PColumnSpec`);
+      if (!isPColumnSpec(anchor)) throwError(`Anchor "${name}": invalid PColumnSpec`);
       const nativeId = deriveNativeId(anchor);
       const found =
         columns.find((col) => deriveNativeId(col.spec) === nativeId) ??
-        throwError(`Anchor "${key}": no column matching spec found in sources`);
+        throwError(`Anchor "${name}": no column matching spec found in sources`);
       if (resovedIds.has(found.id)) {
-        throwError(getDuplicateError(key));
+        throwError(getDuplicateError(name));
       }
-      result.set(key, { columnId: found.id, spec: anchor });
+      result.set(name, found);
       resovedIds.add(found.id);
     } else {
       const matched = discoverColumns({
@@ -498,19 +396,23 @@ function resolveAnchorMap(
       });
 
       if (matched.hits.length === 0) {
-        throwError(`Anchor "${key}": no columns matched selector`);
+        throwError(`Anchor "${name}": no columns matched selector`);
       }
       if (matched.hits.length > 1) {
         throwError(
-          `Anchor "${key}": selector is ambiguous and matched multiple columns; please refine the selector to match exactly one column`,
+          `Anchor "${name}": selector is ambiguous and matched multiple columns; please refine the selector to match exactly one column`,
         );
       }
       if (resovedIds.has(matched.hits[0].hit.columnId as PObjectId)) {
-        throwError(getDuplicateError(key));
+        throwError(getDuplicateError(name));
       }
 
-      result.set(key, matched.hits[0].hit);
-      resovedIds.add(matched.hits[0].hit.columnId);
+      const id = matched.hits[0].hit.columnId as PObjectId;
+      const snap =
+        columns.find((col) => col.id === id) ??
+        throwError(`Anchor "${name}": matched column with id "${id}" not found in sources`);
+      result.set(name, snap);
+      resovedIds.add(snap.id);
     }
   }
 
@@ -519,6 +421,20 @@ function resolveAnchorMap(
   }
 
   return result;
+}
+
+function remapFromIdxToId(
+  qualifications: {
+    forQueries: AxisQualification[][];
+    forHit: AxisQualification[];
+  },
+  anchors: ColumnSnapshot<PObjectId>[],
+): MatchQualifications {
+  const forQueries = qualifications.forQueries.reduce<Record<PObjectId, AxisQualification[]>>(
+    (acc, qs, i) => (anchors[i] ? ((acc[anchors[i].id] = qs), acc) : acc),
+    {},
+  );
+  return { forQueries, forHit: qualifications.forHit };
 }
 
 // --- MatchingMode → DiscoverColumnsConstraints ---

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -343,7 +343,7 @@ function collectColumns(providers: ColumnSnapshotProvider[]): ColumnSnapshot<POb
 
 // --- Shared snapshot helpers ---
 
-/** Normalize SDK ColumnSelectorInput to MultiColumnSelector[]. */
+/** Normalize ColumnSelector (relaxed, single or array) to MultiColumnSelector[]. */
 function toMultiColumnSelectors(input: ColumnSelector): MultiColumnSelector[] {
   return convertColumnSelectorToMultiColumnSelector(input);
 }
@@ -351,9 +351,13 @@ function toMultiColumnSelectors(input: ColumnSelector): MultiColumnSelector[] {
 // --- Anchor resolution ---
 
 /**
- * Resolve each anchor value to a PColumnSpec.
- * - PColumnSpec: used directly
- * - PObjectId (string): looked up in the collected column map
+ * Resolve each anchor entry to a ColumnSnapshot from the collected columns.
+ * - PObjectId (string): looked up by id in the collected columns
+ * - PColumnSpec: matched by deriveNativeId against collected columns
+ * - RelaxedColumnSelector: resolved via discoverColumns in "exact" mode;
+ *   must match exactly one column
+ * Throws on unresolved, ambiguous, or duplicated matches. Requires at least one
+ * anchor to resolve.
  */
 function resolveAnchorMap(
   anchors: Record<string, AnchorEntry>,

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -91,8 +91,16 @@ export interface ColumnMatch {
   readonly column: ColumnSnapshot<SUniversalPColumnId>;
   /** Provider-native ID — for lookups back to the source provider. */
   readonly originalId: PObjectId;
-  /** Match variants — different paths/qualifications that reach this column. */
+  /** Match variants — different ways (paths/qualifications) to reach this column. */
   readonly variants: MatchVariant[];
+}
+
+/** A single mapping variant describing how a hit column can be integrated. */
+export interface MatchVariant {
+  /** Full qualifications needed for integration. */
+  readonly qualifications: MatchQualifications;
+  /** Distinctive (minimal) qualifications needed for integration. */
+  readonly distinctiveQualifications: MatchQualifications;
   /** Linker steps traversed to reach this hit; empty for direct matches. */
   readonly path: {
     linker: ColumnSnapshot<SUniversalPColumnId>;
@@ -106,14 +114,6 @@ export interface MatchQualifications {
   readonly forQueries: AxisQualification[][];
   /** Qualifications for the hit column. */
   readonly forHit: AxisQualification[];
-}
-
-/** A single mapping variant describing how a hit column can be integrated. */
-export interface MatchVariant {
-  /** Full qualifications needed for integration. */
-  readonly qualifications: MatchQualifications;
-  /** Distinctive (minimal) qualifications needed for integration. */
-  readonly distinctiveQualifications: MatchQualifications;
 }
 
 // --- Build options ---
@@ -345,38 +345,34 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
       axes: this.uniqAnchorAxes,
     });
 
-    // Map every WASM discovery hit to a ColumnMatch.
-    // The same physical column may appear multiple times when reachable through
-    // different linker paths — each hit becomes a separate ColumnMatch so that
-    // the caller can expand them into distinct table columns.
-    const results: ColumnMatch[] = [];
-    for (const hit of response.hits) {
+    // Group WASM hits by anchored column id — each physical column appears once;
+    // alternative linker paths become extra entries in `variants`, each carrying
+    // its own `path`. Callers expand variants into distinct table columns.
+    const byColumn = response.hits.reduce<Map<SUniversalPColumnId, ColumnMatch>>((acc, hit) => {
       const origId = hit.hit.columnId as PObjectId;
       const col =
         this.columnsMap.get(origId) ??
         throwError(`Column with id ${origId} not found in collection`);
       const associatedId = this.idDeriver.deriveS(col.spec);
+      const path = hit.path.map((step) => ({
+        linker: remapSnapshot(
+          this.idDeriver.deriveS(step.linker.spec),
+          this.columnsMap.get(step.linker.columnId) ??
+            throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
+        ),
+        qualifications: step.qualifications,
+      }));
+      const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({ ...v, path }));
+      const existing = acc.get(associatedId);
+      return acc.set(
+        associatedId,
+        existing === undefined
+          ? { column: remapSnapshot(associatedId, col), originalId: origId, variants }
+          : { ...existing, variants: [...existing.variants, ...variants] },
+      );
+    }, new Map());
 
-      results.push({
-        path: hit.path.map((step) => {
-          if (step.type !== "linker")
-            throw new Error(`Unexpected discover-columns step type: ${step.type}`);
-          return {
-            linker: remapSnapshot(
-              this.idDeriver.deriveS(step.linker.spec),
-              this.columnsMap.get(step.linker.columnId) ??
-                throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
-            ),
-            qualifications: step.qualifications,
-          };
-        }),
-        column: remapSnapshot(associatedId, col),
-        variants: hit.mappingVariants,
-        originalId: origId,
-      });
-    }
-
-    return results;
+    return Array.from(byColumn.values());
   }
 }
 

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -296,12 +296,19 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
       const col =
         this.columnsMap.get(origId) ??
         throwError(`Column with id ${origId} not found in collection`);
-      const path = hit.path.map((step) => ({
-        linker:
-          this.columnsMap.get(step.linker.columnId) ??
-          throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
-        qualifications: step.qualifications,
-      }));
+
+      const path = hit.path.map((step) => {
+        if (step.type !== "linker") {
+          throw new Error(`Unexpected discover-columns step type: ${step.type}`);
+        }
+
+        return {
+          linker:
+            this.columnsMap.get(step.linker.columnId) ??
+            throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
+          qualifications: step.qualifications,
+        };
+      });
       const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({
         path,
         qualifications: remapFromIdxToId(v.qualifications, anchors),

--- a/sdk/model/src/columns/column_selector.ts
+++ b/sdk/model/src/columns/column_selector.ts
@@ -36,7 +36,7 @@ export interface RelaxedColumnSelector {
   partialAxesMatch?: boolean;
 }
 
-/** Input that normalizes to ColumnSelector[]. */
+/** One or many relaxed column selectors; normalizes to MultiColumnSelector[]. */
 export type ColumnSelector = RelaxedColumnSelector | RelaxedColumnSelector[];
 
 // --- Normalization ---

--- a/sdk/model/src/columns/column_snapshot.ts
+++ b/sdk/model/src/columns/column_snapshot.ts
@@ -13,7 +13,10 @@ export type ColumnDataStatus = "ready" | "computing" | "absent";
  * - `data` holds an active object when data exists (ready or computing),
  *   or `undefined` when data is permanently absent.
  */
-export interface ColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> {
+export interface ColumnSnapshot<
+  Id extends PObjectId | SUniversalPColumnId,
+  Data = PColumnDataUniversal,
+> {
   readonly id: Id;
   readonly spec: PColumnSpec;
   readonly dataStatus: ColumnDataStatus;
@@ -24,7 +27,7 @@ export interface ColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> {
    * - `'computing'`: `data.get()` returns `undefined`, marks context unstable.
    * - `'absent'`: `data` is `undefined` — no active object, no instability.
    */
-  readonly data: ColumnData | undefined;
+  readonly data: ColumnData<Data> | undefined;
 }
 
 // --- ColumnData ---
@@ -33,8 +36,8 @@ export interface ColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> {
  * Active object wrapping lazy column data access.
  * Accessing data on a computing column marks the render context unstable.
  */
-export interface ColumnData {
-  get(): PColumnDataUniversal | undefined;
+export interface ColumnData<Data = PColumnDataUniversal> {
+  get(): Data | undefined;
 }
 
 /** Creates a ColumnData active object for a ready column. */

--- a/sdk/model/src/columns/ctx_column_sources.ts
+++ b/sdk/model/src/columns/ctx_column_sources.ts
@@ -17,8 +17,8 @@ import type { ValueOf } from "@milaboratories/helpers";
  *
  * Returns an array of providers suitable for `ColumnCollectionBuilder.addSource()`.
  */
-export function collectCtxColumnSnapshotProviders<A, U, S>(
-  ctx: RenderCtxBase<A, U, S>,
+export function collectCtxColumnSnapshotProviders<A, U>(
+  ctx: RenderCtxBase<A, U>,
 ): ColumnSnapshotProvider[] {
   const providers: ColumnSnapshotProvider[] = [];
 

--- a/sdk/model/src/columns/ctx_column_sources.ts
+++ b/sdk/model/src/columns/ctx_column_sources.ts
@@ -17,9 +17,7 @@ import type { ValueOf } from "@milaboratories/helpers";
  *
  * Returns an array of providers suitable for `ColumnCollectionBuilder.addSource()`.
  */
-export function collectCtxColumnSnapshotProviders<A, U>(
-  ctx: RenderCtxBase<A, U>,
-): ColumnSnapshotProvider[] {
+export function collectCtxColumnSnapshotProviders(ctx: RenderCtxBase): ColumnSnapshotProvider[] {
   const providers: ColumnSnapshotProvider[] = [];
 
   // ResultPool — all upstream columns

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
@@ -33,8 +33,8 @@ export function createPTableDefV2(params: {
   secondaryColumns.push(...params.labelColumns);
 
   return createPTableDefV3({
-    primaryColumns: coreColumns,
-    secondaryGroups: secondaryColumns.map((c) => [c]),
+    primary: coreColumns.map((column) => ({ column })),
+    secondary: secondaryColumns.map((column) => ({ entries: [{ column }] })),
     primaryJoinType: params.coreJoinType,
     filters: params.filters,
     sorting: params.sorting,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -17,7 +17,7 @@ import type { PlDataTableFilters } from "../typesV5";
 import { distillFilterSpec, filterSpecToSpecQueryExpr } from "../../../filters";
 import type { Nil } from "@milaboratories/helpers";
 
-/** Primary side — base row grid. `key` links secondary groups to their qualifying anchor. */
+/** Primary side — base row grid. */
 export type PrimaryEntry<Data> = {
   column: PColumn<Data>;
 };
@@ -33,7 +33,7 @@ export type SecondaryEntry<Data> = {
 export type SecondaryGroup<Data> = {
   entries: SecondaryEntry<Data>[];
   /** Per-variant qualifications applied to the cloned primary anchors on this group's side.
-   *  Keyed by `PrimaryEntry.anchorName`. Omit → base primary used unqualified (labels, non-variant columns). */
+   *  Keyed by `PrimaryEntry.column.id`. Omit → base primary used unqualified (labels, non-variant columns). */
   primaryQualifications?: Record<PObjectId, AxisQualification[]>;
 };
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -82,8 +82,8 @@ function columnIdToExpr(col: PTableColumnId): SpecQueryExpression {
 }
 
 function toJoinEntry<C>(input: SpecQuery<C>): SpecQueryJoinEntry<C> {
-  return {
-    entry: input,
-    qualifications: [],
-  };
+  // TODO(qualifications): should come from MatchVariant.qualifications on the
+  // originating TableColumnSnapshot. See review.md §3.2 for the structural
+  // rebuild (per-secondary primary duplication).
+  return { entry: input, qualifications: [] };
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -1,4 +1,5 @@
 import type {
+  AxisQualification,
   PColumn,
   PTableColumnId,
   PTableSorting,
@@ -15,31 +16,59 @@ import type { PlDataTableFilters } from "../typesV5";
 import { distillFilterSpec, filterSpecToSpecQueryExpr } from "../../../filters";
 import type { Nil } from "@milaboratories/helpers";
 
+/** Primary side — base row grid. `key` links secondary groups to their qualifying anchor. */
+export type PrimaryEntry<Data> = {
+  column: PColumn<Data>;
+  key?: string;
+};
+
+/** Secondary side leaf — the hit column, a linker step, or a label column. */
+export type SecondaryEntry<Data> = {
+  column: PColumn<Data>;
+  /** For hit: `forHit`. For linker step k: `path[k].qualifications`. For label/direct: omit. */
+  qualifications?: AxisQualification[];
+};
+
+/** Secondary group — one join subtree outer-joined onto primary. */
+export type SecondaryGroup<Data> = {
+  entries: SecondaryEntry<Data>[];
+  /** Per-variant qualifications applied to the cloned primary anchors on this group's side.
+   *  Keyed by `PrimaryEntry.key`. Omit → base primary used unqualified (labels, non-variant columns). */
+  forAnchors?: Record<string, AxisQualification[]>;
+};
+
 export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
   primaryJoinType: "inner" | "full";
-  primaryColumns: PColumn<Data>[];
-  secondaryGroups: PColumn<Data>[][];
+  primary: PrimaryEntry<Data>[];
+  secondary: SecondaryGroup<Data>[];
   filters?: Nil | PlDataTableFilters;
   sorting?: Nil | PTableSorting[];
 }): PTableDefV2<PColumn<Data>> {
-  // Build SpecQuery directly from columns
-  const coreJoinQuery: SpecQuery<PColumn<Data>> = {
-    type: params.primaryJoinType === "inner" ? "innerJoin" : "fullJoin",
-    entries: params.primaryColumns.map((c) => toJoinEntry({ type: "column", column: c })),
+  const basePrimary: SpecQueryJoinEntry<PColumn<Data>> = {
+    entry: {
+      type: params.primaryJoinType === "inner" ? "innerJoin" : "fullJoin",
+      entries: params.primary.map((a) => toLeaf(a.column, [])),
+    },
+    qualifications: [],
   };
+
+  const secondaries: SpecQueryJoinEntry<PColumn<Data>>[] = params.secondary.map((group) => ({
+    entry: {
+      type: "innerJoin" as const,
+      entries: [
+        ...(group.forAnchors !== undefined ? cloneAnchores(params.primary, group.forAnchors) : []),
+        ...group.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
+      ],
+    },
+    qualifications: [],
+  }));
 
   let query: SpecQuery<PColumn<Data>> = {
     type: "outerJoin",
-    primary: toJoinEntry(coreJoinQuery),
-    secondary: params.secondaryGroups.map((group) =>
-      toJoinEntry({
-        type: "innerJoin" as const,
-        entries: group.map((c) => toJoinEntry({ type: "column" as const, column: c })),
-      }),
-    ),
+    primary: basePrimary,
+    secondary: secondaries,
   };
 
-  // Apply filters
   if (!isNil(params.filters)) {
     const nonEmpty = distillFilterSpec(params.filters);
 
@@ -58,7 +87,6 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
     }
   }
 
-  // Apply sorting
   if (!isNil(params.sorting) && params.sorting.length > 0) {
     query = {
       type: "sort",
@@ -74,16 +102,27 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
   return { query };
 }
 
-/** Convert a PTableColumnId to a SpecQueryExpression reference. */
 function columnIdToExpr(col: PTableColumnId): SpecQueryExpression {
   return col.type === "axis"
     ? { type: "axisRef", value: col.id as SingleAxisSelector }
     : { type: "columnRef", value: col.id };
 }
 
-function toJoinEntry<C>(input: SpecQuery<C>): SpecQueryJoinEntry<C> {
-  // TODO(qualifications): should come from MatchVariant.qualifications on the
-  // originating TableColumnSnapshot. See review.md §3.2 for the structural
-  // rebuild (per-secondary primary duplication).
-  return { entry: input, qualifications: [] };
+function toLeaf<Data>(
+  col: PColumn<Data>,
+  qs: AxisQualification[],
+): SpecQueryJoinEntry<PColumn<Data>> {
+  return {
+    entry: { type: "column", column: col },
+    qualifications: qs,
+  };
+}
+
+function cloneAnchores<Data>(
+  entries: PrimaryEntry<Data>[],
+  forAnchors: Record<string, AxisQualification[]>,
+): SpecQueryJoinEntry<PColumn<Data>>[] {
+  return entries
+    .filter((a): a is PrimaryEntry<Data> & { key: string } => a.key !== undefined)
+    .map((a) => toLeaf(a.column, forAnchors[a.key] ?? []));
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -44,32 +44,23 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
   filters?: Nil | PlDataTableFilters;
   sorting?: Nil | PTableSorting[];
 }): PTableDefV2<PColumn<Data>> {
-  const basePrimary: SpecQueryJoinEntry<PColumn<Data>> = {
-    entry: {
-      type: params.primaryJoinType === "inner" ? "innerJoin" : "fullJoin",
-      entries: params.primary.map((a) => toLeaf(a.column, [])),
-    },
-    qualifications: [],
-  };
-
-  const secondaries: SpecQueryJoinEntry<PColumn<Data>>[] = params.secondary.map((group) => ({
-    entry: {
-      type: "innerJoin" as const,
-      entries: [
-        ...(group.primaryQualifications !== undefined
-          ? getQuilifiedPrimary(params.primary, group.primaryQualifications)
-          : []),
-        ...group.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
-      ],
-    },
-    qualifications: [],
-  }));
-
   let query: SpecQuery<PColumn<Data>> = {
-    type: "outerJoin",
-    primary: basePrimary,
-    secondary: secondaries,
+    type: params.primaryJoinType === "inner" ? "innerJoin" : "fullJoin",
+    entries: params.primary.map((a) => toLeaf(a.column, [])),
   };
+
+  for (const group of params.secondary) {
+    query = {
+      type: "outerJoin",
+      primary: {
+        entry: query,
+        qualifications: params.primary.flatMap((p) => {
+          return group.primaryQualifications?.[p.column.id] ?? [];
+        }),
+      },
+      secondary: group.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
+    };
+  }
 
   if (!isNil(params.filters)) {
     const nonEmpty = distillFilterSpec(params.filters);
@@ -118,11 +109,4 @@ function toLeaf<Data>(
     entry: { type: "column", column: col },
     qualifications: qs,
   };
-}
-
-function getQuilifiedPrimary<Data>(
-  entries: PrimaryEntry<Data>[],
-  forAnchors: Record<PObjectId, AxisQualification[]>,
-): SpecQueryJoinEntry<PColumn<Data>>[] {
-  return entries.map((a) => toLeaf(a.column, forAnchors[a.column.id] ?? []));
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -8,6 +8,7 @@ import type {
   SpecQuery,
   SpecQueryExpression,
   SpecQueryJoinEntry,
+  PObjectId,
 } from "@milaboratories/pl-model-common";
 import { isBooleanExpression } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal } from "../../../render";
@@ -19,7 +20,6 @@ import type { Nil } from "@milaboratories/helpers";
 /** Primary side — base row grid. `key` links secondary groups to their qualifying anchor. */
 export type PrimaryEntry<Data> = {
   column: PColumn<Data>;
-  key?: string;
 };
 
 /** Secondary side leaf — the hit column, a linker step, or a label column. */
@@ -33,8 +33,8 @@ export type SecondaryEntry<Data> = {
 export type SecondaryGroup<Data> = {
   entries: SecondaryEntry<Data>[];
   /** Per-variant qualifications applied to the cloned primary anchors on this group's side.
-   *  Keyed by `PrimaryEntry.key`. Omit → base primary used unqualified (labels, non-variant columns). */
-  forAnchors?: Record<string, AxisQualification[]>;
+   *  Keyed by `PrimaryEntry.anchorName`. Omit → base primary used unqualified (labels, non-variant columns). */
+  primaryQualifications?: Record<PObjectId, AxisQualification[]>;
 };
 
 export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
@@ -56,7 +56,9 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
     entry: {
       type: "innerJoin" as const,
       entries: [
-        ...(group.forAnchors !== undefined ? cloneAnchores(params.primary, group.forAnchors) : []),
+        ...(group.primaryQualifications !== undefined
+          ? getQuilifiedPrimary(params.primary, group.primaryQualifications)
+          : []),
         ...group.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
       ],
     },
@@ -118,11 +120,9 @@ function toLeaf<Data>(
   };
 }
 
-function cloneAnchores<Data>(
+function getQuilifiedPrimary<Data>(
   entries: PrimaryEntry<Data>[],
-  forAnchors: Record<string, AxisQualification[]>,
+  forAnchors: Record<PObjectId, AxisQualification[]>,
 ): SpecQueryJoinEntry<PColumn<Data>>[] {
-  return entries
-    .filter((a): a is PrimaryEntry<Data> & { key: string } => a.key !== undefined)
-    .map((a) => toLeaf(a.column, forAnchors[a.key] ?? []));
+  return entries.map((a) => toLeaf(a.column, forAnchors[a.column.id] ?? []));
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -38,6 +38,7 @@ import {
   withLabelAnnotations,
   withTableVisualAnnotations,
 } from "./utils";
+import type { PrimaryEntry, SecondaryGroup } from "./createPTableDefV3";
 import { createPTableDefV3 } from "./createPTableDefV3";
 import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
 import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/helpers";
@@ -125,17 +126,14 @@ export function createPlDataTableV3<A, U>(
     displayOptions: options.displayOptions,
   });
 
-  const primaryColumnIds = new Set<PObjectId>(
-    discovered.filter((dc) => dc.isPrimary).map((dc) => dc.id),
-  );
-  const primarySnapshots = annotated.direct.filter((c) => primaryColumnIds.has(c.id));
-  const secondarySnapshots = annotated.direct.filter((c) => !primaryColumnIds.has(c.id));
+  const primarySnapshots = annotated.direct.filter((c) => c.isPrimary);
+  const secondarySnapshots = annotated.direct.filter((c) => !c.isPrimary);
 
   if (primarySnapshots.length === 0) return undefined;
 
   const columnIsAvailable = createColumnValidationById([
     ...annotated.direct,
-    ...annotated.linked.flatMap((lc) => [...(annotated.linkers.get(lc.id) ?? []), lc]),
+    ...annotated.linked.flatMap((lc) => [...(lc.linkerPath ?? []).map((s) => s.linker), lc]),
     ...annotated.labels,
   ]);
 
@@ -152,17 +150,16 @@ export function createPlDataTableV3<A, U>(
   );
   validateSorting(sorting, columnIsAvailable);
 
+  const primaryEntries: PrimaryEntry<undefined | PColumnDataUniversal>[] = primarySnapshots.map(
+    (snap) => ({
+      key: snap.anchorKey,
+      column: resolveSnapshot(snap),
+    }),
+  );
   const fullDef = createPTableDefV3({
     primaryJoinType,
-    primaryColumns: primarySnapshots.map(resolveSnapshot),
-    secondaryGroups: [
-      ...secondarySnapshots.map((c) => [resolveSnapshot(c)]),
-      ...annotated.linked.map((lc) => [
-        ...(annotated.linkers.get(lc.id) ?? []).map(resolveSnapshot),
-        resolveSnapshot(lc),
-      ]),
-      ...annotated.labels.map((c) => [c]),
-    ],
+    primary: primaryEntries,
+    secondary: buildSecondaryGroups(secondarySnapshots, annotated.linked, annotated.labels),
     filters,
     sorting,
   });
@@ -172,7 +169,7 @@ export function createPlDataTableV3<A, U>(
     ...annotated.direct.map(resolveSnapshot),
     ...annotated.linked.map(resolveSnapshot),
     ...annotated.labels,
-    ...uniqueBy([...annotated.linkers.values()].flat(), (c) => c.id).map(resolveSnapshot),
+    ...collectLinkerSnapshots(annotated.linked).map(resolveSnapshot),
   ]);
 
   const hiddenSpecs = state.pTableParams.hiddenColIds;
@@ -186,15 +183,12 @@ export function createPlDataTableV3<A, U>(
   const visible = buildVisibleColumns(annotated, hiddenColumnIds, labelColumns);
   const visibleDef = createPTableDefV3({
     primaryJoinType,
-    primaryColumns: primarySnapshots.map(resolveSnapshot),
-    secondaryGroups: [
-      ...visible.direct.map((c) => [resolveSnapshot(c)]),
-      ...visible.linked.map((lc) => [
-        ...(annotated.linkers.get(lc.id) ?? []).map(resolveSnapshot),
-        resolveSnapshot(lc),
-      ]),
-      ...visible.labels.map((c) => [c]),
-    ],
+    primary: primaryEntries,
+    secondary: buildSecondaryGroups(
+      visible.direct.filter((c) => !c.isPrimary),
+      visible.linked,
+      visible.labels,
+    ),
     filters,
     sorting,
   });
@@ -212,23 +206,21 @@ export function createPlDataTableV3<A, U>(
 /** A single column discovered from sources — normalized from raw ColumnSnapshot/ColumnMatch. */
 export type TableColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> = ColumnSnapshot<Id> & {
   readonly isPrimary?: boolean;
+  /** Anchor key under which this column was registered; undefined for non-anchor columns. */
+  readonly anchorKey?: string;
   readonly originalId?: PObjectId;
   readonly linkerPath?: MatchVariant["path"];
-  /** TODO(qualifications): carried through discovery but not yet consumed by
-   *  createPTableDefV3 — join entries still use `qualifications: []`. See review.md §2. */
   readonly qualifications?: MatchQualifications;
 };
 
 type SplitDiscoveredColumns = {
   readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
   readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
-  readonly linkers: Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>;
 };
 
 type AnnotatedColumnGroups = {
   readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
   readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
-  readonly linkers: Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>;
   readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
@@ -244,10 +236,17 @@ function splitDiscoveredColumns(
 ): SplitDiscoveredColumns {
   const direct = columns.filter((dc) => isNil(dc.linkerPath) || dc.linkerPath.length === 0);
   const linked = columns.filter((dc) => !isNil(dc.linkerPath) && dc.linkerPath.length > 0);
-  const linkers = new Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>(
-    linked.map((dc) => [dc.id, (dc.linkerPath ?? []).map((lp) => lp.linker)]),
+  return { direct, linked };
+}
+
+/** All linker snapshots across the given linked columns, deduped by id. */
+function collectLinkerSnapshots(
+  linked: TableColumnSnapshot<SUniversalPColumnId>[],
+): ColumnSnapshot<SUniversalPColumnId>[] {
+  return uniqueBy(
+    linked.flatMap((lc) => (lc.linkerPath ?? []).map((s) => s.linker)),
+    (c) => c.id,
   );
-  return { direct, linked, linkers };
 }
 
 /**
@@ -260,19 +259,17 @@ function annotateColumnGroups(params: {
   direct: TableColumnSnapshot<SUniversalPColumnId>[];
   linked: TableColumnSnapshot<SUniversalPColumnId>[];
   labelColumns: PColumn<PColumnDataUniversal>[];
-  linkers: Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>;
   derivedLabels: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
   pframeSpec: PFrameSpecDriver;
 }): AnnotatedColumnGroups {
-  const { direct, linked, linkers, labelColumns, derivedLabels, displayOptions, pframeSpec } =
-    params;
+  const { direct, linked, labelColumns, derivedLabels, displayOptions, pframeSpec } = params;
 
   const allColumnsForRules = [
     ...direct,
     ...linked,
     ...labelColumns,
-    ...uniqueBy([...linkers.values()].flat(), (c) => c.id),
+    ...collectLinkerSnapshots(linked),
   ];
   const visibilityByColId = evaluateRules(
     displayOptions?.visibility ?? [],
@@ -285,25 +282,34 @@ function annotateColumnGroups(params: {
     pframeSpec,
   );
 
+  const linkedAnnotated = withTableVisualAnnotations(
+    visibilityByColId,
+    orderByColId,
+    withLabelAnnotations(derivedLabels, linked),
+  ).map((lc) => ({ ...lc, linkerPath: annotateLinkerPath(derivedLabels, lc.linkerPath) }));
+
   return {
     direct: withTableVisualAnnotations(
       visibilityByColId,
       orderByColId,
       withLabelAnnotations(derivedLabels, direct),
     ),
-    linked: withTableVisualAnnotations(
-      visibilityByColId,
-      orderByColId,
-      withLabelAnnotations(derivedLabels, linked),
-    ),
-    linkers: new Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>(
-      [...linkers].map(([id, cols]) => [
-        id,
-        withHidenAxesAnnotations(withLabelAnnotations(derivedLabels, cols)),
-      ]),
-    ),
+    linked: linkedAnnotated,
     labels: withLabelAnnotations(derivedLabels, labelColumns),
   };
+}
+function annotateLinkerPath(
+  derivedLabels: Record<string, string>,
+  path: TableColumnSnapshot<SUniversalPColumnId>["linkerPath"],
+): TableColumnSnapshot<SUniversalPColumnId>["linkerPath"] {
+  if (isNil(path) || path.length === 0) return path;
+  const annotatedLinkers = withHidenAxesAnnotations(
+    withLabelAnnotations(
+      derivedLabels,
+      path.map((s) => s.linker),
+    ),
+  );
+  return path.map((s, i) => ({ ...s, linker: annotatedLinkers[i] }));
 }
 
 /** Build an index of all valid column IDs (axes + columns) for filter/sorting validation. */
@@ -370,6 +376,36 @@ function validateSorting(sorting: PTableSorting[], isValidColumnId: (id: string)
       `Invalid sorting column ${JSON.stringify(firstInvalid.column)}: column reference does not match the table columns`,
     );
   }
+}
+
+function buildSecondaryGroups(
+  direct: TableColumnSnapshot<SUniversalPColumnId>[],
+  linked: TableColumnSnapshot<SUniversalPColumnId>[],
+  labels: PColumn<PColumnDataUniversal>[],
+): SecondaryGroup<undefined | PColumnDataUniversal>[] {
+  return [
+    ...direct.map(
+      (c): SecondaryGroup<undefined | PColumnDataUniversal> => ({
+        entries: [{ column: resolveSnapshot(c), qualifications: c.qualifications?.forHit }],
+        forAnchors: c.qualifications?.forAnchors,
+      }),
+    ),
+    ...linked.map(
+      (lc): SecondaryGroup<undefined | PColumnDataUniversal> => ({
+        entries: [
+          ...(lc.linkerPath ?? []).map((s) => ({
+            column: resolveSnapshot(s.linker),
+            qualifications: s.qualifications,
+          })),
+          { column: resolveSnapshot(lc), qualifications: lc.qualifications?.forHit },
+        ],
+        forAnchors: lc.qualifications?.forAnchors,
+      }),
+    ),
+    ...labels.map(
+      (c): SecondaryGroup<undefined | PColumnDataUniversal> => ({ entries: [{ column: c }] }),
+    ),
+  ];
 }
 
 /** Determine which columns should be hidden based on state or optional-column defaults. */

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -10,8 +10,8 @@ import type {
   PTableSorting,
   PColumnSpec,
   MultiColumnSelector,
-  SUniversalPColumnId,
   PFrameSpecDriver,
+  DiscoveredPColumnId,
 } from "@milaboratories/pl-model-common";
 import { canonicalizeJson, getAxisId, parseJson, uniqueBy } from "@milaboratories/pl-model-common";
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
@@ -48,7 +48,7 @@ import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/help
 export type createPlDataTableOptionsV3 = {
   tableState?: PlDataTableStateV2;
 
-  columns: Nil | DiscoverTableColumnOptions | TableColumnSnapshot<SUniversalPColumnId>[];
+  columns: Nil | DiscoverTableColumnOptions | TableColumnSnapshot[];
   filters?: PlDataTableFilters;
   sorting?: PTableSorting[];
   primaryJoinType?: "inner" | "full";
@@ -165,10 +165,7 @@ export function createPlDataTableV3<A, U>(
   validateSorting(sorting, columnIsAvailable);
 
   const primaryEntries: PrimaryEntry<undefined | PColumnDataUniversal>[] = primarySnapshots.map(
-    (snap) => ({
-      key: snap.anchorKey,
-      column: resolveSnapshot(snap),
-    }),
+    (snap) => ({ column: resolveSnapshot(snap) }),
   );
   const fullDef = createPTableDefV3({
     primaryJoinType,
@@ -179,6 +176,8 @@ export function createPlDataTableV3<A, U>(
   });
 
   const fullHandle = ctx.createPTableV2(fullDef);
+  // TODO: is workaround for dropdown suggestions.
+  // Pframe have not equivalent data for columns relativly to Ptable
   const pframeHandle = ctx.createPFrame([
     ...annotated.direct.map(resolveSnapshot),
     ...annotated.linked.map(resolveSnapshot),
@@ -218,46 +217,40 @@ export function createPlDataTableV3<A, U>(
 }
 
 /** A single column discovered from sources — normalized from raw ColumnSnapshot/ColumnMatch. */
-export type TableColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> = ColumnSnapshot<Id> & {
+export type TableColumnSnapshot = ColumnSnapshot<DiscoveredPColumnId> & {
+  readonly originalId: PObjectId;
   readonly isPrimary?: boolean;
-  /** Anchor key under which this column was registered; undefined for non-anchor columns. */
-  readonly anchorKey?: string;
-  readonly originalId?: PObjectId;
   readonly linkerPath?: MatchVariant["path"];
   readonly qualifications?: MatchQualifications;
   readonly distinctiveQualifications?: MatchQualifications;
 };
 
 type SplitDiscoveredColumns = {
-  readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
-  readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
+  readonly direct: TableColumnSnapshot[];
+  readonly linked: TableColumnSnapshot[];
 };
 
 type AnnotatedColumnGroups = {
-  readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
-  readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
+  readonly direct: TableColumnSnapshot[];
+  readonly linked: TableColumnSnapshot[];
   readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 type VisibleColumns = {
-  readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
-  readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
+  readonly direct: TableColumnSnapshot[];
+  readonly linked: TableColumnSnapshot[];
   readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 /** Split discovered columns into direct (no linker path) and linked (with linker path). */
-function splitDiscoveredColumns(
-  columns: TableColumnSnapshot<SUniversalPColumnId>[],
-): SplitDiscoveredColumns {
+function splitDiscoveredColumns(columns: TableColumnSnapshot[]): SplitDiscoveredColumns {
   const direct = columns.filter((dc) => isNil(dc.linkerPath) || dc.linkerPath.length === 0);
   const linked = columns.filter((dc) => !isNil(dc.linkerPath) && dc.linkerPath.length > 0);
   return { direct, linked };
 }
 
 /** All linker snapshots across the given linked columns, deduped by id. */
-function collectLinkerSnapshots(
-  linked: TableColumnSnapshot<SUniversalPColumnId>[],
-): ColumnSnapshot<SUniversalPColumnId>[] {
+function collectLinkerSnapshots(linked: TableColumnSnapshot[]): ColumnSnapshot<PObjectId>[] {
   return uniqueBy(
     linked.flatMap((lc) => (lc.linkerPath ?? []).map((s) => s.linker)),
     (c) => c.id,
@@ -271,8 +264,8 @@ function collectLinkerSnapshots(
  * column annotations via `withTableVisualAnnotations`.
  */
 function annotateColumnGroups(params: {
-  direct: TableColumnSnapshot<SUniversalPColumnId>[];
-  linked: TableColumnSnapshot<SUniversalPColumnId>[];
+  direct: TableColumnSnapshot[];
+  linked: TableColumnSnapshot[];
   labelColumns: PColumn<PColumnDataUniversal>[];
   derivedLabels: Record<string, string>;
   derivedTooltips: Record<string, string>;
@@ -310,15 +303,15 @@ function annotateColumnGroups(params: {
     withLabelAnnotations.bind(null, derivedLabels),
     withInfoAnnotations.bind(null, derivedTooltips),
     withTableVisualAnnotations.bind(null, visibilityByColId, orderByColId),
-  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot<SUniversalPColumnId>[], direct);
+  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot[], direct);
 
   const linkedAnnotated = [
     withLabelAnnotations.bind(null, derivedLabels),
     withInfoAnnotations.bind(null, derivedTooltips),
     withTableVisualAnnotations.bind(null, visibilityByColId, orderByColId),
-    (cols: TableColumnSnapshot<SUniversalPColumnId>[]) =>
+    (cols: TableColumnSnapshot[]) =>
       cols.map((lc) => ({ ...lc, linkerPath: annotateLinkerPath(derivedLabels, lc.linkerPath) })),
-  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot<SUniversalPColumnId>[], linked);
+  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot[], linked);
 
   const labelColumnsAnnotated = withLabelAnnotations(derivedLabels, labelColumns);
 
@@ -330,8 +323,8 @@ function annotateColumnGroups(params: {
 }
 function annotateLinkerPath(
   derivedLabels: Record<string, string>,
-  path: TableColumnSnapshot<SUniversalPColumnId>["linkerPath"],
-): TableColumnSnapshot<SUniversalPColumnId>["linkerPath"] {
+  path: TableColumnSnapshot["linkerPath"],
+): TableColumnSnapshot["linkerPath"] {
   if (isNil(path) || path.length === 0) return path;
   const annotatedLinkers = withHidenAxesAnnotations(
     withLabelAnnotations(
@@ -409,15 +402,15 @@ function validateSorting(sorting: PTableSorting[], isValidColumnId: (id: string)
 }
 
 function buildSecondaryGroups(
-  direct: TableColumnSnapshot<SUniversalPColumnId>[],
-  linked: TableColumnSnapshot<SUniversalPColumnId>[],
+  direct: TableColumnSnapshot[],
+  linked: TableColumnSnapshot[],
   labels: PColumn<PColumnDataUniversal>[],
 ): SecondaryGroup<undefined | PColumnDataUniversal>[] {
   return [
     ...direct.map(
       (c): SecondaryGroup<undefined | PColumnDataUniversal> => ({
         entries: [{ column: resolveSnapshot(c), qualifications: c.qualifications?.forHit }],
-        forAnchors: c.qualifications?.forAnchors,
+        primaryQualifications: c.qualifications?.forQueries,
       }),
     ),
     ...linked.map(
@@ -429,7 +422,7 @@ function buildSecondaryGroups(
           })),
           { column: resolveSnapshot(lc), qualifications: lc.qualifications?.forHit },
         ],
-        forAnchors: lc.qualifications?.forAnchors,
+        primaryQualifications: lc.qualifications?.forQueries,
       }),
     ),
     ...labels.map(
@@ -497,7 +490,7 @@ function resolveSnapshot(
 /** Remap column references in sorting entries. */
 function remapSortingColumnIds(
   sorting: Nil | PTableSorting[],
-  columns: TableColumnSnapshot<PObjectId | SUniversalPColumnId>[],
+  columns: TableColumnSnapshot[],
 ): Nil | PTableSorting[] {
   return sorting?.map((s) => {
     if (s.column.type === "axis") return s; // Axis references are unaffected by column ID remapping
@@ -522,7 +515,7 @@ type PlDataTableFilterNode = FilterSpecNode<PlDataTableFilterSpecLeaf>;
 /** Remap column references in a filter tree. */
 function remapFilterColumnIds(
   filters: Nil | PlDataTableFilters,
-  columns: TableColumnSnapshot<PObjectId | SUniversalPColumnId>[],
+  columns: TableColumnSnapshot[],
 ): Nil | PlDataTableFilters {
   if (isNil(filters)) return filters;
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -37,24 +37,19 @@ import {
   withTableVisualAnnotations,
 } from "./utils";
 import { createPTableDefV3 } from "./createPTableDefV3";
-import { discoverTableColumnSnaphots, type DiscoveredTableColumnOptions } from "./discoverColumns";
-import { isNil, RequiredBy, throwError, type Nil } from "@milaboratories/helpers";
+import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
+import { isNil, isPlainObject, RequiredBy, throwError, type Nil } from "@milaboratories/helpers";
 
-export type createPlDataTableOptionsV3 = (
-  | {
-      discoverColumnOptions: DiscoveredTableColumnOptions;
-    }
-  | {
-      columns: Nil | TableColumnSnapshot<SUniversalPColumnId>[];
-    }
-) & {
+export type createPlDataTableOptionsV3 = {
+  tableState?: PlDataTableStateV2;
+
+  columns: Nil | DiscoverTableColumnOptions | TableColumnSnapshot<SUniversalPColumnId>[];
   filters?: PlDataTableFilters;
   sorting?: PTableSorting[];
   primaryJoinType?: "inner" | "full";
 
-  tableState?: PlDataTableStateV2;
   labelsOptions?: DeriveLabelsOptions;
-  columnsDisplayOptions?: ColumnsDisplayOptions;
+  displayOptions?: ColumnsDisplayOptions;
 };
 
 /** Structured source config — selectors/anchors instead of raw ColumnSource. */
@@ -94,10 +89,9 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
   const state = upgradePlDataTableStateV2(options.tableState);
   const primaryJoinType = options.primaryJoinType ?? "full";
 
-  const discovered =
-    "discoverColumnOptions" in options
-      ? discoverTableColumnSnaphots(ctx, options.discoverColumnOptions)
-      : options.columns;
+  const discovered = isPlainObject(options.columns)
+    ? discoverTableColumnSnaphots(ctx, options.columns)
+    : options.columns;
   if (isNil(discovered) || discovered.length === 0) return undefined;
 
   const splited = splitDiscoveredColumns(discovered);
@@ -122,7 +116,7 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
     resolved,
     labelColumns,
     derivedLabels,
-    options.columnsDisplayOptions,
+    options.displayOptions,
   );
 
   const primaryColumnIds = new Set<PObjectId>(

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -11,6 +11,7 @@ import type {
   PColumnSpec,
   MultiColumnSelector,
   SUniversalPColumnId,
+  PFrameSpecDriver,
 } from "@milaboratories/pl-model-common";
 import {
   canonicalizeJson,
@@ -39,7 +40,6 @@ import {
 import { createPTableDefV3 } from "./createPTableDefV3";
 import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
 import { isNil, isPlainObject, RequiredBy, throwError, type Nil } from "@milaboratories/helpers";
-import { getService } from "../../../services";
 
 export type createPlDataTableOptionsV3 = {
   tableState?: PlDataTableStateV2;
@@ -87,6 +87,7 @@ export function createPlDataTableV3<A, U>(
   ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
 ): PlDataTableModel | undefined {
+  const pframeSpec = ctx.getService("pframeSpec");
   const state = upgradePlDataTableStateV2(options.tableState);
   const primaryJoinType = options.primaryJoinType ?? "full";
 
@@ -117,6 +118,7 @@ export function createPlDataTableV3<A, U>(
   });
 
   const annotated = annotateColumnGroups({
+    pframeSpec,
     ...resolved,
     labelColumns,
     derivedLabels,
@@ -281,9 +283,10 @@ function annotateColumnGroups(params: {
   linkers: Map<PObjectId, TableColumn[]>;
   derivedLabels: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
+  pframeSpec: PFrameSpecDriver;
 }): AnnotatedColumnGroups {
-  const { direct, linked, linkers, labelColumns, derivedLabels, displayOptions } = params;
-  const pframeSpec = getService("pframeSpec");
+  const { direct, linked, linkers, labelColumns, derivedLabels, displayOptions, pframeSpec } =
+    params;
 
   const allColumnsForRules = [
     ...direct,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -26,7 +26,13 @@ import { isEmpty } from "es-toolkit/compat";
 import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV5";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
-import type { ColumnMatch, ColumnSelector, ColumnSnapshot, MatchingMode } from "../../../columns";
+import type {
+  ColumnSelector,
+  ColumnSnapshot,
+  MatchingMode,
+  MatchQualifications,
+  MatchVariant,
+} from "../../../columns";
 import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
@@ -215,7 +221,10 @@ export function createPlDataTableV3<A, U>(
 export type TableColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> = ColumnSnapshot<Id> & {
   readonly isPrimary?: boolean;
   readonly originalId?: PObjectId;
-  readonly linkerPath?: ColumnMatch["path"];
+  readonly linkerPath?: MatchVariant["path"];
+  /** TODO(qualifications): carried through discovery but not yet consumed by
+   *  createPTableDefV3 — join entries still use `qualifications: []`. See review.md §2. */
+  readonly qualifications?: MatchQualifications;
 };
 
 type TableColumn = PColumn<undefined | PColumnDataUniversal>;

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -3,7 +3,6 @@ import type {
   CanonicalizedJson,
   FilterSpecNode,
   PColumn,
-  PFrameSpecDriver,
   PObjectId,
   PTableColumnId,
   PTableColumnIdAxis,
@@ -27,7 +26,6 @@ import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } 
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import type { ColumnMatch, ColumnSelector, ColumnSnapshot, MatchingMode } from "../../../columns";
-import { Services, type RequireServices } from "@milaboratories/pl-model-common";
 import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
@@ -41,6 +39,7 @@ import {
 import { createPTableDefV3 } from "./createPTableDefV3";
 import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
 import { isNil, isPlainObject, RequiredBy, throwError, type Nil } from "@milaboratories/helpers";
+import { getService } from "../../../services";
 
 export type createPlDataTableOptionsV3 = {
   tableState?: PlDataTableStateV2;
@@ -84,8 +83,8 @@ export type ColumnMatcher = (spec: PColumnSpec) => boolean;
 
 // Main Function
 
-export function createPlDataTableV3<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
-  ctx: RenderCtxBase<A, U, S>,
+export function createPlDataTableV3<A, U>(
+  ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
 ): PlDataTableModel | undefined {
   const state = upgradePlDataTableStateV2(options.tableState);
@@ -118,9 +117,6 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
   });
 
   const annotated = annotateColumnGroups({
-    pframeSpec:
-      ctx.services.pframeSpec ??
-      throwError("PFrameSpec service is required for display rule evaluation."),
     ...resolved,
     labelColumns,
     derivedLabels,
@@ -279,7 +275,6 @@ function resolveDiscoveredColumns(split: SplitDiscoveredColumns): ResolvedColumn
  * column annotations via `withTableVisualAnnotations`.
  */
 function annotateColumnGroups(params: {
-  pframeSpec: PFrameSpecDriver;
   direct: TableColumn[];
   linked: TableColumn[];
   labelColumns: PColumn<PColumnDataUniversal>[];
@@ -287,8 +282,8 @@ function annotateColumnGroups(params: {
   derivedLabels: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
 }): AnnotatedColumnGroups {
-  const { pframeSpec, direct, linked, linkers, labelColumns, derivedLabels, displayOptions } =
-    params;
+  const { direct, linked, linkers, labelColumns, derivedLabels, displayOptions } = params;
+  const pframeSpec = getService("pframeSpec");
 
   const allColumnsForRules = [
     ...direct,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -13,13 +13,7 @@ import type {
   SUniversalPColumnId,
   PFrameSpecDriver,
 } from "@milaboratories/pl-model-common";
-import {
-  canonicalizeJson,
-  getAxisId,
-  getColumnIdAndSpec,
-  parseJson,
-  uniqueBy,
-} from "@milaboratories/pl-model-common";
+import { canonicalizeJson, getAxisId, parseJson, uniqueBy } from "@milaboratories/pl-model-common";
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
 import type { RenderCtxBase, PColumnDataUniversal } from "../../../render";
 import { isEmpty } from "es-toolkit/compat";
@@ -46,7 +40,7 @@ import {
 } from "./utils";
 import { createPTableDefV3 } from "./createPTableDefV3";
 import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
-import { isNil, isPlainObject, RequiredBy, throwError, type Nil } from "@milaboratories/helpers";
+import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/helpers";
 
 export type createPlDataTableOptionsV3 = {
   tableState?: PlDataTableStateV2;
@@ -104,10 +98,9 @@ export function createPlDataTableV3<A, U>(
   if (isNil(discovered) || discovered.length === 0) return undefined;
 
   const splited = splitDiscoveredColumns(discovered);
-  const resolved = resolveDiscoveredColumns(splited);
 
   const labelColumns = getMatchingLabelColumns(
-    [...resolved.direct, ...resolved.linked],
+    [...splited.direct, ...splited.linked],
     getAllLabelColumns(ctx),
   );
 
@@ -126,7 +119,7 @@ export function createPlDataTableV3<A, U>(
 
   const annotated = annotateColumnGroups({
     pframeSpec,
-    ...resolved,
+    ...splited,
     labelColumns,
     derivedLabels,
     displayOptions: options.displayOptions,
@@ -135,10 +128,10 @@ export function createPlDataTableV3<A, U>(
   const primaryColumnIds = new Set<PObjectId>(
     discovered.filter((dc) => dc.isPrimary).map((dc) => dc.id),
   );
-  const primaryColumns = annotated.direct.filter((c) => primaryColumnIds.has(c.id));
-  const secondaryColumns = annotated.direct.filter((c) => !primaryColumnIds.has(c.id));
+  const primarySnapshots = annotated.direct.filter((c) => primaryColumnIds.has(c.id));
+  const secondarySnapshots = annotated.direct.filter((c) => !primaryColumnIds.has(c.id));
 
-  if (primaryColumns.length === 0) return undefined;
+  if (primarySnapshots.length === 0) return undefined;
 
   const columnIsAvailable = createColumnValidationById([
     ...annotated.direct,
@@ -161,10 +154,13 @@ export function createPlDataTableV3<A, U>(
 
   const fullDef = createPTableDefV3({
     primaryJoinType,
-    primaryColumns,
+    primaryColumns: primarySnapshots.map(resolveSnapshot),
     secondaryGroups: [
-      ...secondaryColumns.map((c) => [c]),
-      ...annotated.linked.map((lc) => [...(annotated.linkers.get(lc.id) ?? []), lc]),
+      ...secondarySnapshots.map((c) => [resolveSnapshot(c)]),
+      ...annotated.linked.map((lc) => [
+        ...(annotated.linkers.get(lc.id) ?? []).map(resolveSnapshot),
+        resolveSnapshot(lc),
+      ]),
       ...annotated.labels.map((c) => [c]),
     ],
     filters,
@@ -173,10 +169,10 @@ export function createPlDataTableV3<A, U>(
 
   const fullHandle = ctx.createPTableV2(fullDef);
   const pframeHandle = ctx.createPFrame([
-    ...annotated.direct,
-    ...annotated.linked,
+    ...annotated.direct.map(resolveSnapshot),
+    ...annotated.linked.map(resolveSnapshot),
     ...annotated.labels,
-    ...uniqueBy([...annotated.linkers.values()].flat(), (c) => c.id),
+    ...uniqueBy([...annotated.linkers.values()].flat(), (c) => c.id).map(resolveSnapshot),
   ]);
 
   const hiddenSpecs = state.pTableParams.hiddenColIds;
@@ -190,10 +186,13 @@ export function createPlDataTableV3<A, U>(
   const visible = buildVisibleColumns(annotated, hiddenColumnIds, labelColumns);
   const visibleDef = createPTableDefV3({
     primaryJoinType,
-    primaryColumns,
+    primaryColumns: primarySnapshots.map(resolveSnapshot),
     secondaryGroups: [
-      ...visible.direct.map((c) => [c]),
-      ...visible.linked.map((lc) => [...(annotated.linkers.get(lc.id) ?? []), lc]),
+      ...visible.direct.map((c) => [resolveSnapshot(c)]),
+      ...visible.linked.map((lc) => [
+        ...(annotated.linkers.get(lc.id) ?? []).map(resolveSnapshot),
+        resolveSnapshot(lc),
+      ]),
       ...visible.labels.map((c) => [c]),
     ],
     filters,
@@ -220,29 +219,22 @@ export type TableColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> = Co
   readonly qualifications?: MatchQualifications;
 };
 
-type TableColumn = PColumn<undefined | PColumnDataUniversal>;
-
 type SplitDiscoveredColumns = {
   readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
   readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
-};
-
-type ResolvedColumns = {
-  readonly direct: TableColumn[];
-  readonly linked: TableColumn[];
-  readonly linkers: Map<PObjectId, TableColumn[]>;
+  readonly linkers: Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>;
 };
 
 type AnnotatedColumnGroups = {
-  readonly direct: TableColumn[];
-  readonly linked: TableColumn[];
-  readonly linkers: Map<PObjectId, TableColumn[]>;
-  readonly labels: TableColumn[];
+  readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
+  readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
+  readonly linkers: Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>;
+  readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 type VisibleColumns = {
-  readonly direct: TableColumn[];
-  readonly linked: TableColumn[];
+  readonly direct: TableColumnSnapshot<SUniversalPColumnId>[];
+  readonly linked: TableColumnSnapshot<SUniversalPColumnId>[];
   readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
@@ -250,25 +242,11 @@ type VisibleColumns = {
 function splitDiscoveredColumns(
   columns: TableColumnSnapshot<SUniversalPColumnId>[],
 ): SplitDiscoveredColumns {
-  return {
-    direct: columns.filter((dc) => isNil(dc.linkerPath) || dc.linkerPath.length === 0),
-    linked: columns.filter((dc) => !isNil(dc.linkerPath) && dc.linkerPath.length > 0),
-  };
-}
-
-/** Resolve DiscoveredColumn snapshots into PColumn objects with lazily-evaluated data. */
-function resolveDiscoveredColumns(split: SplitDiscoveredColumns): ResolvedColumns {
-  const direct = split.direct.map(resolveSnapshot);
-  const linked = split.linked.map(resolveSnapshot);
-  const linkers = new Map<PObjectId, TableColumn[]>(
-    split.linked
-      .filter(
-        (dc): dc is RequiredBy<TableColumnSnapshot<SUniversalPColumnId>, "linkerPath"> =>
-          !isNil(dc.linkerPath),
-      )
-      .map((dc, i) => [linked[i].id, dc.linkerPath.map((s) => resolveSnapshot(s.linker))]),
+  const direct = columns.filter((dc) => isNil(dc.linkerPath) || dc.linkerPath.length === 0);
+  const linked = columns.filter((dc) => !isNil(dc.linkerPath) && dc.linkerPath.length > 0);
+  const linkers = new Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>(
+    linked.map((dc) => [dc.id, (dc.linkerPath ?? []).map((lp) => lp.linker)]),
   );
-
   return { direct, linked, linkers };
 }
 
@@ -279,10 +257,10 @@ function resolveDiscoveredColumns(split: SplitDiscoveredColumns): ResolvedColumn
  * column annotations via `withTableVisualAnnotations`.
  */
 function annotateColumnGroups(params: {
-  direct: TableColumn[];
-  linked: TableColumn[];
+  direct: TableColumnSnapshot<SUniversalPColumnId>[];
+  linked: TableColumnSnapshot<SUniversalPColumnId>[];
   labelColumns: PColumn<PColumnDataUniversal>[];
-  linkers: Map<PObjectId, TableColumn[]>;
+  linkers: Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>;
   derivedLabels: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
   pframeSpec: PFrameSpecDriver;
@@ -318,7 +296,7 @@ function annotateColumnGroups(params: {
       orderByColId,
       withLabelAnnotations(derivedLabels, linked),
     ),
-    linkers: new Map<PObjectId, TableColumn[]>(
+    linkers: new Map<SUniversalPColumnId, ColumnSnapshot<PObjectId>[]>(
       [...linkers].map(([id, cols]) => [
         id,
         withHidenAxesAnnotations(withLabelAnnotations(derivedLabels, cols)),
@@ -329,7 +307,9 @@ function annotateColumnGroups(params: {
 }
 
 /** Build an index of all valid column IDs (axes + columns) for filter/sorting validation. */
-function createColumnValidationById(fullColumns: TableColumn[]) {
+function createColumnValidationById(
+  fullColumns: { readonly id: PObjectId; readonly spec: PColumnSpec }[],
+) {
   const axisIds = uniqueBy(
     fullColumns.flatMap((c) => c.spec.axesSpec.map(getAxisId)),
     (a) => canonicalizeJson<AxisId>(a),
@@ -394,7 +374,7 @@ function validateSorting(sorting: PTableSorting[], isValidColumnId: (id: string)
 
 /** Determine which columns should be hidden based on state or optional-column defaults. */
 function computeHiddenColumns(
-  columns: TableColumn[],
+  columns: { readonly id: PObjectId; readonly spec: PColumnSpec }[],
   sorting: Nil | PTableSorting[],
   filters: Nil | PlDataTableFilters,
   hiddenSpecs: Nil | PTableColumnId[],
@@ -437,10 +417,7 @@ function buildVisibleColumns(
 ): VisibleColumns {
   const direct = annotated.direct.filter((c) => !hiddenColumns.has(c.id));
   const linked = annotated.linked.filter((c) => !hiddenColumns.has(c.id));
-  const labels = getMatchingLabelColumns(
-    [...direct, ...linked].map(getColumnIdAndSpec),
-    originalLabelColumns,
-  );
+  const labels = getMatchingLabelColumns([...direct, ...linked], originalLabelColumns);
   return { direct, linked, labels };
 }
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -40,6 +40,7 @@ import {
   evaluateRules,
   isColumnHidden,
   isColumnOptional,
+  withHidenAxesAnnotations,
   withLabelAnnotations,
   withTableVisualAnnotations,
 } from "./utils";
@@ -187,20 +188,12 @@ export function createPlDataTableV3<A, U>(
   );
 
   const visible = buildVisibleColumns(annotated, hiddenColumnIds, labelColumns);
-  const visibleNonCoreDirect = secondaryColumns.filter((c) => !hiddenColumnIds.has(c.id));
-  const visibleLinkedGroups = buildVisibleLinkedGroups(
-    visible.direct,
-    visible.linked,
-    annotated.linkers,
-    hiddenSpecs,
-  );
-
   const visibleDef = createPTableDefV3({
     primaryJoinType,
     primaryColumns,
     secondaryGroups: [
-      ...visibleNonCoreDirect.map((c) => [c]),
-      ...visibleLinkedGroups,
+      ...visible.direct.map((c) => [c]),
+      ...visible.linked.map((lc) => [...(annotated.linkers.get(lc.id) ?? []), lc]),
       ...visible.labels.map((c) => [c]),
     ],
     filters,
@@ -326,7 +319,10 @@ function annotateColumnGroups(params: {
       withLabelAnnotations(derivedLabels, linked),
     ),
     linkers: new Map<PObjectId, TableColumn[]>(
-      [...linkers].map(([id, cols]) => [id, withLabelAnnotations(derivedLabels, cols)]),
+      [...linkers].map(([id, cols]) => [
+        id,
+        withHidenAxesAnnotations(withLabelAnnotations(derivedLabels, cols)),
+      ]),
     ),
     labels: withLabelAnnotations(derivedLabels, labelColumns),
   };
@@ -411,85 +407,6 @@ function computeHiddenColumns(
   const preserved = collectPreservedColumnIds(sorting, filters);
 
   return new Set(initial.filter((id) => !preserved.has(id)));
-}
-
-/**
- * Build visible linked column groups. Non-hidden groups are included fully;
- * hidden groups are trimmed to only the prefix that brings axes not yet
- * covered by earlier groups (visible or previously trimmed).
- */
-function buildVisibleLinkedGroups(
-  direct: TableColumn[],
-  linked: TableColumn[],
-  linkers: Map<PObjectId, TableColumn[]>,
-  hiddenSpecs: PTableColumnId[] | null,
-): TableColumn[][] {
-  const result: TableColumn[][] = [];
-  const coveredAxisIds = new Set<CanonicalizedJson<AxisId>>();
-
-  const collectAxes = (group: TableColumn[]) => {
-    for (const col of group) {
-      for (const as of col.spec.axesSpec) {
-        coveredAxisIds.add(canonicalizeJson(getAxisId(as)));
-      }
-    }
-  };
-
-  collectAxes(direct);
-
-  for (const lc of linked) {
-    const group = [...(linkers.get(lc.id) ?? []), lc];
-    result.push(group);
-    collectAxes(group);
-  }
-
-  for (const group of linkers.values()) {
-    const trimmed = trimGroupByVisibleAxes(group, hiddenSpecs, coveredAxisIds);
-    if (trimmed.length > 0) {
-      result.push(trimmed);
-      collectAxes(trimmed);
-    }
-  }
-
-  return result;
-}
-
-/**
- * For a linked column group [linker1, ..., linkerN, column], find the rightmost
- * element that has at least one non-hidden and not-yet-covered axis.
- * Return the prefix up to and including that element.
- * If no element has such an axis, return empty array.
- */
-function trimGroupByVisibleAxes(
-  group: TableColumn[],
-  hiddenSpecs: PTableColumnId[] | null,
-  coveredAxisIds: Set<CanonicalizedJson<AxisId>>,
-): TableColumn[] {
-  if (hiddenSpecs === null) return group;
-
-  const hiddenAxisIds = new Set(
-    hiddenSpecs
-      .filter((s): s is PTableColumnIdAxis => s.type === "axis")
-      .map((s) => canonicalizeJson(s.id)),
-  );
-
-  const uncoveredAxisIds = new Set(
-    group
-      .flatMap((c) => c.spec.axesSpec.map((as) => canonicalizeJson(getAxisId(as))))
-      .filter((id) => !hiddenAxisIds.has(id) && !coveredAxisIds.has(id)),
-  );
-
-  let lastNeeded = -1;
-  for (let i = 0; i < group.length; i++) {
-    const newAxes = group[i].spec.axesSpec
-      .map((as) => canonicalizeJson(getAxisId(as)))
-      .filter((id) => uncoveredAxisIds.has(id));
-    if (newAxes.length > 0) {
-      for (const id of newAxes) uncoveredAxisIds.delete(id);
-      lastNeeded = i;
-    }
-  }
-  return lastNeeded === -1 ? [] : group.slice(0, lastNeeded + 1);
 }
 
 /** Collect IDs of columns that must remain visible (sorted, filtered). */

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -31,12 +31,14 @@ import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
   deriveAllLabels,
+  deriveAllTooltips,
   evaluateRules,
   isColumnHidden,
   isColumnOptional,
   withHidenAxesAnnotations,
   withLabelAnnotations,
   withTableVisualAnnotations,
+  withInfoAnnotations,
 } from "./utils";
 import type { PrimaryEntry, SecondaryGroup } from "./createPTableDefV3";
 import { createPTableDefV3 } from "./createPTableDefV3";
@@ -118,11 +120,23 @@ export function createPlDataTableV3<A, U>(
     },
   });
 
+  const derivedTooltips = deriveAllTooltips({
+    columns: discovered.map((dc) => ({
+      id: dc.id,
+      originalId: dc.originalId,
+      spec: dc.spec,
+      linkerPath: dc.linkerPath,
+      qualifications: dc.qualifications,
+      distinctiveQualifications: dc.distinctiveQualifications,
+    })),
+  });
+
   const annotated = annotateColumnGroups({
     pframeSpec,
     ...splited,
     labelColumns,
     derivedLabels,
+    derivedTooltips,
     displayOptions: options.displayOptions,
   });
 
@@ -211,6 +225,7 @@ export type TableColumnSnapshot<Id extends PObjectId | SUniversalPColumnId> = Co
   readonly originalId?: PObjectId;
   readonly linkerPath?: MatchVariant["path"];
   readonly qualifications?: MatchQualifications;
+  readonly distinctiveQualifications?: MatchQualifications;
 };
 
 type SplitDiscoveredColumns = {
@@ -260,10 +275,19 @@ function annotateColumnGroups(params: {
   linked: TableColumnSnapshot<SUniversalPColumnId>[];
   labelColumns: PColumn<PColumnDataUniversal>[];
   derivedLabels: Record<string, string>;
+  derivedTooltips: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
   pframeSpec: PFrameSpecDriver;
 }): AnnotatedColumnGroups {
-  const { direct, linked, labelColumns, derivedLabels, displayOptions, pframeSpec } = params;
+  const {
+    direct,
+    linked,
+    labelColumns,
+    derivedLabels,
+    derivedTooltips,
+    displayOptions,
+    pframeSpec,
+  } = params;
 
   const allColumnsForRules = [
     ...direct,
@@ -282,20 +306,26 @@ function annotateColumnGroups(params: {
     pframeSpec,
   );
 
-  const linkedAnnotated = withTableVisualAnnotations(
-    visibilityByColId,
-    orderByColId,
-    withLabelAnnotations(derivedLabels, linked),
-  ).map((lc) => ({ ...lc, linkerPath: annotateLinkerPath(derivedLabels, lc.linkerPath) }));
+  const directAnnotated = [
+    withLabelAnnotations.bind(null, derivedLabels),
+    withInfoAnnotations.bind(null, derivedTooltips),
+    withTableVisualAnnotations.bind(null, visibilityByColId, orderByColId),
+  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot<SUniversalPColumnId>[], direct);
+
+  const linkedAnnotated = [
+    withLabelAnnotations.bind(null, derivedLabels),
+    withInfoAnnotations.bind(null, derivedTooltips),
+    withTableVisualAnnotations.bind(null, visibilityByColId, orderByColId),
+    (cols: TableColumnSnapshot<SUniversalPColumnId>[]) =>
+      cols.map((lc) => ({ ...lc, linkerPath: annotateLinkerPath(derivedLabels, lc.linkerPath) })),
+  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot<SUniversalPColumnId>[], linked);
+
+  const labelColumnsAnnotated = withLabelAnnotations(derivedLabels, labelColumns);
 
   return {
-    direct: withTableVisualAnnotations(
-      visibilityByColId,
-      orderByColId,
-      withLabelAnnotations(derivedLabels, direct),
-    ),
+    direct: directAnnotated,
     linked: linkedAnnotated,
-    labels: withLabelAnnotations(derivedLabels, labelColumns),
+    labels: labelColumnsAnnotated,
   };
 }
 function annotateLinkerPath(

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalizedJson,
   FilterSpecNode,
   PColumn,
+  PFrameSpecDriver,
   PObjectId,
   PTableColumnId,
   PTableColumnIdAxis,
@@ -25,12 +26,13 @@ import { isEmpty } from "es-toolkit/compat";
 import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV5";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
-import type { ColumnMatch, ColumnSnapshot, MatchingMode } from "../../../columns";
+import type { ColumnMatch, ColumnSelector, ColumnSnapshot, MatchingMode } from "../../../columns";
 import { Services, type RequireServices } from "@milaboratories/pl-model-common";
 import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
   deriveAllLabels,
+  evaluateRules,
   isColumnHidden,
   isColumnOptional,
   withLabelAnnotations,
@@ -68,13 +70,13 @@ export type ColumnsDisplayOptions = {
 };
 
 export type ColumnOrderRule = {
-  match: ColumnMatcher;
+  match: ColumnMatcher | ColumnSelector;
   /** Higher number = further left in table */
   priority: number;
 };
 
 export type ColumnVisibilityRule = {
-  match: ColumnMatcher;
+  match: ColumnMatcher | ColumnSelector;
   visibility: "default" | "optional" | "hidden";
 };
 
@@ -95,9 +97,12 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
   if (isNil(discovered) || discovered.length === 0) return undefined;
 
   const splited = splitDiscoveredColumns(discovered);
-  const resolved = resolveDiscoveredColumns(splited, discovered);
+  const resolved = resolveDiscoveredColumns(splited);
 
-  const labelColumns = getMatchingLabelColumns(resolved.all, getAllLabelColumns(ctx));
+  const labelColumns = getMatchingLabelColumns(
+    [...resolved.direct, ...resolved.linked],
+    getAllLabelColumns(ctx),
+  );
 
   const derivedLabels = deriveAllLabels({
     columns: discovered.map((dc) => ({
@@ -112,12 +117,15 @@ export function createPlDataTableV3<A, U, S extends RequireServices<typeof Servi
     },
   });
 
-  const annotated = annotateColumnGroups(
-    resolved,
+  const annotated = annotateColumnGroups({
+    pframeSpec:
+      ctx.services.pframeSpec ??
+      throwError("PFrameSpec service is required for display rule evaluation."),
+    ...resolved,
     labelColumns,
     derivedLabels,
-    options.displayOptions,
-  );
+    displayOptions: options.displayOptions,
+  });
 
   const primaryColumnIds = new Set<PObjectId>(
     discovered.filter((dc) => dc.isPrimary).map((dc) => dc.id),
@@ -223,7 +231,6 @@ type ResolvedColumns = {
   readonly direct: TableColumn[];
   readonly linked: TableColumn[];
   readonly linkers: Map<PObjectId, TableColumn[]>;
-  readonly all: TableColumn[];
 };
 
 type AnnotatedColumnGroups = {
@@ -250,10 +257,8 @@ function splitDiscoveredColumns(
 }
 
 /** Resolve DiscoveredColumn snapshots into PColumn objects with lazily-evaluated data. */
-function resolveDiscoveredColumns(
-  split: SplitDiscoveredColumns,
-  allDiscovered: TableColumnSnapshot<SUniversalPColumnId>[],
-): ResolvedColumns {
+function resolveDiscoveredColumns(split: SplitDiscoveredColumns): ResolvedColumns {
+  const direct = split.direct.map(resolveSnapshot);
   const linked = split.linked.map(resolveSnapshot);
   const linkers = new Map<PObjectId, TableColumn[]>(
     split.linked
@@ -264,35 +269,60 @@ function resolveDiscoveredColumns(
       .map((dc, i) => [linked[i].id, dc.linkerPath.map((s) => resolveSnapshot(s.linker))]),
   );
 
-  return {
-    all: allDiscovered.map(resolveSnapshot),
-    direct: split.direct.map(resolveSnapshot),
-    linked,
-    linkers,
-  };
+  return { direct, linked, linkers };
 }
 
-/** Annotate all column groups with derived labels and display options. */
-function annotateColumnGroups(
-  resolved: ResolvedColumns,
-  labelColumns: PColumn<PColumnDataUniversal>[],
-  derivedLabels: Record<string, string>,
-  displayOptions: ColumnsDisplayOptions | undefined,
-): AnnotatedColumnGroups {
-  const direct = withTableVisualAnnotations(
-    displayOptions,
-    withLabelAnnotations(derivedLabels, resolved.direct),
-  );
-  const linked = withTableVisualAnnotations(
-    displayOptions,
-    withLabelAnnotations(derivedLabels, resolved.linked),
-  );
-  const linkers = new Map<PObjectId, TableColumn[]>(
-    [...resolved.linkers].map(([id, cols]) => [id, withLabelAnnotations(derivedLabels, cols)]),
-  );
-  const labels = withLabelAnnotations(derivedLabels, labelColumns);
+/**
+ * Annotate all column groups with derived labels and display-rule annotations.
+ * Evaluates `displayOptions` rules against all discovered columns (direct,
+ * linked, labels, linkers) and writes the winning visibility/priority into
+ * column annotations via `withTableVisualAnnotations`.
+ */
+function annotateColumnGroups(params: {
+  pframeSpec: PFrameSpecDriver;
+  direct: TableColumn[];
+  linked: TableColumn[];
+  labelColumns: PColumn<PColumnDataUniversal>[];
+  linkers: Map<PObjectId, TableColumn[]>;
+  derivedLabels: Record<string, string>;
+  displayOptions?: ColumnsDisplayOptions;
+}): AnnotatedColumnGroups {
+  const { pframeSpec, direct, linked, linkers, labelColumns, derivedLabels, displayOptions } =
+    params;
 
-  return { direct, linked, linkers, labels };
+  const allColumnsForRules = [
+    ...direct,
+    ...linked,
+    ...labelColumns,
+    ...uniqueBy([...linkers.values()].flat(), (c) => c.id),
+  ];
+  const visibilityByColId = evaluateRules(
+    displayOptions?.visibility ?? [],
+    allColumnsForRules,
+    pframeSpec,
+  );
+  const orderByColId = evaluateRules(
+    displayOptions?.ordering ?? [],
+    allColumnsForRules,
+    pframeSpec,
+  );
+
+  return {
+    direct: withTableVisualAnnotations(
+      visibilityByColId,
+      orderByColId,
+      withLabelAnnotations(derivedLabels, direct),
+    ),
+    linked: withTableVisualAnnotations(
+      visibilityByColId,
+      orderByColId,
+      withLabelAnnotations(derivedLabels, linked),
+    ),
+    linkers: new Map<PObjectId, TableColumn[]>(
+      [...linkers].map(([id, cols]) => [id, withLabelAnnotations(derivedLabels, cols)]),
+    ),
+    labels: withLabelAnnotations(derivedLabels, labelColumns),
+  };
 }
 
 /** Build an index of all valid column IDs (axes + columns) for filter/sorting validation. */

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -1,23 +1,19 @@
-import type {
-  PColumnIdAndSpec,
-  PColumnSpec,
-  PlRef,
-  PObjectId,
-  SUniversalPColumnId,
-} from "@milaboratories/pl-model-common";
-import { isPlRef } from "@milaboratories/pl-model-common";
+import type { PColumnSpec, PlRef, PObjectId } from "@milaboratories/pl-model-common";
+import { createDiscoveredPColumnId, isPlRef } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
 import type {
   ColumnSource,
   ColumnMatch,
   RelaxedColumnSelector,
   ColumnSnapshotProvider,
+  ColumnSnapshot,
 } from "../../../columns";
 import { ColumnCollectionBuilder } from "../../../columns";
 import { toColumnSnapshotProvider } from "../../../columns/column_snapshot_provider";
 import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_sources";
 import { throwError } from "@milaboratories/helpers";
 import type { ColumnsSelectorConfig, TableColumnSnapshot } from "./createPlDataTableV3";
+import { isNil } from "es-toolkit";
 
 export type DiscoverTableColumnOptions = {
   sources?: ColumnSource[];
@@ -29,7 +25,7 @@ export type DiscoverTableColumnOptions = {
 export function discoverTableColumnSnaphots(
   ctx: RenderCtxBase,
   options: DiscoverTableColumnOptions,
-): TableColumnSnapshot<SUniversalPColumnId>[] | undefined {
+): TableColumnSnapshot[] | undefined {
   // Resolve PlRef anchors to PColumnSpec
   const resolvedOptions = {
     ...options,
@@ -47,9 +43,19 @@ export function discoverTableColumnSnaphots(
   if (collection === undefined) return undefined;
 
   try {
-    const matched = collection.findColumns(resolvedOptions.selector ?? undefined);
+    const columns = collection.findColumns({
+      ...(resolvedOptions.selector ?? {}),
+      exclude: [
+        ...(Array.isArray(resolvedOptions.selector?.exclude)
+          ? resolvedOptions.selector.exclude
+          : !isNil(resolvedOptions.selector.exclude)
+            ? [resolvedOptions.selector.exclude]
+            : []),
+        { name: "pl7.app/label" },
+      ],
+    });
     const anchors = collection.getAnchors();
-    return mapToDiscoveredColumns(matched, anchors);
+    return mapToDiscoveredColumns(columns, anchors);
   } finally {
     collection.dispose();
   }
@@ -90,31 +96,36 @@ function resolveProviders(
 /** Map matched columns into a flat DiscoveredColumn list with deduped IDs. */
 function mapToDiscoveredColumns(
   matched: readonly ColumnMatch[],
-  anchors: Map<string, PColumnIdAndSpec>,
-): TableColumnSnapshot<SUniversalPColumnId>[] {
-  const anchorKeyByColumnId = new Map<PObjectId, string>(
-    Array.from(anchors.entries(), ([key, { columnId }]) => [columnId, key] as const),
+  anchors: Map<string, ColumnSnapshot<PObjectId>>,
+): TableColumnSnapshot[] {
+  const columnIdToAnchorName = new Map<PObjectId, string>(
+    Array.from(anchors.entries(), ([key, { id }]) => [id, key] as const),
   );
 
   return matched.flatMap((match) => {
     const snap = match.column;
-    const multi = match.variants.length > 1;
-    const anchorKey = anchorKeyByColumnId.get(match.originalId);
-    const isPrimary = anchorKey !== undefined;
+    const isPrimary = columnIdToAnchorName.get(match.column.id) !== undefined;
 
-    return match.variants.map(
-      (variant, vi): TableColumnSnapshot<SUniversalPColumnId> => ({
-        id: (multi ? `${snap.id}#q${vi}` : snap.id) as SUniversalPColumnId,
-        originalId: match.originalId,
+    return match.variants.map((variant): TableColumnSnapshot => {
+      const discoveredId = createDiscoveredPColumnId(
+        snap.id,
+        variant.path.map((p) => ({ column: p.linker.id, qualifications: p.qualifications })),
+        variant.qualifications.forHit,
+        Object.values(variant.qualifications.forQueries),
+      );
+      return {
+        id: discoveredId,
+        isPrimary,
+
+        originalId: snap.id,
         spec: snap.spec,
         data: snap.data,
         dataStatus: snap.dataStatus,
-        isPrimary,
-        anchorKey,
+
         linkerPath: variant.path,
         qualifications: variant.qualifications,
         distinctiveQualifications: variant.distinctiveQualifications,
-      }),
-    );
+      };
+    });
   });
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -2,8 +2,6 @@ import type {
   PColumnSpec,
   PlRef,
   PObjectId,
-  RequireServices,
-  Services,
   SUniversalPColumnId,
 } from "@milaboratories/pl-model-common";
 import { isPlRef } from "@milaboratories/pl-model-common";
@@ -14,20 +12,17 @@ import { toColumnSnapshotProvider } from "../../../columns/column_snapshot_provi
 import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_sources";
 import { throwError } from "@milaboratories/helpers";
 import type { ColumnsSelectorConfig, TableColumnSnapshot } from "./createPlDataTableV3";
+import { getService } from "../../../services";
 
 export type DiscoverTableColumnOptions = {
   sources?: ColumnSource[];
   anchors: Record<string, PlRef | PObjectId | PColumnSpec | RelaxedColumnSelector>;
-  columnsSelector: ColumnsSelectorConfig;
+  selector: ColumnsSelectorConfig;
 };
 
 /** Discover columns from sources/anchors and normalize into a flat DiscoveredColumn list. */
-export function discoverTableColumnSnaphots<
-  A,
-  U,
-  S extends RequireServices<typeof Services.PFrameSpec>,
->(
-  ctx: RenderCtxBase<A, U, S>,
+export function discoverTableColumnSnaphots<A, U>(
+  ctx: RenderCtxBase<A, U>,
   options: DiscoverTableColumnOptions,
 ): TableColumnSnapshot<SUniversalPColumnId>[] | undefined {
   // Resolve PlRef anchors to PColumnSpec
@@ -38,15 +33,14 @@ export function discoverTableColumnSnaphots<
   if (providers.length === 0) return undefined;
 
   // Build collection (anchored or plain)
-  const pframeSpec =
-    ctx.services.pframeSpec ?? throwError("PFrameSpec service is required for column discovery.");
+  const pframeSpec = getService("pframeSpec");
   const collection = new ColumnCollectionBuilder(pframeSpec)
     .addSources(providers)
     .build(resolvedOptions);
   if (collection === undefined) return undefined;
 
   try {
-    const matched = collection.findColumns(resolvedOptions.columnsSelector ?? undefined);
+    const matched = collection.findColumns(resolvedOptions.selector ?? undefined);
     const anchors = collection.getAnchors();
     return mapToDiscoveredColumns(
       matched,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -102,16 +102,19 @@ function mapToDiscoveredColumns(
     const anchorKey = anchorKeyByColumnId.get(match.originalId);
     const isPrimary = anchorKey !== undefined;
 
-    return match.variants.map((variant, vi) => ({
-      id: (multi ? `${snap.id}#q${vi}` : snap.id) as SUniversalPColumnId,
-      originalId: match.originalId,
-      spec: snap.spec,
-      data: snap.data,
-      dataStatus: snap.dataStatus,
-      isPrimary,
-      anchorKey,
-      linkerPath: variant.path,
-      qualifications: variant.qualifications,
-    }));
+    return match.variants.map(
+      (variant, vi): TableColumnSnapshot<SUniversalPColumnId> => ({
+        id: (multi ? `${snap.id}#q${vi}` : snap.id) as SUniversalPColumnId,
+        originalId: match.originalId,
+        spec: snap.spec,
+        data: snap.data,
+        dataStatus: snap.dataStatus,
+        isPrimary,
+        anchorKey,
+        linkerPath: variant.path,
+        qualifications: variant.qualifications,
+        distinctiveQualifications: variant.distinctiveQualifications,
+      }),
+    );
   });
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -15,7 +15,7 @@ import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_s
 import { throwError } from "@milaboratories/helpers";
 import type { ColumnsSelectorConfig, TableColumnSnapshot } from "./createPlDataTableV3";
 
-export type DiscoveredTableColumnOptions = {
+export type DiscoverTableColumnOptions = {
   sources?: ColumnSource[];
   anchors: Record<string, PlRef | PObjectId | PColumnSpec | RelaxedColumnSelector>;
   columnsSelector: ColumnsSelectorConfig;
@@ -28,7 +28,7 @@ export function discoverTableColumnSnaphots<
   S extends RequireServices<typeof Services.PFrameSpec>,
 >(
   ctx: RenderCtxBase<A, U, S>,
-  options: DiscoveredTableColumnOptions,
+  options: DiscoverTableColumnOptions,
 ): TableColumnSnapshot<SUniversalPColumnId>[] | undefined {
   // Resolve PlRef anchors to PColumnSpec
   const resolvedOptions = { ...options, anchors: resolveAnchors(ctx, options.anchors) };

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -6,13 +6,17 @@ import type {
 } from "@milaboratories/pl-model-common";
 import { isPlRef } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
-import type { ColumnSource, ColumnMatch, RelaxedColumnSelector } from "../../../columns";
+import type {
+  ColumnSource,
+  ColumnMatch,
+  RelaxedColumnSelector,
+  ColumnSnapshotProvider,
+} from "../../../columns";
 import { ColumnCollectionBuilder } from "../../../columns";
 import { toColumnSnapshotProvider } from "../../../columns/column_snapshot_provider";
 import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_sources";
 import { throwError } from "@milaboratories/helpers";
 import type { ColumnsSelectorConfig, TableColumnSnapshot } from "./createPlDataTableV3";
-import { getService } from "../../../services";
 
 export type DiscoverTableColumnOptions = {
   sources?: ColumnSource[];
@@ -21,20 +25,22 @@ export type DiscoverTableColumnOptions = {
 };
 
 /** Discover columns from sources/anchors and normalize into a flat DiscoveredColumn list. */
-export function discoverTableColumnSnaphots<A, U>(
-  ctx: RenderCtxBase<A, U>,
+export function discoverTableColumnSnaphots(
+  ctx: RenderCtxBase,
   options: DiscoverTableColumnOptions,
 ): TableColumnSnapshot<SUniversalPColumnId>[] | undefined {
   // Resolve PlRef anchors to PColumnSpec
-  const resolvedOptions = { ...options, anchors: resolveAnchors(ctx, options.anchors) };
+  const resolvedOptions = {
+    ...options,
+    anchors: resolveAnchors(ctx, options.anchors),
+  };
 
   // Resolve providers
   const providers = resolveProviders(ctx, resolvedOptions.sources);
   if (providers.length === 0) return undefined;
 
   // Build collection (anchored or plain)
-  const pframeSpec = getService("pframeSpec");
-  const collection = new ColumnCollectionBuilder(pframeSpec)
+  const collection = new ColumnCollectionBuilder(ctx.getService("pframeSpec"))
     .addSources(providers)
     .build(resolvedOptions);
   if (collection === undefined) return undefined;
@@ -54,8 +60,8 @@ export function discoverTableColumnSnaphots<A, U>(
 // --- Pure helper functions ---
 
 /** Resolve PlRef values in anchors to PColumnSpec via the result pool. */
-function resolveAnchors<A, U>(
-  ctx: RenderCtxBase<A, U>,
+function resolveAnchors(
+  ctx: RenderCtxBase,
   anchors: Record<string, PlRef | PObjectId | PColumnSpec | RelaxedColumnSelector>,
 ): Record<string, PObjectId | PColumnSpec | RelaxedColumnSelector> {
   const result: Record<string, PObjectId | PColumnSpec | RelaxedColumnSelector> = {};
@@ -74,7 +80,10 @@ function resolveAnchors<A, U>(
 }
 
 /** Resolve column snapshot providers from explicit sources or context. */
-function resolveProviders<A, U>(ctx: RenderCtxBase<A, U>, sources: undefined | ColumnSource[]) {
+function resolveProviders(
+  ctx: RenderCtxBase,
+  sources: undefined | ColumnSource[],
+): ColumnSnapshotProvider[] {
   return sources !== undefined
     ? sources.map(toColumnSnapshotProvider)
     : collectCtxColumnSnapshotProviders(ctx);

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -107,12 +107,16 @@ function mapToDiscoveredColumns(
     const isPrimary = columnIdToAnchorName.get(match.column.id) !== undefined;
 
     return match.variants.map((variant): TableColumnSnapshot => {
-      const discoveredId = createDiscoveredPColumnId(
-        snap.id,
-        variant.path.map((p) => ({ column: p.linker.id, qualifications: p.qualifications })),
-        variant.qualifications.forHit,
-        Object.values(variant.qualifications.forQueries),
-      );
+      const discoveredId = createDiscoveredPColumnId({
+        column: snap.id,
+        path: variant.path.map((p) => ({
+          type: "linker",
+          column: p.linker.id,
+          qualifications: p.qualifications,
+        })),
+        columnQualifications: variant.qualifications.forHit,
+        queriesQualifications: variant.qualifications.forQueries,
+      });
       return {
         id: discoveredId,
         isPrimary,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -1,4 +1,5 @@
 import type {
+  PColumnIdAndSpec,
   PColumnSpec,
   PlRef,
   PObjectId,
@@ -48,10 +49,7 @@ export function discoverTableColumnSnaphots(
   try {
     const matched = collection.findColumns(resolvedOptions.selector ?? undefined);
     const anchors = collection.getAnchors();
-    return mapToDiscoveredColumns(
-      matched,
-      Array.from(Array.from(anchors.values()).map((v) => v.columnId)),
-    );
+    return mapToDiscoveredColumns(matched, anchors);
   } finally {
     collection.dispose();
   }
@@ -92,14 +90,17 @@ function resolveProviders(
 /** Map matched columns into a flat DiscoveredColumn list with deduped IDs. */
 function mapToDiscoveredColumns(
   matched: readonly ColumnMatch[],
-  anchorColumnIds: readonly PObjectId[],
+  anchors: Map<string, PColumnIdAndSpec>,
 ): TableColumnSnapshot<SUniversalPColumnId>[] {
+  const anchorKeyByColumnId = new Map<PObjectId, string>(
+    Array.from(anchors.entries(), ([key, { columnId }]) => [columnId, key] as const),
+  );
+
   return matched.flatMap((match) => {
     const snap = match.column;
     const multi = match.variants.length > 1;
-    const isPrimary = anchorColumnIds.some(
-      (anchor) => snap.id === anchor || match.originalId === anchor,
-    );
+    const anchorKey = anchorKeyByColumnId.get(match.originalId);
+    const isPrimary = anchorKey !== undefined;
 
     return match.variants.map((variant, vi) => ({
       id: (multi ? `${snap.id}#q${vi}` : snap.id) as SUniversalPColumnId,
@@ -108,6 +109,7 @@ function mapToDiscoveredColumns(
       data: snap.data,
       dataStatus: snap.dataStatus,
       isPrimary,
+      anchorKey,
       linkerPath: variant.path,
       qualifications: variant.qualifications,
     }));

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -94,32 +94,22 @@ function mapToDiscoveredColumns(
   matched: readonly ColumnMatch[],
   anchorColumnIds: readonly PObjectId[],
 ): TableColumnSnapshot<SUniversalPColumnId>[] {
-  const hitCounts = matched.reduce(
-    (acc, match) => acc.set(match.originalId, (acc.get(match.originalId) ?? 0) + 1),
-    new Map<PObjectId, number>(),
-  );
-
-  const hitIndices = new Map<PObjectId, number>();
-  return matched.map((match) => {
+  return matched.flatMap((match) => {
     const snap = match.column;
+    const multi = match.variants.length > 1;
+    const isPrimary = anchorColumnIds.some(
+      (anchor) => snap.id === anchor || match.originalId === anchor,
+    );
 
-    let id = snap.id;
-    if ((hitCounts.get(match.originalId) ?? 0) > 1) {
-      const idx = hitIndices.get(match.originalId) ?? 0;
-      hitIndices.set(match.originalId, idx + 1);
-      id = `${snap.id}#q${idx}` as SUniversalPColumnId;
-    }
-
-    return {
-      id,
+    return match.variants.map((variant, vi) => ({
+      id: (multi ? `${snap.id}#q${vi}` : snap.id) as SUniversalPColumnId,
       originalId: match.originalId,
       spec: snap.spec,
       data: snap.data,
       dataStatus: snap.dataStatus,
-      isPrimary: anchorColumnIds.some(
-        (anchor) => snap.id === anchor || match.originalId === anchor,
-      ),
-      linkerPath: match.path,
-    };
+      isPrimary,
+      linkerPath: variant.path,
+      qualifications: variant.qualifications,
+    }));
   });
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/index.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/index.ts
@@ -1,20 +1,19 @@
-import { Services, type RequireServices } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
 import type { PlDataTableModel } from "../typesV5";
 import { createPlDataTableOptionsV2, createPlDataTableV2 } from "./createPlDataTableV2";
 import { createPlDataTableV3 } from "./createPlDataTableV3";
 import type { createPlDataTableOptionsV3 } from "./createPlDataTableV3";
 
-export function createPlDataTable<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
-  ctx: RenderCtxBase<A, U, S>,
+export function createPlDataTable<A, U>(
+  ctx: RenderCtxBase<A, U>,
   options: { version: "v2" } & createPlDataTableOptionsV2,
 ): ReturnType<typeof createPlDataTableV2>;
-export function createPlDataTable<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
-  ctx: RenderCtxBase<A, U, S>,
+export function createPlDataTable<A, U>(
+  ctx: RenderCtxBase<A, U>,
   options: { version?: "v3" } & createPlDataTableOptionsV3,
 ): ReturnType<typeof createPlDataTableV3>;
-export function createPlDataTable<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
-  ctx: RenderCtxBase<A, U, S>,
+export function createPlDataTable<A, U>(
+  ctx: RenderCtxBase<A, U>,
   options:
     | ({ version: "v2" } & createPlDataTableOptionsV2)
     | ({ version?: "v3" } & createPlDataTableOptionsV3),

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -6,8 +6,10 @@ import {
   type PColumnSpec,
   type PObjectId,
 } from "@milaboratories/pl-model-common";
+import { SpecDriver } from "@milaboratories/pf-spec-driver";
 import { describe, expect, test } from "vitest";
-import { deriveAllLabels, type LabelableColumn } from "./utils";
+import { deriveAllLabels, evaluateRules, type LabelableColumn, type RuleColumn } from "./utils";
+import type { ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -253,5 +255,99 @@ describe("deriveAxisLabels via deriveAllLabels", () => {
 
     expect(result["c1"]).toContain("via ClusterA");
     expect(result["c2"]).not.toContain("via ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateRules
+// ---------------------------------------------------------------------------
+
+function makeRuleColumn(id: string, spec: Partial<PColumnSpec> = {}): RuleColumn {
+  return {
+    id: id as PObjectId,
+    spec: makeSpec({ axesSpec: [{ name: "id", type: "String" }], ...spec }),
+  };
+}
+
+describe("evaluateRules", () => {
+  test("returns empty map when rules or columns are empty", () => {
+    const driver = new SpecDriver();
+    expect(evaluateRules([], [makeRuleColumn("c1")], driver).size).toBe(0);
+    expect(
+      evaluateRules<ColumnVisibilityRule>([{ match: () => true, visibility: "hidden" }], [], driver)
+        .size,
+    ).toBe(0);
+  });
+
+  test("evaluates predicate rules without touching the driver", () => {
+    const driver = new Proxy({} as SpecDriver, {
+      get() {
+        throw new Error("driver should not be called for predicate-only rules");
+      },
+    });
+
+    const rules: ColumnOrderRule[] = [
+      { match: (spec) => spec.name === "alpha", priority: 10 },
+      { match: (spec) => spec.name === "beta", priority: 5 },
+    ];
+    const result = evaluateRules(
+      rules,
+      [
+        makeRuleColumn("a", { name: "alpha" }),
+        makeRuleColumn("b", { name: "beta" }),
+        makeRuleColumn("c", { name: "gamma" }),
+      ],
+      driver,
+    );
+
+    expect(result.get("a" as PObjectId)?.priority).toBe(10);
+    expect(result.get("b" as PObjectId)?.priority).toBe(5);
+    expect(result.has("c" as PObjectId)).toBe(false);
+  });
+
+  test("evaluates selector rules via PFrameSpec.discoverColumns", () => {
+    const driver = new SpecDriver();
+    const rules: ColumnVisibilityRule[] = [
+      { match: { name: "^note$" }, visibility: "hidden" },
+      { match: { name: "^score$" }, visibility: "optional" },
+    ];
+    const columns = [
+      makeRuleColumn("n", { name: "note" }),
+      makeRuleColumn("s", { name: "score" }),
+      makeRuleColumn("x", { name: "other" }),
+    ];
+
+    const result = evaluateRules(rules, columns, driver);
+
+    expect(result.get("n" as PObjectId)?.visibility).toBe("hidden");
+    expect(result.get("s" as PObjectId)?.visibility).toBe("optional");
+    expect(result.has("x" as PObjectId)).toBe(false);
+  });
+
+  test("preserves original rule order when predicate and selector rules are mixed", () => {
+    const driver = new SpecDriver();
+    const rules: ColumnOrderRule[] = [
+      { match: (spec) => spec.name === "alpha", priority: 100 },
+      { match: { name: "^alpha$" }, priority: 1 }, // shadowed by the predicate above
+      { match: { name: "^beta$" }, priority: 50 },
+    ];
+    const result = evaluateRules(
+      rules,
+      [makeRuleColumn("a", { name: "alpha" }), makeRuleColumn("b", { name: "beta" })],
+      driver,
+    );
+
+    expect(result.get("a" as PObjectId)?.priority).toBe(100);
+    expect(result.get("b" as PObjectId)?.priority).toBe(50);
+  });
+
+  test("dedupes columns by id before building spec frame (no duplicate-key crash)", () => {
+    const driver = new SpecDriver();
+    const rules: ColumnVisibilityRule[] = [{ match: { name: "^dup$" }, visibility: "hidden" }];
+    const dup = makeRuleColumn("d", { name: "dup" });
+
+    const result = evaluateRules(rules, [dup, dup, dup], driver);
+
+    expect(result.get("d" as PObjectId)?.visibility).toBe("hidden");
   });
 });

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -125,10 +125,9 @@ function dedupeById(columns: RuleColumn[]): RuleColumn[] {
  * For each column: writes derived label into Annotation.Label (if present in derivedLabels).
  * For each axis in column specs: writes derived axis label into AxisSpec annotations.
  */
-export function withLabelAnnotations<Data>(
-  derivedLabels: undefined | Record<string, string>,
-  columns: PColumn<Data>[],
-): PColumn<Data>[] {
+export function withLabelAnnotations<
+  T extends { readonly id: PObjectId; readonly spec: PColumnSpec },
+>(derivedLabels: undefined | Record<string, string>, columns: T[]): T[] {
   if (derivedLabels === undefined) return columns;
   return columns.map((col) => {
     const colLabel = derivedLabels[col.id];
@@ -146,7 +145,7 @@ export function withLabelAnnotations<Data>(
             : { ...axis, annotations: { ...axis.annotations, [Annotation.Label]: label } };
         }),
       },
-    };
+    } as T;
   });
 }
 
@@ -154,11 +153,13 @@ export function withLabelAnnotations<Data>(
  * Writes effective display properties (OrderPriority, Visibility) from precomputed rule maps
  * into column annotations. Returns new column objects — originals are not mutated.
  */
-export function withTableVisualAnnotations<Data>(
+export function withTableVisualAnnotations<
+  T extends { readonly id: PObjectId; readonly spec: PColumnSpec },
+>(
   visibilityByColId: undefined | Map<PObjectId, ColumnVisibilityRule>,
   orderByColId: undefined | Map<PObjectId, ColumnOrderRule>,
-  columns: PColumn<Data>[],
-): PColumn<Data>[] {
+  columns: T[],
+): T[] {
   if (visibilityByColId === undefined && orderByColId === undefined) return columns;
   return columns.map((col) => {
     const annotations = { ...col.spec.annotations };
@@ -175,21 +176,26 @@ export function withTableVisualAnnotations<Data>(
         ...col.spec,
         annotations: annotations,
       },
-    };
+    } as T;
   });
 }
 
-export function withHidenAxesAnnotations<Data>(columns: PColumn<Data>[]): PColumn<Data>[] {
-  return columns.map((col) => ({
-    ...col,
-    spec: {
-      ...col.spec,
-      axesSpec: col.spec.axesSpec.map((axis) => ({
-        ...axis,
-        annotations: { ...axis.annotations, [Annotation.Table.Visibility]: "hidden" },
-      })),
-    },
-  }));
+export function withHidenAxesAnnotations<T extends { readonly spec: PColumnSpec }>(
+  columns: T[],
+): T[] {
+  return columns.map(
+    (col) =>
+      ({
+        ...col,
+        spec: {
+          ...col.spec,
+          axesSpec: col.spec.axesSpec.map((axis) => ({
+            ...axis,
+            annotations: { ...axis.annotations, [Annotation.Table.Visibility]: "hidden" },
+          })),
+        },
+      }) as T,
+  );
 }
 
 /** Column shape required by label derivation. */

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -14,6 +14,11 @@ import {
   deriveDistinctLabels,
   type DeriveLabelsOptions,
 } from "../../../labels/derive_distinct_labels";
+import {
+  deriveDistinctTooltips,
+  type TooltipEntry,
+} from "../../../labels/derive_distinct_tooltips";
+import type { MatchQualifications, MatchVariant } from "../../../columns";
 import type { ColumnMatcher, ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
 import type { ColumnSelector } from "../../../columns";
 import { ArrayColumnProvider, ColumnCollectionBuilder } from "../../../columns";
@@ -180,6 +185,27 @@ export function withTableVisualAnnotations<
   });
 }
 
+/**
+ * Writes derived info annotations into column annotations.
+ * Columns without an info entry are passed through unchanged.
+ */
+export function withInfoAnnotations<
+  T extends { readonly id: PObjectId; readonly spec: PColumnSpec },
+>(infoById: undefined | Record<string, string>, columns: T[]): T[] {
+  if (isNil(infoById)) return columns;
+  return columns.map((col) => {
+    const info = infoById[col.id];
+    if (isNil(info)) return col;
+    return {
+      ...col,
+      spec: {
+        ...col.spec,
+        annotations: { ...col.spec.annotations, [Annotation.Table.Info]: info },
+      },
+    } as T;
+  });
+}
+
 export function withHidenAxesAnnotations<T extends { readonly spec: PColumnSpec }>(
   columns: T[],
 ): T[] {
@@ -237,4 +263,50 @@ function deriveAxisLabels(
     result[axisKey] = readAnnotation(source ?? {}, Annotation.Label)?.trim() ?? "Unlabeled";
   }
   return result;
+}
+
+/** Column shape required by tooltip derivation. */
+export type TooltipableColumn = {
+  readonly id: PObjectId;
+  readonly originalId?: PObjectId;
+  readonly spec: PColumnSpec;
+  readonly linkerPath?: MatchVariant["path"];
+  readonly qualifications?: MatchQualifications;
+  readonly distinctiveQualifications?: MatchQualifications;
+};
+
+/** Derive origin tooltips for columns whose qualifications or linker path carry info. */
+export function deriveAllTooltips(options: {
+  columns: TooltipableColumn[];
+}): Record<string, string> {
+  const { columns } = options;
+
+  const variantCountByOriginal = columns.reduce<Map<PObjectId, number>>((acc, c) => {
+    if (isNil(c.originalId)) return acc;
+    acc.set(c.originalId, (acc.get(c.originalId) ?? 0) + 1);
+    return acc;
+  }, new Map());
+  const variantSeen = new Map<PObjectId, number>();
+
+  const entries: TooltipEntry[] = columns.map((c) => {
+    const variantCount = isNil(c.originalId) ? undefined : variantCountByOriginal.get(c.originalId);
+    const variantIndex = isNil(c.originalId)
+      ? undefined
+      : (variantSeen.set(c.originalId, (variantSeen.get(c.originalId) ?? 0) + 1),
+        variantSeen.get(c.originalId));
+    return {
+      spec: c.spec,
+      qualifications: c.qualifications,
+      distinctiveQualifications: c.distinctiveQualifications,
+      linkerPath: c.linkerPath,
+      variantIndex,
+      variantCount,
+    };
+  });
+
+  const tooltips = deriveDistinctTooltips(entries);
+
+  return Object.fromEntries(
+    tooltips.flatMap((t, i) => (isNil(t) ? [] : [[columns[i].id, t] as const])),
+  );
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -179,6 +179,19 @@ export function withTableVisualAnnotations<Data>(
   });
 }
 
+export function withHidenAxesAnnotations<Data>(columns: PColumn<Data>[]): PColumn<Data>[] {
+  return columns.map((col) => ({
+    ...col,
+    spec: {
+      ...col.spec,
+      axesSpec: col.spec.axesSpec.map((axis) => ({
+        ...axis,
+        annotations: { ...axis.annotations, [Annotation.Table.Visibility]: "hidden" },
+      })),
+    },
+  }));
+}
+
 /** Column shape required by label derivation. */
 export type LabelableColumn = {
   readonly id: PObjectId;

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -6,6 +6,7 @@ import {
   Annotation,
   canonicalizeAxisId,
   canonicalizeJson,
+  DiscoveredPColumnId,
   getAxisId,
   readAnnotation,
   readAnnotationJson,
@@ -267,9 +268,9 @@ function deriveAxisLabels(
 
 /** Column shape required by tooltip derivation. */
 export type TooltipableColumn = {
-  readonly id: PObjectId;
-  readonly originalId?: PObjectId;
+  readonly id: DiscoveredPColumnId;
   readonly spec: PColumnSpec;
+  readonly originalId: PObjectId;
   readonly linkerPath?: MatchVariant["path"];
   readonly qualifications?: MatchQualifications;
   readonly distinctiveQualifications?: MatchQualifications;
@@ -278,31 +279,33 @@ export type TooltipableColumn = {
 /** Derive origin tooltips for columns whose qualifications or linker path carry info. */
 export function deriveAllTooltips(options: {
   columns: TooltipableColumn[];
-}): Record<string, string> {
+}): Record<DiscoveredPColumnId, string> {
   const { columns } = options;
 
   const variantCountByOriginal = columns.reduce<Map<PObjectId, number>>((acc, c) => {
-    if (isNil(c.originalId)) return acc;
-    acc.set(c.originalId, (acc.get(c.originalId) ?? 0) + 1);
-    return acc;
+    return acc.set(c.originalId, (acc.get(c.originalId) ?? 0) + 1);
   }, new Map());
-  const variantSeen = new Map<PObjectId, number>();
 
-  const entries: TooltipEntry[] = columns.map((c) => {
-    const variantCount = isNil(c.originalId) ? undefined : variantCountByOriginal.get(c.originalId);
-    const variantIndex = isNil(c.originalId)
-      ? undefined
-      : (variantSeen.set(c.originalId, (variantSeen.get(c.originalId) ?? 0) + 1),
+  const { entries } = columns.reduce(
+    ({ entries, variantSeen }, c) => {
+      const variantCount = variantCountByOriginal.get(c.originalId);
+      const variantIndex =
+        (variantSeen.set(c.originalId, (variantSeen.get(c.originalId) ?? 0) + 1),
         variantSeen.get(c.originalId));
-    return {
-      spec: c.spec,
-      qualifications: c.qualifications,
-      distinctiveQualifications: c.distinctiveQualifications,
-      linkerPath: c.linkerPath,
-      variantIndex,
-      variantCount,
-    };
-  });
+
+      entries.push({
+        spec: c.spec,
+        linkerPath: c.linkerPath,
+        qualifications: c.qualifications,
+        distinctiveQualifications: c.distinctiveQualifications,
+        variantIndex,
+        variantCount,
+      });
+
+      return { entries, variantSeen };
+    },
+    { entries: [] as TooltipEntry[], variantSeen: new Map<PObjectId, number>() },
+  );
 
   const tooltips = deriveDistinctTooltips(entries);
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -1,6 +1,7 @@
 import {
   type PColumn,
   type PColumnSpec,
+  type PFrameSpecDriver,
   type PObjectId,
   Annotation,
   canonicalizeAxisId,
@@ -13,7 +14,9 @@ import {
   deriveDistinctLabels,
   type DeriveLabelsOptions,
 } from "../../../labels/derive_distinct_labels";
-import type { ColumnsDisplayOptions } from "./createPlDataTableV3";
+import type { ColumnMatcher, ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
+import type { ColumnSelector } from "../../../columns";
+import { ArrayColumnProvider, ColumnCollectionBuilder } from "../../../columns";
 import { isNil } from "es-toolkit";
 
 /** Check if column should be omitted from the table */
@@ -26,36 +29,93 @@ export function isColumnOptional(spec: { annotations?: Annotation }): boolean {
   return readAnnotation(spec, Annotation.Table.Visibility) === "optional";
 }
 
-/** Get effective visibility for a column, considering display config rules first, then annotations. */
+/** Column shape consumed by rule evaluation. */
+export type RuleColumn = Pick<PColumn<PObjectId>, "id" | "spec">;
+
+/** Get effective visibility for a column. Rule map lookup first, then annotation fallback. */
 export function getEffectiveVisibility(
-  spec: PColumnSpec,
-  displayConfig?: ColumnsDisplayOptions,
+  col: RuleColumn,
+  visibilityByColId?: Map<PObjectId, ColumnVisibilityRule>,
 ): undefined | "default" | "optional" | "hidden" {
-  if (displayConfig?.visibility) {
-    for (const rule of displayConfig.visibility) {
-      if (rule.match(spec)) {
-        return rule.visibility;
-      }
-    }
-  }
-  if (isColumnHidden(spec)) return "hidden";
-  if (isColumnOptional(spec)) return "optional";
+  const rule = visibilityByColId?.get(col.id);
+  if (rule !== undefined) return rule.visibility;
+  if (isColumnHidden(col.spec)) return "hidden";
+  if (isColumnOptional(col.spec)) return "optional";
   return undefined;
 }
 
-/** Get ordering priority for a column. Display config rules first, then annotation fallback. */
+/** Get ordering priority for a column. Rule map lookup first, then annotation fallback. */
 export function getOrderPriority(
-  spec: PColumnSpec,
-  displayConfig?: ColumnsDisplayOptions,
+  col: RuleColumn,
+  orderByColId?: Map<PObjectId, ColumnOrderRule>,
 ): undefined | number {
-  if (displayConfig?.ordering) {
-    for (const rule of displayConfig.ordering) {
-      if (rule.match(spec)) {
-        return rule.priority;
+  const rule = orderByColId?.get(col.id);
+  if (rule !== undefined) return rule.priority;
+  return readAnnotationJson(col.spec, Annotation.Table.OrderPriority);
+}
+
+/**
+ * Evaluate display rules against a set of columns and return a map of `colId → winning rule`
+ * (first-match-wins, preserving original rule order).
+ *
+ * Predicate-based rules (`ColumnMatcher`) are evaluated directly on the spec.
+ * Selector-based rules (`ColumnSelector`) are matched via `PFrameSpecDriver.discoverColumns`
+ * using the same engine as `ColumnCollection.findColumns` — no client-side matcher.
+ */
+export function evaluateRules<R extends { match: ColumnMatcher | ColumnSelector }>(
+  rules: R[],
+  columns: RuleColumn[],
+  pframeSpec: PFrameSpecDriver,
+): Map<PObjectId, R> {
+  const result = new Map<PObjectId, R>();
+  if (rules.length === 0 || columns.length === 0) return result;
+
+  const hasSelectorRules = rules.some((rule) => typeof rule.match !== "function");
+  const selectorHitsByRule = new Map<R, Set<PObjectId>>();
+
+  if (hasSelectorRules) {
+    const dedupedColumns = dedupeById(columns);
+    const pColumns = dedupedColumns.map((c) => ({ id: c.id, spec: c.spec, data: undefined }));
+    const collection = new ColumnCollectionBuilder(pframeSpec)
+      .addSource(new ArrayColumnProvider(pColumns))
+      .build();
+    if (collection === undefined) return result;
+
+    try {
+      for (const rule of rules) {
+        if (typeof rule.match === "function") continue;
+        const hits = collection.findColumns({ include: rule.match });
+        selectorHitsByRule.set(rule, new Set(hits.map((h) => h.id)));
+      }
+    } finally {
+      collection.dispose();
+    }
+  }
+
+  for (const col of columns) {
+    for (const rule of rules) {
+      const matches =
+        typeof rule.match === "function"
+          ? rule.match(col.spec)
+          : (selectorHitsByRule.get(rule)?.has(col.id) ?? false);
+      if (matches) {
+        result.set(col.id, rule);
+        break;
       }
     }
   }
-  return readAnnotationJson(spec, Annotation.Table.OrderPriority);
+  return result;
+}
+
+function dedupeById(columns: RuleColumn[]): RuleColumn[] {
+  const seen = new Set<PObjectId>();
+  const result: RuleColumn[] = [];
+  for (const col of columns) {
+    if (seen.has(col.id)) continue;
+    seen.add(col.id);
+    result.push(col);
+  }
+  return result;
 }
 
 /**
@@ -91,21 +151,22 @@ export function withLabelAnnotations<Data>(
 }
 
 /**
- * Writes effective display properties (OrderPriority, Visibility) from ColumnDisplayOptions
+ * Writes effective display properties (OrderPriority, Visibility) from precomputed rule maps
  * into column annotations. Returns new column objects — originals are not mutated.
  */
 export function withTableVisualAnnotations<Data>(
-  displayOptions: undefined | ColumnsDisplayOptions,
+  visibilityByColId: undefined | Map<PObjectId, ColumnVisibilityRule>,
+  orderByColId: undefined | Map<PObjectId, ColumnOrderRule>,
   columns: PColumn<Data>[],
 ): PColumn<Data>[] {
-  if (displayOptions === undefined) return columns;
+  if (visibilityByColId === undefined && orderByColId === undefined) return columns;
   return columns.map((col) => {
     const annotations = { ...col.spec.annotations };
 
-    const visibility = getEffectiveVisibility(col.spec, displayOptions);
+    const visibility = getEffectiveVisibility(col, visibilityByColId);
     if (!isNil(visibility)) annotations[Annotation.Table.Visibility] = visibility;
 
-    const orderPriority = getOrderPriority(col.spec, displayOptions);
+    const orderPriority = getOrderPriority(col, orderByColId);
     if (!isNil(orderPriority)) annotations[Annotation.Table.OrderPriority] = String(orderPriority);
 
     return {

--- a/sdk/model/src/components/PlDataTable/labels.ts
+++ b/sdk/model/src/components/PlDataTable/labels.ts
@@ -4,22 +4,19 @@ import {
   isLabelColumn,
   matchAxisId,
   PColumnName,
-  Services,
-  type RequireServices,
 } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal, RenderCtxBase } from "../../render";
 import { ColumnCollectionBuilder, collectCtxColumnSnapshotProviders } from "../../columns";
-import { throwError } from "@milaboratories/helpers";
+import { getService } from "../../services";
 
 /**
  * Get all label columns visible in the current render context
  * (result pool + block outputs + prerun).
  */
-export function getAllLabelColumns<A, U, S extends RequireServices<typeof Services.PFrameSpec>>(
-  ctx: RenderCtxBase<A, U, S>,
+export function getAllLabelColumns<A, U>(
+  ctx: RenderCtxBase<A, U>,
 ): PColumn<PColumnDataUniversal>[] {
-  const pframeSpec =
-    ctx.services.pframeSpec ?? throwError("PFrameSpec service is required for label discovery.");
+  const pframeSpec = getService("pframeSpec");
   const collection = new ColumnCollectionBuilder(pframeSpec)
     .addSources(collectCtxColumnSnapshotProviders(ctx))
     .build({ allowPartialColumnList: true });

--- a/sdk/model/src/components/PlDataTable/labels.ts
+++ b/sdk/model/src/components/PlDataTable/labels.ts
@@ -7,7 +7,6 @@ import {
 } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal, RenderCtxBase } from "../../render";
 import { ColumnCollectionBuilder, collectCtxColumnSnapshotProviders } from "../../columns";
-import { getService } from "../../services";
 
 /**
  * Get all label columns visible in the current render context
@@ -16,7 +15,7 @@ import { getService } from "../../services";
 export function getAllLabelColumns<A, U>(
   ctx: RenderCtxBase<A, U>,
 ): PColumn<PColumnDataUniversal>[] {
-  const pframeSpec = getService("pframeSpec");
+  const pframeSpec = ctx.getService("pframeSpec");
   const collection = new ColumnCollectionBuilder(pframeSpec)
     .addSources(collectCtxColumnSnapshotProviders(ctx))
     .build({ allowPartialColumnList: true });

--- a/sdk/model/src/labels/derive_distinct_tooltips.test.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.test.ts
@@ -1,0 +1,249 @@
+import {
+  Annotation,
+  type AxisQualification,
+  type PColumnSpec,
+  type SUniversalPColumnId,
+} from "@milaboratories/pl-model-common";
+import { describe, expect, test } from "vitest";
+import { deriveDistinctTooltips, type TooltipEntry } from "./derive_distinct_tooltips";
+import type { ColumnSnapshot, MatchVariant } from "../columns";
+
+function createSpec(name: string, label?: string): PColumnSpec {
+  return {
+    kind: "PColumn",
+    name,
+    valueType: "Int",
+    axesSpec: [],
+    annotations: label !== undefined ? { [Annotation.Label]: label } : {},
+  } as PColumnSpec;
+}
+
+function axisQualification(
+  axisName: string,
+  contextDomain: Record<string, string>,
+): AxisQualification {
+  return { axis: { name: axisName }, contextDomain };
+}
+
+function linkerSnapshot(name: string, label?: string): ColumnSnapshot<SUniversalPColumnId> {
+  return {
+    id: `linker-${name}` as SUniversalPColumnId,
+    spec: createSpec(name, label),
+    dataStatus: "ready",
+    data: undefined,
+  };
+}
+
+function pathStep(
+  linkerName: string,
+  qualifications: AxisQualification[],
+  label?: string,
+): MatchVariant["path"][number] {
+  return { linker: linkerSnapshot(linkerName, label), qualifications };
+}
+
+describe("deriveDistinctTooltips", () => {
+  test("empty entry (no qualifications, no linker path) → undefined", () => {
+    const entries: TooltipEntry[] = [{ spec: createSpec("col1") }];
+    expect(deriveDistinctTooltips(entries)).toEqual([undefined]);
+  });
+
+  test("only header info but no sections → undefined (single section filtered)", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Column 1"),
+        variantIndex: 1,
+        variantCount: 1,
+      },
+    ];
+    expect(deriveDistinctTooltips(entries)).toEqual([undefined]);
+  });
+
+  test("linker path produces Origin path section", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("hit_col", "Hit Col"),
+        linkerPath: [
+          pathStep("linker_a", [axisQualification("sample", { batch: "A" })], "Linker A"),
+        ],
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toBeDefined();
+    expect(tooltip).toContain("Column: Hit Col");
+    expect(tooltip).toContain("Origin path");
+    expect(tooltip).toContain("linker 1: Linker A");
+    expect(tooltip).toContain("qualifies: sample context: batch=A");
+    expect(tooltip).toContain("hit column: Hit Col");
+  });
+
+  test("qualifications.forAnchors produces Anchors section", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Col 1"),
+        qualifications: {
+          forAnchors: {
+            main: [axisQualification("sample", { batch: "A" })],
+            other: [axisQualification("gene", { source: "X" })],
+          },
+          forHit: [],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("Anchors (bound via this variant)");
+    expect(tooltip).toContain("main   sample context: batch=A");
+    expect(tooltip).toContain("other   gene context: source=X");
+  });
+
+  test("qualifications.forHit produces Hit section", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Col 1"),
+        qualifications: {
+          forAnchors: {},
+          forHit: [axisQualification("sample", { batch: "B" })],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("Hit column qualifications");
+    expect(tooltip).toContain("sample context: batch=B");
+  });
+
+  test("distinctiveQualifications produces Distinctive section", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Col 1"),
+        distinctiveQualifications: {
+          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forHit: [axisQualification("gene", { source: "Y" })],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("Distinctive (what separates this variant)");
+    expect(tooltip).toContain("main: sample context: batch=A");
+    expect(tooltip).toContain("hit: gene context: source=Y");
+  });
+
+  test("variantCount > 1 adds Variant N of M line in header", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Col 1"),
+        variantIndex: 1,
+        variantCount: 2,
+        qualifications: {
+          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forHit: [],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("Variant: 1 of 2");
+  });
+
+  test("fallback to spec.name when no label annotation", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("raw_name"),
+        qualifications: {
+          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forHit: [],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("Column: raw_name");
+  });
+
+  test("axis qualification with empty contextDomain shows only axis name", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Col 1"),
+        qualifications: {
+          forAnchors: { main: [axisQualification("sample", {})] },
+          forHit: [],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("main   sample");
+    expect(tooltip).not.toContain("context:");
+  });
+
+  test("empty forAnchors object → no Anchors section", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("col1", "Col 1"),
+        qualifications: { forAnchors: {}, forHit: [] },
+        linkerPath: [pathStep("linker_a", [], "Linker A")],
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).not.toContain("Anchors");
+  });
+
+  test("multi-step linker path numbers sequentially", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("hit_col", "Hit Col"),
+        linkerPath: [
+          pathStep("linker_a", [], "Linker A"),
+          pathStep("linker_b", [axisQualification("sample", { batch: "B" })], "Linker B"),
+        ],
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toContain("linker 1: Linker A");
+    expect(tooltip).toContain("linker 2: Linker B");
+  });
+
+  test("all sections compose with double-newline separators", () => {
+    const entries: TooltipEntry[] = [
+      {
+        spec: createSpec("hit_col", "Hit"),
+        variantIndex: 2,
+        variantCount: 2,
+        linkerPath: [pathStep("linker_a", [axisQualification("sample", { batch: "B" })], "LA")],
+        qualifications: {
+          forAnchors: { main: [axisQualification("sample", { batch: "B" })] },
+          forHit: [axisQualification("sample", { batch: "B" })],
+        },
+        distinctiveQualifications: {
+          forAnchors: { main: [axisQualification("sample", { batch: "B" })] },
+          forHit: [],
+        },
+      },
+    ];
+    const [tooltip] = deriveDistinctTooltips(entries);
+    expect(tooltip).toBeDefined();
+    const sections = tooltip!.split("\n\n");
+    expect(sections.length).toBe(5);
+    expect(sections[0]).toContain("Column: Hit");
+    expect(sections[0]).toContain("Variant: 2 of 2");
+    expect(sections[1]).toContain("Origin path");
+    expect(sections[2]).toContain("Anchors");
+    expect(sections[3]).toContain("Hit column qualifications");
+    expect(sections[4]).toContain("Distinctive");
+  });
+
+  test("parallel results — array aligns with input", () => {
+    const entries: TooltipEntry[] = [
+      { spec: createSpec("a") },
+      {
+        spec: createSpec("b", "B"),
+        qualifications: {
+          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forHit: [],
+        },
+      },
+      { spec: createSpec("c") },
+    ];
+    const result = deriveDistinctTooltips(entries);
+    expect(result.length).toBe(3);
+    expect(result[0]).toBeUndefined();
+    expect(result[1]).toBeDefined();
+    expect(result[2]).toBeUndefined();
+  });
+});

--- a/sdk/model/src/labels/derive_distinct_tooltips.test.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.test.ts
@@ -2,7 +2,7 @@ import {
   Annotation,
   type AxisQualification,
   type PColumnSpec,
-  type SUniversalPColumnId,
+  type PObjectId,
 } from "@milaboratories/pl-model-common";
 import { describe, expect, test } from "vitest";
 import { deriveDistinctTooltips, type TooltipEntry } from "./derive_distinct_tooltips";
@@ -25,9 +25,9 @@ function axisQualification(
   return { axis: { name: axisName }, contextDomain };
 }
 
-function linkerSnapshot(name: string, label?: string): ColumnSnapshot<SUniversalPColumnId> {
+function linkerSnapshot(name: string, label?: string): ColumnSnapshot<PObjectId> {
   return {
-    id: `linker-${name}` as SUniversalPColumnId,
+    id: `linker-${name}` as PObjectId,
     spec: createSpec(name, label),
     dataStatus: "ready",
     data: undefined,
@@ -70,21 +70,20 @@ describe("deriveDistinctTooltips", () => {
     ];
     const [tooltip] = deriveDistinctTooltips(entries);
     expect(tooltip).toBeDefined();
-    expect(tooltip).toContain("Column: Hit Col");
     expect(tooltip).toContain("Origin path");
     expect(tooltip).toContain("linker 1: Linker A");
     expect(tooltip).toContain("qualifies: sample context: batch=A");
     expect(tooltip).toContain("hit column: Hit Col");
   });
 
-  test("qualifications.forAnchors produces Anchors section", () => {
+  test("qualifications.forQueries produces Anchors section", () => {
     const entries: TooltipEntry[] = [
       {
         spec: createSpec("col1", "Col 1"),
         qualifications: {
-          forAnchors: {
-            main: [axisQualification("sample", { batch: "A" })],
-            other: [axisQualification("gene", { source: "X" })],
+          forQueries: {
+            ["main" as PObjectId]: [axisQualification("sample", { batch: "A" })],
+            ["other" as PObjectId]: [axisQualification("gene", { source: "X" })],
           },
           forHit: [],
         },
@@ -101,7 +100,7 @@ describe("deriveDistinctTooltips", () => {
       {
         spec: createSpec("col1", "Col 1"),
         qualifications: {
-          forAnchors: {},
+          forQueries: {},
           forHit: [axisQualification("sample", { batch: "B" })],
         },
       },
@@ -116,7 +115,7 @@ describe("deriveDistinctTooltips", () => {
       {
         spec: createSpec("col1", "Col 1"),
         distinctiveQualifications: {
-          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "A" })] },
           forHit: [axisQualification("gene", { source: "Y" })],
         },
       },
@@ -134,7 +133,7 @@ describe("deriveDistinctTooltips", () => {
         variantIndex: 1,
         variantCount: 2,
         qualifications: {
-          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "A" })] },
           forHit: [],
         },
       },
@@ -143,26 +142,12 @@ describe("deriveDistinctTooltips", () => {
     expect(tooltip).toContain("Variant: 1 of 2");
   });
 
-  test("fallback to spec.name when no label annotation", () => {
-    const entries: TooltipEntry[] = [
-      {
-        spec: createSpec("raw_name"),
-        qualifications: {
-          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
-          forHit: [],
-        },
-      },
-    ];
-    const [tooltip] = deriveDistinctTooltips(entries);
-    expect(tooltip).toContain("Column: raw_name");
-  });
-
   test("axis qualification with empty contextDomain shows only axis name", () => {
     const entries: TooltipEntry[] = [
       {
         spec: createSpec("col1", "Col 1"),
         qualifications: {
-          forAnchors: { main: [axisQualification("sample", {})] },
+          forQueries: { ["main" as PObjectId]: [axisQualification("sample", {})] },
           forHit: [],
         },
       },
@@ -172,11 +157,11 @@ describe("deriveDistinctTooltips", () => {
     expect(tooltip).not.toContain("context:");
   });
 
-  test("empty forAnchors object → no Anchors section", () => {
+  test("empty forQueries object → no Anchors section", () => {
     const entries: TooltipEntry[] = [
       {
         spec: createSpec("col1", "Col 1"),
-        qualifications: { forAnchors: {}, forHit: [] },
+        qualifications: { forQueries: {}, forHit: [] },
         linkerPath: [pathStep("linker_a", [], "Linker A")],
       },
     ];
@@ -207,11 +192,11 @@ describe("deriveDistinctTooltips", () => {
         variantCount: 2,
         linkerPath: [pathStep("linker_a", [axisQualification("sample", { batch: "B" })], "LA")],
         qualifications: {
-          forAnchors: { main: [axisQualification("sample", { batch: "B" })] },
+          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "B" })] },
           forHit: [axisQualification("sample", { batch: "B" })],
         },
         distinctiveQualifications: {
-          forAnchors: { main: [axisQualification("sample", { batch: "B" })] },
+          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "B" })] },
           forHit: [],
         },
       },
@@ -220,7 +205,6 @@ describe("deriveDistinctTooltips", () => {
     expect(tooltip).toBeDefined();
     const sections = tooltip!.split("\n\n");
     expect(sections.length).toBe(5);
-    expect(sections[0]).toContain("Column: Hit");
     expect(sections[0]).toContain("Variant: 2 of 2");
     expect(sections[1]).toContain("Origin path");
     expect(sections[2]).toContain("Anchors");
@@ -234,7 +218,7 @@ describe("deriveDistinctTooltips", () => {
       {
         spec: createSpec("b", "B"),
         qualifications: {
-          forAnchors: { main: [axisQualification("sample", { batch: "A" })] },
+          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "A" })] },
           forHit: [],
         },
       },

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -1,5 +1,6 @@
 import {
   Annotation,
+  PObjectId,
   readAnnotation,
   type AxisQualification,
   type PColumnSpec,
@@ -79,12 +80,12 @@ function formatOriginPath(entry: TooltipEntry): undefined | string {
 
 function formatAnchors(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q)) return undefined;
-  const keys = Object.keys(q.forAnchors);
+  const keys = Object.keys(q.forQueries);
   if (keys.length === 0) return undefined;
 
   const lines = ["Anchors (bound via this variant)"];
   for (const key of keys) {
-    const axisQs = q.forAnchors[key];
+    const axisQs = q.forQueries[key as PObjectId];
     const rendered = formatAxisQualifications(axisQs);
     lines.push(`  • ${key}${rendered !== undefined ? `   ${rendered}` : ""}`);
   }
@@ -101,8 +102,8 @@ function formatHit(q: undefined | MatchQualifications): undefined | string {
 function formatDistinctive(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q)) return undefined;
   const bullets: string[] = [];
-  for (const key of Object.keys(q.forAnchors)) {
-    for (const item of q.forAnchors[key])
+  for (const key of Object.keys(q.forQueries)) {
+    for (const item of q.forQueries[key as PObjectId])
       bullets.push(`  • ${key}: ${formatOneQualification(item)}`);
   }
   for (const item of q.forHit) bullets.push(`  • hit: ${formatOneQualification(item)}`);

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -51,8 +51,7 @@ function formatTooltip(entry: TooltipEntry): undefined | string {
 }
 
 function formatHeader(entry: TooltipEntry): undefined | string {
-  const name = readAnnotation(entry.spec, Annotation.Label)?.trim() ?? entry.spec.name;
-  const lines: string[] = [`Column: ${name}`];
+  const lines: string[] = [];
   if (entry.variantCount !== undefined && entry.variantCount > 1) {
     lines.push(`Variant: ${entry.variantIndex ?? "?"} of ${entry.variantCount}`);
   }
@@ -80,16 +79,19 @@ function formatOriginPath(entry: TooltipEntry): undefined | string {
 
 function formatAnchors(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q)) return undefined;
-  const keys = Object.keys(q.forQueries);
-  if (keys.length === 0) return undefined;
+  const ids = Object.keys(q.forQueries);
+  if (ids.length === 0) return undefined;
 
-  const lines = ["Anchors (bound via this variant)"];
-  for (const key of keys) {
-    const axisQs = q.forQueries[key as PObjectId];
-    const rendered = formatAxisQualifications(axisQs);
-    lines.push(`  • ${key}${rendered !== undefined ? `   ${rendered}` : ""}`);
+  const lines = [];
+  for (const id of ids) {
+    const item = q.forQueries[id as PObjectId];
+    if (item.length === 0) continue;
+    const rendered = formatAxisQualifications(item);
+    lines.push(`  • ${id}${rendered !== undefined ? `   ${rendered}` : ""}`);
   }
-  return lines.join("\n");
+  return lines.length > 0
+    ? ["Anchors (bound via this variant)"].concat(lines).join("\n")
+    : undefined;
 }
 
 function formatHit(q: undefined | MatchQualifications): undefined | string {
@@ -102,21 +104,21 @@ function formatHit(q: undefined | MatchQualifications): undefined | string {
 function formatDistinctive(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q)) return undefined;
   const bullets: string[] = [];
-  for (const key of Object.keys(q.forQueries)) {
-    for (const item of q.forQueries[key as PObjectId])
-      bullets.push(`  • ${key}: ${formatOneQualification(item)}`);
+  for (const id of Object.keys(q.forQueries)) {
+    for (const item of q.forQueries[id as PObjectId])
+      bullets.push(`  • ${id}: ${formatQualification(item)}`);
   }
-  for (const item of q.forHit) bullets.push(`  • hit: ${formatOneQualification(item)}`);
+  for (const item of q.forHit) bullets.push(`  • hit: ${formatQualification(item)}`);
   if (bullets.length === 0) return undefined;
   return ["Distinctive (what separates this variant)", ...bullets].join("\n");
 }
 
 function formatAxisQualifications(qs: AxisQualification[]): undefined | string {
   if (qs.length === 0) return undefined;
-  return qs.map(formatOneQualification).join("; ");
+  return qs.map(formatQualification).join("; ");
 }
 
-function formatOneQualification(q: AxisQualification): string {
+function formatQualification(q: AxisQualification): string {
   const axisName = typeof q.axis === "string" ? q.axis : (q.axis.name ?? JSON.stringify(q.axis));
   const entries = Object.entries(q.contextDomain);
   if (entries.length === 0) return axisName;

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -68,13 +68,13 @@ function formatOriginPath(entry: TooltipEntry): undefined | string {
       readAnnotation(step.linker.spec, Annotation.LinkLabel) ??
       readAnnotation(step.linker.spec, Annotation.Label) ??
       step.linker.spec.name;
-    lines.push(`  • linker ${i + 1}: ${label}`);
+    lines.push(`linker ${i + 1}: ${label}`);
     const qs = formatAxisQualifications(step.qualifications);
     if (qs !== undefined) lines.push(`      qualifies: ${qs}`);
   });
   const hitName = readAnnotation(entry.spec, Annotation.Label) ?? entry.spec.name;
-  lines.push(`  • hit column: ${hitName}`);
-  return lines.join("\n");
+  lines.push(`hit column: ${hitName}`);
+  return lines.join("\n  • ");
 }
 
 function formatAnchors(q: undefined | MatchQualifications): undefined | string {
@@ -87,10 +87,10 @@ function formatAnchors(q: undefined | MatchQualifications): undefined | string {
     const item = q.forQueries[id as PObjectId];
     if (item.length === 0) continue;
     const rendered = formatAxisQualifications(item);
-    lines.push(`  • ${id}${rendered !== undefined ? `   ${rendered}` : ""}`);
+    lines.push(`${id}${rendered !== undefined ? `   ${rendered}` : ""}`);
   }
   return lines.length > 0
-    ? ["Anchors (bound via this variant)"].concat(lines).join("\n")
+    ? ["Anchors (bound via this variant)"].concat(lines).join("\n  • ")
     : undefined;
 }
 
@@ -98,7 +98,7 @@ function formatHit(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q) || q.forHit.length === 0) return undefined;
   const rendered = formatAxisQualifications(q.forHit);
   if (rendered === undefined) return undefined;
-  return ["Hit column qualifications", `  • ${rendered}`].join("\n");
+  return ["Hit column qualifications", rendered].join("\n  • ");
 }
 
 function formatDistinctive(q: undefined | MatchQualifications): undefined | string {
@@ -106,11 +106,11 @@ function formatDistinctive(q: undefined | MatchQualifications): undefined | stri
   const bullets: string[] = [];
   for (const id of Object.keys(q.forQueries)) {
     for (const item of q.forQueries[id as PObjectId])
-      bullets.push(`  • ${id}: ${formatQualification(item)}`);
+      bullets.push(`${id}: ${formatQualification(item)}`);
   }
-  for (const item of q.forHit) bullets.push(`  • hit: ${formatQualification(item)}`);
+  for (const item of q.forHit) bullets.push(`hit: ${formatQualification(item)}`);
   if (bullets.length === 0) return undefined;
-  return ["Distinctive (what separates this variant)", ...bullets].join("\n");
+  return ["Distinctive (what separates this variant)", ...bullets].join("\n  • ");
 }
 
 function formatAxisQualifications(qs: AxisQualification[]): undefined | string {

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -50,6 +50,9 @@ function formatTooltip(entry: TooltipEntry): undefined | string {
   return sections.join("\n\n");
 }
 
+const BULLET_1 = "  • ";
+const SUB_BULLET = "      ";
+
 function formatHeader(entry: TooltipEntry): undefined | string {
   const lines: string[] = [];
   if (entry.variantCount !== undefined && entry.variantCount > 1) {
@@ -68,13 +71,13 @@ function formatOriginPath(entry: TooltipEntry): undefined | string {
       readAnnotation(step.linker.spec, Annotation.LinkLabel) ??
       readAnnotation(step.linker.spec, Annotation.Label) ??
       step.linker.spec.name;
-    lines.push(`linker ${i + 1}: ${label}`);
+    lines.push(`${BULLET_1}linker ${i + 1}: ${label}`);
     const qs = formatAxisQualifications(step.qualifications);
-    if (qs !== undefined) lines.push(`      qualifies: ${qs}`);
+    if (qs !== undefined) lines.push(`${SUB_BULLET}qualifies: ${qs}`);
   });
   const hitName = readAnnotation(entry.spec, Annotation.Label) ?? entry.spec.name;
-  lines.push(`hit column: ${hitName}`);
-  return lines.join("\n  • ");
+  lines.push(`${BULLET_1}hit column: ${hitName}`);
+  return lines.join("\n");
 }
 
 function formatAnchors(q: undefined | MatchQualifications): undefined | string {
@@ -87,10 +90,10 @@ function formatAnchors(q: undefined | MatchQualifications): undefined | string {
     const item = q.forQueries[id as PObjectId];
     if (item.length === 0) continue;
     const rendered = formatAxisQualifications(item);
-    lines.push(`${id}${rendered !== undefined ? `   ${rendered}` : ""}`);
+    lines.push(`${BULLET_1}${id}${rendered !== undefined ? `   ${rendered}` : ""}`);
   }
   return lines.length > 0
-    ? ["Anchors (bound via this variant)"].concat(lines).join("\n  • ")
+    ? ["Anchors (bound via this variant)"].concat(lines).join("\n")
     : undefined;
 }
 
@@ -98,7 +101,7 @@ function formatHit(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q) || q.forHit.length === 0) return undefined;
   const rendered = formatAxisQualifications(q.forHit);
   if (rendered === undefined) return undefined;
-  return ["Hit column qualifications", rendered].join("\n  • ");
+  return ["Hit column qualifications", `${BULLET_1}${rendered}`].join("\n");
 }
 
 function formatDistinctive(q: undefined | MatchQualifications): undefined | string {
@@ -106,11 +109,11 @@ function formatDistinctive(q: undefined | MatchQualifications): undefined | stri
   const bullets: string[] = [];
   for (const id of Object.keys(q.forQueries)) {
     for (const item of q.forQueries[id as PObjectId])
-      bullets.push(`${id}: ${formatQualification(item)}`);
+      bullets.push(`${BULLET_1}${id}: ${formatQualification(item)}`);
   }
-  for (const item of q.forHit) bullets.push(`hit: ${formatQualification(item)}`);
+  for (const item of q.forHit) bullets.push(`${BULLET_1}hit: ${formatQualification(item)}`);
   if (bullets.length === 0) return undefined;
-  return ["Distinctive (what separates this variant)", ...bullets].join("\n  • ");
+  return ["Distinctive (what separates this variant)", ...bullets].join("\n");
 }
 
 function formatAxisQualifications(qs: AxisQualification[]): undefined | string {

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -1,0 +1,124 @@
+import {
+  Annotation,
+  readAnnotation,
+  type AxisQualification,
+  type PColumnSpec,
+} from "@milaboratories/pl-model-common";
+import { isNil } from "es-toolkit";
+import type { MatchQualifications, MatchVariant } from "../columns";
+
+export type TooltipEntry = {
+  /** Main column spec — used for column-name fallback when no label. */
+  spec: PColumnSpec;
+  /** Full qualifications carried by this variant. */
+  qualifications?: MatchQualifications;
+  /** Minimal qualifications that separate this variant from its siblings. */
+  distinctiveQualifications?: MatchQualifications;
+  /** Linker steps traversed to reach the hit column. */
+  linkerPath?: MatchVariant["path"];
+  /** Position of this variant within the same physical column (1-based). */
+  variantIndex?: number;
+  /** Total variants for the same physical column. */
+  variantCount?: number;
+};
+
+/** Format tooltip strings for each entry. Returns `undefined` when nothing useful. */
+export function deriveDistinctTooltips(entries: TooltipEntry[]): (undefined | string)[] {
+  return entries.map(formatTooltip);
+}
+
+function formatTooltip(entry: TooltipEntry): undefined | string {
+  const sections: string[] = [];
+
+  const header = formatHeader(entry);
+  if (header !== undefined) sections.push(header);
+
+  const origin = formatOriginPath(entry);
+  if (origin !== undefined) sections.push(origin);
+
+  const anchors = formatAnchors(entry.qualifications);
+  if (anchors !== undefined) sections.push(anchors);
+
+  const hit = formatHit(entry.qualifications);
+  if (hit !== undefined) sections.push(hit);
+
+  const distinctive = formatDistinctive(entry.distinctiveQualifications);
+  if (distinctive !== undefined) sections.push(distinctive);
+
+  if (sections.length <= 1) return undefined;
+  return sections.join("\n\n");
+}
+
+function formatHeader(entry: TooltipEntry): undefined | string {
+  const name = readAnnotation(entry.spec, Annotation.Label)?.trim() ?? entry.spec.name;
+  const lines: string[] = [`Column: ${name}`];
+  if (entry.variantCount !== undefined && entry.variantCount > 1) {
+    lines.push(`Variant: ${entry.variantIndex ?? "?"} of ${entry.variantCount}`);
+  }
+  return lines.join("\n");
+}
+
+function formatOriginPath(entry: TooltipEntry): undefined | string {
+  const path = entry.linkerPath ?? [];
+  if (path.length === 0) return undefined;
+
+  const lines = ["Origin path"];
+  path.forEach((step, i) => {
+    const label =
+      readAnnotation(step.linker.spec, Annotation.LinkLabel) ??
+      readAnnotation(step.linker.spec, Annotation.Label) ??
+      step.linker.spec.name;
+    lines.push(`  • linker ${i + 1}: ${label}`);
+    const qs = formatAxisQualifications(step.qualifications);
+    if (qs !== undefined) lines.push(`      qualifies: ${qs}`);
+  });
+  const hitName = readAnnotation(entry.spec, Annotation.Label) ?? entry.spec.name;
+  lines.push(`  • hit column: ${hitName}`);
+  return lines.join("\n");
+}
+
+function formatAnchors(q: undefined | MatchQualifications): undefined | string {
+  if (isNil(q)) return undefined;
+  const keys = Object.keys(q.forAnchors);
+  if (keys.length === 0) return undefined;
+
+  const lines = ["Anchors (bound via this variant)"];
+  for (const key of keys) {
+    const axisQs = q.forAnchors[key];
+    const rendered = formatAxisQualifications(axisQs);
+    lines.push(`  • ${key}${rendered !== undefined ? `   ${rendered}` : ""}`);
+  }
+  return lines.join("\n");
+}
+
+function formatHit(q: undefined | MatchQualifications): undefined | string {
+  if (isNil(q) || q.forHit.length === 0) return undefined;
+  const rendered = formatAxisQualifications(q.forHit);
+  if (rendered === undefined) return undefined;
+  return ["Hit column qualifications", `  • ${rendered}`].join("\n");
+}
+
+function formatDistinctive(q: undefined | MatchQualifications): undefined | string {
+  if (isNil(q)) return undefined;
+  const bullets: string[] = [];
+  for (const key of Object.keys(q.forAnchors)) {
+    for (const item of q.forAnchors[key])
+      bullets.push(`  • ${key}: ${formatOneQualification(item)}`);
+  }
+  for (const item of q.forHit) bullets.push(`  • hit: ${formatOneQualification(item)}`);
+  if (bullets.length === 0) return undefined;
+  return ["Distinctive (what separates this variant)", ...bullets].join("\n");
+}
+
+function formatAxisQualifications(qs: AxisQualification[]): undefined | string {
+  if (qs.length === 0) return undefined;
+  return qs.map(formatOneQualification).join("; ");
+}
+
+function formatOneQualification(q: AxisQualification): string {
+  const axisName = typeof q.axis === "string" ? q.axis : (q.axis.name ?? JSON.stringify(q.axis));
+  const entries = Object.entries(q.contextDomain);
+  if (entries.length === 0) return axisName;
+  const kv = entries.map(([k, v]) => `${k}=${v}`).join(", ");
+  return `${axisName} context: ${kv}`;
+}

--- a/sdk/model/src/labels/index.ts
+++ b/sdk/model/src/labels/index.ts
@@ -1,1 +1,2 @@
 export * from "./derive_distinct_labels";
+export * from "./derive_distinct_tooltips";

--- a/sdk/model/src/render/api.ts
+++ b/sdk/model/src/render/api.ts
@@ -3,6 +3,7 @@ import type {
   AnyFunction,
   AxisId,
   DataInfo,
+  ModelServices,
   Option,
   PColumn,
   PColumnLazy,
@@ -71,6 +72,7 @@ import type { APColumnSelectorWithSplit } from "./util/split_selectors";
 import { patchInSetFilters } from "./util/pframe_upgraders";
 import { allPColumnsReady } from "./util/pcolumn_data";
 import type { PColumnDataUniversal } from "./internal";
+import { getService } from "../services";
 
 /**
  * Helper function to match domain objects
@@ -584,6 +586,10 @@ export abstract class RenderCtxBase<Args = unknown, Data = unknown> {
       };
     }
     return this.activeArgsCache.v;
+  }
+
+  public getService<T extends keyof ModelServices>(name: T): ModelServices[T] {
+    return getService(name);
   }
 
   // /** Can be used to determine features provided by the desktop instance. */

--- a/sdk/model/src/render/api.ts
+++ b/sdk/model/src/render/api.ts
@@ -23,7 +23,6 @@ import type {
   PlRef,
   ResolveAnchorsOptions,
   ResultCollection,
-  ServiceName,
   SUniversalPColumnId,
   ValueOrError,
 } from "@milaboratories/pl-model-common";
@@ -55,11 +54,8 @@ import type {
   PluginHandle,
   PluginFactoryLike,
   InferFactoryData,
-  InferFactoryModelServices,
   InferFactoryParams,
 } from "../plugin_handle";
-import type { BlockDefaultModelServices } from "../services/service_resolve";
-import type { ModelServices as AllModelServices } from "@milaboratories/pl-model-common";
 import { TreeNodeAccessor, ifDef } from "./accessor";
 import type { FutureRef } from "./future";
 import type { AccessorHandle, GlobalCfgRenderCtx } from "./internal";
@@ -554,40 +550,11 @@ export class ResultPool implements ColumnProvider, AxisLabelProvider {
 }
 
 /** Main entry point to the API available within model lambdas (like outputs, sections, etc..) */
-export abstract class RenderCtxBase<
-  Args = unknown,
-  Data = unknown,
-  ModelServices = Partial<AllModelServices>,
-> {
+export abstract class RenderCtxBase<Args = unknown, Data = unknown> {
   protected readonly ctx: GlobalCfgRenderCtx;
-  private readonly requiredServiceNames: ServiceName[];
-  private cachedServices?: ModelServices;
 
-  constructor(requiredServiceNames: ServiceName[] = []) {
+  constructor() {
     this.ctx = getCfgRenderCtx();
-    this.requiredServiceNames = requiredServiceNames;
-  }
-
-  get services(): ModelServices {
-    if (this.cachedServices) return this.cachedServices;
-    const ctx = this.ctx;
-    const services = Object.freeze(
-      Object.fromEntries(
-        this.requiredServiceNames.map((id) => [
-          id,
-          Object.freeze(
-            Object.fromEntries(
-              (ctx.getServiceMethods(id) as string[]).map((method) => [
-                method,
-                (...args: unknown[]) => ctx.callServiceMethod(id, method, ...args),
-              ]),
-            ),
-          ),
-        ]),
-      ),
-    ) as ModelServices;
-    this.cachedServices = services;
-    return services;
   }
 
   private dataCache?: { v: Data };
@@ -771,11 +738,7 @@ export abstract class RenderCtxBase<
 }
 
 /** Main entry point to the API available within model lambdas (like outputs, sections, etc..) for v3+ blocks */
-export class BlockRenderCtx<
-  Args = unknown,
-  Data = unknown,
-  ModelServices = BlockDefaultModelServices,
-> extends RenderCtxBase<Args, Data, ModelServices> {
+export class BlockRenderCtx<Args = unknown, Data = unknown> extends RenderCtxBase<Args, Data> {
   private argsCache?: { v: Args | undefined };
   public get args(): Args | undefined {
     if (this.argsCache === undefined) {
@@ -824,19 +787,15 @@ export class RenderCtxLegacy<Args = unknown, UiState = unknown> extends RenderCt
  *
  * @typeParam F - PluginFactoryLike phantom carrying data/params/outputs types
  */
-export class PluginRenderCtx<
-  F extends PluginFactoryLike = PluginFactoryLike,
-  ModelServices = InferFactoryModelServices<F>,
-> extends RenderCtxBase<unknown, InferFactoryData<F>, ModelServices> {
+export class PluginRenderCtx<F extends PluginFactoryLike = PluginFactoryLike> extends RenderCtxBase<
+  unknown,
+  InferFactoryData<F>
+> {
   private readonly handle: PluginHandle<F>;
   private readonly wrappedInputs: Record<string, () => unknown>;
 
-  constructor(
-    handle: PluginHandle<F>,
-    wrappedInputs: Record<string, () => unknown>,
-    requiredServiceNames: ServiceName[] = [],
-  ) {
-    super(requiredServiceNames);
+  constructor(handle: PluginHandle<F>, wrappedInputs: Record<string, () => unknown>) {
+    super();
     this.handle = handle;
     this.wrappedInputs = wrappedInputs;
   }

--- a/sdk/model/src/services/get_services.ts
+++ b/sdk/model/src/services/get_services.ts
@@ -2,15 +2,27 @@ import { ModelServices, ServiceName } from "@milaboratories/pl-model-common";
 import { getCfgRenderCtx } from "../internal";
 import { ValueOf } from "@milaboratories/helpers";
 import { createServiceProxy } from "./service_bridge";
+import { GlobalCfgRenderCtx } from "../render/internal";
 
-let cachedServices = new Map<keyof ModelServices, ValueOf<ModelServices>>();
+const cachedServices = new WeakMap<
+  GlobalCfgRenderCtx,
+  Map<keyof ModelServices, ValueOf<ModelServices>>
+>();
 
 export function getService<T extends keyof ModelServices>(name: T): ModelServices[T] {
-  if (!cachedServices.has(name)) {
-    const id = name as ServiceName;
-    const ctx = getCfgRenderCtx();
-    cachedServices.set(name, createServiceProxy(ctx)(id) as ModelServices[T]);
-  }
+  const ctx = getCfgRenderCtx();
 
-  return cachedServices.get(name) as ModelServices[T];
+  const map = cachedServices.has(ctx)
+    ? cachedServices.get(ctx)!
+    : (() => {
+        cachedServices.set(ctx, new Map());
+        return cachedServices.get(ctx)!;
+      })();
+
+  return map.has(name)
+    ? (map.get(name) as ModelServices[T])
+    : (() => {
+        map.set(name, createServiceProxy(ctx)(name as ServiceName) as ModelServices[T]);
+        return map.get(name) as ModelServices[T];
+      })();
 }

--- a/sdk/model/src/services/get_services.ts
+++ b/sdk/model/src/services/get_services.ts
@@ -5,14 +5,12 @@ import { createServiceProxy } from "./service_bridge";
 
 let cachedServices = new Map<keyof ModelServices, ValueOf<ModelServices>>();
 
-export function getService<Service extends keyof ModelServices>(
-  name: Service,
-): ModelServices[Service] {
+export function getService<T extends keyof ModelServices>(name: T): ModelServices[T] {
   if (!cachedServices.has(name)) {
     const id = name as ServiceName;
     const ctx = getCfgRenderCtx();
-    cachedServices.set(name, createServiceProxy(ctx)(id) as ModelServices[Service]);
+    cachedServices.set(name, createServiceProxy(ctx)(id) as ModelServices[T]);
   }
 
-  return cachedServices.get(name) as ModelServices[Service];
+  return cachedServices.get(name) as ModelServices[T];
 }

--- a/sdk/model/src/services/get_services.ts
+++ b/sdk/model/src/services/get_services.ts
@@ -1,0 +1,18 @@
+import { ModelServices, ServiceName } from "@milaboratories/pl-model-common";
+import { getCfgRenderCtx } from "../internal";
+import { ValueOf } from "@milaboratories/helpers";
+import { createServiceProxy } from "./service_bridge";
+
+let cachedServices = new Map<keyof ModelServices, ValueOf<ModelServices>>();
+
+export function getService<Service extends keyof ModelServices>(
+  name: Service,
+): ModelServices[Service] {
+  if (!cachedServices.has(name)) {
+    const id = name as ServiceName;
+    const ctx = getCfgRenderCtx();
+    cachedServices.set(name, createServiceProxy(ctx)(id) as ModelServices[Service]);
+  }
+
+  return cachedServices.get(name) as ModelServices[Service];
+}

--- a/sdk/model/src/services/index.ts
+++ b/sdk/model/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from "./block_services";
 export * from "./service_resolve";
 export * from "./service_bridge";
+export * from "./get_services";

--- a/sdk/model/src/services/service_bridge.ts
+++ b/sdk/model/src/services/service_bridge.ts
@@ -15,7 +15,7 @@ import { UiServiceRegistry } from "@milaboratories/pl-model-common";
 // Makes a remote node service appear local.
 // Given a service ID, returns an object implementing the service's UI interface.
 // Provided by the desktop app (e.g. backed by Electron IPC).
-export type NodeServiceProxy = <S extends ServiceTypesLike>(
+export type ServiceProxy = <S extends ServiceTypesLike>(
   serviceId: ServiceName<S>,
 ) => InferServiceUi<S>;
 
@@ -53,10 +53,10 @@ export function buildServices<S extends Partial<AllUiServices> = Partial<AllUiSe
 }
 
 /**
- * Builds a NodeServiceProxy from a ServiceDispatch.
+ * Builds a ServiceProxy from a ServiceDispatch.
  * Each service method call is forwarded to dispatch.callServiceMethod.
  */
-export function createNodeServiceProxy(dispatch: ServiceDispatch): NodeServiceProxy {
+export function createServiceProxy(dispatch: ServiceDispatch): ServiceProxy {
   return ((serviceId: ServiceName) =>
     Object.freeze(
       Object.fromEntries(
@@ -67,5 +67,5 @@ export function createNodeServiceProxy(dispatch: ServiceDispatch): NodeServicePr
             async (...args: unknown[]) => dispatch.callServiceMethod(serviceId, method, ...args),
           ]),
       ),
-    )) as NodeServiceProxy;
+    )) as ServiceProxy;
 }

--- a/sdk/model/src/services/service_bridge.ts
+++ b/sdk/model/src/services/service_bridge.ts
@@ -64,7 +64,7 @@ export function createServiceProxy(dispatch: ServiceDispatch): ServiceProxy {
           .getServiceMethods(serviceId)
           .map((method) => [
             method,
-            async (...args: unknown[]) => dispatch.callServiceMethod(serviceId, method, ...args),
+            (...args: unknown[]) => dispatch.callServiceMethod(serviceId, method, ...args),
           ]),
       ),
     )) as ServiceProxy;

--- a/sdk/ui-vue/src/components/PlAgColumnHeader/PlAgColumnHeader.vue
+++ b/sdk/ui-vue/src/components/PlAgColumnHeader/PlAgColumnHeader.vue
@@ -64,15 +64,20 @@ function showMenu() {
 
 <template>
   <div class="pl-ag-column-header d-flex align-center gap-6" @click="onSortRequested">
-    <PlTooltip>
-      <template v-if="params.tooltip" #tooltip>{{ params.tooltip }}</template>
-      <div class="pl-ag-column-header__title d-flex align-center gap-6 flex-grow-1">
-        <PlMaskIcon16 :name="icon" class="pl-ag-column-header__type-icon" />
+    <div class="pl-ag-column-header__title d-flex align-center gap-6 flex-grow-1">
+      <PlMaskIcon16 :name="icon" class="pl-ag-column-header__type-icon" />
+      <PlTooltip>
+        <template v-if="params.tooltip" #tooltip>{{ params.tooltip }}</template>
         <span>{{ params.displayName }}</span>
-        <PlMaskIcon16 v-if="params.info" name="info" />
-        <PlMaskIcon16 v-if="sortIcon" :name="sortIcon" />
-      </div>
-    </PlTooltip>
+      </PlTooltip>
+      <PlTooltip v-if="params.info" max-width="500px" position="bottom" :close-delay="10000000000">
+        <template #tooltip>
+          <span style="white-space: pre-wrap">{{ params.info }}</span>
+        </template>
+        <PlMaskIcon16 name="info" />
+      </PlTooltip>
+      <PlMaskIcon16 v-if="sortIcon" :name="sortIcon" />
+    </div>
     <div
       v-if="params.enableMenu"
       ref="menuActivatorBtn"

--- a/sdk/ui-vue/src/components/PlAgColumnHeader/PlAgColumnHeader.vue
+++ b/sdk/ui-vue/src/components/PlAgColumnHeader/PlAgColumnHeader.vue
@@ -69,6 +69,7 @@ function showMenu() {
       <div class="pl-ag-column-header__title d-flex align-center gap-6 flex-grow-1">
         <PlMaskIcon16 :name="icon" class="pl-ag-column-header__type-icon" />
         <span>{{ params.displayName }}</span>
+        <PlMaskIcon16 v-if="params.info" name="info" />
         <PlMaskIcon16 v-if="sortIcon" :name="sortIcon" />
       </div>
     </PlTooltip>

--- a/sdk/ui-vue/src/components/PlAgColumnHeader/types.ts
+++ b/sdk/ui-vue/src/components/PlAgColumnHeader/types.ts
@@ -3,4 +3,5 @@ export type PlAgHeaderComponentType = "Text" | "Number" | "File" | "Date" | "Dur
 export type PlAgHeaderComponentParams = {
   type?: PlAgHeaderComponentType;
   tooltip?: string;
+  info?: string;
 };

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -314,6 +314,9 @@ export function makeColDef(
         }
       })(),
       tooltip: readAnnotation(labeledSpec.spec, Annotation.Description)?.trim(),
+      info:
+        readAnnotation(labeledSpec.spec, Annotation.Table.Info)?.trim() ??
+        readAnnotation(spec.spec, Annotation.Table.Info)?.trim(),
     } satisfies PlAgHeaderComponentParams,
     cellDataType: (() => {
       switch (valueType) {

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -63,15 +63,15 @@ function columns2rows(
   axesResultIndices: number[],
 ): PlAgDataTableV2Row[] {
   const rowData: PlAgDataTableV2Row[] = [];
-  for (let iRow = 0; iRow < columns[0].data.length; ++iRow) {
-    const axesKey: PTableKey = axesResultIndices.map((ri) => pTableValue(columns[ri], iRow));
+  for (let rowIdx = 0; rowIdx < columns[0].data.length; ++rowIdx) {
+    const axesKey: PTableKey = axesResultIndices.map((ri) => pTableValue(columns[ri], rowIdx));
     const id = canonicalizeJson<PlTableRowId>(axesKey);
     const row = fields.reduce<PlAgDataTableV2Row>(
-      (acc, field, iCol) => {
+      (acc, field, colIdx) => {
         acc[field.toString() as `${number}`] =
-          fieldResultMapping[iCol] === -1
+          fieldResultMapping[colIdx] === -1
             ? PTableHidden
-            : pTableValue(columns[fieldResultMapping[iCol]], iRow);
+            : pTableValue(columns[fieldResultMapping[colIdx]], rowIdx);
         return acc;
       },
       { id, axesKey },
@@ -156,10 +156,10 @@ export async function calculateGridOptions({
   // request indices: non-hidden display fields + visible axes for row selection keys.
   // Axes replaced by label columns request label data (display); original axis values
   // are fetched via visibleAxes (row keys).
-  const { requestIndices, fieldResultMapping, axesResultIndices } = buildRequestIndices(
+  const { requestIndices, axesResultIndices, fieldResultMapping } = buildRequestIndices(
     indices,
+    visibleAxes.map(([idx]) => idx),
     specsToVisibleSpecsMapping,
-    visibleAxes.map(([i]) => i),
   );
 
   let rowCount = -1;
@@ -313,10 +313,12 @@ export function makeColDef(
             throw Error(`unsupported data type: ${valueType}`);
         }
       })(),
-      tooltip: readAnnotation(labeledSpec.spec, Annotation.Description)?.trim(),
+      tooltip:
+        readAnnotation(spec.spec, Annotation.Description)?.trim() ??
+        readAnnotation(labeledSpec.spec, Annotation.Description)?.trim(),
       info:
-        readAnnotation(labeledSpec.spec, Annotation.Table.Info)?.trim() ??
-        readAnnotation(spec.spec, Annotation.Table.Info)?.trim(),
+        readAnnotation(spec.spec, Annotation.Table.Info)?.trim() ??
+        readAnnotation(labeledSpec.spec, Annotation.Table.Info)?.trim(),
     } satisfies PlAgHeaderComponentParams,
     cellDataType: (() => {
       switch (valueType) {
@@ -468,26 +470,23 @@ function collectVisibleAxes(
  */
 function buildRequestIndices(
   indices: number[],
-  specsToVisibleSpecsMapping: Map<number, number>,
   visibleAxesIndices: number[],
+  specsToVisibleSpecsMapping: Map<number, number>,
 ): {
   requestIndices: number[];
-  fieldResultMapping: number[];
   axesResultIndices: number[];
+  fieldResultMapping: number[];
 } {
   const resolved = indices.map((displayField) => {
     const idx = specsToVisibleSpecsMapping.get(displayField);
-    return idx === undefined || idx === -1 ? null : idx;
+    return isNil(idx) || idx === -1 ? null : idx;
   });
-  const requestedFields = resolved.filter((v): v is number => v !== null);
-
-  const fieldResultMapping: number[] = [];
-  let pos = 0;
-  for (const v of resolved) {
-    fieldResultMapping.push(v === null ? -1 : pos++);
-  }
-
-  const requestIndices = uniq([...requestedFields, ...visibleAxesIndices]);
+  const requestIndices = uniq([
+    ...resolved.filter((v): v is number => v !== null),
+    ...visibleAxesIndices,
+  ]);
+  const fieldResultMapping = resolved.map((v) => (v === null ? -1 : requestIndices.indexOf(v)));
   const axesResultIndices = visibleAxesIndices.map((vi) => requestIndices.indexOf(vi));
-  return { requestIndices, fieldResultMapping, axesResultIndices };
+
+  return { requestIndices, axesResultIndices, fieldResultMapping };
 }

--- a/sdk/ui-vue/src/internal/createAppV3.ts
+++ b/sdk/ui-vue/src/internal/createAppV3.ts
@@ -309,7 +309,7 @@ export function createAppV3<
     },
   };
 
-  const services = getServices<UiServices>();
+  const services = getServices<UiServices>({ platforma });
 
   /** Creates a lazily-cached per-plugin reactive state. */
   const createPluginState = <F extends PluginFactoryLike>(

--- a/sdk/ui-vue/src/internal/createAppV3.ts
+++ b/sdk/ui-vue/src/internal/createAppV3.ts
@@ -22,11 +22,8 @@ import {
   getPluginData,
   isPluginOutputKey,
   pluginOutputPrefix,
-  createNodeServiceProxy,
-  buildServices,
 } from "@platforma-sdk/model";
 import { type UiServices as AllUiServices } from "@milaboratories/pl-model-common";
-import { createUiServiceRegistry } from "./service_factories";
 import type { Ref } from "vue";
 import { reactive, computed, ref, markRaw } from "vue";
 import type { OutputValues, OutputErrors, AppSettings } from "../types";
@@ -36,6 +33,8 @@ import { applyPatch } from "fast-json-patch";
 import { UpdateSerializer } from "./UpdateSerializer";
 import { watchIgnorable } from "@vueuse/core";
 import type { PluginState, PluginAccess } from "../usePlugin";
+import { logDebug, logError } from "./utils";
+import { getServices } from "./getServices";
 
 export const patchPoolingDelay = 150;
 
@@ -52,14 +51,6 @@ export const createNextAuthorMarker = (marker: AuthorMarker | undefined): Author
   authorId: marker?.authorId ?? uniqueId(),
   localVersion: (marker?.localVersion ?? 0) + 1,
 });
-
-const stringifyForDebug = (v: unknown) => {
-  try {
-    return JSON.stringify(v, null, 2);
-  } catch (err) {
-    return err instanceof Error ? err.message : String(err);
-  }
-};
 
 /**
  * Creates an application instance with reactive state management, outputs, and methods for state updates and navigation.
@@ -87,25 +78,8 @@ export function createAppV3<
   platforma: PlatformaExtended<PlatformaV3<Data, Args, Outputs, Href, Plugins, UiServices>>,
   settings: AppSettings,
 ) {
-  const debug = (msg: string, ...rest: unknown[]) => {
-    if (settings.debug) {
-      console.log(
-        `%c>>> %c${msg}`,
-        "color: orange; font-weight: bold",
-        "color: orange",
-        ...rest.map((r) => stringifyForDebug(r)),
-      );
-    }
-  };
-
-  const error = (msg: string, ...rest: unknown[]) => {
-    console.error(
-      `%c>>> %c${msg}`,
-      "color: red; font-weight: bold",
-      "color: red",
-      ...rest.map((r) => stringifyForDebug(r)),
-    );
-  };
+  const debug = settings.debug ? logDebug : () => {};
+  const error = logError;
 
   const data = {
     isExternalSnapshot: false,
@@ -230,11 +204,12 @@ export function createAppV3<
   (async () => {
     window.addEventListener("beforeunload", () => {
       closedRef.value = true;
-      Promise.allSettled([uiRegistry.dispose(), platforma.dispose().then(unwrapResult)]).catch(
-        (err) => {
+      platforma
+        .dispose()
+        .then(unwrapResult)
+        .catch((err) => {
           error("error in dispose", err);
-        },
-      );
+        });
     });
 
     while (!closedRef.value) {
@@ -334,9 +309,7 @@ export function createAppV3<
     },
   };
 
-  const proxy = createNodeServiceProxy(platforma.serviceDispatch);
-  const uiRegistry = createUiServiceRegistry({ proxy });
-  const services = buildServices<UiServices>(platforma.serviceDispatch, uiRegistry);
+  const services = getServices<UiServices>();
 
   /** Creates a lazily-cached per-plugin reactive state. */
   const createPluginState = <F extends PluginFactoryLike>(

--- a/sdk/ui-vue/src/internal/getServices.ts
+++ b/sdk/ui-vue/src/internal/getServices.ts
@@ -1,0 +1,34 @@
+import {
+  BlockDefaultUiServices,
+  buildServices,
+  createNodeServiceProxy,
+  getRawPlatformaInstance,
+  PlatformaV3,
+  UiServices,
+} from "@platforma-sdk/model";
+import { createUiServiceRegistry } from "./service_factories";
+import { isNil } from "es-toolkit";
+import { logError } from "./utils";
+
+let cachedServices: null | Partial<UiServices> = null;
+
+export function getServices<
+  Services extends Partial<UiServices> = BlockDefaultUiServices,
+>(): Services {
+  if (!isNil(cachedServices)) {
+    return cachedServices as Services;
+  }
+
+  const platforma = getRawPlatformaInstance() as PlatformaV3<any, any, any, any, any, Services>;
+  const proxy = createNodeServiceProxy(platforma.serviceDispatch);
+  const uiRegistry = createUiServiceRegistry({ proxy });
+  const services = buildServices<Services>(platforma.serviceDispatch, uiRegistry);
+
+  window.addEventListener("beforeunload", () => {
+    Promise.allSettled([uiRegistry.dispose()]).catch((err) => {
+      logError("error in dispose", err);
+    });
+  });
+
+  return (cachedServices = services) as Services;
+}

--- a/sdk/ui-vue/src/internal/getServices.ts
+++ b/sdk/ui-vue/src/internal/getServices.ts
@@ -25,8 +25,8 @@ export function getServices<
   const services = buildServices<Services>(platforma.serviceDispatch, uiRegistry);
 
   window.addEventListener("beforeunload", () => {
-    Promise.allSettled([uiRegistry.dispose()]).catch((err) => {
-      logError("error in dispose", err);
+    uiRegistry.dispose().catch((err) => {
+      logError("uiRegistry error in dispose", err);
     });
   });
 

--- a/sdk/ui-vue/src/internal/getServices.ts
+++ b/sdk/ui-vue/src/internal/getServices.ts
@@ -12,14 +12,16 @@ import { logError } from "./utils";
 
 let cachedServices: null | Partial<UiServices> = null;
 
-export function getServices<
-  Services extends Partial<UiServices> = BlockDefaultUiServices,
->(): Services {
+export function getServices<Services extends Partial<UiServices> = BlockDefaultUiServices>(deps?: {
+  platforma?: PlatformaV3<any, any, any, any, any, Services>;
+}): Services {
   if (!isNil(cachedServices)) {
     return cachedServices as Services;
   }
 
-  const platforma = getRawPlatformaInstance() as PlatformaV3<any, any, any, any, any, Services>;
+  const platforma =
+    deps?.platforma ??
+    (getRawPlatformaInstance() as PlatformaV3<any, any, any, any, any, Services>);
   const proxy = createServiceProxy(platforma.serviceDispatch);
   const uiRegistry = createUiServiceRegistry({ proxy });
   const services = buildServices<Services>(platforma.serviceDispatch, uiRegistry);

--- a/sdk/ui-vue/src/internal/getServices.ts
+++ b/sdk/ui-vue/src/internal/getServices.ts
@@ -1,7 +1,7 @@
 import {
   BlockDefaultUiServices,
   buildServices,
-  createNodeServiceProxy,
+  createServiceProxy,
   getRawPlatformaInstance,
   PlatformaV3,
   UiServices,
@@ -20,7 +20,7 @@ export function getServices<
   }
 
   const platforma = getRawPlatformaInstance() as PlatformaV3<any, any, any, any, any, Services>;
-  const proxy = createNodeServiceProxy(platforma.serviceDispatch);
+  const proxy = createServiceProxy(platforma.serviceDispatch);
   const uiRegistry = createUiServiceRegistry({ proxy });
   const services = buildServices<Services>(platforma.serviceDispatch, uiRegistry);
 

--- a/sdk/ui-vue/src/internal/service_factories.ts
+++ b/sdk/ui-vue/src/internal/service_factories.ts
@@ -9,10 +9,10 @@
 
 import { Services, UiServiceRegistry } from "@milaboratories/pl-model-common";
 import { SpecDriver } from "@milaboratories/pf-spec-driver";
-import type { NodeServiceProxy } from "@platforma-sdk/model";
+import type { ServiceProxy } from "@platforma-sdk/model";
 
 export type UiServiceOptions = {
-  proxy: NodeServiceProxy;
+  proxy: ServiceProxy;
 };
 
 export function createUiServiceRegistry(options: UiServiceOptions) {

--- a/sdk/ui-vue/src/internal/utils.ts
+++ b/sdk/ui-vue/src/internal/utils.ts
@@ -1,0 +1,25 @@
+export const logDebug = (msg: string, ...rest: unknown[]) => {
+  console.log(
+    `%c>>> %c${msg}`,
+    "color: orange; font-weight: bold",
+    "color: orange",
+    ...rest.map((r) => stringifyForDebug(r)),
+  );
+};
+
+export const logError = (msg: string, ...rest: unknown[]) => {
+  console.error(
+    `%c>>> %c${msg}`,
+    "color: red; font-weight: bold",
+    "color: red",
+    ...rest.map((r) => stringifyForDebug(r)),
+  );
+};
+
+const stringifyForDebug = (v: unknown) => {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+};


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the model and table test infrastructure, focusing on simplifying service access patterns, updating table configuration APIs, and adding support for discovered columns in the model layer. It also enhances test workflows to support more complex linker and axis domain scenarios.

**Service Access Refactoring and Test Simplification:**

* Refactored plugin and block outputs in `etc/blocks/model-test/model/src/index.ts` to use the global `getService` function instead of accessing services via `ctx.services`, simplifying the code and making service usage more consistent. [[1]](diffhunk://#diff-a1270e54b3d283997db970912d4f20d96c6d13fdb8259b750319d9984c02e4acR12) [[2]](diffhunk://#diff-a1270e54b3d283997db970912d4f20d96c6d13fdb8259b750319d9984c02e4acL81-R88) [[3]](diffhunk://#diff-a1270e54b3d283997db970912d4f20d96c6d13fdb8259b750319d9984c02e4acL139-R148)
* Updated test comments in `etc/blocks/model-test/test/src/wf.test.ts` to reflect the new service access patterns. [[1]](diffhunk://#diff-be72b4b0309e3d2932eb1031c6588ffa9dcf85006a73a46a21e01e5e0fc39df9L70-R70) [[2]](diffhunk://#diff-be72b4b0309e3d2932eb1031c6588ffa9dcf85006a73a46a21e01e5e0fc39df9L86-R93)

**Table Configuration and API Modernization:**

* Updated table model and test code to use new `columns` and `selector` properties instead of the deprecated `discoverColumnOptions` and `columnsSelector`, and replaced `columnsDisplayOptions` with `displayOptions` for clarity and future compatibility. [[1]](diffhunk://#diff-a1270e54b3d283997db970912d4f20d96c6d13fdb8259b750319d9984c02e4acL156-R157) [[2]](diffhunk://#diff-c7962b8870d6a5f043292073ba1891a3504cd3feb2b7015f7bae34652b64abeeR44-R56) [[3]](diffhunk://#diff-c7962b8870d6a5f043292073ba1891a3504cd3feb2b7015f7bae34652b64abeeL66-R84)

**Enhanced Linker and Axis Domain Testing:**

* Extended the table test workflow (`etc/blocks/table-test/workflow/src/main.tpl.tengo`) to create and use multiple linkers with distinct axis domains, simulating more complex data relationships and ensuring correct handling of axis qualifications and context domains. [[1]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092L22-R36) [[2]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R75) [[3]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R84) [[4]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R95) [[5]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R110-R131) [[6]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R140-R172) [[7]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R235-R237) [[8]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R264-R274) [[9]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092L207-R316) [[10]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R443) [[11]](diffhunk://#diff-150cda0708dbbd06540aecc95afb1a17ad0617adc53d957d623d5ecacbc7d092R461-R463)

**Model Layer and Type System Improvements:**

* Added a new `DiscoveredPColumn` type and supporting functions in the model layer, enabling canonical serialization and parsing of discovered columns, and extended `UniversalPColumnId` to support this new type. [[1]](diffhunk://#diff-483158677773b9b3d856a6d4ed4e69bd3db6dba0f5ffd4465c7c0c581acb0f9cR1-R72) [[2]](diffhunk://#diff-3c4289414f84b7e3dee52d9e1e1587e813f5c56019b3aff0a26be1d0aacfdcb6R6-R11) [[3]](diffhunk://#diff-20490cff4031a5c938a8acc8fae96846163c2633449e92f16f74c71ed63f5ffaR7)
* Added an `Info` annotation to table column specs, expanding metadata capabilities for columns. [[1]](diffhunk://#diff-1f8b619bd73fd63cbab4a3c532b437110dbfe20bb5dbea5d9a54952624ae76afR167) [[2]](diffhunk://#diff-1f8b619bd73fd63cbab4a3c532b437110dbfe20bb5dbea5d9a54952624ae76afR209)
* Minor internal refactoring in the `AnchoredIdDeriver` class to clarify property initialization order.
* Marked the `resolveAnchors` function as deprecated in favor of a parent collection method.
* Renamed internal type `SMap` to `TServices` for clarity in service type derivation.

These changes collectively improve test coverage for complex table relationships, modernize configuration APIs, and lay groundwork for advanced column discovery and annotation in the model infrastructure.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reimplements the column collection builder, modernizes service access patterns (`ctx.services` → `getService()`/`getServices()`), and introduces `DiscoveredPColumn` as a new model type. The `MatchQualifications.forQueries` shape changes from a positional array to an ID-keyed record, and `path` moves from `ColumnMatch` into `MatchVariant`.

Prior threads flag two open issues that remain unresolved: `forAnchors` vs `forQueries` naming in tests, and the module-level service cache in `get_services.ts` capturing a stale render context. Two new observations in this pass: `async` is silently dropped from service-method proxies in `service_bridge.ts`, changing synchronous-throw propagation; and `getServices<T>()` in `ui-vue` returns a module-level cache cast to whichever `T` the caller requests, which is type-unsafe when callers use different `Services` type parameters.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge — prior-thread issues (test field-name mismatch, stale render-context cache) are still open and likely cause test failures.

Two issues from previous review threads appear unresolved: the forAnchors/forQueries naming mismatch that will cause test failures, and the stale-context risk in the module-level service cache. Combined with the new async removal in the service proxy, the PR has multiple correctness concerns that should be addressed before merge.

sdk/model/src/columns/column_collection_builder.test.ts (forAnchors vs forQueries), sdk/model/src/labels/derive_distinct_tooltips.test.ts (same naming issue), sdk/model/src/services/get_services.ts (stale context cache), sdk/model/src/services/service_bridge.ts (async removal)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/columns/column_collection_builder.ts | Major refactoring: removes getColumn/originalId, changes MatchQualifications.forQueries from array-indexed to ID-keyed map via new remapFromIdxToId helper, and moves path into MatchVariant. Logic is sound; anchors array ordering is shared between discoverColumns axes and the index mapping, which must stay in sync. |
| sdk/model/src/services/service_bridge.ts | Renames NodeServiceProxy to ServiceProxy and createNodeServiceProxy to createServiceProxy; silently removes async from service method lambdas, changing synchronous-throw propagation behavior. |
| sdk/ui-vue/src/internal/getServices.ts | New module-level singleton for UI services; type-unsafe generic caching means the first caller's Services type is returned to all subsequent callers regardless of their type parameter. |
| sdk/model/src/services/get_services.ts | New module-level service cache; stale-context risk flagged in prior thread — cache persists after render-context recreation, routing calls to a potentially disposed context. |
| sdk/model/src/labels/derive_distinct_tooltips.ts | New tooltip derivation logic; formatHeader missing 'Column:' line and empty-string vs undefined issue flagged in prior thread. |
| sdk/model/src/columns/column_collection_builder.test.ts | Updated tests use forAnchors instead of forQueries (prior thread mismatch), and replace getColumn with findColumns-based lookups; tests likely fail as-is. |
| sdk/model/src/render/api.ts | Services removed from RenderCtxBase constructor/type params; ctx.services getter replaced with getService() helper; clean simplification with no issues found. |
| sdk/ui-vue/src/internal/createAppV3.ts | Cleanup: debug/error helpers extracted to utils, services initialization delegated to getServices(); uiRegistry.dispose() moved to a separate beforeunload listener inside getServices.ts. |
| lib/model/common/src/drivers/pframe/spec/discovered_column.ts | New DiscoveredPColumn type with serialization helpers; canonicalize undefined case is now handled via throwError (prior thread concern is addressed). |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/model/src/services/service_bridge.ts
Line: 67

Comment:
**`async` wrapper removed — synchronous throws no longer become rejected Promises**

Service method proxies previously used `async (...args) => dispatch.callServiceMethod(...)`, which guaranteed that any synchronous throw inside `callServiceMethod` would surface as a rejected Promise. Removing `async` means a synchronous throw now propagates synchronously, breaking callers that chain `.then()` / `.catch()` instead of using `await`. While Electron IPC calls rarely throw synchronously, this changes the error-propagation contract silently.

If the intent is to keep the same async-only contract, restore `async`:
```
async (...args: unknown[]) => dispatch.callServiceMethod(serviceId, method, ...args),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/ui-vue/src/internal/getServices.ts
Line: 15-20

Comment:
**Type-unsafe generic cache — first caller's type wins for all subsequent callers**

`cachedServices` is typed as `null | Partial<UiServices>` and is shared across all callers. If `getServices<ServiceSetA>()` is called first and caches the result, a later `getServices<ServiceSetB>()` call returns that cached value cast to `ServiceSetB` without verification. The TypeScript type parameter `Services` has no runtime effect on what's actually cached, so callers that expect a narrower or different `Services` shape may receive services that don't match.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: enhance error handling in Anch..."](https://github.com/milaboratory/platforma/commit/d8bd59feedcce9435a5c8c5a6561da6a31309d97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29431658)</sub>

<!-- /greptile_comment -->