### PR TITLE
fix(pframe): correct PFrameWasmV3 shape

### DIFF
--- a/.changeset/pframe-wasm-v3-interface-fix.md
+++ b/.changeset/pframe-wasm-v3-interface-fix.md
@@ -11,7 +11,10 @@ Correct `PFrameWasmV3` shape:
   frame state, so it should not require a frame instance.
 - Add the missing `listColumns(): PColumnInfo[]` on the per-frame
   interface, mirroring `PFrameReadApi.listColumns` on the data layer.
-- Delete the legacy `PFrameWasmV2` / `PFrameWasmAPIV2` interfaces.
+
+`PFrameWasmV2` / `PFrameWasmAPIV2` are kept as legacy shims until the V3
+surface is implemented on the pframes-rs side and `pframes-rs-wasm`
+stops returning V2 from its top-level exports.
 
 Requires a matching `pframes-rs-wasm` release that exposes `buildQuery`
 as a top-level export and `listColumns` on the frame resource.

--- a/.changeset/pframe-wasm-v3-interface-fix.md
+++ b/.changeset/pframe-wasm-v3-interface-fix.md
@@ -1,0 +1,17 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+"@milaboratories/pl-model-common": patch
+"@milaboratories/pf-spec-driver": patch
+---
+
+Correct `PFrameWasmV3` shape:
+
+- Move `buildQuery` from the per-frame interface to the API factory
+  (`PFrameWasmAPIV3`). It is pure over its input and does not consult
+  frame state, so it should not require a frame instance.
+- Add the missing `listColumns(): PColumnInfo[]` on the per-frame
+  interface, mirroring `PFrameReadApi.listColumns` on the data layer.
+- Delete the legacy `PFrameWasmV2` / `PFrameWasmAPIV2` interfaces.
+
+Requires a matching `pframes-rs-wasm` release that exposes `buildQuery`
+as a top-level export and `listColumns` on the frame resource.

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -128,7 +128,7 @@ export interface DiscoverColumnsFilterStep {
 export type DiscoverColumnsStepInfo = DiscoverColumnsLinkerStep | DiscoverColumnsFilterStep;
 
 /**
- * Input to {@link PFrameWasmV4.buildQuery}: a terminal column plus an ordered
+ * Input to `buildQuery`: a terminal column plus an ordered
  * path of wrapping steps (linker hops, filter joins). Produces a
  * {@link SpecQueryJoinEntry} ready to be plugged into an
  * `innerJoin`/`fullJoin`/`outerJoin` entry list.
@@ -138,8 +138,8 @@ export type DiscoverColumnsStepInfo = DiscoverColumnsLinkerStep | DiscoverColumn
  * wrapping.
  *
  * Columns are referenced by id — specs are resolved later at
- * {@link PFrameWasmV4.evaluateQuery} against the registered specs of the
- * PFrame, so the caller cannot disagree with the frame about spec content.
+ * `evaluateQuery` against the registered specs of the PFrame, so the
+ * caller cannot disagree with the frame about spec content.
  *
  * Qualifications annotate the resulting outermost entry; they do not
  * propagate into the inner query.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -3,6 +3,7 @@ import type {
   AxesSpec,
   BuildQueryInput,
   JoinEntry,
+  PColumnInfo,
   PColumnSpec,
   PObjectId,
   PTableColumnId,
@@ -22,7 +23,11 @@ import type { DiscoverColumnsRequestV2, DiscoverColumnsResponse } from "./discov
 import type { FindColumnsRequest, FindColumnsResponse } from "./find_columns";
 
 /**
- * V3 PFrame interface: adds {@link PFrameWasmV3.buildQuery} on top of V2.
+ * V3 PFrame interface — per-frame instance operations.
+ *
+ * Pure spec-assembly operations (e.g. {@link PFrameWasmAPIV3.buildQuery}) live
+ * on the API factory because they don't read frame state. Everything here
+ * consults the registered specs of this frame.
  */
 export interface PFrameWasmV3 extends Disposable {
   /**
@@ -31,11 +36,16 @@ export interface PFrameWasmV3 extends Disposable {
   deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
 
   /**
+   * Lists all columns currently registered in this PFrame, with their ids and specs.
+   */
+  listColumns(): PColumnInfo[];
+
+  /**
    * Discovers columns compatible with a given axes integration. Include and
    * exclude filters are applied in order (exclude removes matches from the
    * include set). Each hit carries its traversal `path`; feed the hit's
-   * column id and `path` into {@link buildQuery} to materialize it as a
-   * {@link SpecQueryJoinEntry}.
+   * column id and `path` into {@link PFrameWasmAPIV3.buildQuery} to
+   * materialize it as a {@link SpecQueryJoinEntry}.
    */
   discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
 
@@ -53,26 +63,11 @@ export interface PFrameWasmV3 extends Disposable {
    * Rewrites a legacy query format (V4) to the current SpecQuery format.
    */
   rewriteLegacyQuery(request: LegacyQuery): SpecQuery;
-
-  /**
-   * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
-   * ordered path of wrapping steps (linker hops, filter joins).
-   *
-   * Right-fold over `path` starting from `Column(column)`: each `linker` step
-   * wraps the current subquery as `linkerJoin`, each `filter` step as
-   * `innerJoin` with the filter column. `qualifications` annotate the
-   * outermost entry only.
-   *
-   * Pure over its input — column ids are resolved later in
-   * {@link evaluateQuery}. Throws only on malformed input: shape violations
-   * and unknown step tags (so v1 callers are shielded from step variants
-   * added in later versions).
-   */
-  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
 }
 
 /**
- * V3 PFrame API factory with createPFrame returning {@link PFrameWasmV3}.
+ * V3 PFrame API factory — pure spec-layer operations plus frame construction.
+ * Everything here is stateless and does not require a frame instance.
  */
 export interface PFrameWasmAPIV3 {
   /**
@@ -102,48 +97,22 @@ export interface PFrameWasmAPIV3 {
    * selector within a table spec. Returns -1 if not found.
    */
   findTableColumn(tableSpec: PTableColumnSpec[], selector: PTableColumnId): number;
-}
 
-/**
- * V2 PFrame interface. Superseded by {@link PFrameWasmV3}, which adds
- * {@link PFrameWasmV3.buildQuery}. Will be removed in a future PFrames update.
- */
-export interface PFrameWasmV2 extends Disposable {
-  /** @see PFrameWasmV3.deleteColumns */
-  deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
-
-  /** @see PFrameWasmV3.discoverColumns */
-  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
-
-  /** @see PFrameWasmV3.findColumns */
-  findColumns(request: FindColumnsRequest): FindColumnsResponse;
-
-  /** @see PFrameWasmV3.evaluateQuery */
-  evaluateQuery(request: SpecQuery): EvaluateQueryResponse;
-
-  /** @see PFrameWasmV3.rewriteLegacyQuery */
-  rewriteLegacyQuery(request: LegacyQuery): SpecQuery;
-}
-
-/**
- * V2 PFrame API factory. Superseded by {@link PFrameWasmAPIV3}; will be removed
- * in a future PFrames update.
- */
-export interface PFrameWasmAPIV2 {
-  /** @see PFrameWasmAPIV3.createPFrame */
-  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV2;
-
-  /** @see PFrameWasmAPIV3.expandAxes */
-  expandAxes(spec: AxesSpec): AxesId;
-
-  /** @see PFrameWasmAPIV3.collapseAxes */
-  collapseAxes(ids: AxesId): AxesSpec;
-
-  /** @see PFrameWasmAPIV3.findAxis */
-  findAxis(spec: AxesSpec, selector: SingleAxisSelector): number;
-
-  /** @see PFrameWasmAPIV3.findTableColumn */
-  findTableColumn(tableSpec: PTableColumnSpec[], selector: PTableColumnId): number;
+  /**
+   * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
+   * ordered path of wrapping steps (linker hops, filter joins).
+   *
+   * Right-fold over `path` starting from `Column(column)`: each `linker` step
+   * wraps the current subquery as `linkerJoin`, each `filter` step as
+   * `innerJoin` with the filter column. `qualifications` annotate the
+   * outermost entry only.
+   *
+   * Pure over its input — no frame needed. Column ids are resolved later at
+   * {@link PFrameWasmV3.evaluateQuery} against the registered specs. Throws
+   * only on malformed input: shape violations and unknown step tags (so v1
+   * callers are shielded from step variants added in later versions).
+   */
+  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
 }
 
 /**

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -116,10 +116,8 @@ export interface PFrameWasmAPIV3 {
 }
 
 /**
- * V2 PFrame interface. Kept as a legacy shim while pframes-rs-wasm still
- * exposes this as the return type of `createPFrame`; will be removed once
- * the V3 surface (with `listColumns` and factory-level `buildQuery`) is
- * implemented on the pframes-rs side.
+ * V2 PFrame interface. Superseded by {@link PFrameWasmV3}; will be removed
+ * in a future PFrames update.
  */
 export interface PFrameWasmV2 extends Disposable {
   /** @see PFrameWasmV3.deleteColumns */
@@ -139,9 +137,8 @@ export interface PFrameWasmV2 extends Disposable {
 }
 
 /**
- * V2 PFrame API factory. Kept as a legacy shim while pframes-rs-wasm still
- * returns this from its top-level exports; will be removed once the V3
- * surface is implemented on the pframes-rs side.
+ * V2 PFrame API factory. Superseded by {@link PFrameWasmAPIV3}; will be removed
+ * in a future PFrames update.
  */
 export interface PFrameWasmAPIV2 {
   /** @see PFrameWasmAPIV3.createPFrame */

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -116,6 +116,51 @@ export interface PFrameWasmAPIV3 {
 }
 
 /**
+ * V2 PFrame interface. Kept as a legacy shim while pframes-rs-wasm still
+ * exposes this as the return type of `createPFrame`; will be removed once
+ * the V3 surface (with `listColumns` and factory-level `buildQuery`) is
+ * implemented on the pframes-rs side.
+ */
+export interface PFrameWasmV2 extends Disposable {
+  /** @see PFrameWasmV3.deleteColumns */
+  deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
+
+  /** @see PFrameWasmV3.discoverColumns */
+  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
+
+  /** @see PFrameWasmV3.findColumns */
+  findColumns(request: FindColumnsRequest): FindColumnsResponse;
+
+  /** @see PFrameWasmV3.evaluateQuery */
+  evaluateQuery(request: SpecQuery): EvaluateQueryResponse;
+
+  /** @see PFrameWasmV3.rewriteLegacyQuery */
+  rewriteLegacyQuery(request: LegacyQuery): SpecQuery;
+}
+
+/**
+ * V2 PFrame API factory. Kept as a legacy shim while pframes-rs-wasm still
+ * returns this from its top-level exports; will be removed once the V3
+ * surface is implemented on the pframes-rs side.
+ */
+export interface PFrameWasmAPIV2 {
+  /** @see PFrameWasmAPIV3.createPFrame */
+  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV2;
+
+  /** @see PFrameWasmAPIV3.expandAxes */
+  expandAxes(spec: AxesSpec): AxesId;
+
+  /** @see PFrameWasmAPIV3.collapseAxes */
+  collapseAxes(ids: AxesId): AxesSpec;
+
+  /** @see PFrameWasmAPIV3.findAxis */
+  findAxis(spec: AxesSpec, selector: SingleAxisSelector): number;
+
+  /** @see PFrameWasmAPIV3.findTableColumn */
+  findTableColumn(tableSpec: PTableColumnSpec[], selector: PTableColumnId): number;
+}
+
+/**
  * Response from evaluating a query against a PFrame.
  */
 export type EvaluateQueryResponse = {

--- a/lib/model/pf-spec-driver/src/pframe_pool.ts
+++ b/lib/model/pf-spec-driver/src/pframe_pool.ts
@@ -15,7 +15,7 @@ import { bytesToHex } from "@noble/hashes/utils.js";
 export class PFramePool extends RefCountPoolBase<
   Record<string, PColumnSpec>,
   SpecFrameHandle,
-  PFrameInternal.PFrameWasmV3
+  PFrameInternal.PFrameWasmV2
 > {
   constructor(private readonly logger: MiLogger) {
     super();
@@ -30,14 +30,14 @@ export class PFramePool extends RefCountPoolBase<
   protected createNewResource(
     params: Record<string, PColumnSpec>,
     key: SpecFrameHandle,
-  ): PFrameInternal.PFrameWasmV3 {
+  ): PFrameInternal.PFrameWasmV2 {
     if (logPFrames()) {
       this.logger.info(`Creating SpecFrame for handle = ${key}, columns: ` + stringifyJson(params));
     }
     return createPFrame(params);
   }
 
-  public getByKey(key: SpecFrameHandle): PFrameInternal.PFrameWasmV3 {
+  public getByKey(key: SpecFrameHandle): PFrameInternal.PFrameWasmV2 {
     const resource = super.tryGetByKey(key);
     if (!resource) {
       const error = new PFrameDriverError(`Invalid SpecFrame handle`);

--- a/lib/model/pf-spec-driver/src/pframe_pool.ts
+++ b/lib/model/pf-spec-driver/src/pframe_pool.ts
@@ -15,7 +15,7 @@ import { bytesToHex } from "@noble/hashes/utils.js";
 export class PFramePool extends RefCountPoolBase<
   Record<string, PColumnSpec>,
   SpecFrameHandle,
-  PFrameInternal.PFrameWasmV2
+  PFrameInternal.PFrameWasmV3
 > {
   constructor(private readonly logger: MiLogger) {
     super();
@@ -30,14 +30,14 @@ export class PFramePool extends RefCountPoolBase<
   protected createNewResource(
     params: Record<string, PColumnSpec>,
     key: SpecFrameHandle,
-  ): PFrameInternal.PFrameWasmV2 {
+  ): PFrameInternal.PFrameWasmV3 {
     if (logPFrames()) {
       this.logger.info(`Creating SpecFrame for handle = ${key}, columns: ` + stringifyJson(params));
     }
     return createPFrame(params);
   }
 
-  public getByKey(key: SpecFrameHandle): PFrameInternal.PFrameWasmV2 {
+  public getByKey(key: SpecFrameHandle): PFrameInternal.PFrameWasmV3 {
     const resource = super.tryGetByKey(key);
     if (!resource) {
       const error = new PFrameDriverError(`Invalid SpecFrame handle`);


### PR DESCRIPTION
## Summary
- `buildQuery` moves from the per-frame `PFrameWasmV3` interface to the `PFrameWasmAPIV3` factory. It is pure over its input and does not consult frame state, so it should not require a frame instance.
- Add the missing `listColumns(): PColumnInfo[]` on `PFrameWasmV3`, mirroring `PFrameReadApi.listColumns` on the data layer.
- Drop the legacy `PFrameWasmV2` / `PFrameWasmAPIV2` interfaces. `pf-spec-driver`'s pool switches to the V3 type.

## Requires
A matching `pframes-rs-wasm` release that exposes `buildQuery` as a top-level export (e.g. alongside `expandAxes`) and `listColumns` on the frame resource. Until that ships, consumers of the V3 API factory and `listColumns` will not resolve at runtime even though types compile — do not merge this ahead of the pframes-rs-wasm change.

## Test plan
- [x] `pnpm check` — full monorepo tsc + lint + format passes.
- [ ] After matching pframes-rs-wasm release: smoke test `buildQuery` at API level and `listColumns` on a frame instance.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects the `PFrameWasmV3` interface shape by relocating `buildQuery` (which is pure/stateless) from the per-frame instance to the `PFrameWasmAPIV3` factory, adds the missing `listColumns(): PColumnInfo[]` to `PFrameWasmV3` mirroring the data-layer API, and removes the now-superseded `PFrameWasmV2`/`PFrameWasmAPIV2` interfaces. The pool in `pf-spec-driver` is updated to use the V3 type accordingly.

The PR description correctly calls out that `buildQuery` on the factory and `listColumns` on frame instances require a matching `pframes-rs-wasm` WASM release to resolve at runtime — this dependency is also captured in the changeset.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining concerns are process/deployment rather than code correctness.

No active callers of `PFrameWasmV2` or `PFrameWasmV3.buildQuery` exist in the codebase (only CHANGELOG references), so removing V2 and moving `buildQuery` to the factory introduces no runtime regressions in the current code. The type changes are consistent across all files. The runtime dependency on a new `pframes-rs-wasm` release is clearly documented and is a deployment concern, not a code defect.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts | Moves `buildQuery` from per-frame `PFrameWasmV3` to the stateless `PFrameWasmAPIV3` factory, adds `listColumns(): PColumnInfo[]` to `PFrameWasmV3`, and removes the legacy `PFrameWasmV2`/`PFrameWasmAPIV2` interfaces. Logic and types look correct. |
| lib/model/pf-spec-driver/src/pframe_pool.ts | Upgrades pool generic type parameter from `PFrameWasmV2` to `PFrameWasmV3`; no logic changes. |
| lib/model/common/src/drivers/pframe/spec_driver.ts | Documentation-only update: removes stale `PFrameWasmV4` JSDoc references and replaces them with plain backtick references. |
| .changeset/pframe-wasm-v3-interface-fix.md | Changeset marking `pl-model-middle-layer` as minor and `pl-model-common`/`pf-spec-driver` as patch; accurately describes all changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pframe): correct PFrameWasmV3 shape"](https://github.com/milaboratory/platforma/commit/d39ef4b6ad7b6a418bba538341f05d149a85cb4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29432374)</sub>

<!-- /greptile_comment -->