### PR TITLE
fix: new order for linkers detection

### DIFF
--- a/.changeset/hungry-apes-teach.md
+++ b/.changeset/hungry-apes-teach.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-common": patch
+---
+
+update tests

--- a/.changeset/smart-sheep-strive.md
+++ b/.changeset/smart-sheep-strive.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-common": minor
+---
+
+update linker connection order

--- a/lib/model/common/src/drivers/pframe/linker_columns.test.ts
+++ b/lib/model/common/src/drivers/pframe/linker_columns.test.ts
@@ -99,7 +99,7 @@ describe("Linker columns", () => {
     };
 
     testCase({ from: [axis2], to: [axis3], expected: [] });
-    testCase({ from: [axis1], to: [axis2], expected: ["c12"] });
+    testCase({ from: [axis2], to: [axis1], expected: ["c12"] });
     testCase({ from: [axis1], to: [axis4], expected: [] });
   });
 
@@ -126,8 +126,8 @@ describe("Linker columns", () => {
     };
 
     testCase({
-      from: getNormalizedAxesList([axisA, axisB]),
-      to: getNormalizedAxesList([axisC]),
+      from: getNormalizedAxesList([axisC]),
+      to: getNormalizedAxesList([axisA, axisB]),
       expected: ["abc"],
     });
   });
@@ -239,13 +239,13 @@ describe("Linker columns", () => {
 
     const linkersMap = LinkerMap.fromColumns([linker1, linker2]);
 
-    // Forward-only: from group2 we only reach group3 (no back edge to group1)
+    // Reversed edges: from group2 we reach group1 (no forward edge to group3)
     expect(
       new Set(
         linkersMap.getReachableByLinkersAxesFromAxesNormalized(group2Normalized).map((a) => a.name),
       ),
-    ).toEqual(new Set([...group3].map((a) => a.name)));
-    // Non-root axes (axisDn, axisBn) don't match linker map keys, so no forward reachability
+    ).toEqual(new Set(group1.map((a) => a.name)));
+    // Non-root axes (axisDn, axisBn) don't match linker map keys, so no reachability
     expect(linkersMap.getReachableByLinkersAxesFromAxesNormalized([axisDn])).toEqual([]);
     expect(linkersMap.getReachableByLinkersAxesFromAxesNormalized([axisBn])).toEqual([]);
   });
@@ -257,13 +257,17 @@ describe("Linker columns", () => {
     const axisC2 = makeTestAxis({ name: "c", parents: [axisB, axisA] });
     const axisD = makeTestAxis({ name: "d" });
 
-    const [, , c1, c2] = getNormalizedAxesList([axisA, axisB, axisC1, axisC2, axisD]);
+    const [, , c1, c2, dn] = getNormalizedAxesList([axisA, axisB, axisC1, axisC2, axisD]);
     const linkerMap = LinkerMap.fromColumns([
       makeLinkerColumn({ name: "linker1", from: [axisA, axisB, axisC1], to: [axisD] }),
     ]);
 
-    expect(linkerMap.getReachableByLinkersAxesFromAxesNormalized([c2])).not.toHaveLength(0);
-    expect(linkerMap.getReachableByLinkersAxesFromAxesNormalized([c1])).not.toHaveLength(0);
+    expect(
+      linkerMap.getLinkerColumnsForAxes({ from: [dn], to: [c2], throwWhenNoLinkExists: false }),
+    ).not.toHaveLength(0);
+    expect(
+      linkerMap.getLinkerColumnsForAxes({ from: [dn], to: [c1], throwWhenNoLinkExists: false }),
+    ).not.toHaveLength(0);
   });
 
   test("Non-linkable axes", () => {
@@ -284,7 +288,7 @@ describe("Linker columns", () => {
           getNormalizedAxesList([axisA, axisB, axisC, axisE]),
         )
         .map((v) => v.name),
-    ).toEqual(["a", "b", "c", "e"]);
+    ).toEqual(["a", "b", "e"]);
 
     expect(
       linkerMap
@@ -304,9 +308,9 @@ describe("Linker columns", () => {
       makeLinkerColumn({ name: "linker3", from: [axisC], to: [axisD] }),
     ]);
 
-    expect(linkerMap.getReachableByLinkersAxesFromAxes([axisA])).toEqual(
-      getNormalizedAxesList([axisB, axisC, axisD]),
+    expect(linkerMap.getReachableByLinkersAxesFromAxes([axisD])).toEqual(
+      getNormalizedAxesList([axisC, axisB, axisA]),
     );
-    expect(linkerMap.getReachableByLinkersAxesFromAxes([axisD])).toEqual([]);
+    expect(linkerMap.getReachableByLinkersAxesFromAxes([axisA])).toEqual([]);
   });
 });

--- a/lib/model/common/src/drivers/pframe/linker_columns.ts
+++ b/lib/model/common/src/drivers/pframe/linker_columns.ts
@@ -86,9 +86,9 @@ export class LinkerMap implements LinkersData {
           result.set(keyRight, { keyAxesSpec: spec, linkWith: new Map() });
         }
       }
-      for (const [keyLeft] of leftKeyVariants) {
-        for (const [keyRight] of rightKeyVariants) {
-          result.get(keyLeft)?.linkWith.set(keyRight, linker);
+      for (const [keyRight] of rightKeyVariants) {
+        for (const [keyLeft] of leftKeyVariants) {
+          result.get(keyRight)?.linkWith.set(keyLeft, linker);
         }
       }
     }

--- a/sdk/model/src/components/PFrameForGraphs.test.ts
+++ b/sdk/model/src/components/PFrameForGraphs.test.ts
@@ -214,8 +214,8 @@ describe("PFrameForGraph", () => {
       valueType: "String",
       annotations: { [Annotation.IsLinkerColumn]: "true" },
       axesSpec: [
-        { type: "String", name: "axis1" },
         { type: "String", name: "axis3" },
+        { type: "String", name: "axis1" },
       ],
     };
 
@@ -240,8 +240,8 @@ describe("PFrameForGraph", () => {
       valueType: "String",
       annotations: { [Annotation.IsLinkerColumn]: "true" },
       axesSpec: [
-        { type: "String", name: "axis1" },
         { type: "String", name: "axis2" },
+        { type: "String", name: "axis1" },
       ],
     };
     const linkerColumn23: PColumnSpec = {
@@ -250,8 +250,8 @@ describe("PFrameForGraph", () => {
       valueType: "String",
       annotations: { [Annotation.IsLinkerColumn]: "true" },
       axesSpec: [
-        { type: "String", name: "axis2" },
         { type: "String", name: "axis3" },
+        { type: "String", name: "axis2" },
       ],
     };
     const linkerColumn34: PColumnSpec = {
@@ -260,8 +260,8 @@ describe("PFrameForGraph", () => {
       valueType: "String",
       annotations: { [Annotation.IsLinkerColumn]: "true" },
       axesSpec: [
-        { type: "String", name: "axis3" },
         { type: "String", name: "axis4" },
+        { type: "String", name: "axis3" },
       ],
     };
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reverses the direction of edge population in the `LinkerMap` graph: edges were previously added as `leftKey → rightKey` (via `linkWith`); they are now added as `rightKey → leftKey`. The fix addresses a bug where BFS traversal starting from a right-side axis key could not reach left-side keys because right-side `linkWith` maps were always empty.

- The graph remains **one-directional** after the flip — `leftKey.linkWith` is now always empty, so any call to `searchLinkerPath(leftKey, rightKey)` or traversal starting from a left-side key will return no results. If bidirectional traversal is ever required, a reverse mapping will need to be added alongside this change.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge if all call-sites are confirmed to start traversal from right-side keys; the one-directional nature of the graph may be a silent regression for left-to-right traversal.

The core logic change is internally consistent and intentional, but the graph is still one-directional (now right→left only). Without confirmation that no existing caller relies on left→right traversal, there is a potential regression risk, keeping the score at 4 rather than 5.

lib/model/common/src/drivers/pframe/linker_columns.ts — confirm no caller uses searchLinkerPath or getLinkerColumnsForAxes with a left-side start key.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/drivers/pframe/linker_columns.ts | Reverses the linker graph edge direction from left→right to right→left; graph remains one-directional, so traversal starting from a left-side key will find no links. |
| .changeset/smart-sheep-strive.md | Changeset marks the bump as `minor`; PR intent is a bug fix (`fix:` prefix), which normally warrants a `patch` bump. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/model/common/src/drivers/pframe/linker_columns.ts
Line: 89-93

Comment:
**Graph remains one-directional after direction flip**

The change correctly reverses the traversal direction from `left → right` to `right → left`, but the graph is still only one-directional. `leftKey` entries are now populated with an empty `linkWith`, while `rightKey` entries carry the links. Any caller that starts BFS/path search from a left-side key (e.g. `searchLinkerPath(leftKey, rightKey)`) will get an empty result because `leftKey.linkWith` is always empty. If there are use-cases where traversal needs to go in both directions, the loop should also add the reverse mapping: `result.get(keyLeft)?.linkWith.set(keyRight, linker)`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .changeset/smart-sheep-strive.md
Line: 2

Comment:
**Bump type mismatch with PR title**

The changeset uses `minor` but the PR title is prefixed `fix:`, which conventionally corresponds to a `patch` bump. If this truly is a bug fix with no intentional API additions, consider using `patch` instead.

```suggestion
"@milaboratories/pl-model-common": patch
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/milaboratory/platforma/commit/05abdfbd28de62c376b6854d0ab726799b7a7767) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29440987)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->