### PR TITLE
Broken annotations

### DIFF
--- a/.changeset/forty-tips-win.md
+++ b/.changeset/forty-tips-win.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/milaboratories.ui-examples.ui": minor
+"@platforma-sdk/ui-vue": minor
+---
+
+fix broken annotations

--- a/etc/blocks/ui-examples/ui/src/pages/PlAnnotationPage.vue
+++ b/etc/blocks/ui-examples/ui/src/pages/PlAnnotationPage.vue
@@ -163,20 +163,27 @@ async function getSuggestModel({
   );
 }
 
-const getValuesForSelectedColumns = async () => {
+async function getValuesForSelectedColumns() {
   // Mock implementation - in real app this would fetch actual column values
   return {
     columnId: sampleNameId as PObjectId,
     values: ["Sample_001", "Sample_002", "Sample_003", "Control_001", "Control_002"],
   };
-};
+}
+
+function handleUpdateAnnotation(annotation: Annotation) {
+  console.log("Updated Annotation:", annotation);
+  mockAnnotations.value = annotation;
+}
 </script>
 
 <template>
   <div :class="$style.page">
     <PlAnnotationsModal
-      v-model:opened="showModal"
-      v-model:annotation="mockAnnotations"
+      :opened="showModal"
+      :annotation="mockAnnotations"
+      :on-update-opened="(v: boolean) => (showModal = v)"
+      :on-update-annotation="handleUpdateAnnotation"
       :columns="mockColumns"
       :hasSelectedColumns="true"
       :getSuggestOptions="getSuggestOptions"

--- a/lib/util/helpers/src/types/index.ts
+++ b/lib/util/helpers/src/types/index.ts
@@ -31,6 +31,8 @@ export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
+export type NullableBy<T, K extends keyof T> = Omit<T, K> & { [P in K]: null | T[P] };
+
 export type MethodOf<T> = {
   [K in keyof T]: T[K] extends AnyFunction ? K : never;
 }[keyof T];

--- a/sdk/model/src/filters/distill.test.ts
+++ b/sdk/model/src/filters/distill.test.ts
@@ -188,4 +188,95 @@ describe("distillFilterSpec", () => {
     const filter: F = { type: "and", filters: [a, b] };
     expect(distillFilterSpec(filter)).toBeNull();
   });
+
+  // --- per-type required-field checks ---
+
+  it("keeps patternFuzzyContainSubsequence without optional fields", () => {
+    const filter: F = { type: "patternFuzzyContainSubsequence", column: "c1", value: "abc" };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("keeps patternFuzzyContainSubsequence when optional fields undefined", () => {
+    const filter: F = {
+      type: "patternFuzzyContainSubsequence",
+      column: "c1",
+      value: "abc",
+      maxEdits: undefined,
+      substitutionsOnly: undefined,
+      wildcard: undefined,
+    };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("preserves optional fields on patternFuzzyContainSubsequence when filled", () => {
+    const filter: F = {
+      type: "patternFuzzyContainSubsequence",
+      column: "c1",
+      value: "abc",
+      maxEdits: 2,
+      substitutionsOnly: true,
+      wildcard: "*",
+    };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("keeps lessThanColumn without optional minDiff", () => {
+    const filter: F = { type: "lessThanColumn", column: "c1", rhs: "c2" };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("returns null for lessThanColumn with missing required rhs", () => {
+    const filter: F = {
+      type: "lessThanColumn",
+      column: "c1",
+      rhs: undefined as unknown as string,
+    };
+    expect(distillFilterSpec(filter)).toBeNull();
+  });
+
+  it("returns null for ifNa with missing required replacement", () => {
+    const filter: F = {
+      type: "ifNa",
+      column: "c1",
+      replacement: undefined as unknown as string,
+    };
+    expect(distillFilterSpec(filter)).toBeNull();
+  });
+
+  // --- isFilledValue edge cases ---
+
+  it("returns null for empty-string value after trim", () => {
+    const filter: F = { type: "patternEquals", column: "c1", value: "   " };
+    expect(distillFilterSpec(filter)).toBeNull();
+  });
+
+  it("returns null for inSet with empty array", () => {
+    const filter: F = { type: "inSet", column: "c1", value: [] };
+    expect(distillFilterSpec(filter)).toBeNull();
+  });
+
+  it("returns null for inSet with array containing empty string", () => {
+    const filter: F = { type: "inSet", column: "c1", value: ["a", "  "] };
+    expect(distillFilterSpec(filter)).toBeNull();
+  });
+
+  it("keeps inSet with non-empty string items", () => {
+    const filter: F = { type: "inSet", column: "c1", value: ["a", "b"] };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("keeps equal with x=0 (falsy but filled)", () => {
+    const filter: F = { type: "equal", column: "c1", x: 0 };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("keeps isNA (single required column)", () => {
+    const filter: F = { type: "isNA", column: "c1" };
+    expect(distillFilterSpec(filter)).toEqual(filter);
+  });
+
+  it("returns null for isNA with missing column", () => {
+    const filter: F = { type: "isNA", column: undefined as unknown as string };
+    expect(distillFilterSpec(filter)).toBeNull();
+  });
 });

--- a/sdk/model/src/filters/distill.ts
+++ b/sdk/model/src/filters/distill.ts
@@ -1,4 +1,4 @@
-import { DistributiveKeys, UnionToTuples } from "@milaboratories/helpers";
+import { DistributiveKeys, isNil, UnionToTuples } from "@milaboratories/helpers";
 import {
   RootFilterSpec,
   type FilterSpec,
@@ -7,51 +7,6 @@ import {
 import { traverseFilterSpec } from "./traverse";
 import { InferFilterSpecLeaf } from "@milaboratories/pl-model-common";
 import { isEmpty } from "es-toolkit/compat";
-
-/** All possible field names that can appear in any FilterSpecLeaf variant. */
-type FilterSpecLeafKey = DistributiveKeys<FilterSpecLeaf<string>>;
-
-/** Compile-time check: every key in the tuple is a valid leaf key (via satisfies). */
-const KNOWN_LEAF_KEYS_TUPLE: UnionToTuples<FilterSpecLeafKey> = [
-  "n",
-  "x",
-  "rhs",
-  "type",
-  "value",
-  "column",
-  "minDiff",
-  "maxEdits",
-  "wildcard",
-  "replacement",
-  "substitutionsOnly",
-];
-const KNOWN_LEAF_KEYS: Set<FilterSpecLeafKey> = new Set(KNOWN_LEAF_KEYS_TUPLE);
-
-/** Returns true if the leaf is filled — type is defined and no required fields are undefined. */
-function isFilledLeaf<T>(node: FilterSpecLeaf<T>): boolean {
-  if (node.type == null) return false;
-  return !Object.values(node).some((value) => {
-    switch (typeof value) {
-      case "number":
-      case "boolean":
-        return false;
-      case "string":
-        return value.trim() === "";
-      default: // undefined, null, empty objects/arrays
-        return isEmpty(value);
-    }
-  });
-}
-
-function distillLeaf<T>(node: FilterSpecLeaf<T>): FilterSpecLeaf<T> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(node)) {
-    if (KNOWN_LEAF_KEYS.has(key as FilterSpecLeafKey)) {
-      result[key] = value;
-    }
-  }
-  return result as FilterSpecLeaf<T>;
-}
 
 /**
  * Strips non-FilterSpec metadata (whitelist approach) and removes
@@ -80,3 +35,104 @@ export function distillFilterSpec<
     not: (result) => (result === null ? null : ({ type: "not", filter: result } as R)),
   });
 }
+
+function distillLeaf<T>(node: FilterSpecLeaf<T>): FilterSpecLeaf<T> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (KNOWN_LEAF_KEYS.has(key as FilterSpecLeafKey)) {
+      result[key] = value;
+    }
+  }
+  return result as FilterSpecLeaf<T>;
+}
+
+/** Returns true if the leaf is filled — type is defined and every required field per-type is filled. */
+function isFilledLeaf<T>(node: FilterSpecLeaf<T>): boolean {
+  if (isNil(node.type)) return false;
+  const required = REQUIRED_KEYS_BY_TYPE[node.type];
+  const record = node as Record<string, unknown>;
+  return required.every((key) => isFilledValue(record[key]));
+}
+
+/**
+ * Returns true if the value is considered "filled":
+ * - primitives (number, boolean): always true
+ * - string: non-empty after trim
+ * - array: non-empty AND every item is filled
+ * - plain object: non-empty AND every field value is filled
+ * - null/undefined: false
+ */
+function isFilledValue(value: unknown): boolean {
+  if (isNil(value)) return false;
+  switch (typeof value) {
+    case "number":
+    case "boolean":
+      return true;
+    case "string":
+      return value.trim() !== "";
+    default:
+      if (isEmpty(value)) return false;
+      if (Array.isArray(value)) return value.every(isFilledValue);
+      return Object.values(value as Record<string, unknown>).every(isFilledValue);
+  }
+}
+
+/** All possible field names that can appear in any FilterSpecLeaf variant. */
+type FilterSpecLeafKey = DistributiveKeys<FilterSpecLeaf<string>>;
+
+/** Leaf type discriminators (excludes the placeholder `undefined` variant). */
+type FilterSpecLeafType = Exclude<FilterSpecLeaf<unknown>, { type: undefined }>["type"];
+
+type LeafOfType<T extends FilterSpecLeafType> = Extract<FilterSpecLeaf<unknown>, { type: T }>;
+
+type RequiredKeys<O> = { [K in keyof O]-?: {} extends Pick<O, K> ? never : K }[keyof O];
+
+/** Required field keys of a given leaf variant (excluding the `type` discriminator). */
+type RequiredLeafKeys<T extends FilterSpecLeafType> = Exclude<RequiredKeys<LeafOfType<T>>, "type">;
+
+/** Exact per-type shape — adding a key not required by that variant becomes a type error. */
+type RequiredKeysByType = { readonly [T in FilterSpecLeafType]: readonly RequiredLeafKeys<T>[] };
+
+/** Compile-time check: every key in the tuple is a valid leaf key (via satisfies). */
+const KNOWN_LEAF_KEYS_TUPLE: UnionToTuples<FilterSpecLeafKey> = [
+  "n",
+  "x",
+  "rhs",
+  "type",
+  "value",
+  "column",
+  "minDiff",
+  "maxEdits",
+  "wildcard",
+  "replacement",
+  "substitutionsOnly",
+];
+const KNOWN_LEAF_KEYS: Set<FilterSpecLeafKey> = new Set(KNOWN_LEAF_KEYS_TUPLE);
+
+/** Required fields per leaf type. Optional fields (e.g. minDiff, maxEdits) excluded. */
+const REQUIRED_KEYS_BY_TYPE = {
+  isNA: ["column"],
+  isNotNA: ["column"],
+  ifNa: ["column", "replacement"],
+  patternEquals: ["column", "value"],
+  patternNotEquals: ["column", "value"],
+  patternContainSubsequence: ["column", "value"],
+  patternNotContainSubsequence: ["column", "value"],
+  patternMatchesRegularExpression: ["column", "value"],
+  patternFuzzyContainSubsequence: ["column", "value"],
+  inSet: ["column", "value"],
+  notInSet: ["column", "value"],
+  topN: ["column", "n"],
+  bottomN: ["column", "n"],
+  equal: ["column", "x"],
+  notEqual: ["column", "x"],
+  lessThan: ["column", "x"],
+  greaterThan: ["column", "x"],
+  lessThanOrEqual: ["column", "x"],
+  greaterThanOrEqual: ["column", "x"],
+  equalToColumn: ["column", "rhs"],
+  lessThanColumn: ["column", "rhs"],
+  greaterThanColumn: ["column", "rhs"],
+  lessThanColumnOrEqual: ["column", "rhs"],
+  greaterThanColumnOrEqual: ["column", "rhs"],
+} as const satisfies RequiredKeysByType;

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.test.ts
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.test.ts
@@ -127,7 +127,7 @@ describe("FilterEditor.vue: changeFilterType", () => {
     expect(onUpdateFilter.mock.calls[0][0]).not.toHaveProperty("value");
   });
 
-  it("changing between numeric filters preserves `x`", () => {
+  it("changing between numeric filters resets `x` to default (data fields are not preserved)", () => {
     const onUpdateFilter = vi.fn();
     const wrapper = mountEditor(
       { type: "greaterThan", column: columnA, x: 42 },
@@ -139,7 +139,7 @@ describe("FilterEditor.vue: changeFilterType", () => {
     expect(onUpdateFilter).toHaveBeenCalledWith({
       type: "lessThan",
       column: columnA,
-      x: 42,
+      x: 0,
     });
   });
 
@@ -162,6 +162,45 @@ describe("FilterEditor.vue: changeFilterType", () => {
     findDropdowns(wrapper)[1].vm.$emit("update:modelValue", undefined);
 
     expect(onUpdateFilter).not.toHaveBeenCalled();
+  });
+
+  it("preserves meta fields (id, isExpanded, isSuppressed, source) across type change", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor(
+      {
+        type: "patternEquals",
+        column: columnA,
+        value: "foo",
+        id: 777,
+        isExpanded: true,
+        isSuppressed: false,
+        source: "abc",
+      } as unknown as EditableFilter,
+      { onUpdateFilter },
+    );
+
+    findDropdowns(wrapper)[1].vm.$emit("update:modelValue", "greaterThan");
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "greaterThan",
+      column: columnA,
+      x: 0,
+      id: 777,
+      isExpanded: true,
+      isSuppressed: false,
+      source: "abc",
+    });
+  });
+
+  it("does not carry over unknown data fields from the old filter", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "topN", column: columnA, n: 7 }, { onUpdateFilter });
+
+    findDropdowns(wrapper)[1].vm.$emit("update:modelValue", "isNA");
+
+    const emitted = onUpdateFilter.mock.calls[0][0];
+    expect(emitted).toEqual({ type: "isNA", column: columnA });
+    expect(emitted).not.toHaveProperty("n");
   });
 });
 

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.test.ts
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment happy-dom
+import { mount } from "@vue/test-utils";
+import { defineComponent, h } from "vue";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+function makeStub(name: string) {
+  return defineComponent({
+    name,
+    props: ["modelValue", "options", "optionsSearch", "error", "errorStatus"],
+    emits: ["update:modelValue"],
+    setup(_, { slots }) {
+      return () => h("div", { "data-stub": name }, slots.default?.());
+    },
+  });
+}
+
+vi.mock("@milaboratories/uikit", () => ({
+  PlAutocomplete: makeStub("PlAutocomplete"),
+  PlAutocompleteMulti: makeStub("PlAutocompleteMulti"),
+  PlDropdown: makeStub("PlDropdown"),
+  PlIcon16: makeStub("PlIcon16"),
+  PlNumberField: makeStub("PlNumberField"),
+  PlTextField: makeStub("PlTextField"),
+  PlToggleSwitch: makeStub("PlToggleSwitch"),
+  Slider: makeStub("Slider"),
+  filterUiMetadata: new Proxy(
+    {},
+    {
+      get: (_t, key: string) => ({
+        label: key,
+        supportedFor: () => true,
+      }),
+    },
+  ),
+}));
+
+let FilterEditor: typeof import("./FilterEditor.vue").default;
+let DEFAULT_FILTERS: typeof import("./constants").DEFAULT_FILTERS;
+let SUPPORTED_FILTER_TYPES: typeof import("./constants").SUPPORTED_FILTER_TYPES;
+
+type EditableFilter = import("./types").EditableFilter;
+type PlAdvancedFilterColumnId = import("./types").PlAdvancedFilterColumnId;
+type SourceOptionInfo = import("./types").SourceOptionInfo;
+
+beforeAll(async () => {
+  FilterEditor = (await import("./FilterEditor.vue")).default;
+  const constants = await import("./constants");
+  DEFAULT_FILTERS = constants.DEFAULT_FILTERS;
+  SUPPORTED_FILTER_TYPES = constants.SUPPORTED_FILTER_TYPES;
+});
+
+const columnA = "colA" as PlAdvancedFilterColumnId;
+const columnB = "colB" as PlAdvancedFilterColumnId;
+
+const columnOptions: SourceOptionInfo[] = [
+  {
+    id: columnA,
+    label: "Column A",
+    spec: { kind: "PColumn", name: "a", valueType: "String", axesSpec: [] },
+  },
+  {
+    id: columnB,
+    label: "Column B",
+    spec: { kind: "PColumn", name: "b", valueType: "Int", axesSpec: [] },
+  },
+];
+
+function mountEditor(
+  filter: EditableFilter,
+  handlers: {
+    onUpdateFilter?: (f: EditableFilter) => void;
+    onDelete?: (c: PlAdvancedFilterColumnId) => void;
+    onChangeOperand?: () => void;
+  } = {},
+) {
+  return mount(FilterEditor, {
+    props: {
+      filter,
+      isLast: false,
+      operand: "and",
+      enableDnd: false,
+      columnOptions,
+      supportedFilters: SUPPORTED_FILTER_TYPES,
+      getSuggestOptions: () => [],
+      onDelete: handlers.onDelete ?? (() => {}),
+      onUpdateFilter: handlers.onUpdateFilter ?? (() => {}),
+      onChangeOperand: handlers.onChangeOperand ?? (() => {}),
+    },
+  });
+}
+
+function findDropdowns(wrapper: ReturnType<typeof mount>) {
+  return wrapper.findAllComponents({ name: "PlDropdown" });
+}
+
+describe("FilterEditor.vue: changeFilterType", () => {
+  it("changing type from isNA to greaterThan emits filter with new type and default x", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onUpdateFilter });
+
+    // second PlDropdown (index 1) is the filter-type selector
+    const typeDropdown = findDropdowns(wrapper)[1];
+    typeDropdown.vm.$emit("update:modelValue", "greaterThan");
+
+    expect(onUpdateFilter).toHaveBeenCalledTimes(1);
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "greaterThan",
+      column: columnA,
+      x: 0,
+    });
+  });
+
+  it("changing type from patternEquals to greaterThan drops stale `value`", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor(
+      { type: "patternEquals", column: columnA, value: "hello" },
+      { onUpdateFilter },
+    );
+
+    findDropdowns(wrapper)[1].vm.$emit("update:modelValue", "greaterThan");
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "greaterThan",
+      column: columnA,
+      x: 0,
+    });
+    expect(onUpdateFilter.mock.calls[0][0]).not.toHaveProperty("value");
+  });
+
+  it("changing between numeric filters preserves `x`", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor(
+      { type: "greaterThan", column: columnA, x: 42 },
+      { onUpdateFilter },
+    );
+
+    findDropdowns(wrapper)[1].vm.$emit("update:modelValue", "lessThan");
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "lessThan",
+      column: columnA,
+      x: 42,
+    });
+  });
+
+  it("changing to patternFuzzyContainSubsequence populates all default fields", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onUpdateFilter });
+
+    findDropdowns(wrapper)[1].vm.$emit("update:modelValue", "patternFuzzyContainSubsequence");
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      ...DEFAULT_FILTERS.patternFuzzyContainSubsequence,
+      column: columnA,
+    });
+  });
+
+  it("undefined newType is ignored (no emit)", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onUpdateFilter });
+
+    findDropdowns(wrapper)[1].vm.$emit("update:modelValue", undefined);
+
+    expect(onUpdateFilter).not.toHaveBeenCalled();
+  });
+});
+
+describe("FilterEditor.vue: updateFilterProp", () => {
+  it("editing `x` on greaterThan filter emits updated filter preserving type and column", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "greaterThan", column: columnA, x: 0 }, { onUpdateFilter });
+
+    const numberField = wrapper.findComponent({ name: "PlNumberField" });
+    numberField.vm.$emit("update:modelValue", 99);
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "greaterThan",
+      column: columnA,
+      x: 99,
+    });
+  });
+
+  it("editing `value` on patternEquals emits updated value", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor(
+      { type: "patternEquals", column: columnA, value: "" },
+      { onUpdateFilter },
+    );
+
+    const autocomplete = wrapper.findComponent({ name: "PlAutocomplete" });
+    autocomplete.vm.$emit("update:modelValue", "abc");
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "patternEquals",
+      column: columnA,
+      value: "abc",
+    });
+  });
+
+  it("editing substring `value` on patternContainSubsequence emits updated value", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor(
+      { type: "patternContainSubsequence", column: columnA, value: "" },
+      { onUpdateFilter },
+    );
+
+    const textField = wrapper.findComponent({ name: "PlTextField" });
+    textField.vm.$emit("update:modelValue", "xyz");
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "patternContainSubsequence",
+      column: columnA,
+      value: "xyz",
+    });
+  });
+
+  it("editing `n` on topN emits updated value", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "topN", column: columnA, n: 10 }, { onUpdateFilter });
+
+    const numberField = wrapper.findComponent({ name: "PlNumberField" });
+    numberField.vm.$emit("update:modelValue", 5);
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "topN",
+      column: columnA,
+      n: 5,
+    });
+  });
+});
+
+describe("FilterEditor.vue: changeSourceId", () => {
+  it("changing source to a column supporting the current filter keeps the filter type", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onUpdateFilter });
+
+    // first PlDropdown is the source selector
+    findDropdowns(wrapper)[0].vm.$emit("update:modelValue", columnB);
+
+    expect(onUpdateFilter).toHaveBeenCalledWith({
+      type: "isNA",
+      column: columnB,
+    });
+  });
+
+  it("undefined newSourceId is ignored", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onUpdateFilter });
+
+    findDropdowns(wrapper)[0].vm.$emit("update:modelValue", undefined);
+
+    expect(onUpdateFilter).not.toHaveBeenCalled();
+  });
+
+  it("unknown source id is ignored", () => {
+    const onUpdateFilter = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onUpdateFilter });
+
+    findDropdowns(wrapper)[0].vm.$emit("update:modelValue", "unknown" as PlAdvancedFilterColumnId);
+
+    expect(onUpdateFilter).not.toHaveBeenCalled();
+  });
+});
+
+describe("FilterEditor.vue: onDelete", () => {
+  it("clicking the close icon invokes onDelete with the current column id", async () => {
+    const onDelete = vi.fn();
+    const wrapper = mountEditor({ type: "isNA", column: columnA }, { onDelete });
+
+    // the close button wraps a PlIcon16 with name="close"
+    const closeBtn = wrapper.find('[class*="closeButton"]');
+    await closeBtn.trigger("click");
+
+    expect(onDelete).toHaveBeenCalledWith(columnA);
+  });
+});

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.vue
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.vue
@@ -33,6 +33,7 @@ import {
   isPositionFilter,
   mergeFilterForTypeChange,
 } from "./utils";
+import { isNil } from "es-toolkit";
 
 const props = defineProps<{
   filter: EditableFilter;
@@ -93,7 +94,7 @@ async function getMultiSuggestOptionsFn(
 }
 
 function changeFilterType(newType?: EditableFilter["type"]) {
-  if (!newType) return;
+  if (isNil(newType)) return;
   props.onUpdateFilter(mergeFilterForTypeChange(props.filter, newType));
 }
 

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.vue
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.vue
@@ -26,8 +26,13 @@ import type { SUPPORTED_FILTER_TYPES } from "./constants";
 import { DEFAULT_FILTER_TYPE, DEFAULT_FILTERS } from "./constants";
 import OperandButton from "./OperandButton.vue";
 import type { EditableFilter, Operand, PlAdvancedFilterColumnId, SourceOptionInfo } from "./types";
-import { getFilterInfo, getNormalizedSpec, isNumericFilter, isPositionFilter } from "./utils";
-import { Entries } from "@milaboratories/helpers";
+import {
+  getFilterInfo,
+  getNormalizedSpec,
+  isNumericFilter,
+  isPositionFilter,
+  mergeFilterForTypeChange,
+} from "./utils";
 
 const props = defineProps<{
   filter: EditableFilter;
@@ -87,21 +92,9 @@ async function getMultiSuggestOptionsFn(
   throw new Error("Invalid arguments combination");
 }
 
-function changeFilterType(newType: EditableFilter["type"]) {
-  const defaultFilter = DEFAULT_FILTERS[newType];
-
-  props.onUpdateFilter(
-    (Object.entries(defaultFilter) as Entries<EditableFilter>).reduce(
-      (res, [key, val]) => {
-        res[key] = props.filter[key] ?? val;
-        return res;
-      },
-      { ...props.filter, type: newType } as Record<
-        keyof EditableFilter,
-        EditableFilter[keyof EditableFilter]
-      >,
-    ) as EditableFilter,
-  );
+function changeFilterType(newType?: EditableFilter["type"]) {
+  if (!newType) return;
+  props.onUpdateFilter(mergeFilterForTypeChange(props.filter, newType));
 }
 
 function changeSourceId(newSourceId?: PlAdvancedFilterColumnId) {
@@ -333,7 +326,7 @@ const stringMatchesError = computed(() => {
         :group-position="
           props.filter.type === 'isNA' || props.filter.type === 'isNotNA' ? 'bottom' : 'middle'
         "
-        @update:model-value="(v) => changeFilterType(v!)"
+        @update:model-value="changeFilterType"
       />
     </div>
 

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
@@ -252,12 +252,7 @@ function validateFilter<T extends CommonFilter>(item: T): EditableFilter {
       </template>
       <template #item-content="{ item, index }">
         <div
-          :class="[
-            $style.groupContent,
-            {
-              [$style.suppressedLabel]: item.isSuppressed,
-            },
-          ]"
+          :class="[$style.groupContent, { [$style.suppressedLabel]: item.isSuppressed }]"
           dropzone="true"
           @drop="(event) => handleDropToExistingGroup(index, event)"
           @dragover="dragOver"

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/types.ts
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/types.ts
@@ -9,6 +9,7 @@ import type {
   SUniversalPColumnId,
 } from "@platforma-sdk/model";
 import type { SUPPORTED_FILTER_TYPES } from "./constants";
+import { PartialBy, RequiredBy } from "@milaboratories/helpers";
 
 export type Operand = "or" | "and";
 
@@ -52,9 +53,6 @@ export type RootFilter<Meta extends RequiredMeta = RequiredMeta> = Omit<
 // or, and, not - in groups
 export type SupportedFilterTypes = (typeof SUPPORTED_FILTER_TYPES)[number];
 
-type RequireFields<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
-type OptionalFields<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
 type NumericalWithOptionalN = "topN" | "bottomN";
 type NumericalWithOptionalX =
   | "lessThan"
@@ -64,21 +62,21 @@ type NumericalWithOptionalX =
   | "equal"
   | "notEqual";
 type StringWithOptionalValue = "patternEquals" | "patternNotEquals";
-// types from ui with some changed by optionality fields
 type EditedTypes =
   | "patternFuzzyContainSubsequence"
   | NumericalWithOptionalX
   | StringWithOptionalValue
   | NumericalWithOptionalN;
+
 export type EditableFilter =
   | Exclude<FilterLeafContent, { type: EditedTypes }>
-  | RequireFields<
+  | RequiredBy<
       Extract<FilterLeafContent, { type: "patternFuzzyContainSubsequence" }>,
       "maxEdits" | "substitutionsOnly"
     >
-  | OptionalFields<Extract<FilterLeafContent, { type: NumericalWithOptionalN }>, "n">
-  | OptionalFields<Extract<FilterLeafContent, { type: NumericalWithOptionalX }>, "x">
-  | OptionalFields<Extract<FilterLeafContent, { type: StringWithOptionalValue }>, "value">;
+  | PartialBy<Extract<FilterLeafContent, { type: NumericalWithOptionalN }>, "n">
+  | PartialBy<Extract<FilterLeafContent, { type: NumericalWithOptionalX }>, "x">
+  | PartialBy<Extract<FilterLeafContent, { type: StringWithOptionalValue }>, "value">;
 
 export type FixedAxisInfo = {
   idx: number;

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts
@@ -153,20 +153,18 @@ export function mergeFilterForTypeChange(
   oldFilter: EditableFilter,
   newType: SupportedFilterTypes,
 ): EditableFilter {
-  const defaultFilter = DEFAULT_FILTERS[newType];
-  const oldRecord = oldFilter as Record<string, unknown>;
+  const oldDefault = DEFAULT_FILTERS[oldFilter.type] as Record<string, unknown>;
+  const newDefault = DEFAULT_FILTERS[newType];
 
-  const merged = Object.entries(defaultFilter).reduce<Record<string, unknown>>(
-    (res, [key, val]) => {
-      if (key === "type") {
-        res[key] = newType;
-      } else {
-        res[key] = oldRecord[key] ?? val;
-      }
-      return res;
-    },
-    {},
-  );
+  const stripped = { ...oldFilter } as Record<string, unknown>;
+  for (const key of Object.keys(oldDefault)) {
+    if (key === "type" || key === "column") continue;
+    delete stripped[key];
+  }
 
-  return merged as EditableFilter;
+  return {
+    ...newDefault,
+    ...stripped,
+    type: newType,
+  } as EditableFilter;
 }

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts
@@ -148,3 +148,25 @@ export function isValidColumnId(id: unknown): id is PlAdvancedFilterColumnId {
     return false;
   }
 }
+
+export function mergeFilterForTypeChange(
+  oldFilter: EditableFilter,
+  newType: SupportedFilterTypes,
+): EditableFilter {
+  const defaultFilter = DEFAULT_FILTERS[newType];
+  const oldRecord = oldFilter as Record<string, unknown>;
+
+  const merged = Object.entries(defaultFilter).reduce<Record<string, unknown>>(
+    (res, [key, val]) => {
+      if (key === "type") {
+        res[key] = newType;
+      } else {
+        res[key] = oldRecord[key] ?? val;
+      }
+      return res;
+    },
+    {},
+  );
+
+  return merged as EditableFilter;
+}

--- a/sdk/ui-vue/src/components/PlAnnotations/components/AnnotationsSidebar.vue
+++ b/sdk/ui-vue/src/components/PlAnnotations/components/AnnotationsSidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import $commonStyle from "./style.module.css";
 
+import { produce } from "immer";
 import { randomInt } from "@milaboratories/helpers";
 import {
   PlBtnGhost,
@@ -14,26 +15,53 @@ import type { Annotation } from "../types";
 import { validateTitle } from "../utils";
 import { isEmpty } from "es-toolkit/compat";
 
-// Models
-const annotation = defineModel<Annotation>("annotation", { required: true });
-const selectedStepId = defineModel<undefined | number>("selectedStepId");
-// Emits
+const props = defineProps<{
+  annotation: Annotation;
+  selectedStepId: undefined | number;
+  onUpdateAnnotation: (annotation: Annotation) => void;
+  onUpdateSelectedStepId: (id: undefined | number) => void;
+}>();
+
 const emits = defineEmits<{
   (e: "delete-schema"): void;
 }>();
-// Actions
+
+function produceAnnotationUpdate(updater: (draft: Annotation) => void) {
+  props.onUpdateAnnotation(produce(props.annotation, updater));
+}
+
+function updateTitle(title: string) {
+  produceAnnotationUpdate((draft) => {
+    draft.title = title;
+  });
+}
+
+function updateSteps(steps: Annotation["steps"]) {
+  produceAnnotationUpdate((draft) => {
+    draft.steps = steps;
+  });
+}
+
+function updateDefaultValue(value: string) {
+  produceAnnotationUpdate((draft) => {
+    draft.defaultValue = value === "" ? undefined : value;
+  });
+}
+
 function handleAddStep() {
   const id = randomInt();
-  annotation.value.steps.push({
-    id,
-    label: "",
-    filter: {
-      id: randomInt(),
-      type: "and",
-      filters: [],
-    },
+  produceAnnotationUpdate((draft) => {
+    draft.steps.push({
+      id,
+      label: "",
+      filter: {
+        id: randomInt(),
+        type: "and",
+        filters: [],
+      },
+    });
   });
-  selectedStepId.value = id;
+  props.onUpdateSelectedStepId(id);
 }
 </script>
 
@@ -41,28 +69,29 @@ function handleAddStep() {
   <PlSidebarItem>
     <template #header-content>
       <PlEditableTitle
-        v-model="annotation.title"
-        :class="{ [$commonStyle.flashing]: annotation.title.length === 0 }"
+        :model-value="props.annotation.title"
+        :class="{ [$commonStyle.flashing]: props.annotation.title.length === 0 }"
         :max-length="40"
         max-width="600px"
         placeholder="Annotation Title"
-        :autofocus="annotation.title.length === 0"
+        :autofocus="props.annotation.title.length === 0"
         :validate="validateTitle"
+        @update:model-value="updateTitle"
       />
     </template>
-    <template v-if="annotation" #body-content>
-      <div :class="[$style.root, { [$commonStyle.disabled]: annotation.title.length === 0 }]">
-        <span :class="$style.tip"
-          >Above annotations override the ones below. Rearrange them by dragging.</span
-        >
-
+    <template v-if="props.annotation" #body-content>
+      <div :class="[$style.root, { [$commonStyle.disabled]: props.annotation.title.length === 0 }]">
+        <span :class="$style.tip">
+          Above annotations override the ones below. Rearrange them by dragging.
+        </span>
         <PlElementList
-          v-model:items="annotation.steps"
+          :items="props.annotation.steps"
           :get-item-key="(item) => item.id"
-          :is-active="(item) => item.id === selectedStepId"
+          :is-active="(item) => item.id === props.selectedStepId"
           :item-class="$style.stepItem"
           :class="$style.steps"
-          @item-click="(item) => (selectedStepId = item.id)"
+          @update:items="updateSteps"
+          @item-click="(item) => props.onUpdateSelectedStepId(item.id)"
         >
           <template #item-title="{ item }">
             {{ item.label }}
@@ -74,15 +103,15 @@ function handleAddStep() {
         <PlTextField
           :class="[
             $style.defaultValue,
-            { [$style.emptyDefaultValue]: isEmpty(annotation.defaultValue) },
+            { [$style.emptyDefaultValue]: isEmpty(props.annotation.defaultValue) },
           ]"
-          :model-value="annotation.defaultValue ?? ''"
+          :model-value="props.annotation.defaultValue ?? ''"
           label="Label remaining with"
           placeholder="No label"
           clearable
           helper="This label will be applied to the remaining rows, after all other filters are applied."
           @click.stop
-          @update:model-value="annotation.defaultValue = $event === '' ? undefined : $event"
+          @update:model-value="updateDefaultValue"
         />
       </div>
     </template>
@@ -90,7 +119,7 @@ function handleAddStep() {
       <PlBtnGhost
         icon="delete-bin"
         reverse
-        :disabled="annotation.steps.length === 0"
+        :disabled="props.annotation.steps.length === 0"
         @click.stop="emits('delete-schema')"
       >
         Delete Schema

--- a/sdk/ui-vue/src/components/PlAnnotations/components/FilterSidebar.vue
+++ b/sdk/ui-vue/src/components/PlAnnotations/components/FilterSidebar.vue
@@ -17,6 +17,7 @@ export type Props = {
 </script>
 <script setup lang="ts">
 import { computed } from "vue";
+import { produce } from "immer";
 import { randomInt } from "@milaboratories/helpers";
 import { PlBtnSecondary, PlEditableTitle, PlSidebarItem } from "@milaboratories/uikit";
 import type { ListOptionBase, PObjectId, SUniversalPColumnId } from "@platforma-sdk/model";
@@ -29,33 +30,53 @@ import type {
   PlAdvancedFilter,
 } from "../../PlAdvancedFilter";
 import type { Filter } from "../types";
-
-import $commonStyle from "./style.module.css";
 import { validateTitle } from "../utils";
 
-// Models
-const step = defineModel<Filter>("step", { required: true });
-// Props
-const props = defineProps<Props>();
-// State
+import $commonStyle from "./style.module.css";
+
+const props = defineProps<
+  Props & {
+    step: Filter;
+    onUpdateStep: (step: Filter) => void;
+  }
+>();
+
 const withSelection = computed(() => {
   return props.hasSelectedColumns !== undefined && props.getValuesForSelectedColumns !== undefined;
 });
-// Actions
-const addFilterPlaceholder = () => {
-  step.value.filter.filters.push({
-    id: randomInt(),
-    isExpanded: true,
-    type: "or",
-    filters: [
-      {
-        id: randomInt(),
-        type: "isNA",
-        column: props.columns[0].id as SUniversalPColumnId,
-      },
-    ],
+
+function produceStepUpdate(updater: (draft: Filter) => void) {
+  props.onUpdateStep(produce(props.step, updater));
+}
+
+function updateLabel(label: string) {
+  produceStepUpdate((draft) => {
+    draft.label = label;
   });
-};
+}
+
+function updateFilter(filter: PlAdvancedFilter) {
+  produceStepUpdate((draft) => {
+    draft.filter = filter as typeof draft.filter;
+  });
+}
+
+function addFilterPlaceholder() {
+  produceStepUpdate((draft) => {
+    draft.filter.filters.push({
+      id: randomInt(),
+      isExpanded: true,
+      type: "or",
+      filters: [
+        {
+          id: randomInt(),
+          type: "isNA",
+          column: props.columns[0].id as SUniversalPColumnId,
+        },
+      ],
+    });
+  });
+}
 
 async function addFilterFromSelected() {
   if (props.hasSelectedColumns === undefined || props.getValuesForSelectedColumns === undefined)
@@ -68,17 +89,19 @@ async function addFilterFromSelected() {
   const shortReminder =
     values.slice(0, 3).join(", ") + (values.length > 3 ? ` and ${values.length - 3} more` : "");
 
-  step.value.filter.filters.push({
-    id: randomInt(),
-    name: `Selected list (${shortReminder})`,
-    isExpanded: false,
-    type: "or",
-    filters: values.map((value, i) => ({
-      id: i,
-      type: "patternEquals",
-      column: columnId as SUniversalPColumnId,
-      value,
-    })),
+  produceStepUpdate((draft) => {
+    draft.filter.filters.push({
+      id: randomInt(),
+      name: `Selected list (${shortReminder})`,
+      isExpanded: false,
+      type: "or",
+      filters: values.map((value, i) => ({
+        id: i,
+        type: "patternEquals",
+        column: columnId as SUniversalPColumnId,
+        value,
+      })),
+    });
   });
 }
 
@@ -101,29 +124,30 @@ const supportedFilters = [
 </script>
 
 <template>
-  <PlSidebarItem v-if="step">
+  <PlSidebarItem v-if="props.step">
     <template #header-content>
       <PlEditableTitle
-        :key="step.id"
-        v-model="step.label"
-        :class="{ [$commonStyle.flashing]: step.label.length === 0 }"
+        :key="props.step.id"
+        :model-value="props.step.label"
+        :class="{ [$commonStyle.flashing]: props.step.label.length === 0 }"
         :max-length="40"
         max-width="600px"
         placeholder="Label"
-        :autofocus="step.label.length === 0"
+        :autofocus="props.step.label.length === 0"
         :validate="validateTitle"
+        @update:model-value="updateLabel"
       />
     </template>
     <template #body-content>
       <PlAdvancedFilterComponent
-        :filters="step.filter as PlAdvancedFilter"
-        :class="[$style.root, { [$commonStyle.disabled]: step.label.length === 0 }]"
+        :class="[$style.root, { [$commonStyle.disabled]: props.step.label.length === 0 }]"
         :options="props.columns"
+        :filters="props.step.filter as PlAdvancedFilter"
+        :on-update-filters="updateFilter"
         :supported-filters="supportedFilters"
         :get-suggest-options="props.getSuggestOptions"
         :enable-dnd="false"
         :enable-add-group-button="true"
-        @update-filters="(v) => (step = { ...step, filter: v as typeof step.filter })"
       >
         <template #add-group-buttons>
           <div :class="$style.actions">
@@ -131,7 +155,7 @@ const supportedFilters = [
             <PlBtnSecondary
               v-if="withSelection"
               icon="add"
-              :disabled="!props.hasSelectedColumns"
+              :disabled="props.hasSelectedColumns !== true"
               @click="addFilterFromSelected"
             >
               From selection

--- a/sdk/ui-vue/src/components/PlAnnotations/components/FilterSidebar.vue
+++ b/sdk/ui-vue/src/components/PlAnnotations/components/FilterSidebar.vue
@@ -62,6 +62,7 @@ function updateFilter(filter: PlAdvancedFilter) {
 }
 
 function addFilterPlaceholder() {
+  if (props.columns.length === 0) return;
   produceStepUpdate((draft) => {
     draft.filter.filters.push({
       id: randomInt(),

--- a/sdk/ui-vue/src/components/PlAnnotations/components/PlAnnotations.vue
+++ b/sdk/ui-vue/src/components/PlAnnotations/components/PlAnnotations.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import type { Props as BaseProps } from "./FilterSidebar.vue";
-export type Props = BaseProps & {
+export type Props = Omit<BaseProps, "step" | "onUpdateStep"> & {
+  annotation: Annotation;
+  onUpdateAnnotation: (annotation: Annotation) => void;
   onDeleteSchema?: () => void;
 };
 </script>
@@ -9,43 +11,56 @@ export type Props = BaseProps & {
 import { computed, effect, shallowRef } from "vue";
 
 import { isNil } from "@milaboratories/helpers";
+import { produce } from "immer";
 import { PlSidebarGroup, useConfirm } from "@milaboratories/uikit";
 
-import type { Annotation } from "../types";
+import type { Annotation, Filter } from "../types";
 import AnnotationsSidebar from "./AnnotationsSidebar.vue";
 import FilterSidebar from "./FilterSidebar.vue";
 
-// Models
-const annotation = defineModel<Annotation>("annotation", { required: true });
-// Props
 const props = defineProps<Props>();
-// State
-const selectedStepId = shallowRef<number | undefined>(undefined);
+
+const selectedStepId = shallowRef<undefined | number>(undefined);
+
 const selectedStep = computed(() => {
-  return isNil(selectedStepId.value) || isNil(annotation.value)
+  return isNil(selectedStepId.value) || isNil(props.annotation)
     ? undefined
-    : annotation.value.steps.find((step) => step.id === selectedStepId.value);
+    : props.annotation.steps.find((step) => step.id === selectedStepId.value);
 });
 
-// Watchers
 effect(function setDefaultStepId() {
-  if (selectedStepId.value === undefined && annotation.value.steps.length > 0) {
-    selectedStepId.value = annotation.value.steps[0].id;
+  if (selectedStepId.value === undefined && props.annotation.steps.length > 0) {
+    selectedStepId.value = props.annotation.steps[0].id;
   }
 });
-// Hooks
+
 const confirmResetSchema = useConfirm({
   title: "Reset Schema",
   message: "Are you sure you want to reset the schema? This action cannot be undone.",
   confirmLabel: "Yes, reset",
   cancelLabel: "No, cancel",
 });
-// Actions
+
 async function handleDeleteSchema() {
   if (await confirmResetSchema()) {
     selectedStepId.value = undefined;
     props.onDeleteSchema?.();
   }
+}
+
+function updateSelectedStepId(id: undefined | number) {
+  selectedStepId.value = id;
+}
+
+function updateSelectedStep(step: Filter) {
+  props.onUpdateAnnotation(
+    produce(props.annotation, (draft) => {
+      const idx = draft.steps.findIndex((s) => s.id === step.id);
+      if (idx !== -1) {
+        draft.steps[idx] = step;
+      }
+    }),
+  );
 }
 </script>
 
@@ -53,21 +68,22 @@ async function handleDeleteSchema() {
   <PlSidebarGroup>
     <template #item-0>
       <AnnotationsSidebar
-        v-model:annotation="annotation"
-        v-model:selectedStepId="selectedStepId"
+        :annotation="props.annotation"
+        :selected-step-id="selectedStepId"
+        :on-update-annotation="props.onUpdateAnnotation"
+        :on-update-selected-step-id="updateSelectedStepId"
         :class="$style.sidebarItem"
-        :columns="props.columns"
         @delete-schema="handleDeleteSchema"
       />
     </template>
     <template #item-1>
       <FilterSidebar
         v-if="selectedStep"
-        v-model:step="selectedStep"
+        :step="selectedStep"
+        :on-update-step="updateSelectedStep"
         :class="$style.sidebarItem"
         :columns="props.columns"
         :get-suggest-options="props.getSuggestOptions"
-        :selectedStepId="selectedStepId"
         :hasSelectedColumns="props.hasSelectedColumns"
         :getValuesForSelectedColumns="props.getValuesForSelectedColumns"
       />

--- a/sdk/ui-vue/src/components/PlAnnotations/components/PlAnnotationsModal.vue
+++ b/sdk/ui-vue/src/components/PlAnnotations/components/PlAnnotationsModal.vue
@@ -1,41 +1,38 @@
 <script setup lang="ts">
 import { PlPureSlideModal } from "@milaboratories/uikit";
-import { effect, shallowRef } from "vue";
 
-import type { Annotation } from "../types";
 import type { Props } from "./PlAnnotations.vue";
 import PlAnnotations from "./PlAnnotations.vue";
 
-// Models
-const annotation = defineModel<Annotation>("annotation", { required: true });
-const opened = defineModel<boolean>("opened", { required: true });
-// Props
-const props = defineProps<Props>();
-// State
-const selectedStepId = shallowRef<number | undefined>(undefined);
-// Watchers
-effect(function setDefaultStepId() {
-  if (selectedStepId.value === undefined && annotation.value.steps.length > 0) {
-    selectedStepId.value = annotation.value.steps[0].id;
+const props = defineProps<
+  Props & {
+    opened: boolean;
+    onUpdateOpened: (opened: boolean) => void;
   }
-});
-// Actions
+>();
+
 async function handleDeleteSchema() {
-  opened.value = false;
+  props.onUpdateOpened(false);
   props.onDeleteSchema?.();
 }
 </script>
 
 <template>
-  <PlPureSlideModal v-model="opened" :class="$style.modal" width="768px">
+  <PlPureSlideModal
+    :model-value="props.opened"
+    :class="$style.modal"
+    width="768px"
+    @update:model-value="props.onUpdateOpened"
+  >
     <PlAnnotations
-      v-model:annotation="annotation"
       :class="$style.content"
       :columns="props.columns"
-      :get-suggest-options="props.getSuggestOptions"
+      :annotation="props.annotation"
+      :on-update-annotation="props.onUpdateAnnotation"
+      :on-delete-schema="handleDeleteSchema"
       :has-selected-columns="props.hasSelectedColumns"
-      :getValuesForSelectedColumns="props.getValuesForSelectedColumns"
-      @delete-schema="handleDeleteSchema"
+      :get-suggest-options="props.getSuggestOptions"
+      :get-values-for-selected-columns="props.getValuesForSelectedColumns"
     />
   </PlPureSlideModal>
 </template>


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes broken annotations by migrating the `PlAnnotations` component tree from Vue's `defineModel`/`v-model` to explicit prop+callback contracts, and refactors `distillFilterSpec` to validate only per-type *required* fields (instead of all fields), so optional fields like `minDiff`, `maxEdits`, and `wildcard` no longer cause valid filters to be silently dropped. The `mergeFilterForTypeChange` helper and a new `FilterEditor` test suite are also added.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are P2 quality suggestions with no correctness or runtime impact on production paths.

Both open findings are P2: a leftover console.log in a demo file and a theoretical defensive-coding gap in mergeFilterForTypeChange (not reachable under current component usage). The core bug fixes (distill logic, v-model on read-only computed) are correct and well-tested.

sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts — defensive guard for unsupported oldFilter.type
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/filters/distill.ts | Refactored isFilledLeaf to per-type required-field validation instead of checking all fields, fixing the root bug where optional fields caused valid filters to be incorrectly dropped |
| sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts | Added mergeFilterForTypeChange: correctly strips old-type data fields and merges with new defaults, but has no guard for oldFilter.type being absent from DEFAULT_FILTERS |
| sdk/ui-vue/src/components/PlAnnotations/components/PlAnnotations.vue | Migrated from defineModel to explicit props+callbacks using immer produce; fixes the broken v-model on a read-only computed (selectedStep was computed without a setter) |
| sdk/ui-vue/src/components/PlAnnotations/components/PlAnnotationsModal.vue | Removed duplicated selectedStepId tracking (now lives in PlAnnotations); migrated to explicit prop/callback API pattern |
| sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.test.ts | New test file covering changeFilterType, updateFilterProp, changeSourceId, and onDelete with stubs for all uikit components |
| etc/blocks/ui-examples/ui/src/pages/PlAnnotationPage.vue | Demo page updated to use explicit prop/callback API; handleUpdateAnnotation contains a leftover console.log |
| sdk/model/src/filters/distill.test.ts | Added comprehensive per-type tests for the new isFilledLeaf/isFilledValue logic, covering optional fields, edge cases (falsy-but-filled x=0, empty arrays, whitespace strings) |
| sdk/ui-vue/src/components/PlAnnotations/components/AnnotationsSidebar.vue | Replaced defineModel with explicit props+callbacks; all mutations now go through immer produce for immutable updates |
| sdk/ui-vue/src/components/PlAnnotations/components/FilterSidebar.vue | Replaced defineModel with explicit props+callbacks; added guard for empty columns in addFilterPlaceholder; tightened disabled check to !== true |
| sdk/ui-vue/src/components/PlAdvancedFilter/FilterEditor.vue | Extracted changeFilterType logic into mergeFilterForTypeChange utility; added isNil guard for undefined newType |
| lib/util/helpers/src/types/index.ts | Added NullableBy utility type, consistent with existing PartialBy/RequiredBy patterns |
| sdk/ui-vue/src/components/PlAdvancedFilter/types.ts | Replaced local RequireFields/OptionalFields with imported RequiredBy/PartialBy from helpers; no semantic change |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: etc/blocks/ui-examples/ui/src/pages/PlAnnotationPage.vue
Line: 175

Comment:
**Leftover debug `console.log`**

This log statement will appear in the browser console for all users of the demo page. Even in example code it's noise worth removing.

```suggestion
function handleUpdateAnnotation(annotation: Annotation) {
  mockAnnotations.value = annotation;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/ui-vue/src/components/PlAdvancedFilter/utils.ts
Line: 156-163

Comment:
**`mergeFilterForTypeChange` crashes when `oldFilter.type` is not in `DEFAULT_FILTERS`**

`DEFAULT_FILTERS` only covers `SupportedFilterTypes`, but `EditableFilter` includes any type from `FilterLeafContent` (e.g. `equalToColumn`, `ifNa`, `undefined`). If such a filter is ever passed in, `DEFAULT_FILTERS[oldFilter.type]` is `undefined` and `Object.keys(undefined)` throws a `TypeError`. A defensive fallback keeps the function safe:

```ts
const oldDefault = (DEFAULT_FILTERS[oldFilter.type as SupportedFilterTypes] ?? {}) as Record<string, unknown>;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add NullableBy type and improve fil..."](https://github.com/milaboratory/platforma/commit/43d45ef77d2e6865cee9d921c92b33d1277c5808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29504529)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->