### PR TITLE
Fixing a stuck valve in filters.

### DIFF
--- a/.changeset/short-baboons-follow.md
+++ b/.changeset/short-baboons-follow.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/uikit": patch
+---
+
+Choose correct label from options

--- a/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
+++ b/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
@@ -32,6 +32,7 @@ import { getErrorMessage } from "../../helpers/error.ts";
 import type { ListOptionBase } from "@platforma-sdk/model";
 import { PlSvg } from "../PlSvg";
 import SvgRequired from "../../assets/images/required.svg?raw";
+import { isNil } from "@milaboratories/helpers";
 
 /**
  * The current selected value.
@@ -319,23 +320,18 @@ const searchDebounced = refDebounced(search, 300, { maxWait: 1000 });
 
 const optionsRequest = useWatchFetch(
   () => searchDebounced.value,
-  async (v) => {
-    if (v !== null) {
-      // search is null when dropdown is closed;
-      return props.optionsSearch(v, "label");
-    }
-    return undefined;
-  },
+  async (v) => (isNil(v) ? undefined : props.optionsSearch(v, "label")),
 );
 
 const modelOptionRequest = useWatchFetch(
   () => model.value,
   async (v) => {
-    if (v != null && !deepEqual(modelOptionRef.value?.value, v)) {
-      // load label for selected value if it was updated from outside the component
-      return (await props.optionsSearch(String(v), "value"))?.[0];
+    if (isNil(v) || deepEqual(modelOptionRef.value?.value, v)) {
+      return modelOptionRef.value;
     }
-    return modelOptionRef.value;
+
+    const options = await props.optionsSearch(String(v), "value");
+    return options.find((o) => String(o.value) === String(v));
   },
 );
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `PlAutocomplete` showing the wrong label after an external model update. Previously, `modelOptionRequest` returned `options[0]` — the first search result — instead of the option whose `value` actually matched the model; the fix replaces that with `options.find((o) => String(o.value) === String(v))`. The nil-guard on `optionsRequest` is also tightened from a `!== null` check to `isNil`, which covers `undefined` as well.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted two-line logic fix with no regressions.

Both changes are correct: the core fix (find by value instead of [0]) directly addresses the reported bug, and the isNil guard is strictly more defensive. No new edge cases introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/short-baboons-follow.md | Patch-level changeset entry for the uikit fix; no issues. |
| lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue | Fixes modelOptionRequest to find the exact matching option by value instead of blindly taking index 0; also tightens the nil-guard on optionsRequest using isNil. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/milaboratory/platforma/commit/0c30e02c19607b379dca4f063c16b6dd0cf9f6e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29578238)</sub>

<!-- /greptile_comment -->