### PR TITLE
Add block dev deployment scripts

### DIFF
--- a/scripts/deploy-block-remote.sh
+++ b/scripts/deploy-block-remote.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Build a block and deploy it to a remote bare-metal server via rsync.
+#
+# Usage:
+#   ./scripts/deploy-block-remote.sh <block-dir> <remote-host>
+#
+# Examples:
+#   ./scripts/deploy-block-remote.sh /path/to/blocks/gpu-test nova0.milaboratories.com
+#   ./scripts/deploy-block-remote.sh blocks/gpu-test nova0.milaboratories.com
+#
+# What it does:
+#   1. Builds the block (pnpm build --force)
+#   2. Rsyncs the entire block directory (including node_modules) to the same path on the remote
+#   3. Prints instructions for adding the dev block in the Desktop App
+#
+# Notes:
+#   - Remote path matches local absolute path (required for dev blocks)
+#   - node_modules is included because the remote server doesn't run pnpm install
+#   - .git and .turbo are excluded to save bandwidth
+
+set -euo pipefail
+
+BLOCK_DIR=""
+REMOTE_HOST=""
+
+usage() {
+    echo "Usage: $0 <block-dir> <remote-host>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 /path/to/blocks/gpu-test nova0.milaboratories.com"
+    echo "  $0 blocks/gpu-test nova0.milaboratories.com"
+    exit 1
+}
+
+[[ $# -lt 2 ]] && usage
+
+BLOCK_DIR="$1"
+REMOTE_HOST="$2"
+
+# Resolve to absolute path
+BLOCK_DIR=$(cd "$BLOCK_DIR" && pwd)
+
+# Verify it's a block directory
+if [[ ! -f "$BLOCK_DIR/package.json" ]]; then
+    echo "Error: $BLOCK_DIR/package.json not found — not a valid block directory"
+    exit 1
+fi
+
+# Find the block/ subdirectory (for dev block path)
+BLOCK_PACK_DIR=""
+if [[ -d "$BLOCK_DIR/block" ]]; then
+    BLOCK_PACK_DIR="$BLOCK_DIR/block"
+fi
+
+echo "=== Building block ==="
+cd "$BLOCK_DIR"
+pnpm run build --force
+
+echo ""
+echo "=== Syncing to $REMOTE_HOST ==="
+rsync -avz --delete \
+    --exclude .turbo \
+    --exclude .git \
+    "$BLOCK_DIR/" "$REMOTE_HOST:$BLOCK_DIR/"
+
+echo ""
+echo "=== Done ==="
+echo ""
+if [[ -n "$BLOCK_PACK_DIR" ]]; then
+    echo "Add as dev block in Desktop App pointing to:"
+    echo "  $BLOCK_PACK_DIR"
+else
+    echo "Add as dev block in Desktop App pointing to:"
+    echo "  $BLOCK_DIR"
+fi

--- a/scripts/override-sdk.sh
+++ b/scripts/override-sdk.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Apply a local SDK override to a block's pnpm workspace.
+#
+# Usage:
+#   ./scripts/override-sdk.sh <block-dir> [--sdk <sdk-package-name>]
+#
+# Examples:
+#   ./scripts/override-sdk.sh /path/to/blocks/gpu-test
+#   ./scripts/override-sdk.sh blocks/gpu-test --sdk @platforma-sdk/workflow-tengo
+#
+# What it does:
+#   1. Builds and packs the SDK from the monorepo
+#   2. Activates the pnpm override in the block's package.json
+#   3. Runs pnpm install --force to apply the override
+#   4. Rebuilds the block
+#
+# To revert: change "pnpm" back to "//pnpm" in the block's package.json and run pnpm install
+
+set -euo pipefail
+
+BLOCK_DIR=""
+SDK_PACKAGE="@platforma-sdk/workflow-tengo"
+
+usage() {
+    echo "Usage: $0 <block-dir> [--sdk <package-name>]"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --sdk) SDK_PACKAGE="$2"; shift 2 ;;
+        --help|-h) usage ;;
+        -*) echo "Unknown option: $1"; usage ;;
+        *) BLOCK_DIR="$1"; shift ;;
+    esac
+done
+
+[[ -z "$BLOCK_DIR" ]] && { echo "Error: block directory required"; usage; }
+
+BLOCK_DIR=$(cd "$BLOCK_DIR" && pwd)
+
+# Find the monorepo root (this script lives in core/platforma/scripts/)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MONOREPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Map SDK package name to directory
+case "$SDK_PACKAGE" in
+    "@platforma-sdk/workflow-tengo")
+        SDK_DIR="$MONOREPO_ROOT/sdk/workflow-tengo"
+        ;;
+    *)
+        echo "Error: unknown SDK package '$SDK_PACKAGE'"
+        echo "Supported: @platforma-sdk/workflow-tengo"
+        exit 1
+        ;;
+esac
+
+echo "=== Building SDK: $SDK_PACKAGE ==="
+cd "$SDK_DIR"
+pnpm run build
+TGZ=$(pnpm pack 2>&1 | tail -1)
+TGZ_PATH="$SDK_DIR/$TGZ"
+
+if [[ ! -f "$TGZ_PATH" ]]; then
+    echo "Error: pack did not produce expected file: $TGZ_PATH"
+    exit 1
+fi
+
+echo "=== Packed: $TGZ_PATH ==="
+
+echo "=== Applying override in $BLOCK_DIR ==="
+cd "$BLOCK_DIR"
+
+# Activate the override: replace "//pnpm" with "pnpm" and set the path
+python3 -c "
+import json, sys
+
+with open('package.json') as f:
+    pkg = json.load(f)
+
+# Remove commented-out overrides
+pkg.pop('//pnpm', None)
+
+# Set active override
+pkg['pnpm'] = {
+    'overrides': {
+        '$SDK_PACKAGE': 'file:$TGZ_PATH'
+    }
+}
+
+with open('package.json', 'w') as f:
+    json.dump(pkg, f, indent=2)
+    f.write('\n')
+
+print('Override set in package.json')
+"
+
+echo "=== Installing with override ==="
+pnpm install --force
+
+echo "=== Building block ==="
+pnpm run build --force
+
+echo ""
+echo "=== SDK override applied ==="
+echo "To revert: edit package.json, change 'pnpm' back to '//pnpm', then run 'pnpm install'"


### PR DESCRIPTION
## Summary

Scripts for deploying blocks to remote servers during development.

### New files
- `scripts/deploy-block-remote.sh` — build block + rsync to remote bare-metal server
- `scripts/override-sdk.sh` — apply local SDK override for testing unreleased SDK changes

## Test plan

### Deploy block to remote server
```bash
# Build and sync a block to nova0
./scripts/deploy-block-remote.sh /path/to/blocks/gpu-test nova0.milaboratories.com

# Then in Desktop App: add dev block pointing to the printed path
```

### Apply SDK override
```bash
# Override workflow-tengo SDK with local build
./scripts/override-sdk.sh /path/to/blocks/gpu-test

# Verify
grep gpuMemory blocks/gpu-test/workflow/node_modules/@platforma-sdk/workflow-tengo/dist/tengo/lib/exec.lib.tengo

# Revert: edit package.json, change "pnpm" to "//pnpm", run pnpm install
```

### Full workflow: override + deploy
```bash
./scripts/override-sdk.sh /path/to/blocks/gpu-test
./scripts/deploy-block-remote.sh /path/to/blocks/gpu-test nova0.milaboratories.com
# Add dev block in Desktop App, run it
```