### PR TITLE
MILAB-6155: 'getUserRoot' method from pl-client used by pl-cli tool

### DIFF
--- a/.changeset/beige-rocks-laugh.md
+++ b/.changeset/beige-rocks-laugh.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": minor
+---
+
+Expose getUserRoot method to obtain actual user root from modern backends

--- a/.changeset/green-terms-yell.md
+++ b/.changeset/green-terms-yell.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/pl-cli": minor
+---
+
+Use PlClient.getUserRoot() to get user's root on modern backends

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -179,6 +179,25 @@ export class PlClient {
     return await this.ll.license();
   }
 
+  /**
+   * Returns the user root ResourceId via ListUserResources.
+   * @param opts.login - target user login; omit for the authenticated user.
+   * @returns ResourceId of the user root, or undefined if the server returned no userRoot entry.
+   * @throws if the backend does not implement ListUserResources (callers should catch with isUnimplementedError).
+   */
+  public async getUserRoot(opts: { login?: string } = {}): Promise<ResourceId | undefined> {
+    const responses = await this.ll.listUserResources({
+      login: opts.login,
+      limit: 1,
+    });
+    for (const msg of responses) {
+      if (msg.entry.oneofKind === "userRoot") {
+        return bigintToResourceId(msg.entry.userRoot.resourceId);
+      }
+    }
+    return undefined;
+  }
+
   public get conf(): PlClientConfig {
     return this.ll.conf;
   }

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -463,9 +463,10 @@ export class LLPlClient implements WireClientProviderFactory {
 
   public async getJwtToken(
     ttlSeconds: bigint,
-    options?: { authorization?: string },
+    options?: { authorization?: string; role?: AuthAPI_GetJWTToken_Role },
   ): Promise<string> {
     const cl = this.clientProvider.get();
+    const role = options?.role ?? AuthAPI_GetJWTToken_Role.ROLE_UNSPECIFIED;
 
     if (cl instanceof GrpcPlApiClient) {
       const meta: Record<string, string> = {};
@@ -474,7 +475,7 @@ export class LLPlClient implements WireClientProviderFactory {
         await cl.getJWTToken(
           {
             expiration: { seconds: ttlSeconds, nanos: 0 },
-            requestedRole: AuthAPI_GetJWTToken_Role.USER,
+            requestedRole: role,
           },
           { meta },
         ).response
@@ -483,7 +484,7 @@ export class LLPlClient implements WireClientProviderFactory {
       const headers: Record<string, string> = {};
       if (options?.authorization) headers.authorization = options.authorization;
       const resp = cl.POST("/v1/auth/jwt-token", {
-        body: { expiration: `${ttlSeconds}s`, requestedRole: AuthAPI_GetJWTToken_Role.USER },
+        body: { expiration: `${ttlSeconds}s`, requestedRole: role },
         headers,
       });
       return notEmpty((await resp).data, "REST: empty response for JWT token request").token;

--- a/tools/pl-cli/src/project_ops.ts
+++ b/tools/pl-cli/src/project_ops.ts
@@ -1,5 +1,5 @@
 import type { PlClient, ResourceId, PlTransaction } from "@milaboratories/pl-client";
-import { field, isNullResourceId } from "@milaboratories/pl-client";
+import { field, isNullResourceId, isUnimplementedError } from "@milaboratories/pl-client";
 import {
   ProjectMetaKey,
   ProjectCreatedTimestamp,
@@ -219,23 +219,37 @@ export async function getProjectListRid(pl: PlClient): Promise<ResourceId> {
 
 /**
  * Navigates to a specific user's project list resource ID.
- * Computes SHA256(username) to find the user's root, then reads the "projects" field.
+ * Tries ListUserResources first (new backend), falls back to SHA256 named resource lookup.
  */
 export async function navigateToUserRoot(
   pl: PlClient,
   username: string,
 ): Promise<{ userRoot: ResourceId; projectListRid: ResourceId }> {
-  const rootName = createHash("sha256").update(username).digest("hex");
+  let userRootRid: ResourceId | undefined;
 
+  // Try new ListUserResources API first
+  try {
+    userRootRid = await pl.getUserRoot({ login: username });
+  } catch (err) {
+    if (!isUnimplementedError(err)) throw err;
+    // Backend doesn't support ListUserResources — fall through to legacy
+  }
+
+  // Legacy fallback: SHA256 named resource lookup
+  if (userRootRid === undefined) {
+    const rootName = createHash("sha256").update(username).digest("hex");
+    userRootRid = await pl.withReadTx("navigateToUserRoot:legacy", async (tx) => {
+      if (!(await tx.checkResourceNameExists(rootName))) {
+        throw new Error(`User "${username}" not found on this server (no root resource).`);
+      }
+      return await tx.getResourceByName(rootName);
+    });
+  }
+
+  // Read the projects field from the resolved user root
   return await pl.withReadTx("navigateToUserRoot", async (tx) => {
-    if (!(await tx.checkResourceNameExists(rootName))) {
-      throw new Error(`User "${username}" not found on this server (no root resource).`);
-    }
-
-    const userRootRid = await tx.getResourceByName(rootName);
-
     const projectsFieldData = await tx.getField({
-      resourceId: userRootRid,
+      resourceId: userRootRid!,
       fieldName: ProjectsField,
     });
 
@@ -243,7 +257,7 @@ export async function navigateToUserRoot(
       throw new Error(`User "${username}" has no project list.`);
     }
 
-    return { userRoot: userRootRid, projectListRid: projectsFieldData.value };
+    return { userRoot: userRootRid!, projectListRid: projectsFieldData.value };
   });
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR exposes a new `PlClient.getUserRoot()` method that calls `ListUserResources` to retrieve a user's root `ResourceId`, and updates `pl-cli`'s `navigateToUserRoot` to try the new API first and fall back to the legacy SHA256 named-resource lookup when the backend returns an unimplemented error. The implementation closely mirrors the existing pattern used in `PlClient.init()` and the changeset versioning is correct.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the single P2 finding is about an edge case (REST wire protocol) that is also present in pre-existing init code and unlikely to affect real users.

Only P2 findings — no logic errors on the gRPC path. The REST-protocol throw documentation gap mirrors a pre-existing pattern in the codebase.

`lib/node/pl-client/src/core/client.ts` — the `@throws` JSDoc for `getUserRoot` should document the REST-protocol error case.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/client.ts | Adds `getUserRoot` public method wrapping `ll.listUserResources`; mirrors the pattern used in the existing `init()` code but the JSDoc omits the REST-protocol throw case |
| tools/pl-cli/src/project_ops.ts | Refactors `navigateToUserRoot` to try the new `getUserRoot` API first and fall back to SHA256 named-resource lookup; correct use of `isUnimplementedError` guard but REST-protocol errors are not covered by that guard |
| .changeset/beige-rocks-laugh.md | Changeset entry marking `@milaboratories/pl-client` as a minor version bump for the new `getUserRoot` export |
| .changeset/green-terms-yell.md | Changeset entry marking `@platforma-sdk/pl-cli` as a minor version bump for the updated `navigateToUserRoot` logic |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/node/pl-client/src/core/client.ts
Line: 183-197

Comment:
**Incomplete `@throws` documentation for REST connections**

`ll.listUserResources` throws a plain `new Error("ListUserResources requires gRPC wire protocol; REST is not supported")` when the wire connection is REST (not gRPC). This error is **not** matched by `isUnimplementedError` (which only matches `RpcError/UNIMPLEMENTED` or `RESTError/UNIMPLEMENTED`). Callers that follow the JSDoc and catch only with `isUnimplementedError` — like the new fallback in `project_ops.ts` — will not fall back to the legacy path on REST connections; the plain error propagates instead.

The `@throws` tag should mention this additional failure mode, or `getUserRoot` should internally catch and re-map the REST "not supported" error to something `isUnimplementedError` will recognise.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6155: &#39;getUserRoot&#39; method from pl..."](https://github.com/milaboratory/platforma/commit/6710306b3a57565eda6386d5f9d65e873155f12b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29912393)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->