### PR TITLE
feat: enhance PlRef handling

### DIFF
--- a/.changeset/args-detect-embedded-ref.md
+++ b/.changeset/args-detect-embedded-ref.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+inferAllReferencedBlocks: detect PlRef embedded as canonicalized JSON string (global-form PObjectId) and account for it in block upstreams the same way as object-shaped PlRef.

--- a/.changeset/bundle-add-single-global-ref.md
+++ b/.changeset/bundle-add-single-global-ref.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Fix bundle.addSingle on global-form PObjectId.

--- a/lib/node/pl-middle-layer/src/model/args.test.ts
+++ b/lib/node/pl-middle-layer/src/model/args.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import canonicalize from "canonicalize";
 import { inferAllReferencedBlocks, outputRef } from "./args";
 
 describe("inferAllReferencedBlocks", () => {
@@ -28,5 +29,107 @@ describe("inferAllReferencedBlocks", () => {
 
     expect(result.upstreams).toContain("block1");
     expect(result.upstreams.size).toBe(1);
+  });
+
+  it("extracts PlRef embedded as canonicalized JSON string (global-form PObjectId)", () => {
+    const id = canonicalize(outputRef("blockA", "exportName"))!;
+
+    const result = inferAllReferencedBlocks({ columnId: id });
+
+    expect(result.upstreams).toContain("blockA");
+    expect(result.upstreams.size).toBe(1);
+    expect(result.upstreamsRequiringEnrichments.size).toBe(0);
+    expect(result.missingReferences).toBe(false);
+  });
+
+  it("propagates requireEnrichments from canonicalized PlRef string", () => {
+    const id = canonicalize(outputRef("blockA", "exportName", true))!;
+
+    const result = inferAllReferencedBlocks(id);
+
+    expect(result.upstreams).toContain("blockA");
+    expect(result.upstreamsRequiringEnrichments).toContain("blockA");
+  });
+
+  it("finds multiple PlRef strings inside an args object", () => {
+    const a = canonicalize(outputRef("blockA", "n1"))!;
+    const b = canonicalize(outputRef("blockB", "n2", true))!;
+
+    const result = inferAllReferencedBlocks({ first: a, second: b });
+
+    expect(result.upstreams).toEqual(new Set(["blockA", "blockB"]));
+    expect(result.upstreamsRequiringEnrichments).toEqual(new Set(["blockB"]));
+  });
+
+  it("respects allowed set for embedded refs", () => {
+    const id = canonicalize(outputRef("blockX", "n"))!;
+
+    const result = inferAllReferencedBlocks({ id }, new Set(["blockY"]));
+
+    expect(result.upstreams.size).toBe(0);
+    expect(result.missingReferences).toBe(true);
+  });
+
+  it("decodes JSON escapes inside blockId", () => {
+    const id = canonicalize(outputRef('weird"id\\with\nescapes', "n"))!;
+
+    const result = inferAllReferencedBlocks({ id });
+
+    expect(result.upstreams).toContain('weird"id\\with\nescapes');
+  });
+
+  it("ignores strings without __isRef marker", () => {
+    const result = inferAllReferencedBlocks({
+      a: "plain text",
+      b: '{"some":"json","without":"ref"}',
+    });
+
+    expect(result.upstreams.size).toBe(0);
+    expect(result.missingReferences).toBe(false);
+  });
+
+  it("detects PlRef string regardless of JSON.stringify nesting depth (depth 0..10)", () => {
+    const id = canonicalize(outputRef("blockA", "n", true))!;
+
+    for (let depth = 0; depth <= 10; depth++) {
+      let value: string = id;
+      for (let i = 0; i < depth; i++) value = JSON.stringify(value);
+
+      const result = inferAllReferencedBlocks({ raw: value });
+
+      expect(result.upstreams, `depth=${depth}`).toContain("blockA");
+      expect(result.upstreamsRequiringEnrichments, `depth=${depth}`).toContain("blockA");
+    }
+  });
+
+  it("detects PlRef when the entire args container is stringified multiple times", () => {
+    const ref = outputRef("blockZ", "n");
+    const container: { col: unknown } = { col: ref };
+
+    let value: unknown = container;
+    for (let i = 0; i < 5; i++) value = JSON.stringify(value);
+
+    const result = inferAllReferencedBlocks({ wrapper: value });
+
+    expect(result.upstreams).toContain("blockZ");
+  });
+
+  it("detects PlRef when args itself is the multi-stringified ref string", () => {
+    let value: string = canonicalize(outputRef("blockTop", "n"))!;
+    for (let i = 0; i < 4; i++) value = JSON.stringify(value);
+
+    const result = inferAllReferencedBlocks(value);
+
+    expect(result.upstreams).toContain("blockTop");
+  });
+
+  it("ignores malformed __isRef occurrences", () => {
+    const result = inferAllReferencedBlocks({
+      a: '{"__isRef":true,"blockId"', // truncated
+      b: '"__isRef":false', // wrong value
+      c: "__isRef without quotes",
+    });
+
+    expect(result.upstreams.size).toBe(0);
   });
 });

--- a/lib/node/pl-middle-layer/src/model/args.ts
+++ b/lib/node/pl-middle-layer/src/model/args.ts
@@ -75,15 +75,18 @@ function addAllReferencedBlocks(result: BlockUpstreams, node: unknown, allowed?:
  * Detect a PlRef carried inside a string and hand the decoded value to `onParsed`.
  *
  * A PlRef-as-string is canonical `{...}` optionally wrapped by N `JSON.stringify`
- * passes. Each pass adds a symmetric prefix/suffix of quotes and backslashes, so
- * the first `{` and last `}` sit at mirrored offsets. We use that as a cheap
- * shape gate before paying for `JSON.parse`. One pass is peeled per call —
- * deeper nesting is unwrapped via recursion in the caller.
+ * passes. Each pass adds a symmetric prefix/suffix made only of `"` and `\`
+ * chars (the escape padding) of equal length. The regex below is the strict
+ * shape gate — non-ref strings fail at the very first character, so we never
+ * scan their body. One pass is peeled per call; deeper nesting is unwrapped
+ * via recursion in the caller.
  */
+const EMBEDDED_REF_RE = /^(?<pre>[\\"]*)\{[\s\S]*?__isRef[\s\S]*\}(?<suf>[\\"]*)$/;
+
 function unwrapEmbeddedRef(s: string, onParsed: (value: unknown) => void) {
-  const i = s.indexOf("{");
-  if (i < 0 || s.charCodeAt(s.length - 1 - i) !== 0x7d /* } */) return;
-  if (s.indexOf("__isRef", i) < 0) return;
+  const m = EMBEDDED_REF_RE.exec(s);
+  if (m === null) return;
+  if (m.groups!.pre.length !== m.groups!.suf.length) return;
   let parsed: unknown;
   try {
     parsed = JSON.parse(s);

--- a/lib/node/pl-middle-layer/src/model/args.ts
+++ b/lib/node/pl-middle-layer/src/model/args.ts
@@ -84,6 +84,8 @@ function addAllReferencedBlocks(result: BlockUpstreams, node: unknown, allowed?:
 const EMBEDDED_REF_RE = /^(?<pre>[\\"]*)\{[\s\S]*?__isRef[\s\S]*\}(?<suf>[\\"]*)$/;
 
 function unwrapEmbeddedRef(s: string, onParsed: (value: unknown) => void) {
+  const c0 = s.charCodeAt(0);
+  if (c0 !== 0x7b /* { */ && c0 !== 0x22 /* " */) return;
   const m = EMBEDDED_REF_RE.exec(s);
   if (m === null) return;
   if (m.groups!.pre.length !== m.groups!.suf.length) return;

--- a/lib/node/pl-middle-layer/src/model/args.ts
+++ b/lib/node/pl-middle-layer/src/model/args.ts
@@ -17,40 +17,6 @@ export function isBlockOutputReference(obj: unknown): obj is PlRef {
   );
 }
 
-function addAllReferencedBlocks(result: BlockUpstreams, node: unknown, allowed?: Set<string>) {
-  const type = typeof node;
-  switch (type) {
-    case "function":
-    case "bigint":
-    case "number":
-    case "string":
-    case "boolean":
-    case "symbol":
-    case "undefined":
-      return;
-
-    case "object":
-      if (node === null) return;
-
-      if (isBlockOutputReference(node)) {
-        if (allowed === undefined || allowed.has(node.blockId)) {
-          result.upstreams.add(node.blockId);
-          if (node.requireEnrichments) result.upstreamsRequiringEnrichments.add(node.blockId);
-        } else result.missingReferences = true;
-      } else if (Array.isArray(node)) {
-        for (const child of node) addAllReferencedBlocks(result, child, allowed);
-      } else {
-        for (const [, child] of Object.entries(node as object))
-          addAllReferencedBlocks(result, child, allowed);
-      }
-
-      return;
-
-    default:
-      assertNever(type);
-  }
-}
-
 export interface BlockUpstreams {
   /** All direct block dependencies */
   upstreams: Set<string>;
@@ -69,4 +35,72 @@ export function inferAllReferencedBlocks(args: unknown, allowed?: Set<string>): 
   };
   addAllReferencedBlocks(result, args, allowed);
   return result;
+}
+
+function addAllReferencedBlocks(result: BlockUpstreams, node: unknown, allowed?: Set<string>) {
+  const type = typeof node;
+  switch (type) {
+    case "function":
+    case "bigint":
+    case "number":
+    case "boolean":
+    case "symbol":
+    case "undefined":
+      return;
+    case "string": {
+      unwrapEmbeddedRef(node as string, (parsed) =>
+        addAllReferencedBlocks(result, parsed, allowed),
+      );
+      return;
+    }
+    case "object": {
+      if (node === null) return;
+      if (isBlockOutputReference(node)) {
+        recordRef(result, node.blockId, node.requireEnrichments === true, allowed);
+      } else if (Array.isArray(node)) {
+        for (const child of node) addAllReferencedBlocks(result, child, allowed);
+      } else {
+        for (const [, child] of Object.entries(node as object))
+          addAllReferencedBlocks(result, child, allowed);
+      }
+
+      return;
+    }
+    default:
+      assertNever(type);
+  }
+}
+
+/**
+ * Detect a PlRef carried inside a string and hand the decoded value to `onParsed`.
+ *
+ * A PlRef-as-string is canonical `{...}` optionally wrapped by N `JSON.stringify`
+ * passes. Each pass adds a symmetric prefix/suffix of quotes and backslashes, so
+ * the first `{` and last `}` sit at mirrored offsets. We use that as a cheap
+ * shape gate before paying for `JSON.parse`. One pass is peeled per call —
+ * deeper nesting is unwrapped via recursion in the caller.
+ */
+function unwrapEmbeddedRef(s: string, onParsed: (value: unknown) => void) {
+  const i = s.indexOf("{");
+  if (i < 0 || s.charCodeAt(s.length - 1 - i) !== 0x7d /* } */) return;
+  if (s.indexOf("__isRef", i) < 0) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(s);
+  } catch {
+    return;
+  }
+  if (parsed !== s) onParsed(parsed);
+}
+
+function recordRef(
+  result: BlockUpstreams,
+  blockId: string,
+  requireEnrichments: boolean,
+  allowed?: Set<string>,
+) {
+  if (allowed === undefined || allowed.has(blockId)) {
+    result.upstreams.add(blockId);
+    if (requireEnrichments) result.upstreamsRequiringEnrichments.add(blockId);
+  } else result.missingReferences = true;
 }

--- a/sdk/workflow-tengo/src/pframes/bundle.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/bundle.lib.tengo
@@ -114,6 +114,27 @@ createBuilder := func(ctx) {
 			queryOpts = ops[1]
 		}
 
+		// Global-form PObjectId: canonicalize({__isRef: true, blockId, name}).
+		// Opaque id from cross-block result pool — must be resolved by ref, not as a query.
+		isGlobalRef := is_map(decodedId) && decodedId.__isRef == true
+		if isGlobalRef {
+			refKey := is_string(id) ? id : canonical.encode(decodedId)
+			if !is_undefined(queryKey) {
+				refKey = queryKey
+			}
+			ref := { blockId: decodedId.blockId, name: decodedId.name }
+			if !is_string(refs[refKey]) {
+				refs[refKey] = ref
+			}
+			return
+		}
+
+		// Local-form PObjectId: canonicalize({resolvePath, name}).
+		// Not yet supported here — addSingle has no resolver for local refs.
+		if is_map(decodedId) && !is_undefined(decodedId.resolvePath) {
+			ll.panic("addSingle does not support local-form PObjectId (resolvePath): ", decodedId)
+		}
+
 		isFiltered := is_map(decodedId) && !is_undefined(decodedId.source) && !is_undefined(decodedId.axisFilters)
 		if isFiltered && !is_undefined(queryKey) {
 			ll.panic("FilteredPColumnId cannot be used with a queryKey.")


### PR DESCRIPTION
inferAllReferencedBlocks and bundle.addSingle

- Detect embedded PlRef as canonicalized JSON string in inferAllReferencedBlocks.
- Update _QUERY_MAP_SCHEMA to accept global-form PObjectId in bundle.addSingle.
- Ensure local-form PObjectId triggers a panic for unsupported references.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends `inferAllReferencedBlocks` to detect `PlRef` values embedded as canonicalized JSON strings (including multiply-stringified forms), and fixes `bundle.addSingle` in the Tengo layer to route global-form `PObjectId` entries to `refs` instead of `queries`. Both changes are well-tested and correctly handle the enrichment-propagation and allowed-set logic.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all findings are non-blocking style/edge-case suggestions.

Only P2 findings: an unbounded recursion depth in the string-unwrapping logic (harmless for normal args) and a minor key-derivation inconsistency in the Tengo global-ref path when overrides modify identity fields. No correctness or security issues on the primary code paths.

lib/node/pl-middle-layer/src/model/args.ts and sdk/workflow-tengo/src/pframes/bundle.lib.tengo warrant a second look for the edge cases noted, but neither blocks merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/model/args.ts | Adds `unwrapEmbeddedRef` to detect PlRef values embedded as canonicalized JSON strings; symmetry heuristic and `__isRef` fast-path are correct, but no recursion depth limit exists for pathological nesting. |
| lib/node/pl-middle-layer/src/model/args.test.ts | Comprehensive new tests covering single refs, enrichment propagation, allowed-set filtering, multi-level nesting, malformed strings, and deeply-encoded containers; good coverage of the new string-unwrapping logic. |
| sdk/workflow-tengo/src/pframes/bundle.lib.tengo | Adds global-form PObjectId handling in `addSingle`, routing it to `refs` instead of `queries`; `refKey` derivation for string IDs does not account for applied overrides, a minor inconsistency. |
| .changeset/args-detect-embedded-ref.md | Changeset file for the args.ts patch; description is accurate. |
| .changeset/bundle-add-single-global-ref.md | Changeset file for the bundle.lib.tengo patch; description is accurate. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/node/pl-middle-layer/src/model/args.ts
Line: 83-93

Comment:
**No recursion depth limit for deeply-nested strings**

`unwrapEmbeddedRef` calls `onParsed` (which is `addAllReferencedBlocks`), which in turn calls `unwrapEmbeddedRef` again when the result is still a string. There is no depth cap, so a string that is JSON-stringified thousands of times would recurse proportionally — each layer adds roughly two stack frames. For expected system-generated args this is harmless, but abnormal or adversarial input could eventually exhaust the call stack. Consider adding a depth counter or capping unwrapping after a reasonable limit (e.g., 20 levels).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/workflow-tengo/src/pframes/bundle.lib.tengo
Line: 120-129

Comment:
**`refKey` ignores applied overrides when `id` is a string**

`refKey` is assigned as `is_string(id) ? id : canonical.encode(decodedId)`. At this point, `decodedId` may already have overrides merged into it (lines 106-109), so the canonical key for a string `id` is derived from the original, un-overridden value. If overrides change identity fields (`blockId` or `name`), the ref stored in `refs` will have different content than what the key implies. This is an edge case — overriding identity fields on a global ref is unusual — but could produce subtle mismatches. Deriving `refKey` from `canonical.encode(decodedId)` unconditionally (or after the override merge) would make it consistent with the non-global path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: enhance PlRef handling in inferAll..."](https://github.com/milaboratory/platforma/commit/c8d7ce825aba45d44fed0be086d40ebcf554d2bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29986620)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->