### PR TITLE
Refactor label and tooltip handling in PlDataTable

### DIFF
--- a/.changeset/busy-games-listen.md
+++ b/.changeset/busy-games-listen.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Adopt labels for usage qualifications

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -79,7 +79,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
       labelsOptions: {
         // Custom linker label formatter to verify linker path labels in the UI.
         // Default would produce "via L1 > L2"; this makes it "[L1 > L2]" for easy visual identification.
-        linkerLabelFormatter: (linkerLabels) => `[${linkerLabels.join(" > ")}]`,
+        formatters: { linker: (linkerLabels) => `[${linkerLabels.join(" > ")}]` },
       },
       displayOptions: {
         ordering: [

--- a/sdk/model/src/columns/column_collection_builder.test.ts
+++ b/sdk/model/src/columns/column_collection_builder.test.ts
@@ -404,8 +404,6 @@ describe("AnchoredColumnCollection", () => {
     for (const v of col1Match.variants) {
       expect(v.qualifications.forQueries).toBeDefined();
       expect(v.qualifications.forHit).toBeDefined();
-      expect(v.distinctiveQualifications.forQueries).toBeDefined();
-      expect(v.distinctiveQualifications.forHit).toBeDefined();
       // forQueries keys are a subset of anchor ids
       for (const key of Object.keys(v.qualifications.forQueries)) {
         expect([anchorSnap.id]).toContain(key);

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -55,6 +55,9 @@ export interface AnchoredColumnCollection extends Disposable {
 
   /** Axis-aware column discovery. */
   findColumns(options?: AnchoredFindColumnsOptions): ColumnMatch[];
+
+  /** Variant discovery with detailed mapping info for each hit. */
+  findColumnVariants(options?: AnchoredFindColumnsOptions): ColumnVariant[];
 }
 
 /** Controls axis matching behavior for anchored discovery. */
@@ -74,6 +77,20 @@ export interface ColumnMatch {
   readonly column: ColumnSnapshot<PObjectId>;
   /** Match variants — different ways (paths/qualifications) to reach this column. */
   readonly variants: MatchVariant[];
+}
+
+export interface ColumnVariant<Id extends PObjectId = PObjectId> {
+  /** Column snapshot with anchored SUniversalPColumnId. */
+  readonly column: ColumnSnapshot<Id>;
+  /** Full qualifications needed for integration. */
+  readonly qualifications: MatchQualifications;
+  /** Distinctive (minimal) qualifications needed for integration. */
+  readonly distinctiveQualifications: MatchQualifications;
+  /** Linker steps traversed to reach this hit; empty for direct matches. */
+  readonly path: {
+    linker: ColumnSnapshot<PObjectId>;
+    qualifications: AxisQualification[];
+  }[];
 }
 
 /** A single mapping variant describing how a hit column can be integrated. */
@@ -324,6 +341,18 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
     }, new Map());
 
     return Array.from(byColumn.values());
+  }
+
+  findColumnVariants(options?: AnchoredFindColumnsOptions): ColumnVariant[] {
+    const matches = this.findColumns(options);
+    return matches.flatMap((match) =>
+      match.variants.map((variant) => ({
+        column: match.column,
+        path: variant.path,
+        qualifications: variant.qualifications,
+        distinctiveQualifications: variant.distinctiveQualifications,
+      })),
+    );
   }
 }
 

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -84,8 +84,6 @@ export interface ColumnVariant<Id extends PObjectId = PObjectId> {
   readonly column: ColumnSnapshot<Id>;
   /** Full qualifications needed for integration. */
   readonly qualifications: MatchQualifications;
-  /** Distinctive (minimal) qualifications needed for integration. */
-  readonly distinctiveQualifications: MatchQualifications;
   /** Linker steps traversed to reach this hit; empty for direct matches. */
   readonly path: {
     linker: ColumnSnapshot<PObjectId>;
@@ -97,8 +95,6 @@ export interface ColumnVariant<Id extends PObjectId = PObjectId> {
 export interface MatchVariant {
   /** Full qualifications needed for integration. */
   readonly qualifications: MatchQualifications;
-  /** Distinctive (minimal) qualifications needed for integration. */
-  readonly distinctiveQualifications: MatchQualifications;
   /** Linker steps traversed to reach this hit; empty for direct matches. */
   readonly path: {
     linker: ColumnSnapshot<PObjectId>;
@@ -329,7 +325,6 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
       const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({
         path,
         qualifications: remapFromIdxToId(v.qualifications, anchors),
-        distinctiveQualifications: remapFromIdxToId(v.distinctiveQualifications, anchors),
       }));
       const existing = acc.get(origId);
       return acc.set(
@@ -350,7 +345,6 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
         column: match.column,
         path: variant.path,
         qualifications: variant.qualifications,
-        distinctiveQualifications: variant.distinctiveQualifications,
       })),
     );
   }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -106,7 +106,7 @@ export function createPlDataTableV3<A, U>(
       id: dc.column.id,
       spec: dc.column.spec,
       linkerPath: dc.path,
-      qualifications: dc.distinctiveQualifications,
+      qualifications: dc.qualifications,
     })),
     labelColumns,
     deriveLabelsOptions: {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -322,6 +322,10 @@ function withVariantColumns<V extends { readonly column: ColumnSnapshot<Discover
   fn: (cols: ColumnSnapshot<DiscoveredPColumnId>[]) => ColumnSnapshot<DiscoveredPColumnId>[],
 ): V[] {
   const cols = fn(variants.map((v) => v.column));
+  if (cols.length !== variants.length)
+    throw new Error(
+      `withVariantColumns: fn must preserve array length (got ${cols.length}, expected ${variants.length})`,
+    );
   return variants.map((v, i) => ({ ...v, column: cols[i] }));
 }
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -20,13 +20,7 @@ import { isEmpty } from "es-toolkit/compat";
 import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV5";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
-import type {
-  ColumnSelector,
-  ColumnSnapshot,
-  MatchingMode,
-  MatchQualifications,
-  MatchVariant,
-} from "../../../columns";
+import type { ColumnSelector, ColumnSnapshot, ColumnVariant, MatchingMode } from "../../../columns";
 import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
@@ -48,7 +42,7 @@ import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/help
 export type createPlDataTableOptionsV3 = {
   tableState?: PlDataTableStateV2;
 
-  columns: Nil | DiscoverTableColumnOptions | TableColumnSnapshot[];
+  columns: Nil | DiscoverTableColumnOptions | TableColumnVariant[];
   filters?: PlDataTableFilters;
   sorting?: PTableSorting[];
   primaryJoinType?: "inner" | "full";
@@ -103,15 +97,16 @@ export function createPlDataTableV3<A, U>(
   const splited = splitDiscoveredColumns(discovered);
 
   const labelColumns = getMatchingLabelColumns(
-    [...splited.direct, ...splited.linked],
+    [...splited.direct, ...splited.linked].map((v) => v.column),
     getAllLabelColumns(ctx),
   );
 
   const derivedLabels = deriveAllLabels({
     columns: discovered.map((dc) => ({
-      id: dc.id,
-      spec: dc.spec,
-      linkerPath: dc.linkerPath?.map((lp) => ({ spec: lp.linker.spec })),
+      id: dc.column.id,
+      spec: dc.column.spec,
+      linkerPath: dc.path,
+      qualifications: dc.distinctiveQualifications,
     })),
     labelColumns,
     deriveLabelsOptions: {
@@ -122,12 +117,11 @@ export function createPlDataTableV3<A, U>(
 
   const derivedTooltips = deriveAllTooltips({
     columns: discovered.map((dc) => ({
-      id: dc.id,
+      id: dc.column.id,
       originalId: dc.originalId,
-      spec: dc.spec,
-      linkerPath: dc.linkerPath,
+      spec: dc.column.spec,
+      linkerPath: dc.path,
       qualifications: dc.qualifications,
-      distinctiveQualifications: dc.distinctiveQualifications,
     })),
   });
 
@@ -146,8 +140,8 @@ export function createPlDataTableV3<A, U>(
   if (primarySnapshots.length === 0) return undefined;
 
   const columnIsAvailable = createColumnValidationById([
-    ...annotated.direct,
-    ...annotated.linked.flatMap((lc) => [...(lc.linkerPath ?? []).map((s) => s.linker), lc]),
+    ...annotated.direct.map((v) => v.column),
+    ...annotated.linked.flatMap((lc) => [...lc.path.map((s) => s.linker), lc.column]),
     ...annotated.labels,
   ]);
 
@@ -165,7 +159,7 @@ export function createPlDataTableV3<A, U>(
   validateSorting(sorting, columnIsAvailable);
 
   const primaryEntries: PrimaryEntry<undefined | PColumnDataUniversal>[] = primarySnapshots.map(
-    (snap) => ({ column: resolveSnapshot(snap) }),
+    (v) => ({ column: resolveSnapshot(v.column) }),
   );
   const fullDef = createPTableDefV3({
     primaryJoinType,
@@ -179,15 +173,15 @@ export function createPlDataTableV3<A, U>(
   // TODO: is workaround for dropdown suggestions.
   // Pframe have not equivalent data for columns relativly to Ptable
   const pframeHandle = ctx.createPFrame([
-    ...annotated.direct.map(resolveSnapshot),
-    ...annotated.linked.map(resolveSnapshot),
+    ...annotated.direct.map((v) => resolveSnapshot(v.column)),
+    ...annotated.linked.map((v) => resolveSnapshot(v.column)),
     ...annotated.labels,
     ...collectLinkerSnapshots(annotated.linked).map(resolveSnapshot),
   ]);
 
   const hiddenSpecs = state.pTableParams.hiddenColIds;
   const hiddenColumnIds = computeHiddenColumns(
-    [...annotated.direct, ...annotated.linked],
+    [...annotated.direct, ...annotated.linked].map((v) => v.column),
     sorting,
     filters,
     hiddenSpecs,
@@ -216,43 +210,39 @@ export function createPlDataTableV3<A, U>(
   } satisfies PlDataTableModel;
 }
 
-/** A single column discovered from sources — normalized from raw ColumnSnapshot/ColumnMatch. */
-export type TableColumnSnapshot = ColumnSnapshot<DiscoveredPColumnId> & {
+export type TableColumnVariant = ColumnVariant<DiscoveredPColumnId> & {
   readonly originalId: PObjectId;
   readonly isPrimary?: boolean;
-  readonly linkerPath?: MatchVariant["path"];
-  readonly qualifications?: MatchQualifications;
-  readonly distinctiveQualifications?: MatchQualifications;
 };
 
 type SplitDiscoveredColumns = {
-  readonly direct: TableColumnSnapshot[];
-  readonly linked: TableColumnSnapshot[];
+  readonly direct: TableColumnVariant[];
+  readonly linked: TableColumnVariant[];
 };
 
 type AnnotatedColumnGroups = {
-  readonly direct: TableColumnSnapshot[];
-  readonly linked: TableColumnSnapshot[];
+  readonly direct: TableColumnVariant[];
+  readonly linked: TableColumnVariant[];
   readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 type VisibleColumns = {
-  readonly direct: TableColumnSnapshot[];
-  readonly linked: TableColumnSnapshot[];
+  readonly direct: TableColumnVariant[];
+  readonly linked: TableColumnVariant[];
   readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 /** Split discovered columns into direct (no linker path) and linked (with linker path). */
-function splitDiscoveredColumns(columns: TableColumnSnapshot[]): SplitDiscoveredColumns {
-  const direct = columns.filter((dc) => isNil(dc.linkerPath) || dc.linkerPath.length === 0);
-  const linked = columns.filter((dc) => !isNil(dc.linkerPath) && dc.linkerPath.length > 0);
+function splitDiscoveredColumns(columns: TableColumnVariant[]): SplitDiscoveredColumns {
+  const direct = columns.filter((dc) => dc.path.length === 0);
+  const linked = columns.filter((dc) => dc.path.length > 0);
   return { direct, linked };
 }
 
 /** All linker snapshots across the given linked columns, deduped by id. */
-function collectLinkerSnapshots(linked: TableColumnSnapshot[]): ColumnSnapshot<PObjectId>[] {
+function collectLinkerSnapshots(linked: TableColumnVariant[]): ColumnSnapshot<PObjectId>[] {
   return uniqueBy(
-    linked.flatMap((lc) => (lc.linkerPath ?? []).map((s) => s.linker)),
+    linked.flatMap((lc) => lc.path.map((s) => s.linker)),
     (c) => c.id,
   );
 }
@@ -264,8 +254,8 @@ function collectLinkerSnapshots(linked: TableColumnSnapshot[]): ColumnSnapshot<P
  * column annotations via `withTableVisualAnnotations`.
  */
 function annotateColumnGroups(params: {
-  direct: TableColumnSnapshot[];
-  linked: TableColumnSnapshot[];
+  direct: TableColumnVariant[];
+  linked: TableColumnVariant[];
   labelColumns: PColumn<PColumnDataUniversal>[];
   derivedLabels: Record<string, string>;
   derivedTooltips: Record<string, string>;
@@ -283,8 +273,8 @@ function annotateColumnGroups(params: {
   } = params;
 
   const allColumnsForRules = [
-    ...direct,
-    ...linked,
+    ...direct.map((v) => v.column),
+    ...linked.map((v) => v.column),
     ...labelColumns,
     ...collectLinkerSnapshots(linked),
   ];
@@ -299,20 +289,23 @@ function annotateColumnGroups(params: {
     pframeSpec,
   );
 
-  const directAnnotated = [
-    withLabelAnnotations.bind(null, derivedLabels),
-    withInfoAnnotations.bind(null, derivedTooltips),
-    withTableVisualAnnotations.bind(null, visibilityByColId, orderByColId),
-  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot[], direct);
+  const directAnnotated = withVariantColumns(direct, (cols) =>
+    withTableVisualAnnotations(
+      visibilityByColId,
+      orderByColId,
+      withInfoAnnotations(derivedTooltips, withLabelAnnotations(derivedLabels, cols)),
+    ),
+  );
 
-  const linkedAnnotated = [
-    withLabelAnnotations.bind(null, derivedLabels),
-    withInfoAnnotations.bind(null, derivedTooltips),
-    withHidenAxesAnnotations.bind(null),
-    withTableVisualAnnotations.bind(null, visibilityByColId, orderByColId),
-    (cols: TableColumnSnapshot[]) =>
-      cols.map((lc) => ({ ...lc, linkerPath: annotateLinkerPath(derivedLabels, lc.linkerPath) })),
-  ].reduce((cols, fn) => fn(cols) as TableColumnSnapshot[], linked);
+  const linkedAnnotated = withVariantColumns(linked, (cols) =>
+    withTableVisualAnnotations(
+      visibilityByColId,
+      orderByColId,
+      withHidenAxesAnnotations(
+        withInfoAnnotations(derivedTooltips, withLabelAnnotations(derivedLabels, cols)),
+      ),
+    ),
+  ).map((lc) => ({ ...lc, path: annotateLinkerPath(derivedLabels, lc.path) }));
 
   const labelColumnsAnnotated = withLabelAnnotations(derivedLabels, labelColumns);
 
@@ -322,11 +315,21 @@ function annotateColumnGroups(params: {
     labels: labelColumnsAnnotated,
   };
 }
+
+/** Apply a snapshot-array transformation to the inner `column` of each variant. */
+function withVariantColumns<V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId> }>(
+  variants: V[],
+  fn: (cols: ColumnSnapshot<DiscoveredPColumnId>[]) => ColumnSnapshot<DiscoveredPColumnId>[],
+): V[] {
+  const cols = fn(variants.map((v) => v.column));
+  return variants.map((v, i) => ({ ...v, column: cols[i] }));
+}
+
 function annotateLinkerPath(
   derivedLabels: Record<string, string>,
-  path: TableColumnSnapshot["linkerPath"],
-): TableColumnSnapshot["linkerPath"] {
-  if (isNil(path) || path.length === 0) return path;
+  path: TableColumnVariant["path"],
+): TableColumnVariant["path"] {
+  if (path.length === 0) return path;
   const annotatedLinkers = withHidenAxesAnnotations(
     withLabelAnnotations(
       derivedLabels,
@@ -403,27 +406,27 @@ function validateSorting(sorting: PTableSorting[], isValidColumnId: (id: string)
 }
 
 function buildSecondaryGroups(
-  direct: TableColumnSnapshot[],
-  linked: TableColumnSnapshot[],
+  direct: TableColumnVariant[],
+  linked: TableColumnVariant[],
   labels: PColumn<PColumnDataUniversal>[],
 ): SecondaryGroup<undefined | PColumnDataUniversal>[] {
   return [
     ...direct.map(
       (c): SecondaryGroup<undefined | PColumnDataUniversal> => ({
-        entries: [{ column: resolveSnapshot(c), qualifications: c.qualifications?.forHit }],
-        primaryQualifications: c.qualifications?.forQueries,
+        entries: [{ column: resolveSnapshot(c.column), qualifications: c.qualifications.forHit }],
+        primaryQualifications: c.qualifications.forQueries,
       }),
     ),
     ...linked.map(
       (lc): SecondaryGroup<undefined | PColumnDataUniversal> => ({
         entries: [
-          ...(lc.linkerPath ?? []).map((s) => ({
+          ...lc.path.map((s) => ({
             column: resolveSnapshot(s.linker),
             qualifications: s.qualifications,
           })),
-          { column: resolveSnapshot(lc), qualifications: lc.qualifications?.forHit },
+          { column: resolveSnapshot(lc.column), qualifications: lc.qualifications.forHit },
         ],
-        primaryQualifications: lc.qualifications?.forQueries,
+        primaryQualifications: lc.qualifications.forQueries,
       }),
     ),
     ...labels.map(
@@ -475,9 +478,12 @@ function buildVisibleColumns(
   hiddenColumns: Set<PObjectId>,
   originalLabelColumns: PColumn<PColumnDataUniversal>[],
 ): VisibleColumns {
-  const direct = annotated.direct.filter((c) => !hiddenColumns.has(c.id));
-  const linked = annotated.linked.filter((c) => !hiddenColumns.has(c.id));
-  const labels = getMatchingLabelColumns([...direct, ...linked], originalLabelColumns);
+  const direct = annotated.direct.filter((c) => !hiddenColumns.has(c.column.id));
+  const linked = annotated.linked.filter((c) => !hiddenColumns.has(c.column.id));
+  const labels = getMatchingLabelColumns(
+    [...direct, ...linked].map((v) => v.column),
+    originalLabelColumns,
+  );
   return { direct, linked, labels };
 }
 
@@ -491,21 +497,21 @@ function resolveSnapshot(
 /** Remap column references in sorting entries. */
 function remapSortingColumnIds(
   sorting: Nil | PTableSorting[],
-  columns: TableColumnSnapshot[],
+  columns: TableColumnVariant[],
 ): Nil | PTableSorting[] {
   return sorting?.map((s) => {
     if (s.column.type === "axis") return s; // Axis references are unaffected by column ID remapping
 
     const id = s.column.id;
     const column =
-      columns.find((c) => (c.originalId ?? c.id) === id) ??
+      columns.find((c) => (c.originalId ?? c.column.id) === id) ??
       throwError(`Column ID "${id}" in sorting does not match any discovered column`);
 
     return {
       ...s,
       column: {
         type: "column",
-        id: column.id,
+        id: column.column.id,
       },
     };
   });
@@ -516,7 +522,7 @@ type PlDataTableFilterNode = FilterSpecNode<PlDataTableFilterSpecLeaf>;
 /** Remap column references in a filter tree. */
 function remapFilterColumnIds(
   filters: Nil | PlDataTableFilters,
-  columns: TableColumnSnapshot[],
+  columns: TableColumnVariant[],
 ): Nil | PlDataTableFilters {
   if (isNil(filters)) return filters;
 
@@ -528,12 +534,12 @@ function remapFilterColumnIds(
 
     const originalId = parsed.id;
     const column =
-      columns.find((c) => (c.originalId ?? c.id) === originalId) ??
+      columns.find((c) => (c.originalId ?? c.column.id) === originalId) ??
       throwError(`Column ID "${parsed.id}" in filters does not match any discovered column`);
 
     return canonicalizeJson<PTableColumnId>({
       type: "column",
-      id: column.id,
+      id: column.column.id,
     });
   };
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -123,11 +123,10 @@ function mapToTableColumnVariants(
         data: snap.data,
         dataStatus: snap.dataStatus,
       },
-      originalId: snap.id,
-      isPrimary,
       path: variant.path,
       qualifications: variant.qualifications,
-      distinctiveQualifications: variant.distinctiveQualifications,
+      originalId: snap.id,
+      isPrimary,
     };
   });
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -3,7 +3,7 @@ import { createDiscoveredPColumnId, isPlRef } from "@milaboratories/pl-model-com
 import type { RenderCtxBase } from "../../../render";
 import type {
   ColumnSource,
-  ColumnMatch,
+  ColumnVariant,
   RelaxedColumnSelector,
   ColumnSnapshotProvider,
   ColumnSnapshot,
@@ -12,7 +12,7 @@ import { ColumnCollectionBuilder } from "../../../columns";
 import { toColumnSnapshotProvider } from "../../../columns/column_snapshot_provider";
 import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_sources";
 import { throwError } from "@milaboratories/helpers";
-import type { ColumnsSelectorConfig, TableColumnSnapshot } from "./createPlDataTableV3";
+import type { ColumnsSelectorConfig, TableColumnVariant } from "./createPlDataTableV3";
 import { isNil } from "es-toolkit";
 
 export type DiscoverTableColumnOptions = {
@@ -21,11 +21,11 @@ export type DiscoverTableColumnOptions = {
   selector: ColumnsSelectorConfig;
 };
 
-/** Discover columns from sources/anchors and normalize into a flat DiscoveredColumn list. */
+/** Discover columns from sources/anchors and normalize into a flat TableColumnVariant list. */
 export function discoverTableColumnSnaphots(
   ctx: RenderCtxBase,
   options: DiscoverTableColumnOptions,
-): TableColumnSnapshot[] | undefined {
+): TableColumnVariant[] | undefined {
   // Resolve PlRef anchors to PColumnSpec
   const resolvedOptions = {
     ...options,
@@ -43,7 +43,7 @@ export function discoverTableColumnSnaphots(
   if (collection === undefined) return undefined;
 
   try {
-    const columns = collection.findColumns({
+    const variants = collection.findColumnVariants({
       ...(resolvedOptions.selector ?? {}),
       exclude: [
         ...(Array.isArray(resolvedOptions.selector?.exclude)
@@ -55,7 +55,7 @@ export function discoverTableColumnSnaphots(
       ],
     });
     const anchors = collection.getAnchors();
-    return mapToDiscoveredColumns(columns, anchors);
+    return mapToTableColumnVariants(variants, anchors);
   } finally {
     collection.dispose();
   }
@@ -93,43 +93,41 @@ function resolveProviders(
     : collectCtxColumnSnapshotProviders(ctx);
 }
 
-/** Map matched columns into a flat DiscoveredColumn list with deduped IDs. */
-function mapToDiscoveredColumns(
-  matched: readonly ColumnMatch[],
+/** Map column variants into TableColumnVariant list with anchor-derived isPrimary flag. */
+function mapToTableColumnVariants(
+  variants: readonly ColumnVariant[],
   anchors: Map<string, ColumnSnapshot<PObjectId>>,
-): TableColumnSnapshot[] {
+): TableColumnVariant[] {
   const columnIdToAnchorName = new Map<PObjectId, string>(
     Array.from(anchors.entries(), ([key, { id }]) => [id, key] as const),
   );
 
-  return matched.flatMap((match) => {
-    const snap = match.column;
-    const isPrimary = columnIdToAnchorName.get(match.column.id) !== undefined;
+  return variants.map((variant): TableColumnVariant => {
+    const snap = variant.column;
+    const isPrimary = columnIdToAnchorName.get(snap.id) !== undefined;
 
-    return match.variants.map((variant): TableColumnSnapshot => {
-      const discoveredId = createDiscoveredPColumnId({
-        column: snap.id,
-        path: variant.path.map((p) => ({
-          type: "linker",
-          column: p.linker.id,
-          qualifications: p.qualifications,
-        })),
-        columnQualifications: variant.qualifications.forHit,
-        queriesQualifications: variant.qualifications.forQueries,
-      });
-      return {
+    const discoveredId = createDiscoveredPColumnId({
+      column: snap.id,
+      path: variant.path.map((p) => ({
+        type: "linker",
+        column: p.linker.id,
+        qualifications: p.qualifications,
+      })),
+      columnQualifications: variant.qualifications.forHit,
+      queriesQualifications: variant.qualifications.forQueries,
+    });
+    return {
+      column: {
         id: discoveredId,
-        isPrimary,
-
-        originalId: snap.id,
         spec: snap.spec,
         data: snap.data,
         dataStatus: snap.dataStatus,
-
-        linkerPath: variant.path,
-        qualifications: variant.qualifications,
-        distinctiveQualifications: variant.distinctiveQualifications,
-      };
-    });
+      },
+      originalId: snap.id,
+      isPrimary,
+      path: variant.path,
+      qualifications: variant.qualifications,
+      distinctiveQualifications: variant.distinctiveQualifications,
+    };
   });
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -239,7 +239,7 @@ describe("deriveAxisLabels via deriveAllLabels", () => {
       makeLabelableColumn(
         "c1",
         { name: "shared", annotations: { [Annotation.Label]: "Cluster size" } },
-        [{ spec: linkerSpec }],
+        [{ linker: { id: "lk" as PObjectId, spec: linkerSpec } as never, qualifications: [] }],
       ),
       makeLabelableColumn("c2", {
         name: "shared",

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -229,7 +229,8 @@ export function withHidenAxesAnnotations<T extends { readonly spec: PColumnSpec 
 export type LabelableColumn = {
   readonly id: PObjectId;
   readonly spec: PColumnSpec;
-  readonly linkerPath?: { spec: PColumnSpec }[];
+  readonly linkerPath?: MatchVariant["path"];
+  readonly qualifications?: MatchQualifications;
 };
 
 /** Derive labels for all table elements: columns via deriveDistinctLabels, axes from label columns. */
@@ -240,7 +241,15 @@ export function deriveAllLabels(options: {
 }): Record<string, string> {
   const { columns, labelColumns, deriveLabelsOptions } = options;
   const axisLabels = deriveAxisLabels(columns, labelColumns);
-  const columnLabels = deriveDistinctLabels(columns, deriveLabelsOptions).reduce(
+  const entries = columns.map((c) => ({
+    spec: c.spec,
+    linkerPath: c.linkerPath?.map((step) => ({
+      spec: step.linker.spec,
+      qualifications: step.qualifications,
+    })),
+    qualifications: c.qualifications,
+  }));
+  const columnLabels = deriveDistinctLabels(entries, deriveLabelsOptions).reduce(
     (acc, label, index) => ((acc[columns[index].id] = label), acc),
     {} as Record<string, string>,
   );
@@ -273,7 +282,6 @@ export type TooltipableColumn = {
   readonly originalId: PObjectId;
   readonly linkerPath?: MatchVariant["path"];
   readonly qualifications?: MatchQualifications;
-  readonly distinctiveQualifications?: MatchQualifications;
 };
 
 /** Derive origin tooltips for columns whose qualifications or linker path carry info. */
@@ -297,7 +305,6 @@ export function deriveAllTooltips(options: {
         spec: c.spec,
         linkerPath: c.linkerPath,
         qualifications: c.qualifications,
-        distinctiveQualifications: c.distinctiveQualifications,
         variantIndex,
         variantCount,
       });

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -1,5 +1,10 @@
-import { Annotation, type PColumnSpec } from "@milaboratories/pl-model-common";
-import { expect, test } from "vitest";
+import {
+  Annotation,
+  type AxisQualification,
+  type PColumnSpec,
+  type PObjectId,
+} from "@milaboratories/pl-model-common";
+import { describe, expect, test } from "vitest";
 import { deriveDistinctLabels, type Entry, type Trace } from "./derive_distinct_labels";
 
 function tracesToSpecs(traces: Trace[]) {
@@ -316,90 +321,84 @@ test("Entry with extraTrace position prefix prepends to labels", () => {
 
 // --- linkerPath ---
 
-test("linkerPath appends default 'via' suffix", () => {
+test("linkerPath appends default 'via' suffix when needed for uniqueness", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col1" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
-      linkerPath: [
-        {
-          spec: createSpec({
-            annotations: { [Annotation.LinkLabel]: "MyLinker" },
-          }),
-        },
-      ],
     },
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col2" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
+      linkerPath: [{ spec: createSpec({ annotations: { [Annotation.LinkLabel]: "MyLinker" } }) }],
     },
   ];
   const labels = deriveDistinctLabels(entries);
-  expect(labels).toEqual(["Col1 via MyLinker", "Col2"]);
+  expect(labels).toEqual(["Col", "Col via MyLinker"]);
 });
 
 test("linkerPath with multiple steps joins with ' > '", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col1" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
+      }),
+    },
+    {
+      spec: createSpec({
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
       linkerPath: [
         { spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L1" } }) },
         { spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L2" } }) },
       ],
     },
-    {
-      spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col2" }]) },
-      }),
-    },
   ];
   const labels = deriveDistinctLabels(entries);
-  expect(labels).toEqual(["Col1 via L1 > L2", "Col2"]);
+  expect(labels).toEqual(["Col", "Col via L1 > L2"]);
 });
 
 test("linkerPath skips steps without labels", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col1" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
+      }),
+    },
+    {
+      spec: createSpec({
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
       linkerPath: [
         { spec: createSpec() },
         { spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L2" } }) },
       ],
     },
-    {
-      spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col2" }]) },
-      }),
-    },
   ];
   const labels = deriveDistinctLabels(entries);
-  expect(labels).toEqual(["Col1 via L2", "Col2"]);
+  expect(labels).toEqual(["Col", "Col via L2"]);
 });
 
 test("linkerPath with custom linkerLabelFormatter", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col1" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
-      linkerPath: [{ spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L1" } }) }],
     },
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col2" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
+      linkerPath: [{ spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L1" } }) }],
     },
   ];
   const labels = deriveDistinctLabels(entries, {
-    linkerLabelFormatter: (linkerLabels) => `[${linkerLabels.join(", ")}]`,
+    formatters: { linker: (linkerLabels) => `[${linkerLabels.join(", ")}]` },
   });
-  expect(labels).toEqual(["Col1 [L1]", "Col2"]);
+  expect(labels).toEqual(["Col", "Col [L1]"]);
 });
 
 test("linkerPath with linkerLabelFormatter returning undefined suppresses suffix", () => {
@@ -417,7 +416,7 @@ test("linkerPath with linkerLabelFormatter returning undefined suppresses suffix
     },
   ];
   const labels = deriveDistinctLabels(entries, {
-    linkerLabelFormatter: () => undefined,
+    formatters: { linker: () => undefined },
   });
   expect(labels).toEqual(["Col1", "Col2"]);
 });
@@ -426,18 +425,141 @@ test("linkerPath falls back to Label when LinkLabel is absent", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col1" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
-      linkerPath: [{ spec: createSpec({ annotations: { [Annotation.Label]: "FallbackLabel" } }) }],
     },
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col2" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
+      linkerPath: [{ spec: createSpec({ annotations: { [Annotation.Label]: "FallbackLabel" } }) }],
     },
   ];
   const labels = deriveDistinctLabels(entries);
-  expect(labels).toEqual(["Col1 via FallbackLabel", "Col2"]);
+  expect(labels).toEqual(["Col", "Col via FallbackLabel"]);
+});
+
+// --- formatters: nativeLabel / hitQualification / anchorQualification / linkerStepQualification ---
+
+test("formatters.native customizes label rendering", () => {
+  const s = ((label: string) =>
+    ({
+      kind: "PColumn",
+      name: "n",
+      valueType: "Int",
+      axesSpec: [],
+      annotations: { [Annotation.Label]: label },
+    }) as PColumnSpec)("Counts");
+  const labels = deriveDistinctLabels([{ spec: s }, { spec: s }], {
+    formatters: { native: (l) => `<<${l}>>` },
+  });
+  expect(labels).toEqual(["<<Counts>>", "<<Counts>>"]);
+});
+
+test("formatters.native returning undefined drops label entry", () => {
+  const traces: Trace[] = [[{ type: "t1", label: "X" }], [{ type: "t1", label: "Y" }]];
+  const labels = deriveDistinctLabels(tracesToSpecs(traces), {
+    includeNativeLabel: true,
+    formatters: { native: () => undefined },
+  });
+  expect(labels).toEqual(["X", "Y"]);
+});
+
+test("formatters.hitQualification customizes hit zone", () => {
+  const s = {
+    kind: "PColumn",
+    name: "n",
+    valueType: "Int",
+    axesSpec: [],
+    annotations: { [Annotation.Label]: "Expr" },
+  } as PColumnSpec;
+  const entries: Entry[] = [
+    {
+      spec: s,
+      qualifications: {
+        forQueries: {},
+        forHit: [{ axis: { name: "gene" }, contextDomain: { gene: "BRCA1" } }],
+      },
+    },
+    {
+      spec: s,
+      qualifications: {
+        forQueries: {},
+        forHit: [{ axis: { name: "gene" }, contextDomain: { gene: "TP53" } }],
+      },
+    },
+  ];
+  const labels = deriveDistinctLabels(entries, {
+    formatters: { hitQualification: (qs) => `<hit:${qs[0].contextDomain.gene}>` },
+  });
+  expect(labels).toEqual(["Expr <hit:BRCA1>", "Expr <hit:TP53>"]);
+});
+
+test("formatters.anchorQualification receives anchorId", () => {
+  const s = {
+    kind: "PColumn",
+    name: "n",
+    valueType: "Int",
+    axesSpec: [],
+    annotations: { [Annotation.Label]: "Counts" },
+  } as PColumnSpec;
+  const A = "A" as PObjectId;
+  const entries: Entry[] = [
+    {
+      spec: s,
+      qualifications: {
+        forQueries: { [A]: [{ axis: { name: "sample" }, contextDomain: { batch: "X" } }] },
+        forHit: [],
+      },
+    },
+    {
+      spec: s,
+      qualifications: {
+        forQueries: { [A]: [{ axis: { name: "sample" }, contextDomain: { batch: "Y" } }] },
+        forHit: [],
+      },
+    },
+  ];
+  const labels = deriveDistinctLabels(entries, {
+    formatters: {
+      anchorQualification: (id, qs) => `(${id}=${qs[0].contextDomain.batch})`,
+    },
+  });
+  expect(labels).toEqual(["Counts (A=X)", "Counts (A=Y)"]);
+});
+
+test("formatters.linkerStepQualification controls inline step quals", () => {
+  const s = {
+    kind: "PColumn",
+    name: "n",
+    valueType: "Int",
+    axesSpec: [],
+    annotations: { [Annotation.Label]: "Counts" },
+  } as PColumnSpec;
+  const entries: Entry[] = [
+    {
+      spec: s,
+      linkerPath: [
+        {
+          spec: createSpec({ annotations: { [Annotation.LinkLabel]: "Mapper" } }),
+          qualifications: [{ axis: { name: "sample" }, contextDomain: { batch: "X" } }],
+        },
+      ],
+    },
+    {
+      spec: s,
+      linkerPath: [
+        {
+          spec: createSpec({ annotations: { [Annotation.LinkLabel]: "Mapper" } }),
+          qualifications: [{ axis: { name: "sample" }, contextDomain: { batch: "Y" } }],
+        },
+      ],
+    },
+  ];
+  const labels = deriveDistinctLabels(entries, {
+    formatters: { linkerStepQualification: (qs) => `(${qs[0].contextDomain.batch})` },
+  });
+  expect(labels).toEqual(["Counts via Mapper (X)", "Counts via Mapper (Y)"]);
 });
 
 // --- addLabelAsSuffix ---
@@ -556,4 +678,248 @@ test("includeNativeLabel with no native label does not break", () => {
   ];
   const labels = deriveDistinctLabels(specs, { includeNativeLabel: true });
   expect(labels).toEqual(["X", "Y"]);
+});
+
+// ---------------------------------------------------------------------------
+// v2: linker path + qualifications as additional disambiguation layers
+// ---------------------------------------------------------------------------
+
+describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
+  function labeledSpec(label: string, name = "col"): PColumnSpec {
+    return {
+      kind: "PColumn",
+      name,
+      valueType: "Int",
+      axesSpec: [],
+      annotations: { [Annotation.Label]: label },
+    } as PColumnSpec;
+  }
+
+  function linkerSpec(label: string, name = "linker"): PColumnSpec {
+    return {
+      kind: "PColumn",
+      name,
+      valueType: "Int",
+      axesSpec: [],
+      annotations: { [Annotation.LinkLabel]: label },
+    } as PColumnSpec;
+  }
+
+  function qual(axis: string, ctx: Record<string, string> = {}): AxisQualification {
+    return { axis: { name: axis }, contextDomain: ctx };
+  }
+
+  const A = "anchor-main" as PObjectId;
+  const B = "anchor-other" as PObjectId;
+
+  test("linkerPath not appended when name alone is unique", () => {
+    const entries: Entry[] = [
+      { spec: labeledSpec("Read counts") },
+      { spec: labeledSpec("Coverage"), linkerPath: [{ spec: linkerSpec("Sample mapper") }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual(["Read counts", "Coverage"]);
+  });
+
+  test("linkerPath appended only when needed for uniqueness", () => {
+    const entries: Entry[] = [
+      { spec: labeledSpec("Read counts") },
+      { spec: labeledSpec("Read counts"), linkerPath: [{ spec: linkerSpec("Sample mapper") }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual(["Read counts", "Read counts via Sample mapper"]);
+  });
+
+  test("two linker paths → both get distinguishing via-suffix", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [
+      { spec: s, linkerPath: [{ spec: linkerSpec("Path A") }] },
+      { spec: s, linkerPath: [{ spec: linkerSpec("Path B") }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual(["Counts via Path A", "Counts via Path B"]);
+  });
+
+  test("multi-step paths joined with ' > '", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [
+      { spec: s, linkerPath: [{ spec: linkerSpec("Hub") }, { spec: linkerSpec("Tail X") }] },
+      { spec: s, linkerPath: [{ spec: linkerSpec("Hub") }, { spec: linkerSpec("Tail Y") }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts via Hub > Tail X",
+      "Counts via Hub > Tail Y",
+    ]);
+  });
+
+  test("hit qualifications used when nothing else differs", () => {
+    const s = labeledSpec("Expression");
+    const entries: Entry[] = [
+      { spec: s, qualifications: { forQueries: {}, forHit: [qual("gene", { gene: "BRCA1" })] } },
+      { spec: s, qualifications: { forQueries: {}, forHit: [qual("gene", { gene: "TP53" })] } },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Expression [gene=BRCA1]",
+      "Expression [gene=TP53]",
+    ]);
+  });
+
+  test("per-anchor qualifications named by anchor key", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [
+      {
+        spec: s,
+        qualifications: { forQueries: { [A]: [qual("sample", { batch: "X" })] }, forHit: [] },
+      },
+      {
+        spec: s,
+        qualifications: { forQueries: { [A]: [qual("sample", { batch: "Y" })] }, forHit: [] },
+      },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts [anchor-main: sample batch=X]",
+      "Counts [anchor-main: sample batch=Y]",
+    ]);
+  });
+
+  test("linker-step qualifications used to disambiguate identical linker labels", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [
+      {
+        spec: s,
+        linkerPath: [
+          { spec: linkerSpec("Mapper"), qualifications: [qual("sample", { batch: "X" })] },
+        ],
+      },
+      {
+        spec: s,
+        linkerPath: [
+          { spec: linkerSpec("Mapper"), qualifications: [qual("sample", { batch: "Y" })] },
+        ],
+      },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts via Mapper [sample batch=X]",
+      "Counts via Mapper [sample batch=Y]",
+    ]);
+  });
+
+  test("layers compose only as far as needed; no over-decoration", () => {
+    const entries: Entry[] = [
+      { spec: labeledSpec("Read counts") },
+      { spec: labeledSpec("Coverage") },
+      {
+        spec: labeledSpec("Coverage"),
+        qualifications: { forQueries: { [A]: [qual("sample", { batch: "X" })] }, forHit: [] },
+      },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Read counts",
+      "Coverage",
+      "Coverage [anchor-main: sample batch=X]",
+    ]);
+  });
+
+  test("hit and anchor qualifications combined when both needed", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [
+      {
+        spec: s,
+        qualifications: {
+          forQueries: { [A]: [qual("sample", { batch: "X" })] },
+          forHit: [qual("gene", { gene: "BRCA1" })],
+        },
+      },
+      {
+        spec: s,
+        qualifications: {
+          forQueries: { [A]: [qual("sample", { batch: "X" })] },
+          forHit: [qual("gene", { gene: "TP53" })],
+        },
+      },
+      {
+        spec: s,
+        qualifications: {
+          forQueries: { [A]: [qual("sample", { batch: "Y" })] },
+          forHit: [qual("gene", { gene: "BRCA1" })],
+        },
+      },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts [anchor-main: sample batch=X] [gene=BRCA1]",
+      "Counts [anchor-main: sample batch=X] [gene=TP53]",
+      "Counts [anchor-main: sample batch=Y] [gene=BRCA1]",
+    ]);
+  });
+
+  test("only distinctive anchor qualifications appear in the label", () => {
+    const s = labeledSpec("Counts");
+    const sharedB = [qual("project", { id: "P1" })];
+    const entries: Entry[] = [
+      {
+        spec: s,
+        qualifications: {
+          forQueries: { [A]: [qual("sample", { batch: "X" })], [B]: sharedB },
+          forHit: [],
+        },
+      },
+      {
+        spec: s,
+        qualifications: {
+          forQueries: { [A]: [qual("sample", { batch: "Y" })], [B]: sharedB },
+          forHit: [],
+        },
+      },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts [anchor-main: sample batch=X]",
+      "Counts [anchor-main: sample batch=Y]",
+    ]);
+  });
+
+  test("full decoration when every layer carries information", () => {
+    const sA: PColumnSpec = {
+      ...labeledSpec("Counts"),
+      annotations: {
+        [Annotation.Label]: "Counts",
+        [Annotation.Trace]: JSON.stringify([{ type: "stage", label: "RNAseq" }]),
+      },
+    } as PColumnSpec;
+    const sB: PColumnSpec = {
+      ...labeledSpec("Counts"),
+      annotations: {
+        [Annotation.Label]: "Counts",
+        [Annotation.Trace]: JSON.stringify([{ type: "stage", label: "ATACseq" }]),
+      },
+    } as PColumnSpec;
+    const entries: Entry[] = [
+      { spec: sA, linkerPath: [{ spec: linkerSpec("Mapper") }] },
+      {
+        spec: sA,
+        linkerPath: [{ spec: linkerSpec("Mapper") }],
+        qualifications: { forQueries: { [A]: [qual("sample", { batch: "X" })] }, forHit: [] },
+      },
+      { spec: sB, linkerPath: [{ spec: linkerSpec("Mapper") }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts / RNAseq via Mapper",
+      "Counts / RNAseq via Mapper [anchor-main: sample batch=X]",
+      "Counts / ATACseq via Mapper",
+    ]);
+  });
+
+  test("identical variants produce identical labels (cannot disambiguate)", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [{ spec: s }, { spec: s }];
+    expect(deriveDistinctLabels(entries)).toEqual(["Counts", "Counts"]);
+  });
+
+  test("axis-only qualification (no contextDomain) renders as axis name", () => {
+    const s = labeledSpec("Counts");
+    const entries: Entry[] = [
+      { spec: s, qualifications: { forQueries: { [A]: [qual("sample")] }, forHit: [] } },
+      { spec: s, qualifications: { forQueries: { [A]: [qual("gene")] }, forHit: [] } },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts [anchor-main: sample]",
+      "Counts [anchor-main: gene]",
+    ]);
+  });
 });

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -289,8 +289,6 @@ test.each<{ name: string; traces: Trace[]; labels: string[]; forceTraceElements:
   },
 );
 
-// --- Entry with { spec, extraTrace } ---
-
 test("Entry with extraTrace (suffix, default) appends to labels", () => {
   const spec = createSpec({
     annotations: {
@@ -318,8 +316,6 @@ test("Entry with extraTrace position prefix prepends to labels", () => {
   const labels = deriveDistinctLabels(entries);
   expect(labels).toEqual(["P1", "P2"]);
 });
-
-// --- linkerPath ---
 
 test("linkerPath appends default 'via' suffix when needed for uniqueness", () => {
   const entries: Entry[] = [
@@ -438,8 +434,6 @@ test("linkerPath falls back to Label when LinkLabel is absent", () => {
   const labels = deriveDistinctLabels(entries);
   expect(labels).toEqual(["Col", "Col via FallbackLabel"]);
 });
-
-// --- formatters: nativeLabel / hitQualification / anchorQualification / linkerStepQualification ---
 
 test("formatters.native customizes label rendering", () => {
   const s = ((label: string) =>
@@ -562,8 +556,6 @@ test("formatters.linkerStepQualification controls inline step quals", () => {
   expect(labels).toEqual(["Counts via Mapper (X)", "Counts via Mapper (Y)"]);
 });
 
-// --- addLabelAsSuffix ---
-
 test("addLabelAsSuffix places native label at the end", () => {
   const specs = tracesToSpecs([[{ type: "t1", label: "L1" }], [{ type: "t1", label: "L2" }]]);
   const labels = deriveDistinctLabels(specs, {
@@ -572,8 +564,6 @@ test("addLabelAsSuffix places native label at the end", () => {
   });
   expect(labels).toEqual(["L1 / Label", "L2 / Label"]);
 });
-
-// --- separator ---
 
 test("custom separator is used between label parts", () => {
   const specs = tracesToSpecs([
@@ -594,15 +584,11 @@ test("custom separator is used between label parts", () => {
   expect(labels).toEqual(["A - X", "A - Y", "B - Y"]);
 });
 
-// --- single value ---
-
 test("single value gets its trace label", () => {
   const specs = tracesToSpecs([[{ type: "t1", label: "Only" }]]);
   const labels = deriveDistinctLabels(specs);
   expect(labels).toEqual(["Only"]);
 });
-
-// --- Unlabeled fallback ---
 
 test("Unlabeled fallback when no trace entries match", () => {
   // Two identical specs with identical traces — fallback path
@@ -624,8 +610,6 @@ test("Unlabeled when no traces and no label", () => {
   expect(result.every((r) => r === "Unlabeled")).toBe(true);
 });
 
-// --- repeated type occurrences (secondaryTypes path) ---
-
 test("repeated type occurrences are used as secondary types", () => {
   // Two records where "t1" appears twice in each, with different labels on 2nd occurrence
   const specs = tracesToSpecs([
@@ -643,8 +627,6 @@ test("repeated type occurrences are used as secondary types", () => {
   // t1@2 is secondary since it only appears when there are 2 occurrences
   expect(labels).toEqual(["A", "B"]);
 });
-
-// --- spec without Annotation.Label (only Trace) ---
 
 test("spec without native label uses only trace entries", () => {
   const specs = [
@@ -679,10 +661,6 @@ test("includeNativeLabel with no native label does not break", () => {
   const labels = deriveDistinctLabels(specs, { includeNativeLabel: true });
   expect(labels).toEqual(["X", "Y"]);
 });
-
-// ---------------------------------------------------------------------------
-// v2: linker path + qualifications as additional disambiguation layers
-// ---------------------------------------------------------------------------
 
 describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
   function labeledSpec(label: string, name = "col"): PColumnSpec {

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -112,6 +112,8 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
   const labelForced =
     (options.includeNativeLabel === true || hasAnySynthetic) &&
     stats.countByType.has(LABEL_TYPE_FULL);
+  // Tied to labeled-step presence, not path presence: entries with a non-empty linkerPath
+  // but no labeled steps contribute no LINKER_TYPE trace entry, so they do not count here.
   const linkerForced = stats.countByType.get(LINKER_TYPE_FULL) === values.length;
 
   const forcedSet = new Set<string>();

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -2,23 +2,43 @@ import {
   Annotation,
   parseJson,
   readAnnotation,
+  type AxisQualification,
+  type PObjectId,
   type PObjectSpec,
   type StringifiedJson,
   type Trace,
 } from "@milaboratories/pl-model-common";
 import { throwError } from "@milaboratories/helpers";
 import { isFunction, isNil } from "es-toolkit";
+import type { MatchQualifications } from "../columns/column_collection_builder";
 
 export type { Trace, TraceEntry } from "@milaboratories/pl-model-common";
 
 const DISTANCE_PENALTY = 0.001;
 const LABEL_TYPE = "__LABEL__";
 const LABEL_TYPE_FULL = "__LABEL__@1";
+const LINKER_TYPE = "__LINKER__";
+const LINKER_TYPE_FULL = "__LINKER__@1";
+const HIT_QUAL_TYPE = "__HIT_QUAL__";
+const ANCHOR_QUAL_TYPE_PREFIX = "__ANCHOR_QUAL__:";
+
+function isAnchorQualType(t: string): boolean {
+  return t.startsWith(ANCHOR_QUAL_TYPE_PREFIX);
+}
+
+function isSyntheticType(t: string): boolean {
+  return t === LINKER_TYPE || t === HIT_QUAL_TYPE || isAnchorQualType(t);
+}
 
 /** SDK-internal trace shape — adds fields used by this algorithm only, not part of the on-disk contract. */
 type ExtendedTraceEntry = Trace[number] & {
   importance?: number;
   position?: "prefix" | "suffix";
+};
+
+export type LinkerStep = {
+  spec: PObjectSpec;
+  qualifications?: AxisQualification[];
 };
 
 export type Entry =
@@ -27,27 +47,55 @@ export type Entry =
       spec: PObjectSpec;
       /** Extra trace entries merged with the base trace from annotations. */
       extraTrace?: ExtendedTraceEntry[];
-      /** Linker steps traversed to discover this column; used to append "via $linkLabel" to derived labels. */
-      linkerPath?: { spec: PObjectSpec }[];
+      /** Linker steps traversed to discover this column; rendered as "via …" only when needed for uniqueness. */
+      linkerPath?: LinkerStep[];
+      /** Axis qualifications applied to the hit column / already-bound anchors; rendered as "[…]" suffixes. */
+      qualifications?: MatchQualifications;
     };
 
-export type DeriveLabelsOptions = {
-  /** Separator to use between label parts (" / " by default) */
-  separator?: string;
-  /** If true, label will be added as suffix (at the end of the generated label). By default label added as a prefix. */
-  addLabelAsSuffix?: boolean;
-  /** Force inclusion of native column label */
-  includeNativeLabel?: boolean;
-  /** Trace elements list that will be forced to be included in the label. */
-  forceTraceElements?: string[];
-  /** Custom formatter for linker path suffix. Receives the array of linker labels from the full traversal chain,
-   *  the column spec, and the column index.
-   *  If returns undefined, no linker suffix is appended. By default labels are joined with " > " and prefixed with "via ". */
-  linkerLabelFormatter?: (
-    linkerLabels: string[],
+/**
+ * Per-zone formatters. Each one receives raw inputs and returns the rendered text for that zone,
+ * or `undefined` to suppress the zone entirely (no synthetic injection → no minimization, no render).
+ */
+export type DeriveLabelsFormatters = {
+  /** Native column label. Default: identity. `undefined` → label entry not added (treated as if spec had no label). */
+  native?: (label: string, spec: PObjectSpec, index: number) => string | undefined;
+  /** Linker zone (whole "via …" piece). Receives step labels with step-quals already inlined.
+   *  Default: `via ${steps.join(" > ")}`. */
+  linker?: (linkerLabels: string[], spec: PObjectSpec, index: number) => string | undefined;
+  /** Per-step linker qualifications inlined into the step base label.
+   *  Default: `[${formatQualifications(qs)}]`. `undefined` → step rendered without quals. */
+  linkerStepQualification?: (
+    qualifications: AxisQualification[],
+    stepIndex: number,
+    stepSpec: PObjectSpec,
+  ) => string | undefined;
+  /** Hit-axis qualifications block. Default: `[${formatQualifications(qs)}]`. */
+  hitQualification?: (
+    qualifications: AxisQualification[],
     spec: PObjectSpec,
     index: number,
   ) => string | undefined;
+  /** Per-anchor qualifications block. Default: `[${anchorId}: ${formatQualifications(qs)}]`. */
+  anchorQualification?: (
+    anchorId: PObjectId,
+    qualifications: AxisQualification[],
+    spec: PObjectSpec,
+    index: number,
+  ) => string | undefined;
+};
+
+export type DeriveLabelsOptions = {
+  /** Separator to use between label parts (" / " by default). */
+  separator?: string;
+  /** If true, native label is appended at the end of the trace zone. By default it is prepended (label is the most important name). */
+  addLabelAsSuffix?: boolean;
+  /** Force inclusion of native column label even when not needed for uniqueness. */
+  includeNativeLabel?: boolean;
+  /** Trace types that must be included in the label. */
+  forceTraceElements?: string[];
+  /** Per-zone custom formatters. Returning `undefined` from any formatter suppresses the corresponding zone. */
+  formatters?: DeriveLabelsFormatters;
 };
 
 export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptions = {}): string[] {
@@ -57,23 +105,19 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
       : undefined;
   const separator = options.separator ?? " / ";
 
-  // Collect per-entry linker suffixes before disambiguation
-  const linkerSuffixes = values.map((v, i) => {
-    const spec = "spec" in v && typeof v.spec === "object" ? v.spec : (v as PObjectSpec);
-    const linkerLabels = extractLinkerLabels(v);
-    if (linkerLabels.length === 0) return undefined;
-    return isFunction(options.linkerLabelFormatter)
-      ? options.linkerLabelFormatter(linkerLabels, spec, i)
-      : `via ${linkerLabels.join(" > ")}`;
-  });
-
-  // Phase 1: enrich each value with parsed trace
-  const records = values.map((v) => enrichRecord(v, options));
-
-  // Phase 2: collect global type statistics
+  const records = values.map((v, i) => enrichRecord(v, i, options));
   const stats = collectTypeStats(records);
 
-  // Phase 3: classify types into main (present everywhere) and secondary
+  const hasAnySynthetic = records.some((r) => r.fullTrace.some((ft) => isSyntheticType(ft.type)));
+  const labelForced =
+    (options.includeNativeLabel === true || hasAnySynthetic) &&
+    stats.countByType.has(LABEL_TYPE_FULL);
+  const linkerForced = stats.countByType.get(LINKER_TYPE_FULL) === values.length;
+
+  const forcedSet = new Set<string>();
+  if (labelForced) forcedSet.add(LABEL_TYPE_FULL);
+  if (linkerForced) forcedSet.add(LINKER_TYPE_FULL);
+
   const { mainTypes, secondaryTypes } = classifyTypes(stats, values.length);
 
   const build = (typeSet: Set<string>, force: boolean) =>
@@ -83,28 +127,16 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
     if (secondaryTypes.length !== 0)
       throw new Error("Non-empty secondary types list while main types list is empty.");
 
-    return applyLinkerSuffixes(
-      build(new Set(LABEL_TYPE_FULL), true) ??
-        throwError("Failed to derive labels using native column labels"),
-      linkerSuffixes,
+    return (
+      build(new Set([LABEL_TYPE_FULL]), true) ??
+      throwError("Failed to derive labels using native column labels")
     );
   }
 
-  // Phase 4: search for minimal type set that produces unique labels
-  //
-  // includedCount = 2
-  // *  *
-  // T0 T1 T2 T3 T4 T5
-  //          *
-  // additionalType = 3
-  //
-  // Resulting set: T0, T1, T3
-  //
   let includedCount = 0;
   let additionalType = -1;
   while (includedCount < mainTypes.length) {
-    const currentSet = new Set<string>();
-    if (options.includeNativeLabel) currentSet.add(LABEL_TYPE_FULL);
+    const currentSet = new Set<string>(forcedSet);
     for (let i = 0; i < includedCount; ++i) currentSet.add(mainTypes[i]);
     if (additionalType >= 0) currentSet.add(mainTypes[additionalType]);
 
@@ -115,13 +147,10 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
         records,
         stats,
         forceTraceElements,
-        options,
+        forcedSet,
         separator,
       );
-      return applyLinkerSuffixes(
-        build(minimized, false) ?? throwError("Failed to derive unique labels"),
-        linkerSuffixes,
-      );
+      return build(minimized, false) ?? throwError("Failed to derive unique labels");
     }
 
     additionalType++;
@@ -131,42 +160,16 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
     }
   }
 
-  // Fallback: include all types, then minimize
-  const fallbackSet = new Set([...mainTypes, ...secondaryTypes]);
+  const fallbackSet = new Set([...forcedSet, ...mainTypes, ...secondaryTypes]);
   const minimized = minimizeTypeSet(
     fallbackSet,
     records,
     stats,
     forceTraceElements,
-    options,
+    forcedSet,
     separator,
   );
-  return applyLinkerSuffixes(
-    build(minimized, true) ?? throwError("Failed to derive unique labels"),
-    linkerSuffixes,
-  );
-}
-
-/** Apply pre-formatted linker suffixes to labels that have them. */
-function applyLinkerSuffixes(labels: string[], suffixes: (string | undefined)[]): string[] {
-  return labels.map((label, i) => (isNil(suffixes[i]) ? label : `${label} ${suffixes[i]}`));
-}
-
-/** Extract linker labels from every step of the linkers path. */
-function extractLinkerLabels(entry: Entry): string[] {
-  if (!("spec" in entry) || typeof entry.spec !== "object") return [];
-  const path = entry.linkerPath;
-  if (path === undefined || path.length === 0) return [];
-  const labels: string[] = [];
-  for (const step of path) {
-    const label = (
-      readAnnotation(step.spec, Annotation.LinkLabel) ?? readAnnotation(step.spec, Annotation.Label)
-    )?.trim();
-    if (label !== undefined && label.length > 0) {
-      labels.push(label);
-    }
-  }
-  return labels;
+  return build(minimized, true) ?? throwError("Failed to derive unique labels");
 }
 
 // --- Pure helpers ---
@@ -176,17 +179,55 @@ type EnrichedRecord = {
   fullTrace: FullTraceEntry[];
 };
 
-function extractSpecAndTrace(entry: Entry): {
+function extractEntryParts(entry: Entry): {
   spec: PObjectSpec;
   extraTrace: ExtendedTraceEntry[] | undefined;
-  linkerPath: { spec: PObjectSpec }[] | undefined;
+  linkerPath: LinkerStep[] | undefined;
+  qualifications: MatchQualifications | undefined;
 } {
   const isEnriched = "spec" in entry && typeof entry.spec === "object";
+  if (!isEnriched) {
+    return {
+      spec: entry as PObjectSpec,
+      extraTrace: undefined,
+      linkerPath: undefined,
+      qualifications: undefined,
+    };
+  }
   return {
-    spec: isEnriched ? entry.spec : (entry as PObjectSpec),
-    extraTrace: isEnriched ? entry.extraTrace : undefined,
-    linkerPath: isEnriched ? entry.linkerPath : undefined,
+    spec: entry.spec,
+    extraTrace: entry.extraTrace,
+    linkerPath: entry.linkerPath,
+    qualifications: entry.qualifications,
   };
+}
+
+function formatQualification(q: AxisQualification): string {
+  const ctx = q.contextDomain ?? {};
+  const keys = Object.keys(ctx);
+  if (keys.length === 0) return q.axis.name;
+  const pairs = keys.map((k) => `${k}=${ctx[k]}`).join(", ");
+  return Object.prototype.hasOwnProperty.call(ctx, q.axis.name) ? pairs : `${q.axis.name} ${pairs}`;
+}
+
+function formatQualifications(qs: AxisQualification[]): string {
+  return qs.map(formatQualification).join("; ");
+}
+
+function computeStepLabel(
+  step: LinkerStep,
+  stepIndex: number,
+  formatters: DeriveLabelsFormatters | undefined,
+): string | undefined {
+  const base = (
+    readAnnotation(step.spec, Annotation.LinkLabel) ?? readAnnotation(step.spec, Annotation.Label)
+  )?.trim();
+  if (isNil(base) || base.length === 0) return undefined;
+  if (step.qualifications === undefined || step.qualifications.length === 0) return base;
+  const qualText = isFunction(formatters?.linkerStepQualification)
+    ? formatters.linkerStepQualification(step.qualifications, stepIndex, step.spec)
+    : `[${formatQualifications(step.qualifications)}]`;
+  return isNil(qualText) ? base : `${base} ${qualText}`;
 }
 
 function buildFullTrace(trace: ExtendedTraceEntry[]): FullTraceEntry[] {
@@ -208,22 +249,65 @@ function buildFullTrace(trace: ExtendedTraceEntry[]): FullTraceEntry[] {
   return result;
 }
 
-function enrichRecord(value: Entry, options: DeriveLabelsOptions): EnrichedRecord {
-  const { spec, extraTrace } = extractSpecAndTrace(value);
+function enrichRecord(value: Entry, index: number, options: DeriveLabelsOptions): EnrichedRecord {
+  const { spec, extraTrace, linkerPath, qualifications } = extractEntryParts(value);
+  const formatters = options.formatters;
 
-  const label = readAnnotation(spec, Annotation.Label);
+  const rawLabel = readAnnotation(spec, Annotation.Label);
   const traceStr = readAnnotation(spec, Annotation.Trace);
   const baseTrace = traceStr
     ? (parseJson(traceStr as StringifiedJson<ExtendedTraceEntry[]>) ?? [])
     : [];
   const prefixExtra = extraTrace?.filter((e) => e.position === "prefix") ?? [];
   const suffixExtra = extraTrace?.filter((e) => e.position !== "prefix") ?? [];
-  const trace = [...prefixExtra, ...baseTrace, ...suffixExtra];
+  const trace: ExtendedTraceEntry[] = [...prefixExtra, ...baseTrace, ...suffixExtra];
 
-  if (label !== undefined) {
-    const labelEntry = { label, type: LABEL_TYPE, importance: -2 };
-    if (options.addLabelAsSuffix) trace.push(labelEntry);
-    else trace.splice(0, 0, labelEntry);
+  if (!isNil(rawLabel)) {
+    const label = isFunction(formatters?.native)
+      ? formatters.native(rawLabel, spec, index)
+      : rawLabel;
+    if (!isNil(label)) {
+      const labelEntry = { label, type: LABEL_TYPE, importance: -2 };
+      if (options.addLabelAsSuffix === true) trace.push(labelEntry);
+      else trace.splice(0, 0, labelEntry);
+    }
+  }
+
+  if (linkerPath !== undefined && linkerPath.length > 0) {
+    const stepLabels = linkerPath
+      .map((step, i) => computeStepLabel(step, i, formatters))
+      .filter((s): s is string => !isNil(s));
+    if (stepLabels.length > 0) {
+      const linkerText = isFunction(formatters?.linker)
+        ? formatters.linker(stepLabels, spec, index)
+        : `via ${stepLabels.join(" > ")}`;
+      if (!isNil(linkerText)) {
+        trace.push({ type: LINKER_TYPE, label: linkerText, importance: -10 });
+      }
+    }
+  }
+
+  if (qualifications !== undefined) {
+    for (const [anchorId, qs] of Object.entries(qualifications.forQueries)) {
+      if (qs.length === 0) continue;
+      const anchorText = isFunction(formatters?.anchorQualification)
+        ? formatters.anchorQualification(anchorId as PObjectId, qs, spec, index)
+        : `[${anchorId}: ${formatQualifications(qs)}]`;
+      if (isNil(anchorText)) continue;
+      trace.push({
+        type: `${ANCHOR_QUAL_TYPE_PREFIX}${anchorId}`,
+        label: anchorText,
+        importance: -11,
+      });
+    }
+    if (qualifications.forHit.length > 0) {
+      const hitText = isFunction(formatters?.hitQualification)
+        ? formatters.hitQualification(qualifications.forHit, spec, index)
+        : `[${formatQualifications(qualifications.forHit)}]`;
+      if (!isNil(hitText)) {
+        trace.push({ type: HIT_QUAL_TYPE, label: hitText, importance: -12 });
+      }
+    }
   }
 
   return { fullTrace: buildFullTrace(trace) };
@@ -283,20 +367,40 @@ function buildLabels(
   const result: string[] = [];
 
   for (const r of records) {
-    const parts: string[] = [];
+    const traceParts: string[] = [];
+    const anchorParts: string[] = [];
+    let linkerLabel: string | undefined;
+    let hitLabel: string | undefined;
+
     for (const ft of r.fullTrace) {
-      if (includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type)) {
-        parts.push(ft.label);
-      }
+      if (!(includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type))) continue;
+      if (ft.type === LINKER_TYPE) linkerLabel = ft.label;
+      else if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
+      else if (isAnchorQualType(ft.type)) anchorParts.push(ft.label);
+      else traceParts.push(ft.label);
     }
 
-    if (parts.length === 0) {
+    const isEmpty =
+      traceParts.length === 0 &&
+      anchorParts.length === 0 &&
+      linkerLabel === undefined &&
+      hitLabel === undefined;
+
+    if (isEmpty) {
       if (!force) return undefined;
       result.push("Unlabeled");
       continue;
     }
 
-    result.push(parts.join(separator));
+    let label = traceParts.join(separator);
+    const append = (part: string) => {
+      label = label.length === 0 ? part : `${label} ${part}`;
+    };
+    if (linkerLabel !== undefined) append(linkerLabel);
+    for (const a of anchorParts) append(a);
+    if (hitLabel !== undefined) append(hitLabel);
+
+    result.push(label);
   }
 
   return result;
@@ -312,7 +416,7 @@ function minimizeTypeSet(
   records: EnrichedRecord[],
   stats: TypeStats,
   forceTraceElements: Set<string> | undefined,
-  options: DeriveLabelsOptions,
+  forcedSet: Set<string>,
   separator: string,
 ): Set<string> {
   const initialResult = buildLabels(records, typeSet, forceTraceElements, separator, false);
@@ -322,11 +426,7 @@ function minimizeTypeSet(
   const result = new Set(typeSet);
 
   const removable = [...result]
-    .filter(
-      (t) =>
-        !forceTraceElements?.has(t.split("@")[0]) &&
-        !(options.includeNativeLabel && t === LABEL_TYPE_FULL),
-    )
+    .filter((t) => !forceTraceElements?.has(t.split("@")[0]) && !forcedSet.has(t))
     .sort((a, b) => (stats.importances.get(a) ?? 0) - (stats.importances.get(b) ?? 0));
 
   for (const typeToRemove of removable) {

--- a/sdk/model/src/labels/derive_distinct_tooltips.test.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.test.ts
@@ -110,22 +110,6 @@ describe("deriveDistinctTooltips", () => {
     expect(tooltip).toContain("sample context: batch=B");
   });
 
-  test("distinctiveQualifications produces Distinctive section", () => {
-    const entries: TooltipEntry[] = [
-      {
-        spec: createSpec("col1", "Col 1"),
-        distinctiveQualifications: {
-          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "A" })] },
-          forHit: [axisQualification("gene", { source: "Y" })],
-        },
-      },
-    ];
-    const [tooltip] = deriveDistinctTooltips(entries);
-    expect(tooltip).toContain("Distinctive (what separates this variant)");
-    expect(tooltip).toContain("main: sample context: batch=A");
-    expect(tooltip).toContain("hit: gene context: source=Y");
-  });
-
   test("variantCount > 1 adds Variant N of M line in header", () => {
     const entries: TooltipEntry[] = [
       {
@@ -195,21 +179,16 @@ describe("deriveDistinctTooltips", () => {
           forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "B" })] },
           forHit: [axisQualification("sample", { batch: "B" })],
         },
-        distinctiveQualifications: {
-          forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "B" })] },
-          forHit: [],
-        },
       },
     ];
     const [tooltip] = deriveDistinctTooltips(entries);
     expect(tooltip).toBeDefined();
     const sections = tooltip!.split("\n\n");
-    expect(sections.length).toBe(5);
+    expect(sections.length).toBe(4);
     expect(sections[0]).toContain("Variant: 2 of 2");
     expect(sections[1]).toContain("Origin path");
     expect(sections[2]).toContain("Anchors");
     expect(sections[3]).toContain("Hit column qualifications");
-    expect(sections[4]).toContain("Distinctive");
   });
 
   test("parallel results — array aligns with input", () => {

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -11,10 +11,8 @@ import type { MatchQualifications, MatchVariant } from "../columns";
 export type TooltipEntry = {
   /** Main column spec — used for column-name fallback when no label. */
   spec: PColumnSpec;
-  /** Full qualifications carried by this variant. */
+  /** Qualifications carried by this variant. */
   qualifications?: MatchQualifications;
-  /** Minimal qualifications that separate this variant from its siblings. */
-  distinctiveQualifications?: MatchQualifications;
   /** Linker steps traversed to reach the hit column. */
   linkerPath?: MatchVariant["path"];
   /** Position of this variant within the same physical column (1-based). */
@@ -42,9 +40,6 @@ function formatTooltip(entry: TooltipEntry): undefined | string {
 
   const hit = formatHit(entry.qualifications);
   if (hit !== undefined) sections.push(hit);
-
-  const distinctive = formatDistinctive(entry.distinctiveQualifications);
-  if (distinctive !== undefined) sections.push(distinctive);
 
   if (sections.length <= 1) return undefined;
   return sections.join("\n\n");
@@ -102,18 +97,6 @@ function formatHit(q: undefined | MatchQualifications): undefined | string {
   const rendered = formatAxisQualifications(q.forHit);
   if (rendered === undefined) return undefined;
   return ["Hit column qualifications", `${BULLET_1}${rendered}`].join("\n");
-}
-
-function formatDistinctive(q: undefined | MatchQualifications): undefined | string {
-  if (isNil(q)) return undefined;
-  const bullets: string[] = [];
-  for (const id of Object.keys(q.forQueries)) {
-    for (const item of q.forQueries[id as PObjectId])
-      bullets.push(`${BULLET_1}${id}: ${formatQualification(item)}`);
-  }
-  for (const item of q.forHit) bullets.push(`${BULLET_1}hit: ${formatQualification(item)}`);
-  if (bullets.length === 0) return undefined;
-  return ["Distinctive (what separates this variant)", ...bullets].join("\n");
 }
 
 function formatAxisQualifications(qs: AxisQualification[]): undefined | string {


### PR DESCRIPTION
- Updated `deriveDistinctLabels` to support qualifications and linker paths for better label disambiguation.
- Enhanced `deriveAllLabels` to process qualifications and linker steps, improving label generation logic.
- Removed `distinctiveQualifications` from tooltip entries, simplifying tooltip formatting.
- Adjusted tests to reflect changes in label generation and tooltip structure, ensuring consistency and correctness.
- Introduced formatters for custom label rendering, allowing more flexible label outputs based on qualifications and linker paths.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors `PlDataTable` label generation to treat the linker path and axis qualifications as first-class disambiguation layers: they are now injected as synthetic trace entries that participate in the same minimization loop as regular trace types, replacing the previous always-on suffix approach. The `distinctiveQualifications` field is removed from tooltips, and `TableColumnSnapshot` is renamed to `TableColumnVariant` throughout. All changes are well-tested with an extensive new scenario-driven suite.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all findings are style/documentation concerns with no runtime impact on current callers.

No P0/P1 issues found. Three P2 items: an unguarded length assumption in withVariantColumns, an as never cast in a test fixture, and an undocumented invariant around linkerForced. The core algorithm change is well-exercised by the new test suite.

sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts (withVariantColumns) and sdk/model/src/labels/derive_distinct_labels.ts (linkerForced invariant)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/model/src/labels/derive_distinct_labels.ts | Core label-derivation refactor: linker path and qualifications now injected as synthetic trace entries participating in the disambiguation loop, with new formatters API replacing linkerLabelFormatter |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | TableColumnSnapshot replaced with TableColumnVariant; introduces withVariantColumns helper that relies on an implicit length-preservation invariant from its fn argument |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts | LabelableColumn.linkerPath updated to MatchVariant["path"] and qualifications added; deriveAllLabels builds Entry objects including per-step qualifications for disambiguation |
| sdk/model/src/columns/column_collection_builder.ts | Adds ColumnVariant interface and findColumnVariants method; flattens ColumnMatch variants into individual ColumnVariant entries |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts | Single test fixture updated to use the new MatchVariant["path"] shape for linkerPath; uses as never cast to bypass type-checking of the inner ColumnSnapshot fields |
| sdk/model/src/labels/derive_distinct_labels.test.ts | Extensive new test suite for qualification-based disambiguation; linker-path tests rewritten to reflect on-demand (not always-on) suffix behavior |
| sdk/model/src/labels/derive_distinct_tooltips.ts | Removes distinctiveQualifications from TooltipEntry and the corresponding formatDistinctive section; simplifies tooltip formatting |
| sdk/model/src/labels/derive_distinct_tooltips.test.ts | Removes tests for distinctiveQualifications section; adjusts section-count assertion from 5 to 4 |
| etc/blocks/table-test/model/src/index.ts | Updates linkerLabelFormatter to new formatters.linker API; straightforward rename |
| sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts | Switches from findColumns/mapToDiscoveredColumns to findColumnVariants/mapToTableColumnVariants; flattening of match variants now happens in column_collection_builder instead |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts`, line 546 ([link](https://github.com/milaboratory/platforma/blob/1e5cb8af3fee04b132b087d8274ba00d4c864b59/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts#L546)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`as never` bypasses type-safety in test fixture**

   The `as never` cast is used because `{ id, spec }` is missing the required `ColumnSnapshot` fields (`data`, `dataStatus`). This silently drops the type check that guards the `MatchVariant["path"]` element shape. If the `ColumnSnapshot` interface gains additional required fields, this test will still compile but fail at runtime.

   The fixture should either use a proper stub that satisfies `ColumnSnapshot<PObjectId>`, or `as ColumnSnapshot<PObjectId>` (narrower cast) to at least document the intent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
   Line: 546

   Comment:
   **`as never` bypasses type-safety in test fixture**

   The `as never` cast is used because `{ id, spec }` is missing the required `ColumnSnapshot` fields (`data`, `dataStatus`). This silently drops the type check that guards the `MatchVariant["path"]` element shape. If the `ColumnSnapshot` interface gains additional required fields, this test will still compile but fail at runtime.

   The fixture should either use a proper stub that satisfies `ColumnSnapshot<PObjectId>`, or `as ColumnSnapshot<PObjectId>` (narrower cast) to at least document the intent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
Line: 319-326

Comment:
**Implicit length-preservation contract in `withVariantColumns`**

`variants.map((v, i) => ({ ...v, column: cols[i] }))` silently produces `{ column: undefined }` entries if `fn` returns a shorter or reordered array. TypeScript does not enforce that the returned slice matches the input length, so a future caller passing a filtering transform would corrupt `qualifications`, `path`, `originalId`, and `isPrimary` without any type error or runtime warning.

Consider adding an assertion to make the invariant explicit:

```suggestion
function withVariantColumns<V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId> }>(
  variants: V[],
  fn: (cols: ColumnSnapshot<DiscoveredPColumnId>[]) => ColumnSnapshot<DiscoveredPColumnId>[],
): V[] {
  const cols = fn(variants.map((v) => v.column));
  if (cols.length !== variants.length)
    throw new Error(`withVariantColumns: fn must preserve array length (got ${cols.length}, expected ${variants.length})`);
  return variants.map((v, i) => ({ ...v, column: cols[i] }));
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
Line: 546

Comment:
**`as never` bypasses type-safety in test fixture**

The `as never` cast is used because `{ id, spec }` is missing the required `ColumnSnapshot` fields (`data`, `dataStatus`). This silently drops the type check that guards the `MatchVariant["path"]` element shape. If the `ColumnSnapshot` interface gains additional required fields, this test will still compile but fail at runtime.

The fixture should either use a proper stub that satisfies `ColumnSnapshot<PObjectId>`, or `as ColumnSnapshot<PObjectId>` (narrower cast) to at least document the intent.

```suggestion
        [{ linker: { id: "lk" as PObjectId, spec: linkerSpec } as ColumnSnapshot<PObjectId>, qualifications: [] }],
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/model/src/labels/derive_distinct_labels.ts
Line: 115

Comment:
**`linkerForced` does not account for entries whose linker path has no labeled steps**

`linkerForced` is `true` only when the `LINKER_TYPE_FULL` count equals `values.length`. However, `enrichRecord` only pushes a `LINKER_TYPE` entry when `stepLabels.length > 0` (i.e., at least one linker step carries a label annotation). If one or more entries have a non-empty `linkerPath` but every step is unlabeled, those entries contribute no `LINKER_TYPE` trace entry, so `linkerForced` stays `false` even though all entries "have" a linker path conceptually.

This is probably intentional (no point forcing an empty linker suffix), but it's worth a comment documenting the invariant — the forced flag is tied to labeled-step presence, not path presence.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor label and tooltip handling in P..."](https://github.com/milaboratory/platforma/commit/1e5cb8af3fee04b132b087d8274ba00d4c864b59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30013513)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->