### PR TITLE
feat(pframes): EnrichmentRef + tableBuilder linker support

### DIFF
--- a/.changeset/enrichment-ref-tablebuilder.md
+++ b/.changeset/enrichment-ref-tablebuilder.md
@@ -1,0 +1,45 @@
+---
+"@milaboratories/pl-model-common": minor
+"@platforma-sdk/model": minor
+"@platforma-sdk/workflow-tengo": minor
+"@milaboratories/pf-driver": patch
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pl-middle-layer": patch
+"@platforma-open/milaboratories.software-ptabler": patch
+---
+
+Add `EnrichmentRef` — a versioned envelope around a terminal column hit
+and an ordered linker path, mirroring `PrimaryRef`'s pattern so the
+dependency scanner deep-walks `PlRef`s inside it without changes. Adds
+`EnrichmentStep`, `isEnrichmentRef`, `createEnrichmentRef` exports.
+Today only `linker` steps are supported; the `type` discriminant leaves
+room for future step kinds.
+
+`tableBuilder.addColumn` / `addColumns` accept `EnrichmentRef` and
+`ResolvedEnrichmentRef`. The `:pframes.build-table` ephemeral registers
+the hit + every hop column in the PFrame, calls
+`pframes.build-query.buildQuery` to assemble the query, and hands the
+resulting `SpecQueryJoinEntry` straight to `pt.p._rawQueryEntry` — ptabler
+resolves the linker join natively, no node-by-node translation.
+
+Adds `pt.p._rawQueryEntry(columnsByName, joinEntry)` (internal — `_`
+prefixed) for wrapping a pre-built `SpecQueryJoinEntry` (e.g. from
+`bquery.buildQuery`) into a PEntry. Application code should compose
+with the public builders (`p.column / p.inner / p.linkerJoin / …`).
+
+The spec distiller now preserves the `pl7.app/isLinkerColumn`
+annotation on column specs (all other annotations are still stripped).
+ptabler reads this annotation at execution time to populate the spec
+frame's linker index — without it, `linkerJoin` queries silently
+degrade to inner joins.
+
+Drops the `qualifications` field from the typed shapes of
+`DiscoverColumnsLinkerStep`, `MatchVariant.path[]` items, and
+`DiscoveredPColumn`'s linker path items. Per-step linker qualifications
+were always empty (qualifications attach to query/hit ends, not to
+intermediate steps) — `BuildQuery` already discarded them, and the
+tooltip / `createPlDataTableV3` consumers were forwarding empty arrays.
+
+`DiscoveredPColumnId` no longer carries per-step `qualifications` in
+its canonicalized JSON form. The Rust side still emits the field on
+the wire; the TS deserializer ignores it.

--- a/etc/blocks/filter-column-test/model/src/index.ts
+++ b/etc/blocks/filter-column-test/model/src/index.ts
@@ -1,34 +1,45 @@
-import type { InferHrefType, InferOutputsType } from "@platforma-sdk/model";
-import {
-  BlockModelV3,
-  DataModelBuilder,
-  buildDatasetOptions,
-  createPrimaryRef,
-  isPrimaryRef,
+import type {
+  DatasetSelection,
+  LabeledEnrichmentRefs,
+  InferHrefType,
+  InferOutputsType,
+  PObjectSpec,
+  PrimaryRef,
 } from "@platforma-sdk/model";
-import type { PlRef, PrimaryRef } from "@platforma-sdk/model";
+import { BlockModelV3, DataModelBuilder, buildDatasetOptions } from "@platforma-sdk/model";
 import { z } from "zod";
 
 export const BlockData = z.object({
-  dataset: z.any().optional(),
+  dataset: z.custom<DatasetSelection>().optional(),
 });
 
 export type BlockData = z.infer<typeof BlockData>;
 
 const dataModel = new DataModelBuilder().from<BlockData>("v1").init(() => ({}));
 
+const PRIMARY_NAMES = new Set(["value", "description"]);
+const isPrimaryColumn = (spec: PObjectSpec): boolean =>
+  spec.kind === "PColumn" && PRIMARY_NAMES.has(spec.name);
+
 export const platforma = BlockModelV3.create(dataModel)
 
-  .args<{ dataset: PrimaryRef }>((data) => {
-    const v = data.dataset;
-    if (v === undefined) throw new Error("Select a dataset");
-    const primary: PrimaryRef = isPrimaryRef(v) ? v : createPrimaryRef(v as PlRef);
-    return { dataset: primary };
+  .args<{ dataset: PrimaryRef; enrichments: LabeledEnrichmentRefs }>((data) => {
+    if (data.dataset === undefined) throw new Error("Select a dataset");
+    return {
+      dataset: data.dataset.primary,
+      enrichments: data.dataset.enrichments ?? [],
+    };
   })
 
-  .output("datasetOptions", (ctx) => buildDatasetOptions(ctx))
+  .output("datasetOptions", (ctx) =>
+    buildDatasetOptions(ctx, { primary: isPrimaryColumn, withEnrichments: () => true }),
+  )
 
   .output("tableContent", (ctx) => ctx.outputs?.resolve("tableFile")?.getFileContentAsString())
+
+  .output("tableContentLinker", (ctx) =>
+    ctx.outputs?.resolve("tableFileLinker")?.getFileContentAsString(),
+  )
 
   .sections((_ctx) => [{ type: "link", href: "/", label: "Main" }])
 

--- a/etc/blocks/filter-column-test/test/package.json
+++ b/etc/blocks/filter-column-test/test/package.json
@@ -14,6 +14,7 @@
     "fmt": "ts-builder format"
   },
   "dependencies": {
+    "@milaboratories/milaboratories.test-block-table": "workspace:*",
     "@milaboratories/milaboratories.test-enter-numbers-v3": "workspace:*",
     "@milaboratories/milaboratories.test-enter-numbers-v3.model": "workspace:*",
     "@milaboratories/milaboratories.test-filter-column.model": "workspace:*",

--- a/etc/blocks/filter-column-test/test/src/wf.test.ts
+++ b/etc/blocks/filter-column-test/test/src/wf.test.ts
@@ -1,9 +1,8 @@
 import type { BlockData } from "@milaboratories/milaboratories.test-filter-column.model";
 import type { platforma } from "@milaboratories/milaboratories.test-filter-column.model";
-import { blockSpec as enterNumbersBlockSpec } from "@milaboratories/milaboratories.test-enter-numbers-v3";
-import type { BlockData as EnterNumbersBlockData } from "@milaboratories/milaboratories.test-enter-numbers-v3.model";
+import { blockSpec as tableTestBlockSpec } from "@milaboratories/milaboratories.test-block-table";
 import type { InferBlockState, Platforma } from "@platforma-sdk/model";
-import { createPrimaryRef, wrapOutputs } from "@platforma-sdk/model";
+import { createDatasetSelection, createPrimaryRef, wrapOutputs } from "@platforma-sdk/model";
 import type { ML, RawHelpers } from "@platforma-sdk/test";
 import { awaitStableState, blockTest } from "@platforma-sdk/test";
 import { blockSpec } from "this-block";
@@ -33,17 +32,11 @@ async function runAndGetOutputs<Pl extends Platforma>(
 }
 
 async function setupProject(project: ML.Project, helpers: RawHelpers) {
-  const enterNumbersId = await project.addBlock("Enter Numbers", enterNumbersBlockSpec);
-  await project.mutateBlockStorage(enterNumbersId, {
-    operation: "update-block-data",
-    value: {
-      numbers: [1, 2, 3],
-      labels: ["test"],
-      description: "test data",
-    } satisfies EnterNumbersBlockData,
-  });
-  await project.runBlock(enterNumbersId);
-  await helpers.awaitBlockDone(enterNumbersId, 30000);
+  // Upstream block exports primaries + linker chain; this block whitelists
+  // `value` / `description` as primaries, the rest become enrichments.
+  const tableTestId = await project.addBlock("Table Test Source", tableTestBlockSpec);
+  await project.runBlock(tableTestId);
+  await helpers.awaitBlockDone(tableTestId, 30000);
 
   const blockId = await project.addBlock("Filter Column Test", blockSpec);
   const outputs = await getStableOutputs<typeof platforma>(project, blockId);
@@ -52,47 +45,37 @@ async function setupProject(project: ML.Project, helpers: RawHelpers) {
 }
 
 blockTest(
-  "PrimaryRef → tableBuilder produces correct TSV",
+  "buildDatasetOptions surfaces whitelisted primaries from table-test",
   { timeout: 60000 },
   async ({ rawPrj: project, helpers, expect }) => {
-    const { blockId, outputs } = await setupProject(project, helpers);
+    const { outputs } = await setupProject(project, helpers);
 
     const datasetOptions = outputs.datasetOptions;
     assert(datasetOptions !== undefined, "datasetOptions output missing");
-    assert(datasetOptions.length > 0, "no dataset options in result pool");
+    expect(datasetOptions.length).toBeGreaterThan(0);
 
-    await project.mutateBlockStorage(blockId, {
-      operation: "update-block-data",
-      value: { dataset: createPrimaryRef(datasetOptions[0].ref) } satisfies BlockData,
-    });
-
-    const finalOutputs = await runAndGetOutputs<typeof platforma>(project, helpers, blockId);
-
-    const tableContent = finalOutputs.tableContent;
-    assert(typeof tableContent === "string", "tableContent output missing");
-
-    const lines = tableContent.trim().split("\n");
-
-    // enter-numbers exports: axis "Index" + value "Numbers", 3 rows (0,1,2).
-    expect(lines[0]).toContain("Index");
-    expect(lines[0]).toContain("Numbers");
-    expect(lines.length).toBe(4); // header + 3 data rows
+    const labels = datasetOptions.map((o) => o.primary.label).sort();
+    expect(labels).toEqual(["Description", "Value"].sort());
   },
 );
 
 blockTest(
-  "plain PlRef normalized to PrimaryRef, tableBuilder produces correct TSV",
+  "PrimaryRef → tableBuilder produces a TSV for the picked primary",
   { timeout: 60000 },
   async ({ rawPrj: project, helpers, expect }) => {
     const { blockId, outputs } = await setupProject(project, helpers);
 
     const datasetOptions = outputs.datasetOptions;
     assert(datasetOptions !== undefined, "datasetOptions output missing");
-    assert(datasetOptions.length > 0, "no dataset options in result pool");
+
+    const valueOption = datasetOptions.find((o) => o.primary.label === "Value");
+    assert(valueOption !== undefined, "no `Value` option");
 
     await project.mutateBlockStorage(blockId, {
       operation: "update-block-data",
-      value: { dataset: datasetOptions[0].ref } satisfies BlockData,
+      value: {
+        dataset: createDatasetSelection(createPrimaryRef(valueOption.primary.ref)),
+      } satisfies BlockData,
     });
 
     const finalOutputs = await runAndGetOutputs<typeof platforma>(project, helpers, blockId);
@@ -101,6 +84,44 @@ blockTest(
     assert(typeof tableContent === "string", "tableContent output missing");
 
     const lines = tableContent.trim().split("\n");
-    expect(lines.length).toBe(4);
+    expect(lines.length).toBe(6); // header + 5 rows (A–E on `name`)
+    expect(lines[0]).toContain("Value");
+  },
+);
+
+blockTest(
+  "EnrichmentRef from buildDatasetOptions joins via the linker column",
+  { timeout: 60000 },
+  async ({ rawPrj: project, helpers, expect }) => {
+    const { blockId, outputs } = await setupProject(project, helpers);
+
+    const datasetOptions = outputs.datasetOptions;
+    assert(datasetOptions !== undefined, "datasetOptions output missing");
+
+    const enriched = datasetOptions.find(
+      (o) => (o.enrichments?.length ?? 0) > 0 && o.primary.label === "Value",
+    );
+    assert(enriched !== undefined, "no option with enrichments for `Value`");
+    assert(enriched.enrichments !== undefined && enriched.enrichments.length > 0);
+
+    await project.mutateBlockStorage(blockId, {
+      operation: "update-block-data",
+      value: {
+        dataset: createDatasetSelection(
+          createPrimaryRef(enriched.primary.ref),
+          enriched.enrichments,
+        ),
+      } satisfies BlockData,
+    });
+
+    const finalOutputs = await runAndGetOutputs<typeof platforma>(project, helpers, blockId);
+
+    const tsv = finalOutputs.tableContentLinker;
+    assert(typeof tsv === "string", "tableContentLinker output missing");
+
+    const lines = tsv.trim().split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    expect(lines[0]).toContain("Name");
+    expect(lines[0]).toContain("Value");
   },
 );

--- a/etc/blocks/filter-column-test/workflow/src/main.tpl.tengo
+++ b/etc/blocks/filter-column-test/workflow/src/main.tpl.tengo
@@ -6,9 +6,15 @@ wf.body(func(args) {
 		addPrimary("main", args.dataset).
 		build()
 
+	tableLinker := wf.tableBuilder("tsv").
+		addPrimary("main", args.dataset).
+		addColumns(args.enrichments).
+		build()
+
 	return {
 		outputs: {
-			tableFile: file.exportFile(table)
+			tableFile: file.exportFile(table),
+			tableFileLinker: file.exportFile(tableLinker)
 		},
 		exports: {}
 	}

--- a/etc/blocks/table-test/workflow/src/main.tpl.tengo
+++ b/etc/blocks/table-test/workflow/src/main.tpl.tengo
@@ -447,40 +447,26 @@ wf.body(func(args) {
 	groupLabelPf := xsv.importFile(groupLabelFile, "tsv", groupLabelSpec, importOps)
 	regionLabelPf := xsv.importFile(regionLabelFile, "tsv", regionLabelSpec, importOps)
 
-	// Merge all into a single pframe
+	// Republish every column as a block export so downstream blocks
+	// can discover the linker chain through the result pool.
 	pf := pframes.pFrameBuilder()
-	for k, v in mainPf {
-		pf.add(k, v.spec, v.data)
+	addAll := func(...srcPfs) {
+		for srcPf in srcPfs {
+			for k, v in srcPf {
+				pf.add(k, v.spec, v.data)
+			}
+		}
 	}
-	for k, v in groupPf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in linkerPf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in linkerAltPf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in regionPf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in linker2Pf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in nameLabelPf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in groupLabelPf {
-		pf.add(k, v.spec, v.data)
-	}
-	for k, v in regionLabelPf {
-		pf.add(k, v.spec, v.data)
-	}
+	addAll(mainPf, groupPf, linkerPf, linkerAltPf, regionPf, linker2Pf,
+		nameLabelPf, groupLabelPf, regionLabelPf)
+	pf = pf.build()
 
 	return {
 		outputs: {
-			tableFrame: pframes.exportFrame(pf.build())
+			tableFrame: pframes.exportFrame(pf)
 		},
-		exports: {}
+		exports: {
+			tableFrame: pf
+		}
 	}
 })

--- a/etc/blocks/ui-examples/ui/src/pages/PlDatasetSelectorPage.vue
+++ b/etc/blocks/ui-examples/ui/src/pages/PlDatasetSelectorPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { DatasetOption, PlRef, PrimaryRef } from "@platforma-sdk/model";
-import { createPlRef, createPrimaryRef } from "@platforma-sdk/model";
+import type { DatasetOption, DatasetSelection } from "@platforma-sdk/model";
+import { createDatasetSelection, createPlRef, createPrimaryRef } from "@platforma-sdk/model";
 import {
   PlBlockPage,
   PlCheckbox,
@@ -22,22 +22,23 @@ const data = reactive({
   clearable: true,
   required: false,
   optionsLoading: false,
-  selected: createPrimaryRef(datasetWithFilters, filterTop1000) as PrimaryRef | PlRef | undefined,
-  plainRefSelected: datasetWithoutFilters as PrimaryRef | PlRef | undefined,
-  emptyOptionsSelected: undefined as PrimaryRef | PlRef | undefined,
+  selected: createDatasetSelection(createPrimaryRef(datasetWithFilters, filterTop1000)) as
+    | DatasetSelection
+    | undefined,
+  secondSelected: undefined as DatasetSelection | undefined,
+  emptyOptionsSelected: undefined as DatasetSelection | undefined,
 });
 
 const optionsBase: DatasetOption[] = [
   {
-    label: "Leads — Clonotypes",
-    ref: datasetWithFilters,
+    primary: { label: "Leads — Clonotypes", ref: datasetWithFilters },
     filters: [
       { label: "Top 1000", ref: filterTop1000 },
       { label: "High confidence", ref: filterHighConfidence },
     ],
   },
   // No `filters` — component hides the filter dropdown when this is picked.
-  { label: "Raw — Clonotypes", ref: datasetWithoutFilters },
+  { primary: { label: "Raw — Clonotypes", ref: datasetWithoutFilters } },
 ];
 
 const options = computed<readonly DatasetOption[] | undefined>(() =>
@@ -73,13 +74,13 @@ const emptyOptions = computed<readonly DatasetOption[] | undefined>(() =>
           />
 
           <PlDatasetSelector
-            v-model="data.plainRefSelected"
+            v-model="data.secondSelected"
             :options="options"
             :disabled="data.disabled"
             :clearable="data.clearable"
             :required="data.required"
-            label="Backward compat (plain PlRef modelValue)"
-            helper="Selected value is a plain PlRef — the component normalizes it."
+            label="Second instance"
+            helper="Independent v-model — picks its own dataset/filter pair."
           />
 
           <PlDatasetSelector

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -1,6 +1,6 @@
 import { Branded, throwError } from "@milaboratories/helpers";
 import { PObjectId } from "../../../pool";
-import { AxisQualification } from "../spec_driver";
+import { AxisQualification } from "./selectors";
 import { canonicalizeJson } from "../../../json";
 
 export type DiscoveredPColumn = {
@@ -15,7 +15,6 @@ export type DiscoveredPColumnId = Branded<PObjectId, "DiscoveredPColumnId">; // 
 type PathItem = {
   type: "linker";
   column: PObjectId;
-  qualifications: AxisQualification[];
 };
 
 export function isDiscoveredPColumn(obj: unknown): obj is DiscoveredPColumn {

--- a/lib/model/common/src/drivers/pframe/spec/selectors.ts
+++ b/lib/model/common/src/drivers/pframe/spec/selectors.ts
@@ -1,4 +1,10 @@
 import { isPColumnSpec, type PObjectSpec } from "../../../pool";
+import type {
+  MatcherMap,
+  MultiAxisSelector,
+  MultiColumnSelector,
+  StringMatcher,
+} from "../spec_driver";
 import type { AxisId, AxisValueType, Domain, PColumnSpec, ValueType } from "./spec";
 import { getAxisId } from "./spec";
 
@@ -60,6 +66,14 @@ export interface SingleAxisSelector {
   domain?: Domain;
   /** Parent axes requirements (optional) */
   parentAxes?: SingleAxisSelector[];
+}
+
+/** Qualification applied to a single axis to make it compatible during integration. */
+export interface AxisQualification {
+  /** Axis selector identifying which axis is qualified. */
+  readonly axis: SingleAxisSelector;
+  /** Additional context domain entries applied to the axis. */
+  readonly contextDomain: Record<string, string>;
 }
 
 /**
@@ -311,4 +325,75 @@ export function legacyColumnSelectorsToPredicate(
     return (spec) =>
       predicateOrSelectors.some((selector) => isPColumnSpec(spec) && matchPColumn(spec, selector));
   else return (spec) => isPColumnSpec(spec) && matchPColumn(spec, predicateOrSelectors);
+}
+
+function matchString(matcher: StringMatcher, value: string): boolean {
+  return matcher.type === "exact" ? value === matcher.value : new RegExp(matcher.value).test(value);
+}
+
+function matchMatcherMap(map: MatcherMap, target: Record<string, string> | undefined): boolean {
+  const t = target ?? {};
+  for (const [key, matchers] of Object.entries(map)) {
+    const v = t[key];
+    if (v === undefined) return false;
+    if (!matchers.some((m) => matchString(m, v))) return false;
+  }
+  return true;
+}
+
+function matchMultiAxis(selector: MultiAxisSelector, axis: AxisId): boolean {
+  if (selector.type !== undefined && !selector.type.includes(axis.type)) return false;
+  if (selector.name !== undefined && !selector.name.some((m) => matchString(m, axis.name)))
+    return false;
+  if (selector.domain !== undefined && !matchMatcherMap(selector.domain, axis.domain)) return false;
+  if (
+    selector.contextDomain !== undefined &&
+    !matchMatcherMap(selector.contextDomain, axis.contextDomain)
+  )
+    return false;
+  return true;
+}
+
+/** Match a {@link PColumnSpec} against a {@link MultiColumnSelector}. */
+export function matchMultiColumnSelector(
+  spec: PColumnSpec,
+  selector: MultiColumnSelector,
+): boolean {
+  if (selector.type !== undefined && !selector.type.includes(spec.valueType)) return false;
+  if (selector.name !== undefined && !selector.name.some((m) => matchString(m, spec.name)))
+    return false;
+  if (selector.domain !== undefined && !matchMatcherMap(selector.domain, spec.domain)) return false;
+  if (
+    selector.contextDomain !== undefined &&
+    !matchMatcherMap(selector.contextDomain, spec.contextDomain)
+  )
+    return false;
+  if (
+    selector.annotations !== undefined &&
+    !matchMatcherMap(selector.annotations, spec.annotations)
+  )
+    return false;
+  if (selector.axes !== undefined) {
+    const columnAxes = spec.axesSpec.map(getAxisId);
+    if (selector.partialAxesMatch ?? true) {
+      for (const axisSelector of selector.axes)
+        if (!columnAxes.some((axis) => matchMultiAxis(axisSelector, axis))) return false;
+    } else {
+      if (columnAxes.length !== selector.axes.length) return false;
+      for (let i = 0; i < selector.axes.length; i++)
+        if (!matchMultiAxis(selector.axes[i], columnAxes[i])) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Convert a {@link MultiColumnSelector} (or array; selectors OR-ed) to a predicate.
+ * Non-PColumn specs always return false.
+ */
+export function multiColumnSelectorsToPredicate(
+  selectors: MultiColumnSelector | MultiColumnSelector[],
+): (spec: PObjectSpec) => boolean {
+  const arr = Array.isArray(selectors) ? selectors : [selectors];
+  return (spec) => isPColumnSpec(spec) && arr.some((sel) => matchMultiColumnSelector(spec, sel));
 }

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -9,6 +9,7 @@ import type {
   PColumnInfo,
   PColumnSpec,
   SingleAxisSelector,
+  AxisQualification,
   AxisValueType,
   ColumnValueType,
 } from "./spec";
@@ -62,14 +63,6 @@ export interface MultiColumnSelector {
   readonly partialAxesMatch?: boolean;
 }
 
-/** Qualification applied to a single axis to make it compatible during integration. */
-export interface AxisQualification {
-  /** Axis selector identifying which axis is qualified. */
-  readonly axis: SingleAxisSelector;
-  /** Additional context domain entries applied to the axis. */
-  readonly contextDomain: Record<string, string>;
-}
-
 /** Qualifications needed for both query (already-integrated) columns and the hit column. */
 export interface ColumnAxesWithQualifications {
   /** Already integrated (query) columns with their qualifications. */
@@ -109,8 +102,6 @@ export interface DiscoverColumnsLinkerStep {
   type: "linker";
   /** The linker column traversed in this step */
   linker: PColumnIdAndSpec;
-  /** Axis qualifications produced when matching the linker's many-side axes */
-  qualifications: AxisQualification[];
 }
 
 /**

--- a/lib/model/common/src/ref.test.ts
+++ b/lib/model/common/src/ref.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { createPlRef, isPlRef, isPrimaryRef } from "./ref";
+import type { PObjectId } from "./pool/spec";
+import { createEnrichmentRef, createPlRef, isEnrichmentRef, isPlRef, isPrimaryRef } from "./ref";
 
 const sampleRef = createPlRef("block1", "output1", true);
+const sampleHit = "hit-1" as PObjectId;
+const sampleLinker = "linker-1" as PObjectId;
 
 describe("isPrimaryRef", () => {
   it("returns true for a valid PrimaryRef", () => {
@@ -31,7 +34,76 @@ describe("isPlRef", () => {
     expect(isPlRef({ __isPrimaryRef: "v1", column: sampleRef })).toBe(false);
   });
 
+  it("returns false for an EnrichmentRef", () => {
+    expect(isPlRef({ __isEnrichment: "v1", hit: sampleHit, path: [] })).toBe(false);
+  });
+
   it("returns true for a PlRef", () => {
     expect(isPlRef(sampleRef)).toBe(true);
+  });
+});
+
+describe("isEnrichmentRef", () => {
+  it("returns true for an EnrichmentRef with empty path", () => {
+    expect(isEnrichmentRef({ __isEnrichment: "v1", hit: sampleHit, path: [] })).toBe(true);
+  });
+
+  it("returns true for an EnrichmentRef with linker steps", () => {
+    expect(
+      isEnrichmentRef({
+        __isEnrichment: "v1",
+        hit: sampleHit,
+        path: [{ type: "linker", linker: sampleLinker }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a PrimaryRef", () => {
+    expect(isEnrichmentRef({ __isPrimaryRef: "v1", column: sampleRef })).toBe(false);
+  });
+
+  it("returns false for a PlRef", () => {
+    expect(isEnrichmentRef(sampleRef)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isEnrichmentRef(null)).toBe(false);
+  });
+});
+
+describe("createEnrichmentRef", () => {
+  const sampleQual = { axis: { name: "a" }, contextDomain: { d: "1" } };
+
+  it("creates an EnrichmentRef with a non-empty linker path", () => {
+    const ref = createEnrichmentRef(sampleHit, {
+      path: [{ type: "linker", linker: sampleLinker }],
+    });
+    expect(ref).toEqual({
+      __isEnrichment: "v1",
+      hit: sampleHit,
+      path: [{ type: "linker", linker: sampleLinker }],
+    });
+    expect("qualifications" in ref).toBe(false);
+  });
+
+  it("omits path when none given", () => {
+    const ref = createEnrichmentRef(sampleHit);
+    expect(ref).toEqual({ __isEnrichment: "v1", hit: sampleHit });
+    expect("path" in ref).toBe(false);
+  });
+
+  it("omits empty path", () => {
+    const ref = createEnrichmentRef(sampleHit, { path: [] });
+    expect("path" in ref).toBe(false);
+  });
+
+  it("attaches non-empty qualifications", () => {
+    const ref = createEnrichmentRef(sampleHit, { qualifications: [sampleQual] });
+    expect(ref.qualifications).toEqual([sampleQual]);
+  });
+
+  it("omits empty qualifications array", () => {
+    const ref = createEnrichmentRef(sampleHit, { qualifications: [] });
+    expect("qualifications" in ref).toBe(false);
   });
 });

--- a/lib/model/common/src/ref.ts
+++ b/lib/model/common/src/ref.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import type { AxisQualification } from "./drivers/pframe/spec/selectors";
+import type { PObjectId } from "./pool/spec";
 
 export const PlRef = z
   .object({
@@ -125,10 +127,64 @@ export function createPrimaryRef(column: PlRef, filter?: PlRef): PrimaryRef {
 /** Block args accept either form — backward compatible. */
 export type DatasetInput = PlRef | PrimaryRef;
 
-/** Dataset option with optional filter choices. */
-export type DatasetOption = Option & {
-  readonly filters?: readonly Option[];
+/** Many-to-one linker hop. */
+export type EnrichmentLinkerStep = {
+  readonly type: "linker";
+  readonly linker: PObjectId;
 };
+
+/** Step from primary to hit. `path[0]` applied first. */
+export type EnrichmentStep = EnrichmentLinkerStep;
+
+/**
+ * Enrichment column reached via {@link path} linker hops; omitted means zero-hop.
+ * `hit` and `path[].linker` are global-form {@link PObjectId}s
+ * (`canonicalize({ __isRef: true, blockId, name })`) which the workflow decodes
+ * to a PlRef before resolving. For a prerun-sourced hop, supply a resolved
+ * `{spec, data}` map in place of the id — `tableBuilder` accepts both.
+ */
+export type EnrichmentRef = {
+  readonly __isEnrichment: "v1";
+  readonly hit: PObjectId;
+  readonly path?: readonly EnrichmentStep[];
+  readonly qualifications?: readonly AxisQualification[];
+};
+
+export function isEnrichmentRef(value: unknown): value is EnrichmentRef {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isEnrichment?: unknown }).__isEnrichment === "v1" &&
+    "hit" in value
+  );
+}
+
+export type CreateEnrichmentRefOptions = {
+  readonly path?: readonly EnrichmentStep[];
+  readonly qualifications?: readonly AxisQualification[];
+};
+
+export function createEnrichmentRef(
+  hit: PObjectId,
+  options: CreateEnrichmentRefOptions = {},
+): EnrichmentRef {
+  const { path, qualifications } = options;
+  return {
+    __isEnrichment: "v1",
+    hit,
+    ...(path !== undefined && path.length > 0 ? { path } : {}),
+    ...(qualifications !== undefined && qualifications.length > 0 ? { qualifications } : {}),
+  };
+}
+
+/** {@link EnrichmentRef} plus the export header label. */
+export type LabeledEnrichmentRef = {
+  readonly ref: EnrichmentRef;
+  readonly label: string;
+};
+
+/** Auto-attached enrichment payload; not user-picked. */
+export type LabeledEnrichmentRefs = readonly LabeledEnrichmentRef[];
 
 /** Compare two PlRefs and returns true if they are qual */
 export function plRefsEqual(ref1: PlRef, ref2: PlRef, ignoreEnrichments: boolean = false) {

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.27
+polars-pf==1.1.31
 pyarrow==21.0.0
 duckdb==1.4.1
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,11 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.26
-      version: 1.1.26
+      specifier: 1.1.31
+      version: 1.1.31
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.26
-      version: 1.1.26
+      specifier: 1.1.31
+      version: 1.1.31
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -43,8 +43,8 @@ catalogs:
       specifier: ^4.0.37
       version: 4.0.37
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.8.0
-      version: 1.8.0
+      specifier: 1.8.1
+      version: 1.8.1
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -747,6 +747,9 @@ importers:
 
   etc/blocks/filter-column-test/test:
     dependencies:
+      '@milaboratories/milaboratories.test-block-table':
+        specifier: workspace:*
+        version: link:../../table-test/block
       '@milaboratories/milaboratories.test-enter-numbers-v3':
         specifier: workspace:*
         version: link:../../enter-numbers-v3/block
@@ -1853,7 +1856,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1973,10 +1976,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.26(encoding@0.1.13)
+        version: 1.1.31(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2410,10 +2413,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.26(encoding@0.1.13)
+        version: 1.1.31(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -2720,7 +2723,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.8.0
+        version: 1.8.1
       '@platforma-sdk/package-builder':
         specifier: workspace:*
         version: link:../../../tools/package-builder
@@ -2729,7 +2732,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.8.0
+        version: 1.8.1
       '@platforma-sdk/package-builder':
         specifier: 'workspace:'
         version: link:../../tools/package-builder
@@ -3724,7 +3727,7 @@ importers:
         version: link:../ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.8.0
+        version: 1.8.1
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
@@ -4981,36 +4984,35 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@milaboratories/helpers@1.13.5':
-    resolution: {integrity: sha512-BgwkcYrppMZzHyRpq6CgWZrns9zJr9ppSu+TIeJgozHQV+ufIujziyPttonWz2UmTVUEJh3/Q2TLp1bbbWKyNQ==}
-    engines: {node: '>=22'}
-
   '@milaboratories/helpers@1.14.1':
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.26':
-    resolution: {integrity: sha512-RAsTcdPGLDz9h3NKu/VH1gdCZnEUvq+8cNrnjsuwOPHSXjvrd2XpjcOrHlmGZPvsGze6tX9MZ8i+Qrqo/r92cA==}
+  '@milaboratories/pframes-rs-node@1.1.31':
+    resolution: {integrity: sha512-TZkCDFrNiCH+1oRrpCzmD8GvlNky0W70YgGmIDJ/4Vi/Z0bMQQPlsB1OHOz7hfoySD9a0Djc1Q7lhnLmAtnPDA==}
 
-  '@milaboratories/pframes-rs-serv@1.1.26':
-    resolution: {integrity: sha512-bDh2Oj5642wicI66ZAZs8GtqmvuY0U/X0+zmBkfgNOXPfAsJ2At9LwuqfdeKROcv/A3rRzUkLH4xUAOzqNV1Bg==}
+  '@milaboratories/pframes-rs-serv@1.1.31':
+    resolution: {integrity: sha512-Cq/Q4H40bG4xYXNR9oJcDPZE+osMBJVdBnthxbZ0haYspoz7GWegEBW3EeeP/Aetp6G2jwMmPu/CGu/02O8X8g==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasm@1.1.26':
-    resolution: {integrity: sha512-lP56AHUj96WWlcEoKwMn0TIS/EVAOMkXVVS42G9fypV26tGbxrxSgOlcIgRpCpdR+s1r6yoy7/hx9u97Gxvorg==}
+  '@milaboratories/pframes-rs-wasi@1.1.31':
+    resolution: {integrity: sha512-pueH0fOgiCusD2YzlvZAD6FL1Qo2AvFc6+Jmxms+ymADgpTcd0ABYeaxGZih4hfgyJc5Zcnkea9dy+pemju8TA==}
+
+  '@milaboratories/pframes-rs-wasm@1.1.31':
+    resolution: {integrity: sha512-tLUf8FkRvrWOV6uSP1rwFlpNl0DUXkSNrrlTp5qFNFzHZSBtcVlw8bjfrJS7aCWuSMvKHQd49aNitEXF7aNbKw==}
     peerDependencies:
-      '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.32.1
-      '@milaboratories/pl-model-middle-layer': 1.18.0
+      '@bytecodealliance/preview2-shim': 0.17.9
+      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-middle-layer': 1.18.5
 
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-model-common@1.32.1':
-    resolution: {integrity: sha512-XFAJw2Re+YZ4rsgIupcNX8MlnsjU0kj53RA1LLBKps/9a5GmNadsN+vXuCaHv7TffGNweyba5gatih0Ek2AbsQ==}
+  '@milaboratories/pl-model-common@1.36.0':
+    resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
 
-  '@milaboratories/pl-model-middle-layer@1.18.0':
-    resolution: {integrity: sha512-jtCXFydSA6W37a5TvJGe6UL3lrWDN9VwPx2ILqCS2ZBClypm5kqBbPiDs7Xz9zAglL5+K3XOI5opX+HmlB8CzA==}
+  '@milaboratories/pl-model-middle-layer@1.18.5':
+    resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -5370,11 +5372,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.0.1':
     resolution: {integrity: sha512-UzYMBurBrx8LOENLl2ggE83iK/1dWtpuljJiWNdq9yvEsR3Fpm9vnlm2swOnYZ6Jx997Ux87ieB8pFLG8mw7GA==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.9':
-    resolution: {integrity: sha512-FpcHCcEGwjumn4naoYM76NMfHvOtVwnack/XMlvOgYY1zMRYScVkJaMCyakVXGzzApPmilnv3MsGlv9mB5Wtow==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.10':
+    resolution: {integrity: sha512-WOulvGTW7Q/ptaNuGGXy8ZXwf3s1L9ic7OReWkqWmt1QstJCE9HtCZeup6e5xwltHSo6yRRtJsoX30B8JvqAaA==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.8.0':
-    resolution: {integrity: sha512-KGoNJP+/UyeY3Nbj2RVuqDCz3X+DATF7D8fVWfc3912ll6AZUx7t0U7X4ab8DyYNHtE/tyQ/1/RzYGgChYBEhA==}
+  '@platforma-open/milaboratories.runenv-python-3@1.8.1':
+    resolution: {integrity: sha512-oHXq/RUnMLXOkTJF3AVeFQQuLU4ObDaG+fPkQS83h7DH/5raQnvqwocf2FtacyhyZEjpphy9FWD2lrQ7fMmsRA==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -11224,32 +11226,33 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@milaboratories/helpers@1.13.5': {}
-
   '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/pframes-rs-node@1.1.26(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.31(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
-      '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pframes-rs-serv': 1.1.26
-      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pframes-rs-serv': 1.1.31
+      '@milaboratories/pl-model-common': 1.36.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.26':
+  '@milaboratories/pframes-rs-serv@1.1.31':
     dependencies:
-      '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pl-model-common': 1.32.1
-      '@milaboratories/pl-model-middle-layer': 1.18.0
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-middle-layer': 1.18.5
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasi@1.1.31': {}
+
+  '@milaboratories/pframes-rs-wasm@1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
+      '@milaboratories/pframes-rs-wasi': 1.1.31
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11258,17 +11261,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.32.1':
+  '@milaboratories/pl-model-common@1.36.0':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.18.0':
+  '@milaboratories/pl-model-middle-layer@1.18.5':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/pl-model-common': 1.36.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
@@ -11618,11 +11621,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.0.1': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.9': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.10': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.8.0':
+  '@platforma-open/milaboratories.runenv-python-3@1.8.1':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.9
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.10
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.4
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.4
       '@platforma-open/milaboratories.runenv-python-3.12.10-parapred': 1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -248,8 +248,8 @@ catalog:
   "winston": ^3.17.0
 
   "@milaboratories/tengo-tester": ^1.6.4
-  "@milaboratories/pframes-rs-node": 1.1.26
-  "@milaboratories/pframes-rs-wasm": 1.1.26
+  "@milaboratories/pframes-rs-node": 1.1.31
+  "@milaboratories/pframes-rs-wasm": 1.1.31
 
   "quickjs-emscripten": 0.31.0
 
@@ -292,7 +292,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.0.3
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.8.0
+  "@platforma-open/milaboratories.runenv-python-3": 1.8.1
 
   "shx": ^0.4.0
 

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -87,7 +87,6 @@ export interface ColumnVariant<Id extends PObjectId = PObjectId> {
   /** Linker steps traversed to reach this hit; empty for direct matches. */
   readonly path: {
     linker: ColumnSnapshot<PObjectId>;
-    qualifications: AxisQualification[];
   }[];
 }
 
@@ -98,7 +97,6 @@ export interface MatchVariant {
   /** Linker steps traversed to reach this hit; empty for direct matches. */
   readonly path: {
     linker: ColumnSnapshot<PObjectId>;
-    qualifications: AxisQualification[];
   }[];
 }
 
@@ -319,7 +317,6 @@ class AnchoredColumnCollectionImpl implements AnchoredColumnCollection, Disposab
           linker:
             this.columnsMap.get(step.linker.columnId) ??
             throwError(`Linker column with id ${step.linker.columnId} not found in collection`),
-          qualifications: step.qualifications,
         };
       });
       const variants: MatchVariant[] = hit.mappingVariants.map((v) => ({

--- a/sdk/model/src/columns/ctx_column_sources.ts
+++ b/sdk/model/src/columns/ctx_column_sources.ts
@@ -9,31 +9,25 @@ import { ResourceTypeName } from "@milaboratories/pl-model-common";
 import type { ValueOf } from "@milaboratories/helpers";
 
 /**
- * Collect ColumnSnapshotProviders from all render context sources:
- *
- * - **resultPool** — all upstream columns (always included)
- * - **outputs** — PFrame fields from block execution outputs
- * - **prerun** — PFrame fields from prerun/staging results
- *
- * Returns an array of providers suitable for `ColumnCollectionBuilder.addSource()`.
+ * Collect ColumnSnapshotProviders from `outputs`, `prerun`, and
+ * `resultPool` in that order. Dedup keeps the first occurrence per
+ * `NativePObjectId`, so a block re-publishing its own columns keeps
+ * the `outputs`-rooted canonical id instead of the result-pool variant.
  */
 export function collectCtxColumnSnapshotProviders(ctx: RenderCtxBase): ColumnSnapshotProvider[] {
   const providers: ColumnSnapshotProvider[] = [];
 
-  // ResultPool — all upstream columns
-  providers.push(new ResultPoolColumnSnapshotProvider(ctx.resultPool));
-
-  // Outputs — each PFrame-like output field becomes a provider
   const outputs = ctx.outputs;
   if (outputs) {
     providers.push(...collectPFrameProviders(outputs));
   }
 
-  // Prerun — same treatment as outputs
   const prerun = ctx.prerun;
   if (prerun) {
     providers.push(...collectPFrameProviders(prerun));
   }
+
+  providers.push(new ResultPoolColumnSnapshotProvider(ctx.resultPool));
 
   return providers;
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -405,7 +405,6 @@ function buildSecondaryGroups(
         entries: [
           ...lc.path.map((s) => ({
             column: resolveSnapshot(s.linker),
-            qualifications: s.qualifications,
           })),
           { column: resolveSnapshot(lc.column), qualifications: lc.qualifications.forHit },
         ],

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -102,7 +102,6 @@ function mapToTableColumnVariants(
       path: variant.path.map((p) => ({
         type: "linker",
         column: p.linker.id,
-        qualifications: p.qualifications,
       })),
       columnQualifications: variant.qualifications.forHit,
       queriesQualifications: variant.qualifications.forQueries,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -241,7 +241,6 @@ export function deriveAllLabels(options: {
     spec: c.spec,
     linkerPath: c.linkerPath?.map((step) => ({
       spec: step.linker.spec,
-      qualifications: step.qualifications,
     })),
     qualifications: c.qualifications,
   }));

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -1,20 +1,25 @@
-import type {
-  DatasetOption,
-  Option,
-  PColumnSelector,
-  PObjectSpec,
-} from "@milaboratories/pl-model-common";
+import type { MultiColumnSelector, Option, PObjectSpec } from "@milaboratories/pl-model-common";
+import { multiColumnSelectorsToPredicate } from "@milaboratories/pl-model-common";
 import type { DeriveLabelsOptions } from "../../labels/derive_distinct_labels";
 import type { RenderCtxBase } from "../../render";
 import { ColumnCollectionBuilder } from "../../columns/column_collection_builder";
 import { collectCtxColumnSnapshotProviders } from "../../columns/ctx_column_sources";
+import type { DatasetOption } from "./dataset_selection";
 import { buildRefMap, filterMatchesToOptions, findFilterColumns } from "./filter_discovery";
+import { enrichmentVariantsToRefs, findEnrichmentColumns } from "./enrichment_discovery";
 
 export type BuildDatasetOptions = {
   /** Which result pool columns qualify as datasets. Defaults to all. */
-  selector?: PColumnSelector | PColumnSelector[] | ((spec: PObjectSpec) => boolean);
+  primary?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
   /** Formatting options for filter labels. */
   labelOptions?: DeriveLabelsOptions;
+  /**
+   * Enables enrichment discovery and filters hits attached to
+   * `DatasetOption.enrichments`. Use `() => true` to accept all; omit to disable.
+   */
+  withEnrichments?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
+  /** Maximum linker hops considered. Only used when `withEnrichments` is set. */
+  enrichmentMaxHops?: number;
 };
 
 /**
@@ -27,28 +32,54 @@ export function buildDatasetOptions(
   ctx: RenderCtxBase,
   opts?: BuildDatasetOptions,
 ): DatasetOption[] | undefined {
-  const predicate = opts?.selector ?? (() => true);
-  const options = ctx.resultPool.getOptions(predicate, { refsWithEnrichments: true });
+  const primary = opts?.primary;
+  const primaryPredicate =
+    primary === undefined
+      ? () => true
+      : typeof primary === "function"
+        ? primary
+        : multiColumnSelectorsToPredicate(primary);
+  const options = ctx.resultPool.getOptions(primaryPredicate, { refsWithEnrichments: true });
   if (options.length === 0) return [];
 
   const columnSources = collectCtxColumnSnapshotProviders(ctx);
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
 
-  return options.map((o: Option): DatasetOption => {
-    const datasetSpec = ctx.resultPool.getPColumnSpecByRef(o.ref);
-    if (!datasetSpec) return o;
+  return options.map((primary: Option): DatasetOption => {
+    const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
+    if (!datasetSpec) return { primary };
 
     const builder = new ColumnCollectionBuilder(pframeSpec);
     for (const src of columnSources) builder.addSource(src);
     const collection = builder.build({ anchors: { main: datasetSpec } });
-    if (!collection) return o;
+    if (!collection) return { primary };
 
     try {
-      const matches = findFilterColumns(collection);
-      if (matches.length === 0) return o;
-      const filters = filterMatchesToOptions(matches, refMap, opts?.labelOptions);
-      return { ...o, filters };
+      const filterMatches = findFilterColumns(collection);
+      const filters =
+        filterMatches.length === 0
+          ? undefined
+          : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
+
+      let enrichments;
+      if (opts?.withEnrichments !== undefined) {
+        const enrichmentVariants = findEnrichmentColumns(collection, {
+          maxHops: opts.enrichmentMaxHops,
+          ...(typeof opts.withEnrichments === "function"
+            ? { predicate: opts.withEnrichments }
+            : { include: opts.withEnrichments }),
+        });
+        if (enrichmentVariants.length > 0) {
+          enrichments = enrichmentVariantsToRefs(enrichmentVariants, opts.labelOptions);
+        }
+      }
+
+      return {
+        primary,
+        ...(filters !== undefined && filters.length > 0 ? { filters } : {}),
+        ...(enrichments !== undefined && enrichments.length > 0 ? { enrichments } : {}),
+      };
     } finally {
       collection.dispose();
     }

--- a/sdk/model/src/components/PlDatasetSelector/dataset_selection.ts
+++ b/sdk/model/src/components/PlDatasetSelector/dataset_selection.ts
@@ -1,0 +1,37 @@
+import type { LabeledEnrichmentRefs, Option, PrimaryRef } from "@milaboratories/pl-model-common";
+
+/** Dataset picker entry: user picks {@link primary}, gets {@link enrichments} attached. */
+export type DatasetOption = {
+  readonly primary: Option;
+  readonly filters?: readonly Option[];
+  readonly enrichments?: LabeledEnrichmentRefs;
+};
+
+/**
+ * Picked dataset bundle emitted by `PlDatasetSelector`. Stored opaquely in
+ * block data; block authors unbundle inside their args resolver.
+ */
+export type DatasetSelection = {
+  readonly __isDatasetSelection: "v1";
+  readonly primary: PrimaryRef;
+  readonly enrichments?: LabeledEnrichmentRefs;
+};
+
+export function isDatasetSelection(value: unknown): value is DatasetSelection {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __isDatasetSelection?: unknown }).__isDatasetSelection === "v1" &&
+    "primary" in value
+  );
+}
+
+export function createDatasetSelection(
+  primary: PrimaryRef,
+  enrichments?: LabeledEnrichmentRefs,
+): DatasetSelection {
+  if (enrichments !== undefined && enrichments.length > 0) {
+    return { __isDatasetSelection: "v1", primary, enrichments };
+  }
+  return { __isDatasetSelection: "v1", primary };
+}

--- a/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
@@ -1,0 +1,111 @@
+import { Annotation, createEnrichmentRef } from "@milaboratories/pl-model-common";
+import type {
+  EnrichmentStep,
+  LabeledEnrichmentRef,
+  LabeledEnrichmentRefs,
+  MultiColumnSelector,
+  PObjectId,
+  PObjectSpec,
+} from "@milaboratories/pl-model-common";
+import type {
+  AnchoredColumnCollection,
+  ColumnVariant,
+} from "../../columns/column_collection_builder";
+import {
+  deriveDistinctLabels,
+  type DeriveLabelsOptions,
+  type Entry,
+} from "../../labels/derive_distinct_labels";
+
+/**
+ * True for global-form ids — `canonicalize({__isRef: true, blockId, name})` —
+ * which the workflow can resolve via bquery. Local-form ids (`resolvePath`)
+ * fail this check and are excluded from auto-discovery; prerun/outputs hops
+ * must be supplied as resolved `{spec, data}` instead.
+ */
+function isGloballyAddressable(id: PObjectId): boolean {
+  try {
+    const decoded = JSON.parse(id);
+    return (
+      typeof decoded === "object" &&
+      decoded !== null &&
+      decoded.__isRef === true &&
+      typeof decoded.blockId === "string" &&
+      typeof decoded.name === "string"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Linker-reached hits attached to the anchor primary. Drops zero-hop variants
+ * (filters / the primary itself) and structural hits (subset, linker, label
+ * columns). Narrow further with `include` selectors or a `predicate`.
+ */
+export function findEnrichmentColumns(
+  collection: AnchoredColumnCollection,
+  options?: {
+    maxHops?: number;
+    include?: MultiColumnSelector | MultiColumnSelector[];
+    predicate?: (spec: PObjectSpec) => boolean;
+  },
+): ColumnVariant[] {
+  const include =
+    options?.include === undefined
+      ? undefined
+      : Array.isArray(options.include)
+        ? options.include
+        : [options.include];
+  const variants = collection.findColumnVariants({
+    mode: "enrichment",
+    maxHops: options?.maxHops ?? 4,
+    include,
+    exclude: [
+      { annotations: { [Annotation.IsSubset]: "true" } },
+      { annotations: { [Annotation.IsLinkerColumn]: "true" } },
+      { name: Annotation.Label },
+    ],
+  });
+  const predicate = options?.predicate;
+  return variants.filter((v) => {
+    if (v.path.length === 0) return false;
+    if (predicate !== undefined && !predicate(v.column.spec)) return false;
+    if (!isGloballyAddressable(v.column.id)) return false;
+    if (v.path.some((p) => !isGloballyAddressable(p.linker.id))) return false;
+    return true;
+  });
+}
+
+/**
+ * Pair each variant with a path-disambiguated label (so export headers stay
+ * unique) and carry hit/linker `PObjectId`s through verbatim. Propagates
+ * `qualifications.forHit`; `forQueries` is re-derived by the table builder.
+ */
+export function enrichmentVariantsToRefs(
+  variants: ColumnVariant[],
+  labelOptions?: DeriveLabelsOptions,
+): LabeledEnrichmentRefs {
+  if (variants.length === 0) return [];
+
+  const entries: Entry[] = variants.map((variant) => ({
+    spec: variant.column.spec,
+    linkerPath: variant.path.map((p) => ({ spec: p.linker.spec })),
+    qualifications: variant.qualifications,
+  }));
+  const labels = deriveDistinctLabels(entries, labelOptions);
+
+  return variants.map((variant, i): LabeledEnrichmentRef => {
+    const path: EnrichmentStep[] = variant.path.map((step) => ({
+      type: "linker",
+      linker: step.linker.id,
+    }));
+    return {
+      ref: createEnrichmentRef(variant.column.id, {
+        path,
+        qualifications: variant.qualifications.forHit,
+      }),
+      label: labels[i],
+    };
+  });
+}

--- a/sdk/model/src/components/PlDatasetSelector/index.ts
+++ b/sdk/model/src/components/PlDatasetSelector/index.ts
@@ -1,2 +1,3 @@
+export * from "./dataset_selection";
 export * from "./filter_discovery";
 export * from "./build_dataset_options";

--- a/sdk/model/src/labels/derive_distinct_tooltips.test.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.test.ts
@@ -34,12 +34,8 @@ function linkerSnapshot(name: string, label?: string): ColumnSnapshot<PObjectId>
   };
 }
 
-function pathStep(
-  linkerName: string,
-  qualifications: AxisQualification[],
-  label?: string,
-): MatchVariant["path"][number] {
-  return { linker: linkerSnapshot(linkerName, label), qualifications };
+function pathStep(linkerName: string, label?: string): MatchVariant["path"][number] {
+  return { linker: linkerSnapshot(linkerName, label) };
 }
 
 describe("deriveDistinctTooltips", () => {
@@ -63,16 +59,13 @@ describe("deriveDistinctTooltips", () => {
     const entries: TooltipEntry[] = [
       {
         spec: createSpec("hit_col", "Hit Col"),
-        linkerPath: [
-          pathStep("linker_a", [axisQualification("sample", { batch: "A" })], "Linker A"),
-        ],
+        linkerPath: [pathStep("linker_a", "Linker A")],
       },
     ];
     const [tooltip] = deriveDistinctTooltips(entries);
     expect(tooltip).toBeDefined();
     expect(tooltip).toContain("Origin path");
     expect(tooltip).toContain("linker 1: Linker A");
-    expect(tooltip).toContain("qualifies: sample context: batch=A");
     expect(tooltip).toContain("hit column: Hit Col");
   });
 
@@ -146,7 +139,7 @@ describe("deriveDistinctTooltips", () => {
       {
         spec: createSpec("col1", "Col 1"),
         qualifications: { forQueries: {}, forHit: [] },
-        linkerPath: [pathStep("linker_a", [], "Linker A")],
+        linkerPath: [pathStep("linker_a", "Linker A")],
       },
     ];
     const [tooltip] = deriveDistinctTooltips(entries);
@@ -157,10 +150,7 @@ describe("deriveDistinctTooltips", () => {
     const entries: TooltipEntry[] = [
       {
         spec: createSpec("hit_col", "Hit Col"),
-        linkerPath: [
-          pathStep("linker_a", [], "Linker A"),
-          pathStep("linker_b", [axisQualification("sample", { batch: "B" })], "Linker B"),
-        ],
+        linkerPath: [pathStep("linker_a", "Linker A"), pathStep("linker_b", "Linker B")],
       },
     ];
     const [tooltip] = deriveDistinctTooltips(entries);
@@ -174,7 +164,7 @@ describe("deriveDistinctTooltips", () => {
         spec: createSpec("hit_col", "Hit"),
         variantIndex: 2,
         variantCount: 2,
-        linkerPath: [pathStep("linker_a", [axisQualification("sample", { batch: "B" })], "LA")],
+        linkerPath: [pathStep("linker_a", "LA")],
         qualifications: {
           forQueries: { ["main" as PObjectId]: [axisQualification("sample", { batch: "B" })] },
           forHit: [axisQualification("sample", { batch: "B" })],

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -46,7 +46,6 @@ function formatTooltip(entry: TooltipEntry): undefined | string {
 }
 
 const BULLET_1 = "  • ";
-const SUB_BULLET = "      ";
 
 function formatHeader(entry: TooltipEntry): undefined | string {
   const lines: string[] = [];
@@ -67,8 +66,6 @@ function formatOriginPath(entry: TooltipEntry): undefined | string {
       readAnnotation(step.linker.spec, Annotation.Label) ??
       step.linker.spec.name;
     lines.push(`${BULLET_1}linker ${i + 1}: ${label}`);
-    const qs = formatAxisQualifications(step.qualifications);
-    if (qs !== undefined) lines.push(`${SUB_BULLET}qualifies: ${qs}`);
   });
   const hitName = readAnnotation(entry.spec, Annotation.Label) ?? entry.spec.name;
   lines.push(`${BULLET_1}hit column: ${hitName}`);

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 /**
- * Select a dataset and (optionally) a filter column, emitting a `PrimaryRef`.
+ * Select a dataset and (optionally) a filter column, emitting a {@link DatasetSelection}.
  *
  * Behaves like {@link PlDropdownRef} when none of the offered datasets carry
  * filter options. When the selected dataset has compatible filters, a second
  * dropdown appears with the filters plus a "No filter" entry.
  *
- * Accepts `PrimaryRef | PlRef | undefined` as `modelValue` (a plain `PlRef`
- * is treated as an unfiltered dataset), but always emits `PrimaryRef`
- * (or `undefined` when cleared).
+ * The emitted value bundles the user's pick (`primary`) with the auto-attached
+ * `enrichments` payload from the matching `DatasetOption`. Enrichments are
+ * opaque to the UI — block authors unbundle them inside their args resolver.
  */
 export default {
   name: "PlDatasetSelector",
@@ -16,8 +16,8 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import type { DatasetOption, PlRef, PrimaryRef } from "@platforma-sdk/model";
-import { createPrimaryRef, isPrimaryRef, plRefsEqual } from "@platforma-sdk/model";
+import type { DatasetOption, DatasetSelection, PlRef } from "@platforma-sdk/model";
+import { createDatasetSelection, createPrimaryRef, plRefsEqual } from "@platforma-sdk/model";
 import type { ListOption } from "@milaboratories/uikit";
 import { PlDropdown, PlDropdownRef } from "@milaboratories/uikit";
 import { computed } from "vue";
@@ -26,11 +26,7 @@ const slots = defineSlots<{
   tooltip?: () => unknown;
 }>();
 
-/**
- * v-model value. Accepts `PrimaryRef`, plain `PlRef` (treated as unfiltered),
- * or `undefined`. Writes always emit `PrimaryRef` or `undefined`.
- */
-const model = defineModel<PrimaryRef | PlRef | undefined>();
+const model = defineModel<DatasetSelection | undefined>();
 
 const props = withDefaults(
   defineProps<{
@@ -75,22 +71,20 @@ const props = withDefaults(
   },
 );
 
-const selectedDataset = computed<PlRef | undefined>(() => {
-  const v = model.value;
-  if (v === undefined) return undefined;
-  return isPrimaryRef(v) ? v.column : v;
-});
+const selectedDataset = computed<PlRef | undefined>(() => model.value?.primary.column);
 
-const selectedFilter = computed<PlRef | undefined>(() => {
-  const v = model.value;
-  return isPrimaryRef(v) ? v.filter : undefined;
-});
+const selectedFilter = computed<PlRef | undefined>(() => model.value?.primary.filter);
 
 const currentDatasetOption = computed<DatasetOption | undefined>(() => {
   const dataset = selectedDataset.value;
   if (!dataset) return undefined;
-  return props.options?.find((o) => plRefsEqual(o.ref, dataset, true));
+  return props.options?.find((o) => plRefsEqual(o.primary.ref, dataset, true));
 });
+
+// PlDropdownRef expects `Option[]`; project the primary out of each entry.
+const primaryOptions = computed<readonly { ref: PlRef; label: string }[] | undefined>(() =>
+  props.options?.map((o) => o.primary),
+);
 
 const hasFilters = computed(() => (currentDatasetOption.value?.filters?.length ?? 0) > 0);
 
@@ -110,7 +104,14 @@ const filterOptions = computed<ListOption<PlRef | null>[]>(() => {
 const filterValue = computed<PlRef | null>(() => selectedFilter.value ?? null);
 
 function emitValue(dataset: PlRef | undefined, filter: PlRef | undefined) {
-  model.value = dataset === undefined ? undefined : createPrimaryRef(dataset, filter);
+  if (dataset === undefined) {
+    model.value = undefined;
+    return;
+  }
+  // Resolve from `props.options` directly — `currentDatasetOption` may not
+  // have recomputed yet when this runs synchronously inside a change handler.
+  const option = props.options?.find((o) => plRefsEqual(o.primary.ref, dataset, true));
+  model.value = createDatasetSelection(createPrimaryRef(dataset, filter), option?.enrichments);
 }
 
 function onDatasetChange(dataset: PlRef | undefined) {
@@ -128,7 +129,7 @@ function onFilterChange(value: PlRef | null | undefined) {
   <div class="pl-dataset-selector">
     <PlDropdownRef
       :model-value="selectedDataset"
-      :options="options"
+      :options="primaryOptions"
       :label="label"
       :helper="helper"
       :loading-options-helper="loadingOptionsHelper"

--- a/sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from "@vue/test-utils";
-import type { DatasetOption, PrimaryRef } from "@platforma-sdk/model";
-import { createPlRef, createPrimaryRef } from "@platforma-sdk/model";
+import type { DatasetOption, DatasetSelection } from "@platforma-sdk/model";
+import { createDatasetSelection, createPlRef, createPrimaryRef } from "@platforma-sdk/model";
 import { describe, expect, it } from "vitest";
 import PlDatasetSelector from "../PlDatasetSelector.vue";
 
@@ -9,26 +9,40 @@ const datasetB = createPlRef("2", "out-b", true);
 const filterA1 = createPlRef("1", "filter-a1");
 const filterA2 = createPlRef("1", "filter-a2");
 
+import type { PObjectId } from "@platforma-sdk/model";
+const enrichmentA = "enrichment-a" as PObjectId;
+const enrichmentsA = [
+  { ref: { __isEnrichment: "v1" as const, hit: enrichmentA }, label: "Enrichment A" },
+];
+
 const optionsWithFilters: DatasetOption[] = [
   {
-    label: "Dataset A",
-    ref: datasetA,
+    primary: { label: "Dataset A", ref: datasetA },
     filters: [
       { label: "Top 1000", ref: filterA1 },
       { label: "High quality", ref: filterA2 },
     ],
+    enrichments: enrichmentsA,
   },
   // Dataset B has no filters — filter dropdown must stay hidden.
-  { label: "Dataset B", ref: datasetB },
+  { primary: { label: "Dataset B", ref: datasetB } },
 ];
 
 const datasetC = createPlRef("3", "out-c", true);
 
-const optionsNoFilters: DatasetOption[] = [{ label: "Dataset B", ref: datasetB }];
+const optionsNoFilters: DatasetOption[] = [{ primary: { label: "Dataset B", ref: datasetB } }];
 
 const optionsWithEmptyFilters: DatasetOption[] = [
-  { label: "Dataset C", ref: datasetC, filters: [] },
+  { primary: { label: "Dataset C", ref: datasetC }, filters: [] },
 ];
+
+function selection(
+  ref: typeof datasetA,
+  filter?: typeof filterA1,
+  enrichments?: typeof enrichmentsA,
+): DatasetSelection {
+  return createDatasetSelection(createPrimaryRef(ref, filter), enrichments);
+}
 
 async function pickOption(index: number) {
   const options = [...document.body.querySelectorAll(".dropdown-list-item")] as HTMLElement[];
@@ -53,7 +67,7 @@ describe("PlDatasetSelector", () => {
 
   it("shows the filter dropdown when the selected dataset has filters", async () => {
     const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: createPrimaryRef(datasetA), options: optionsWithFilters },
+      props: { modelValue: selection(datasetA), options: optionsWithFilters },
       attachTo: document.body,
     });
     await flushPromises();
@@ -64,7 +78,7 @@ describe("PlDatasetSelector", () => {
 
   it("hides the filter dropdown when the selected dataset has no filters", async () => {
     const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: createPrimaryRef(datasetB), options: optionsWithFilters },
+      props: { modelValue: selection(datasetB), options: optionsWithFilters },
       attachTo: document.body,
     });
     await flushPromises();
@@ -73,63 +87,69 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("emits PrimaryRef with filter: undefined when dataset changes", async () => {
+  it("emits DatasetSelection bundling primary + enrichments when dataset changes", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: createPrimaryRef(datasetA, filterA1),
+        modelValue: selection(datasetA, filterA1, enrichmentsA),
         options: optionsWithFilters,
-        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
       },
       attachTo: document.body,
     });
     await flushPromises();
 
-    // Open the dataset dropdown (the first input — dataset comes first).
     const inputs = wrapper.findAll("input");
     await inputs[0].trigger("focus");
-
-    // Dataset A is already selected (index 0); pick Dataset B (index 1).
+    // Dataset A is index 0; pick Dataset B (index 1) — has no enrichments.
     await pickOption(1);
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
-    const last = emitted![emitted!.length - 1][0] as PrimaryRef;
-    expect(last).toEqual({ __isPrimaryRef: "v1", column: datasetB });
+    const last = emitted![emitted!.length - 1][0] as DatasetSelection;
+    expect(last).toEqual({
+      __isDatasetSelection: "v1",
+      primary: { __isPrimaryRef: "v1", column: datasetB },
+    });
     wrapper.unmount();
   });
 
-  it("emits PrimaryRef with filter set when a filter is picked", async () => {
+  it("emits DatasetSelection with filter set when a filter is picked", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: createPrimaryRef(datasetA),
+        modelValue: selection(datasetA, undefined, enrichmentsA),
         options: optionsWithFilters,
-        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
       },
       attachTo: document.body,
     });
     await flushPromises();
 
-    // Open the filter dropdown — it's the second input in the component.
     const inputs = wrapper.findAll("input");
     expect(inputs.length).toBe(2);
     await inputs[1].trigger("focus");
-
-    // Options are: [No filter, Top 1000, High quality]. Pick "Top 1000" (index 1).
+    // Options: [No filter, Top 1000, High quality]. Pick "Top 1000".
     await pickOption(1);
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
-    const last = emitted![emitted!.length - 1][0] as PrimaryRef;
-    expect(last).toEqual({ __isPrimaryRef: "v1", column: datasetA, filter: filterA1 });
+    const last = emitted![emitted!.length - 1][0] as DatasetSelection;
+    expect(last).toEqual({
+      __isDatasetSelection: "v1",
+      primary: { __isPrimaryRef: "v1", column: datasetA, filter: filterA1 },
+      enrichments: enrichmentsA,
+    });
     wrapper.unmount();
   });
 
-  it("emits PrimaryRef with filter: undefined when 'No filter' is picked", async () => {
+  it("emits DatasetSelection with no filter key when 'No filter' is picked", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: createPrimaryRef(datasetA, filterA1),
+        modelValue: selection(datasetA, filterA1, enrichmentsA),
         options: optionsWithFilters,
-        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
       },
       attachTo: document.body,
     });
@@ -137,43 +157,20 @@ describe("PlDatasetSelector", () => {
 
     const inputs = wrapper.findAll("input");
     await inputs[1].trigger("focus");
-    // Pick "No filter" (index 0).
-    await pickOption(0);
+    await pickOption(0); // "No filter"
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
-    const last = emitted![emitted!.length - 1][0] as PrimaryRef;
-    expect(last).toEqual({ __isPrimaryRef: "v1", column: datasetA });
-    expect("filter" in last).toBe(false);
-    wrapper.unmount();
-  });
-
-  it("accepts plain PlRef as modelValue for backward compat (filterless dataset)", async () => {
-    const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: datasetB, options: optionsWithFilters },
-      attachTo: document.body,
-    });
-    await flushPromises();
-
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(1);
-    wrapper.unmount();
-  });
-
-  it("accepts plain PlRef as modelValue for backward compat (dataset with filters)", async () => {
-    const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: datasetA, options: optionsWithFilters },
-      attachTo: document.body,
-    });
-    await flushPromises();
-
-    // PlRef matching dataset A — filter dropdown should appear since A has filters.
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(2);
+    const last = emitted![emitted!.length - 1][0] as DatasetSelection;
+    expect(last.primary).toEqual({ __isPrimaryRef: "v1", column: datasetA });
+    expect("filter" in last.primary).toBe(false);
+    expect(last.enrichments).toEqual(enrichmentsA);
     wrapper.unmount();
   });
 
   it("hides filter dropdown when dataset has filters: [] (empty array)", async () => {
     const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: createPrimaryRef(datasetC), options: optionsWithEmptyFilters },
+      props: { modelValue: selection(datasetC), options: optionsWithEmptyFilters },
       attachTo: document.body,
     });
     await flushPromises();
@@ -182,25 +179,22 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("filter dropdown defaults to 'No filter' when dataset has filters but none selected", async () => {
+  it("does not emit on mount when no filter is selected", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: createPrimaryRef(datasetA),
+        modelValue: selection(datasetA),
         options: optionsWithFilters,
-        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
       },
       attachTo: document.body,
     });
     await flushPromises();
 
-    // No emission on mount — the component does not auto-select a filter.
     expect(wrapper.emitted("update:modelValue")).toBeUndefined();
 
-    // Filter dropdown is visible.
     const inputs = wrapper.findAll("input");
     expect(inputs.length).toBe(2);
-
-    // Open filter dropdown and verify "No filter" is the first option.
     await inputs[1].trigger("focus");
     const items = document.body.querySelectorAll(".dropdown-list-item");
     expect(items.length).toBe(3); // No filter, Top 1000, High quality
@@ -208,12 +202,13 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("emits PrimaryRef without filter key when selecting a filterless dataset", async () => {
+  it("emits DatasetSelection without enrichments when the option carries none", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
         modelValue: undefined,
         options: optionsNoFilters,
-        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
       },
       attachTo: document.body,
     });
@@ -225,25 +220,28 @@ describe("PlDatasetSelector", () => {
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
-    const last = emitted![emitted!.length - 1][0] as PrimaryRef;
-    expect(last).toEqual({ __isPrimaryRef: "v1", column: datasetB });
-    expect("filter" in last).toBe(false);
+    const last = emitted![emitted!.length - 1][0] as DatasetSelection;
+    expect(last).toEqual({
+      __isDatasetSelection: "v1",
+      primary: { __isPrimaryRef: "v1", column: datasetB },
+    });
+    expect("enrichments" in last).toBe(false);
     wrapper.unmount();
   });
 
   it("emits undefined when cleared via the dataset dropdown", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: createPrimaryRef(datasetA, filterA1),
+        modelValue: selection(datasetA, filterA1, enrichmentsA),
         options: optionsWithFilters,
         clearable: true,
-        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
       },
       attachTo: document.body,
     });
     await flushPromises();
 
-    // PlDropdown's clear button carries the ".clear" class.
     const clearBtn = wrapper.find(".clear");
     expect(clearBtn.exists()).toBe(true);
     await clearBtn.trigger("click");

--- a/sdk/workflow-tengo/src/pframes/build-table.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/build-table.tpl.tengo
@@ -1,38 +1,34 @@
 // Ephemeral template for tableBuilder.build().
-// Receives fully-resolved {spec, data} pairs — all bquery.resolve and
-// bquery.anchoredQuery happen in the builder (workflow body context).
-// This template just assembles the PFrame, joins, and exports via pt.
+// Inputs are pre-resolved {spec, data} (the builder did bquery resolution
+// in the workflow body context); this template just assembles the PFrame,
+// runs the join tree, and exports the file via pt.
 
 ll := import(":ll")
 pt := import(":pt")
+maps := import(":maps")
 pframesSpec := import(":pframes.spec")
 pBuilder := import(":pframes.builder")
 util := import(":pframes.util")
 exportUtil := import(":pframes.export-util")
 bquery := import(":pframes.build-query")
 
-// `:tpl` (not `:tpl.light`) registers `bquery.resultUnmarshaller` by default,
-// so a BQueryResult resource passed via `inputs.columns.*.multiResult` is
-// auto-parsed into `[{ref, spec, data}, ...]` during input unmarshal.
+// `:tpl` (not `:tpl.light`) registers `bquery.resultUnmarshaller`, which
+// auto-parses `inputs.columns.*.multiResult` into `[{ref, spec, data}, ...]`.
 self := import(":tpl")
 
 self.defineOutputs(["result"])
 
-// Each primary in `inputs.primaries` is a v1 ResolvedPrimaryRef
-// (`{__isPrimaryRef: "v1", column: {spec, data}, filter?: {spec, data}}`)
-// plus builder metadata (`name`, `header?`). PrimarySpecsReady awaits the
-// column's spec (required) and filter's spec (optional).
-//
-// Each enrichment column carries either flat {spec, data} (resolved,
-// pre-resolved PlRef, or single-match query) or a `multiResult` BQueryResult
-// (multi-match query from addColumns). Data fields pass as future references —
-// pt awaits them when executing ptabler.
+// Input shape:
+// - primaries: v1 ResolvedPrimaryRef + builder metadata.
+// - columns: flat {spec, data} (single), `multiResult` BQueryResult (multi),
+//   or EnrichmentRef with a resolved-hop list.
+// All specs must be ready before PFrame registration; multi-match data needs
+// inputs locked before resultUnmarshaller can iterate.
 self.awaitState("AllInputsSet")
 self.awaitState("primaries", { wildcard: "*" }, "PrimarySpecsReady")
-// Single-entry columns: spec ready at `columns.*.spec`.
 self.awaitState("columns", { wildcard: "*" }, { match: "^spec$" }, "ResourceReady")
-// Multi-entry columns: the BQueryResult's spec map and every sub-spec need
-// to be ready before resultUnmarshaller can parse; data needs inputs locked.
+self.awaitState("columns", { wildcard: "*" },
+	{ match: "^path$" }, { wildcard: "*" }, "spec", "ResourceReady")
 self.awaitState("columns", { wildcard: "*" },
 	{ match: "^multiResult$" }, "spec", "ResourceReady")
 self.awaitState("columns", { wildcard: "*" },
@@ -47,10 +43,9 @@ self.body(func(inputs) {
 	primaryCount := inputs.primaryCount
 	columnCount := inputs.columnCount
 
-	// Phase 1: Collect primaries (all pre-resolved). A primary's `filter`
-	// is singular in v1 — we normalize it into a `filters` list here so the
-	// downstream PFrame build and join-tree steps handle 0, 1, or (future v2) N
-	// filters uniformly.
+	// Phase 1: Collect primaries. v1 has at most one filter per primary; we
+	// normalize it into a `filters` list so downstream code handles 0, 1, or
+	// (future v2) N filters uniformly.
 
 	primaries := []
 	nextKey := 1
@@ -79,11 +74,9 @@ self.body(func(inputs) {
 		primaries = append(primaries, entry)
 	}
 
-	// Phase 2: Collect enrichment columns. Single entries carry flat
-	// {spec, data}; multi entries (addColumns with a query spec) carry a
-	// `multiResult` that the registered bquery.resultUnmarshaller has already
-	// parsed into a list of {ref, spec, data} — iterate to expand into N
-	// downstream columns, each sharing the same headerPrefix/headerSuffix.
+	// Phase 2: Collect enrichments. Single entries are flat {spec, data}; multi
+	// entries carry a `multiResult` (already parsed by resultUnmarshaller) that
+	// expands into N columns sharing the same headerPrefix/headerSuffix.
 
 	enrichments := []
 	for idx := 0; idx < columnCount; idx++ {
@@ -97,11 +90,25 @@ self.body(func(inputs) {
 					headerPrefix: c.headerPrefix,
 					headerSuffix: c.headerSuffix,
 					pFrameKey: "col" + string(nextKey),
-					mode: c.mode
+					mode: c.mode,
+					path: []
 				})
 				nextKey += 1
 			}
 		} else {
+			path := []
+			if !is_undefined(c.path) && !is_undefined(c.pathLength) {
+				for stepIdx := 0; stepIdx < c.pathLength; stepIdx++ {
+					step := c.path[string(stepIdx)]
+					path = append(path, {
+						type: step.type,
+						spec: step.spec,
+						data: step.data,
+						pFrameKey: "col" + string(nextKey)
+					})
+					nextKey += 1
+				}
+			}
 			enrichments = append(enrichments, {
 				spec: c.spec,
 				data: c.data,
@@ -109,7 +116,9 @@ self.body(func(inputs) {
 				headerPrefix: c.headerPrefix,
 				headerSuffix: c.headerSuffix,
 				pFrameKey: "col" + string(nextKey),
-				mode: c.mode
+				mode: c.mode,
+				path: path,
+				qualifications: c.qualifications
 			})
 			nextKey += 1
 		}
@@ -126,6 +135,9 @@ self.body(func(inputs) {
 	}
 	for e in enrichments {
 		frameBuilder.add(e.pFrameKey, e.spec, e.data)
+		for step in e.path {
+			frameBuilder.add(step.pFrameKey, step.spec, step.data)
+		}
 	}
 	pFrame := frameBuilder.build()
 
@@ -134,58 +146,38 @@ self.body(func(inputs) {
 	resultFile := "result." + format
 	columnsMap := util.pFrameToColumnsMap(pFrame)
 
-	// Build pt entries for each column
-	ptEntry := func(key) {
+	ptColumn := func(key) {
 		return pt.p.column(key, columnsMap[key])
 	}
 
-	// Step 1: per-primary filter wrap. `pframes.build-query.buildQuery`
-	// is the same logic the wasm pf-spec-driver runs; we translate its
-	// SpecQueryJoinEntry tree into pt operations.
-	translateQueryEntry := undefined
-	translateQueryEntry = func(entryWrap) {
-		node := entryWrap.entry
-		if node.type == "column" {
-			return ptEntry(node.column)
-		}
-		if node.type == "innerJoin" {
-			args := []
-			for child in node.entries {
-				args = append(args, translateQueryEntry(child))
-			}
-			return pt.p.inner(args...)
-		}
-		if node.type == "linkerJoin" {
-			ll.assert(len(node.secondary) == 1,
-				"build-table: linkerJoin must have exactly one secondary entry, got %d",
-				len(node.secondary))
-			return pt.p.linkerJoin(
-				ptEntry(node.linker.column),
-				translateQueryEntry(node.secondary[0]))
-		}
-		ll.panic("build-table: unsupported query node type: %v", node.type)
-	}
-
+	// Step 1: per-primary filter wrap via buildQuery → _rawQueryEntry.
 	filteredPrimaries := []
 	for p in primaries {
+		cols := {}
+		cols[p.pFrameKey] = columnsMap[p.pFrameKey]
 		path := []
 		for flt in p.filters {
+			cols[flt.pFrameKey] = columnsMap[flt.pFrameKey]
 			path = append(path, {
 				type: "filter",
 				filter: { columnId: flt.pFrameKey }
 			})
 		}
-		queryEntry := bquery.buildQuery({
-			version: "v1",
-			column: p.pFrameKey,
-			path: path
-		})
-		filteredPrimaries = append(filteredPrimaries, translateQueryEntry(queryEntry))
+		if len(path) == 0 {
+			filteredPrimaries = append(filteredPrimaries, ptColumn(p.pFrameKey))
+		} else {
+			qe := bquery.buildQuery({
+				version: "v1",
+				column: p.pFrameKey,
+				path: path
+			})
+			filteredPrimaries = append(filteredPrimaries, pt.p._rawQueryEntry(cols, qe))
+		}
 	}
 
-	// Step 2: Combine primaries into a single trunk using the configured join
-	// mode (inner or full). With a single primary, the mode has no effect.
-	// Filter joins above are always inner regardless of this setting.
+	// Step 2: Combine primaries into a single trunk via inner or full join.
+	// joinMode has no effect with a single primary; filter joins above are
+	// always inner regardless of this setting.
 	trunk := undefined
 	if len(filteredPrimaries) == 1 {
 		trunk = filteredPrimaries[0]
@@ -195,18 +187,45 @@ self.body(func(inputs) {
 		trunk = pt.p.full(filteredPrimaries...)
 	}
 
-	// Step 3: Full outer-join enrichments to trunk
+	// Step 3: full-join enrichments to the trunk; path-bearing entries become
+	// LinkerJoin chains via buildQuery.
 	frameInput := trunk
 	if len(enrichments) > 0 {
 		enrichEntries := []
 		for e in enrichments {
-			enrichEntries = append(enrichEntries, ptEntry(e.pFrameKey))
+			if len(e.path) == 0 {
+				enrichEntries = append(enrichEntries, ptColumn(e.pFrameKey))
+			} else {
+				cols := {}
+				cols[e.pFrameKey] = columnsMap[e.pFrameKey]
+				bqPath := []
+				for step in e.path {
+					ll.assert(step.type == "linker",
+						"build-table: only \"linker\" enrichment steps are supported, got %q",
+						step.type)
+					cols[step.pFrameKey] = columnsMap[step.pFrameKey]
+					bqPath = append(bqPath, {
+						type: "linker",
+						linker: { columnId: step.pFrameKey }
+					})
+				}
+				bqInput := {
+					version: "v1",
+					column: e.pFrameKey,
+					path: bqPath
+				}
+				if !is_undefined(e.qualifications) && len(e.qualifications) > 0 {
+					bqInput.qualifications = e.qualifications
+				}
+				enrichEntries = append(enrichEntries,
+					pt.p._rawQueryEntry(cols, bquery.buildQuery(bqInput)))
+			}
 		}
 		frameInput = pt.p.full(trunk, enrichEntries...)
 	}
 
-	// Collect all non-filter columns for label/axis processing.
-	// Filters are omitted — they're internal to the join, not rendered.
+	// Collect non-filter columns for label/axis processing.
+	// Filters are internal to the join and not rendered.
 	rawColumns := []
 	for p in primaries {
 		rawColumns = append(rawColumns, {
@@ -216,18 +235,23 @@ self.body(func(inputs) {
 		})
 	}
 	for e in enrichments {
+		spec := columnsMap[e.pFrameKey].spec
+		// linkerJoin strips the hit's own axes; clear axesSpec so
+		// exportUtil doesn't try to select axes that aren't there.
+		if len(e.path) > 0 {
+			spec = maps.deepMerge(spec, { axesSpec: [] })
+		}
 		rawColumns = append(rawColumns, {
 			frameKey: e.pFrameKey,
-			spec: columnsMap[e.pFrameKey].spec,
+			spec: spec,
 			header: e.header,
 			headerPrefix: e.headerPrefix,
 			headerSuffix: e.headerSuffix
 		})
 	}
 
-	// Strict label policy: every axis/column spec must carry pl7.app/label,
-	// unless the caller provided an explicit override (`setAxisHeader` for
-	// axes, `opts.header` for columns).
+	// Every axis/column spec must carry pl7.app/label, unless overridden
+	// (`setAxisHeader` for axes, `opts.header` for columns).
 	getAnnotatedLabel := func(spec) {
 		label := spec.annotations[pframesSpec.A_LABEL]
 		ll.assert(is_string(label) && label != "",

--- a/sdk/workflow-tengo/src/pframes/spec-distiller.test.tengo
+++ b/sdk/workflow-tengo/src/pframes/spec-distiller.test.tengo
@@ -249,3 +249,39 @@ TestDiscriminativeDomainsAreSorted := func() {
 	// Verify the domains are sorted alphabetically
 	test.isEqual(["abc", "def", "xyz"], domains2)
 }
+
+// ptabler reads `pl7.app/isLinkerColumn` from the spec frame to populate
+// the linker index (`pframes-rs/.../frame.rs:90`); the distiller must
+// preserve it even though all other annotations are stripped.
+TestDistillerPreservesIsLinkerColumnAnnotation := func() {
+	specs := [
+		{
+			kind: "PColumn",
+			valueType: "Int",
+			name: "linker",
+			annotations: {
+				"pl7.app/label": "Sample-Gene Linker",
+				"pl7.app/isLinkerColumn": "true"
+			},
+			axesSpec: [
+				{ type: "String", name: "sample" },
+				{ type: "String", name: "gene" }
+			]
+		},
+		{
+			kind: "PColumn",
+			valueType: "Int",
+			name: "data",
+			annotations: { "pl7.app/label": "Some Data" },
+			axesSpec: [{ type: "String", name: "sample" }]
+		}
+	]
+
+	distiller := pSpec.createSpecDistiller(specs)
+
+	distilledLinker := distiller.distill(specs[0])
+	test.isEqual({ "pl7.app/isLinkerColumn": "true" }, distilledLinker.annotations)
+
+	distilledData := distiller.distill(specs[1])
+	test.isEqual(undefined, distilledData.annotations)
+}

--- a/sdk/workflow-tengo/src/pframes/spec.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/spec.lib.tengo
@@ -69,6 +69,8 @@ D_BLOCK := "pl7.app/block"
 
 /** Annotation with axis or column label */
 A_LABEL := "pl7.app/label"
+/** Marks a PColumn as a linker column for spec-driven join discovery */
+A_IS_LINKER_COLUMN := "pl7.app/isLinkerColumn"
 /**
  * Annotation containing trace of operations resulting in a corresponding column.
  *
@@ -424,8 +426,17 @@ createSpecDistiller := func(specs) {
 	distillEntity := func(entity, entityName) {
 		result := maps.clone(entity)
 
+		// Keep `pl7.app/isLinkerColumn` — ptabler reads it to populate
+		// the linker index. Without it, linkerJoin degrades to inner.
 		if !is_undefined(result.annotations) {
-			delete(result, "annotations")
+			linkerVal := result.annotations[A_IS_LINKER_COLUMN]
+			if is_undefined(linkerVal) {
+				delete(result, "annotations")
+			} else {
+				keptAnnotations := {}
+				keptAnnotations[A_IS_LINKER_COLUMN] = linkerVal
+				result.annotations = keptAnnotations
+			}
 		}
 
 		// Filter domains

--- a/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
@@ -28,6 +28,7 @@
  */
 
 ll := import(":ll")
+json := import("json")
 render := import(":render")
 assets := import(":assets")
 maps := import(":maps")
@@ -80,6 +81,42 @@ isResolvedColumn := func(value) {
 // Identifies PrimaryRef / ResolvedPrimaryRef by the version marker.
 isPrimaryRef := func(value) {
 	return ll.isMap(value) && value.__isPrimaryRef == "v1"
+}
+
+isEnrichmentRef := func(value) {
+	return ll.isMap(value) && value.__isEnrichment == "v1"
+}
+
+// `{ ref: EnrichmentRef, label }` from `enrichmentMatchesToRefs`. The
+// per-element label becomes the export header.
+isLabeledEnrichment := func(value) {
+	return ll.isMap(value) &&
+		is_string(value.label) &&
+		isEnrichmentRef(value.ref)
+}
+
+decodeGlobalPObjectId := func(id) {
+	ll.assert(is_string(id),
+		"expected PObjectId string, got %v", id)
+	decoded := json.decode(id)
+	ll.assert(ll.isMap(decoded) && is_string(decoded.blockId) && is_string(decoded.name),
+		"EnrichmentRef id is not a global PlRef; local-form ids must be " +
+		"pre-resolved to {spec, data} on the model side. Got: %v", decoded)
+	return { __isRef: true, blockId: decoded.blockId, name: decoded.name }
+}
+
+// step.linker is either a global-form PObjectId string or a resolved {spec, data}.
+enrichmentStepColumn := func(step) {
+	ll.assert(step.type == "linker",
+		"unsupported enrichment step type %q (only \"linker\" is allowed)", step.type)
+	ll.assert(!is_undefined(step.linker),
+		"linker step missing 'linker' field: %v", step)
+	return step.linker
+}
+
+// Anchored ColumnQuerySpec that needs `bquery.anchoredQuery` to resolve.
+isQuerySpec := func(q) {
+	return !isUnresolved(q) && !isResolvedColumn(q) && !isEnrichmentRef(q)
 }
 
 /**
@@ -154,7 +191,7 @@ tableBuilder := func(format, ...ctxArg) {
 		 * Adds a single enrichment column. Expects exactly one match for query specs.
 		 *
 		 * @param query: ColumnQuerySpec (anchored axes reference primary names) |
-		 *               PColumnResult | PlRef
+		 *               PColumnResult | PlRef | EnrichmentRef | ResolvedEnrichmentRef
 		 * @param opts: (optional) { header?: string } — column header in exported file
 		 * @return self (for chaining)
 		 */
@@ -163,7 +200,7 @@ tableBuilder := func(format, ...ctxArg) {
 			if len(opts) > 0 && ll.isMap(opts[0]) {
 				header = opts[0].header
 			}
-			if isUnresolved(query) {
+			if isUnresolved(query) || isEnrichmentRef(query) {
 				_hasUnresolved = true
 			}
 			_columns = append(_columns, {
@@ -178,7 +215,7 @@ tableBuilder := func(format, ...ctxArg) {
 		 * Adds multiple enrichment columns from a multi-match query or an array
 		 * of pre-resolved columns. Empty match set is allowed (produces no enrichments).
 		 *
-		 * @param query: ColumnQuerySpec | PColumnResult[] | PlRef
+		 * @param query: ColumnQuerySpec | (PColumnResult | EnrichmentRef | ResolvedEnrichmentRef)[] | PlRef
 		 * @param opts: (optional) { headerPrefix?: string, headerSuffix?: string }
 		 * @return self (for chaining)
 		 */
@@ -190,22 +227,40 @@ tableBuilder := func(format, ...ctxArg) {
 				headerSuffix = opts[0].headerSuffix
 			}
 
-			// Array of resolved columns: add each individually
+			// Per-element entries. Labeled enrichments override the
+			// shared header prefix/suffix with their own label.
 			if is_array(query) {
 				for col in query {
-					ll.assert(isResolvedColumn(col),
-						"array elements must be resolved columns {spec, data}")
+					ll.assert(isResolvedColumn(col) || isEnrichmentRef(col) || isLabeledEnrichment(col),
+						"array elements must be resolved columns {spec, data}, EnrichmentRefs, " +
+						"or labeled enrichments {ref, label}; got: %v", col)
+
+					entryQuery := col
+					entryHeader := undefined
+					entryPrefix := headerPrefix
+					entrySuffix := headerSuffix
+					if isLabeledEnrichment(col) {
+						entryQuery = col.ref
+						entryHeader = col.label
+						entryPrefix = undefined
+						entrySuffix = undefined
+					}
+
+					if isUnresolved(entryQuery) || isEnrichmentRef(entryQuery) {
+						_hasUnresolved = true
+					}
 					_columns = append(_columns, {
-						query: col,
-						headerPrefix: headerPrefix,
-						headerSuffix: headerSuffix,
+						query: entryQuery,
+						header: entryHeader,
+						headerPrefix: entryPrefix,
+						headerSuffix: entrySuffix,
 						mode: "multi"
 					})
 				}
 				return self
 			}
 
-			if isUnresolved(query) {
+			if isUnresolved(query) || isEnrichmentRef(query) {
 				_hasUnresolved = true
 			}
 			_columns = append(_columns, {
@@ -268,13 +323,10 @@ tableBuilder := func(format, ...ctxArg) {
 		},
 
 		/**
-		 * Sets the cache duration for the underlying pt execution's inputs.
-		 * Useful when the builder runs in a sequence that may be re-rendered
-		 * shortly afterward — cached inputs enable recovery without recomputation.
-		 * A duration of ~one minute is typical. Pass a duration from the `times`
-		 * library (e.g. `1 * times.minute`).
+		 * Cache pt execution inputs for the given duration so a re-render shortly
+		 * after recovers without recomputation. Typical: ~1 minute.
 		 *
-		 * @param time: duration (int) — cache TTL
+		 * @param time: duration (int) from the `times` library (e.g. `1 * times.minute`)
 		 */
 		cacheInputs: func(time) {
 			ll.assert(is_int(time),
@@ -296,7 +348,7 @@ tableBuilder := func(format, ...ctxArg) {
 			// Determine whether ctx is needed: any unresolved PlRef, or any column query spec.
 			hasQuerySpec := false
 			for _, c in _columns {
-				if !isUnresolved(c.query) && !isResolvedColumn(c.query) {
+				if isQuerySpec(c.query) {
 					hasQuerySpec = true
 					break
 				}
@@ -307,8 +359,17 @@ tableBuilder := func(format, ...ctxArg) {
 					"Use wf.tableBuilder() or pass pre-resolved inputs.")
 			}
 
-			// Resolve a column (PlRef or {spec, data}) into {spec, data} futures.
+			// Resolve a column reference into {spec, data} futures.
+			// Accepts: PObjectId string | PlRef map | resolved {spec, data}.
 			resolveColumn := func(value) {
+				if is_string(value) {
+					ref := decodeGlobalPObjectId(value)
+					r := bquery.resolve(ref, _ctx)
+					return {
+						spec: r.getFutureInputField("spec"),
+						data: r.getFutureInputField("data")
+					}
+				}
 				if isUnresolved(value) {
 					r := bquery.resolve(value, _ctx)
 					return {
@@ -319,12 +380,10 @@ tableBuilder := func(format, ...ctxArg) {
 				return { spec: value.spec, data: value.data }
 			}
 
-			// Resolve primaries: collect {spec, data} and a filters list (0 or 1 entries
-			// today; extensible to N entries when PrimaryRef v2 adds `filters: PlRef[]`).
-			// `primaryPlRefs` tracks the ORIGINAL PlRef for each unresolved primary —
-			// passed as-is to bquery.anchoredQuery as the anchor (it re-resolves
-			// internally), since the result resource's `.ref` field carries an
-			// internal address, not the user's PlRef structure.
+			// Resolve primaries into {spec, data} + a filters list (0 or 1 in v1;
+			// PrimaryRef v2 will allow N). `primaryPlRefs` keeps the ORIGINAL PlRef
+			// per unresolved primary — bquery.anchoredQuery needs the user's PlRef
+			// as the anchor, not the resolved resource's internal `.ref`.
 			primaryEntries := []
 			primaryPlRefs := {}
 			for _, p in _primaries {
@@ -360,16 +419,14 @@ tableBuilder := func(format, ...ctxArg) {
 				primaryEntries = append(primaryEntries, entry)
 			}
 
-			// Run anchored query for column query specs.
-			// `addColumn` uses matchStrategy="expectSingle" — bquery asserts
-			// exactly one match (spec R11: "Expects exactly one match; panics on zero.").
-			// `addColumns` uses matchStrategy="expectMultiple" — bquery returns all
-			// matches as a map resource (spec R11: "Returns empty set on zero matches").
+			// Run anchored query for column query specs (spec R11):
+			//   addColumn  → expectSingle   (panics on zero, asserts exactly one).
+			//   addColumns → expectMultiple (returns all matches; empty set OK).
 			singleQueryByIdx := {}
 			multiQueryResultByIdx := {}
 			qMap := {}
 			for idx, c in _columns {
-				if !isUnresolved(c.query) && !isResolvedColumn(c.query) {
+				if isQuerySpec(c.query) {
 					strategy := "expectSingle"
 					if c.mode == "multi" { strategy = "expectMultiple" }
 					qMap["q" + string(idx)] = maps.deepMerge(c.query, {
@@ -384,7 +441,7 @@ tableBuilder := func(format, ...ctxArg) {
 
 				qResult := bquery.anchoredQuery(_ctx, primaryPlRefs, qMap)
 				for idx, c in _columns {
-					if !isUnresolved(c.query) && !isResolvedColumn(c.query) {
+					if isQuerySpec(c.query) {
 						r := qResult.getResult("q" + string(idx))
 						if c.mode == "multi" {
 							// Template iterates this resource via
@@ -400,8 +457,9 @@ tableBuilder := func(format, ...ctxArg) {
 				}
 			}
 
-			// Resolve enrichment columns. Single entries carry flat {spec, data};
-			// multi entries carry a `multiResult` resource expanded inside the template.
+			// Per-entry shape: flat {spec, data} for single, `multiResult`
+			// for multi-match queries, and resolved hit + path-step list
+			// for EnrichmentRefs.
 			columnEntries := []
 			for idx, c in _columns {
 				entry := {
@@ -410,7 +468,26 @@ tableBuilder := func(format, ...ctxArg) {
 					headerPrefix: c.headerPrefix,
 					headerSuffix: c.headerSuffix
 				}
-				if isResolvedColumn(c.query) {
+				if isEnrichmentRef(c.query) {
+					resolvedHit := resolveColumn(c.query.hit)
+					entry.spec = resolvedHit.spec
+					entry.data = resolvedHit.data
+					steps := []
+					if !is_undefined(c.query.path) {
+						for _, step in c.query.path {
+							resolvedStep := resolveColumn(enrichmentStepColumn(step))
+							steps = append(steps, {
+								type: step.type,
+								spec: resolvedStep.spec,
+								data: resolvedStep.data
+							})
+						}
+					}
+					entry.path = steps
+					if !is_undefined(c.query.qualifications) && len(c.query.qualifications) > 0 {
+						entry.qualifications = c.query.qualifications
+					}
+				} else if isResolvedColumn(c.query) {
 					entry.spec = c.query.spec
 					entry.data = c.query.data
 				} else if isUnresolved(c.query) {
@@ -427,11 +504,10 @@ tableBuilder := func(format, ...ctxArg) {
 				columnEntries = append(columnEntries, entry)
 			}
 
-			// Each primary entry matches v1 ResolvedPrimaryRef exactly
-			// (`__isPrimaryRef: "v1"`, nested `column`, optional singular `filter`)
-			// plus builder metadata (`name`, `header?`). Optional fields are
-			// added only when set — the JSON serializer rejects `undefined`
-			// values inside resource maps.
+			// Mirrors v1 ResolvedPrimaryRef shape (`__isPrimaryRef: "v1"`, nested
+			// `column`, optional singular `filter`) + builder metadata (`name`,
+			// `header?`). Optional fields are omitted when unset — the JSON
+			// serializer rejects `undefined` values inside resource maps.
 			primariesMap := {}
 			for idx, p in primaryEntries {
 				entry := {
@@ -460,6 +536,23 @@ tableBuilder := func(format, ...ctxArg) {
 				} else {
 					entry.spec = c.spec
 					entry.data = c.data
+				}
+				if !is_undefined(c.path) && len(c.path) > 0 {
+					// Map keyed by string(index): the smart serializer
+					// rejects arrays of refs but routes map entries.
+					steps := {}
+					for stepIdx, step in c.path {
+						steps[string(stepIdx)] = {
+							type: step.type,
+							spec: step.spec,
+							data: step.data
+						}
+					}
+					entry.path = steps
+					entry.pathLength = len(c.path)
+				}
+				if !is_undefined(c.qualifications) && len(c.qualifications) > 0 {
+					entry.qualifications = c.qualifications
 				}
 				if !is_undefined(c.header) { entry.header = c.header }
 				if !is_undefined(c.headerPrefix) { entry.headerPrefix = c.headerPrefix }

--- a/sdk/workflow-tengo/src/pframes/table-builder.test.tengo
+++ b/sdk/workflow-tengo/src/pframes/table-builder.test.tengo
@@ -117,6 +117,51 @@ TestMultiplePrimaries := func() {
 	test.isTrue(true, "multiple addPrimary calls accepted")
 }
 
+// EnrichmentRef hops are either a global-form PObjectId string —
+// canonicalize({__isRef: true, blockId, name}) — decoded by the workflow at
+// build() time, or a pre-resolved {spec, data} map (used when the hop is sourced
+// from prerun/outputs and was resolved on the model side).
+sampleHitId := "{\"__isRef\":true,\"blockId\":\"b1\",\"name\":\"hit-1\"}"
+sampleLinkerId := "{\"__isRef\":true,\"blockId\":\"b1\",\"name\":\"linker-1\"}"
+
+TestAddColumnAcceptsEnrichmentRefWithGlobalIds := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleRef)
+	b.addColumn({
+		__isEnrichment: "v1",
+		hit: sampleHitId,
+		path: [{ type: "linker", linker: sampleLinkerId }]
+	})
+	test.isTrue(true, "addColumn accepts EnrichmentRef with global-form PObjectId hops")
+}
+
+TestAddColumnAcceptsEnrichmentRefWithResolvedHops := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleResolved)
+	b.addColumn({
+		__isEnrichment: "v1",
+		hit: sampleResolved,
+		path: [{ type: "linker", linker: sampleResolved }]
+	})
+	test.isTrue(true, "addColumn accepts EnrichmentRef with pre-resolved {spec, data} hops")
+}
+
+TestAddColumnAcceptsEnrichmentRefWithoutPath := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleRef)
+	b.addColumn({ __isEnrichment: "v1", hit: sampleHitId })
+	test.isTrue(true, "addColumn accepts zero-hop EnrichmentRef (path omitted)")
+}
+
+TestAddColumnsAcceptsArrayWithEnrichmentRef := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleRef)
+	b.addColumns(
+		[sampleResolved, { __isEnrichment: "v1", hit: sampleHitId, path: [] }],
+		{ headerPrefix: "x_" })
+	test.isTrue(true, "addColumns accepts array mixing resolved columns and EnrichmentRefs")
+}
+
 // Note on panic-on-misuse coverage: Tengo unit tests can't catch panics
 // (`ll.panic` is terminal, no recover/try-catch). Misuse paths are guarded
 // by `ll.assert` in the source — see the assertions in:

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -278,12 +278,43 @@ p := ll.toStrict({
 		ll.assert(ll.isMap(linkerQuery) && linkerQuery.type == "column",
 			"linkerJoin: linker entry must be a plain p.column(...) result, got: %v", linkerQuery)
 
+		// Without `pl7.app/isLinkerColumn: "true"`, ptabler degrades
+		// silently to inner join. Skipped for futures (still smart objects).
+		linkerSpec := linkerColumnEntry._getColumnsMap()[linkerQuery.column].spec
+		if ll.isMap(linkerSpec) {
+			annotations := linkerSpec.annotations
+			isLinker := ll.isMap(annotations) && annotations[pframesSpec.A_IS_LINKER_COLUMN] == "true"
+			ll.assert(isLinker,
+				"linkerJoin: linker column %q must carry annotation %q == \"true\", got spec: %v",
+				linkerQuery.column, pframesSpec.A_IS_LINKER_COLUMN, linkerSpec)
+		}
+
 		merged := _mergePEntries([linkerColumnEntry, secondaryEntry])
 		return _newPEntry(merged.columns, {
 			type: "linkerJoin",
 			linker: { column: linkerQuery.column },
 			secondary: [_asJoinEntry(merged.specQueries[1])]
 		})
+	},
+	/**
+	 * Internal: wrap a pre-built `SpecQueryJoinEntry` (e.g. from
+	 * `bquery.buildQuery`) as a PEntry without reconstructing the tree.
+	 * Application code should use the public builders instead.
+	 * Drops `joinEntry.qualifications` to match every other `pt.p.*` builder.
+	 *
+	 * @param columnsByName {object} - `{[columnId]: { spec, data }}` for every
+	 *        leaf column referenced inside the query.
+	 * @param joinEntry {object} - `{ entry: SpecQuery, qualifications? }`.
+	 * @returns {object} - A join builder entry object.
+	 */
+	_rawQueryEntry: func(columnsByName, joinEntry) {
+		ll.assert(ll.isMap(columnsByName), "columnsByName must be a map")
+		ll.assert(ll.isMap(joinEntry) && !is_undefined(joinEntry.entry),
+			"joinEntry must be a SpecQueryJoinEntry { entry, qualifications? }, got: %v", joinEntry)
+		for name, info in columnsByName {
+			_validateColumn(name, info)
+		}
+		return _newPEntry(columnsByName, joinEntry.entry)
 	}
 })
 


### PR DESCRIPTION
## Summary

- New `EnrichmentRef` (versioned `{__isEnrichment, hit, path?, qualifications?}`) accepted by `tableBuilder.addColumn`/`addColumns`. The build-table ephemeral registers the hit + every linker hop in the PFrame, calls `pframes.build-query.buildQuery`, and hands the resulting `SpecQueryJoinEntry` straight to a new internal `pt.p._queryEntry` — ptabler resolves the linker join natively, no node-by-node translation.
- Spec distiller preserves `pl7.app/isLinkerColumn`; without it ptabler's spec frame can't populate the linker index and `linkerJoin` silently degrades to inner join (`pframes-rs/.../frame.rs:90`).
- Per-step `qualifications` dropped from the typed shapes of `DiscoverColumnsLinkerStep`, `MatchVariant.path[]`, and `DiscoveredPColumn.path[]`. They were always-empty discovery metadata; `BuildQuery` already discarded them. `DiscoveredPColumnId`'s wire form keeps `qualifications: []` so existing IDs in block storage remain byte-compatible.
- New helper `enrichmentRefFromMatch(match, variant, refMap)` exported from `@platforma-sdk/model` for the model-side discovery → workflow plumbing.

WIP notes for resume across machines in `docs/enrichment-ref-tablebuilder-wip.md`.

## Status

The realistic-flow test rewrite (model-side `ColumnCollectionBuilder` discovery feeding `args.enrichment` into the workflow) is **in progress, not done** — pending a decision on where the linker columns come from for discovery (new fixture block vs. self-published from `filter-column-test`'s own workflow). See the WIP doc for the full open-questions list.

The current block test still exercises the `EnrichmentRef` end-to-end via inline synthesis; it passes against a backend running ptabler 1.16.0.

## Test plan

- [x] `pnpm -C lib/model/common test` — 112/112
- [x] `pnpm -C sdk/model test` — 366/366
- [x] `pnpm -C sdk/workflow-tengo test` — passing (5 new tengo tests)
- [x] `pnpm -C tests/workflow-tengo test src/pframes/build-query.test.ts src/pframes/table-builder.test.ts` — 18/18 (PL_ADDRESS)
- [x] `etc/blocks/filter-column-test/test` — 3/3, twice in a row (PL_ADDRESS)
- [ ] Multi-hop linker chain integration test
- [ ] EnrichmentRef-with-PlRefs in integration test
- [ ] Realistic flow via `ColumnCollectionBuilder` in args mapper

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `EnrichmentRef` — a versioned descriptor for linker-reached enrichment columns — and wires it through `tableBuilder.addColumn/addColumns`, the `build-table` ephemeral template, and `pt.p._rawQueryEntry`, so ptabler resolves multi-hop linker joins natively without node-by-node translation. It also restructures `DatasetOption` / `PlDatasetSelector` to bundle discovered enrichments into a new `DatasetSelection` v-model, and fixes the spec distiller to preserve `pl7.app/isLinkerColumn` so ptabler can populate its linker index.

The two areas worth watching before broader adoption:
- `DatasetOption` shape and `PlDatasetSelector` v-model type are both breaking changes; any block that stores a `PrimaryRef` in args today will silently lose its dataset selection after upgrading — a migration read path or explicit migration guide is needed.
- `pt.p.linkerJoin`'s new annotation guard is skipped for unresolved futures, leaving a silent-degradation window if the linker column reaches ptabler without `pl7.app/isLinkerColumn`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for new functionality; the breaking DatasetOption / PlDatasetSelector API change needs a migration path for existing blocks before production rollout.

All findings are P2 — no runtime correctness bugs in the new EnrichmentRef join path (verified by the inline block test). The DatasetOption/PlDatasetSelector breaking change is the most impactful but is an intended API evolution tracked in the changeset.

sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue and sdk/model/src/components/PlDatasetSelector/dataset_selection.ts — both carry the breaking modelValue / DatasetOption shape change that will silently regress existing blocks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/pframes/build-table.tpl.tengo | Core ephemeral template refactored: replaces node-by-node translateQueryEntry with pt.p._rawQueryEntry; adds path/step registration for EnrichmentRef linker hops; strips axesSpec: [] for path-bearing enrichments before passing to exportUtil |
| sdk/workflow-tengo/src/pframes/table-builder.lib.tengo | Adds EnrichmentRef / LabeledEnrichment support to addColumn/addColumns; serializes path steps as string-keyed map (serializer limitation); unconditionally marks all EnrichmentRefs as needing ctx even when fully pre-resolved |
| sdk/workflow-tengo/src/pt/index.lib.tengo | Adds _rawQueryEntry internal helper and a new pl7.app/isLinkerColumn annotation guard in linkerJoin; guard is correctly skipped for unresolved futures but leaves open a silent degradation path |
| sdk/workflow-tengo/src/pframes/spec.lib.tengo | Spec distiller now preserves pl7.app/isLinkerColumn annotation; all other annotations still discarded; new test confirms the behavior |
| lib/model/common/src/ref.ts | Adds EnrichmentRef, EnrichmentLinkerStep, LabeledEnrichmentRef types and createEnrichmentRef/isEnrichmentRef helpers; removes old DatasetOption (moved to sdk/model); well-tested |
| lib/model/common/src/drivers/pframe/spec/selectors.ts | Adds AxisQualification, MultiColumnSelector, matchMultiColumnSelector, multiColumnSelectorsToPredicate helpers; AxisQualification moved here from spec_driver.ts to break circular dependency |
| sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts | New file: findEnrichmentColumns + enrichmentVariantsToRefs; correctly propagates qualifications.forHit; filters out zero-hop and non-globally-addressable variants |
| sdk/model/src/components/PlDatasetSelector/dataset_selection.ts | New DatasetOption/DatasetSelection types; DatasetOption shape changed from Option& to {primary, filters?, enrichments?} — breaking change for all existing consumers of buildDatasetOptions |
| sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue | v-model type changed to DatasetSelection; backward compat with PrimaryRef/PlRef modelValue removed; emitValue now looks up enrichments from options and bundles them into DatasetSelection |
| sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts | Adds withEnrichments/enrichmentMaxHops options; uses multiColumnSelectorsToPredicate for primary selector; graceful degradation when collection or filters are absent |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
sdk/workflow-tengo/src/pt/index.lib.tengo:281-292
**Linker annotation guard skips futures silently**

The `pl7.app/isLinkerColumn` check is bypassed when `linkerSpec` is not yet a plain map (i.e. it's still a smart-object future). In that case no assertion fires, the column flows through to ptabler without the annotation, and ptabler silently downgrades the `linkerJoin` to an inner join (as noted in `pframes-rs/.../frame.rs:90`). The comment documents this intentionally, but it means the only guard against a misconfigured linker column is the spec-distiller test — there is no runtime catch if the annotation is absent on a column that arrives as a future.

Consider at minimum logging a warning when the spec is a future, or deferring the assertion to the `_rawQueryEntry` call site where the full join entry is already concrete.

### Issue 2 of 4
sdk/workflow-tengo/src/pframes/table-builder.lib.tengo:199-203
**Pre-resolved `EnrichmentRef` unconditionally requires ctx**

`isEnrichmentRef(query) → _hasUnresolved = true` is set regardless of whether `hit` and every `path[].linker` are already `{spec, data}` maps. A caller that constructs a fully pre-resolved `EnrichmentRef` without a workflow context will receive a panic from `build()` even though `resolveColumn` would never touch `_ctx` for those values.

In practice this is unlikely today, but the `TestAddColumnAcceptsEnrichmentRefWithResolvedHops` test confirms the construction path; if `.build()` is exercised without ctx the panic surfaces. The guard could be restricted to only set `_hasUnresolved` when at least one hop is a string or PlRef.

### Issue 3 of 4
sdk/model/src/components/PlDatasetSelector/dataset_selection.ts:1-37
**Breaking `DatasetOption` shape change not guarded by a version discriminant**

`DatasetOption` changed from `Option & {filters?}` (with `ref`/`label` at the top level) to `{primary: Option, filters?, enrichments?}`. Any existing caller that reads `option.ref` or `option.label` directly will silently get `undefined` at runtime. The type was also moved from `@milaboratories/pl-model-common` to `@platforma-sdk/model`, so import paths break.

If blocks still pass old-shaped `DatasetOption[]` to `PlDatasetSelector`, the dataset dropdown will render empty labels and broken refs. The changeset bump should call this out explicitly, and a migration guide (or a transitional `isLegacyDatasetOption` guard) would reduce the blast radius.

### Issue 4 of 4
sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue:32
**Backward compatibility with `PrimaryRef | PlRef` modelValue removed**

The v-model type narrowed from `PrimaryRef | PlRef | undefined` to `DatasetSelection | undefined`. The two backward-compat tests were deleted. Any block that currently stores a `PrimaryRef` or `PlRef` in its args and passes it as `modelValue` will receive no dataset selection — `selectedDataset` returns `undefined` because `model.value?.primary.column` won't exist on those old shapes.

If existing blocks in production store `PrimaryRef` in block data, they will appear as "no dataset selected" after upgrading. Either add a migration read path (`isPrimaryRef(v) ? createDatasetSelection(v) : v`) or document that block data must be migrated.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(pframes): EnrichmentRef + tableBuil..."](https://github.com/milaboratory/platforma/commit/36a87d1163876fe1e7a23b04955d84ab793a3c8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30032734)</sub>

<!-- /greptile_comment -->