### PR TITLE
fix: correct build query for secondary groups in createPTableDefV3

### DIFF
--- a/.changeset/angry-pens-shave.md
+++ b/.changeset/angry-pens-shave.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+fix broken table query

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -16,7 +16,6 @@ import { isNil } from "es-toolkit";
 import type { PlDataTableFilters } from "../typesV5";
 import { distillFilterSpec, filterSpecToSpecQueryExpr } from "../../../filters";
 import type { Nil } from "@milaboratories/helpers";
-import { getCfgRenderCtx } from "../../../internal";
 
 /** Primary side — base row grid. */
 export type PrimaryEntry<Data> = {
@@ -64,8 +63,6 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
       ),
     };
   }
-
-  getCfgRenderCtx().logInfo(JSON.stringify(query));
 
   if (!isNil(params.filters)) {
     const nonEmpty = distillFilterSpec(params.filters);

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -16,6 +16,7 @@ import { isNil } from "es-toolkit";
 import type { PlDataTableFilters } from "../typesV5";
 import { distillFilterSpec, filterSpecToSpecQueryExpr } from "../../../filters";
 import type { Nil } from "@milaboratories/helpers";
+import { getCfgRenderCtx } from "../../../internal";
 
 /** Primary side — base row grid. */
 export type PrimaryEntry<Data> = {
@@ -63,6 +64,8 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
       ),
     };
   }
+
+  getCfgRenderCtx().logInfo(JSON.stringify(query));
 
   if (!isNil(params.filters)) {
     const nonEmpty = distillFilterSpec(params.filters);

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -49,16 +49,18 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
     entries: params.primary.map((a) => toLeaf(a.column, [])),
   };
 
-  for (const group of params.secondary) {
+  if (params.secondary.length > 0) {
     query = {
       type: "outerJoin",
       primary: {
         entry: query,
-        qualifications: params.primary.flatMap((p) => {
-          return group.primaryQualifications?.[p.column.id] ?? [];
-        }),
+        qualifications: params.secondary.flatMap((g) =>
+          params.primary.flatMap((p) => g.primaryQualifications?.[p.column.id] ?? []),
+        ),
       },
-      secondary: group.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
+      secondary: params.secondary.flatMap((g) =>
+        g.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
+      ),
     };
   }
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -167,10 +167,15 @@ export function createPlDataTableV3<A, U>(
   const primaryEntries: PrimaryEntry<undefined | PColumnDataUniversal>[] = primarySnapshots.map(
     (snap) => ({ column: resolveSnapshot(snap) }),
   );
+  const secondaryGroups: SecondaryGroup<undefined | PColumnDataUniversal>[] = buildSecondaryGroups(
+    secondarySnapshots,
+    annotated.linked,
+    annotated.labels,
+  );
   const fullDef = createPTableDefV3({
     primaryJoinType,
     primary: primaryEntries,
-    secondary: buildSecondaryGroups(secondarySnapshots, annotated.linked, annotated.labels),
+    secondary: secondaryGroups,
     filters,
     sorting,
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the per-group loop in `createPTableDefV3` (which chained one `outerJoin` node per secondary group) with a single flat `outerJoin` that merges all groups via `flatMap`. The companion change in `createPlDataTableV3` is cosmetic — it extracts `buildSecondaryGroups` into a local variable with no semantic effect.

- The main concern is that `primaryQualifications` from every secondary group are now concatenated onto the single primary anchor. If two variant groups supply different qualifications for the same primary column (different axis values), the merged array presents conflicting qualifications to the query engine, which could silently produce wrong rows or an empty result.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Hold for clarification — the primaryQualifications merge across groups may produce wrong joins for multi-variant tables

The structural fix (one flat outer join instead of nested per-group joins) is directionally correct, but the unconditional flatMap of primaryQualifications from all groups onto a single primary entry is potentially wrong when groups carry distinct variant qualifications for the same axis. This is a P1 logic concern on the critical query-building path.

sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts — specifically lines 57-59 (primaryQualifications merging)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts | Transforms a per-group loop that produced chained/nested outer joins into a single flat outer join that flatMaps all secondary entries together; primaryQualifications from all groups are merged, which may conflict for multi-variant scenarios |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Purely cosmetic refactor — extracts buildSecondaryGroups call into a local variable (secondaryGroups) for fullDef; no semantic change |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
Line: 57-59

Comment:
**Primary qualifications merged across all groups in a single join**

When multiple secondary groups carry different `primaryQualifications` for the same primary column (e.g., two variant groups that each qualify a shared axis to a distinct value), `flatMap` concatenates both qualification arrays onto the single primary entry. The old loop kept each group's qualifications scoped to its own nested outer-join node. Merging them here means the query engine sees contradictory qualifications on one primary anchor, which could silently produce wrong join behaviour or an empty result set.

If the intent is that all variant groups must share identical primary qualifications (so de-duplication is a no-op), a `uniqueBy` / dedup step would make that invariant explicit. Otherwise, groups with conflicting qualifications may need to remain in separate outer-join subtrees.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove unused logging in createPTab..."](https://github.com/milaboratory/platforma/commit/dc97091724d348c5bdd31fa2193d309db30856e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30036165)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->