### PR TITLE
fix: hide axis from label columns

### DIFF
--- a/.changeset/cruel-vans-feel.md
+++ b/.changeset/cruel-vans-feel.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+hide axes from label columns

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -38,6 +38,7 @@ import type { PrimaryEntry, SecondaryGroup } from "./createPTableDefV3";
 import { createPTableDefV3 } from "./createPTableDefV3";
 import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
 import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/helpers";
+import { flow } from "es-toolkit";
 
 export type createPlDataTableOptionsV3 = {
   tableState?: PlDataTableStateV2;
@@ -294,25 +295,29 @@ function annotateColumnGroups(params: {
     pframeSpec,
   );
 
-  const directAnnotated = withVariantColumns(direct, (cols) =>
-    withTableVisualAnnotations(
-      visibilityByColId,
-      orderByColId,
-      withInfoAnnotations(derivedTooltips, withLabelAnnotations(derivedLabels, cols)),
+  const directAnnotated = liftToVariantColumns(
+    direct,
+    flow(
+      (cols) => withLabelAnnotations(derivedLabels, cols),
+      (cols) => withInfoAnnotations(derivedTooltips, cols),
+      (cols) => withTableVisualAnnotations(visibilityByColId, orderByColId, cols),
     ),
   );
 
-  const linkedAnnotated = withVariantColumns(linked, (cols) =>
-    withTableVisualAnnotations(
-      visibilityByColId,
-      orderByColId,
-      withHidenAxesAnnotations(
-        withInfoAnnotations(derivedTooltips, withLabelAnnotations(derivedLabels, cols)),
-      ),
+  const linkedAnnotated = liftToVariantColumns(
+    linked,
+    flow(
+      (cols) => withHidenAxesAnnotations(cols),
+      (cols) => withLabelAnnotations(derivedLabels, cols),
+      (cols) => withInfoAnnotations(derivedTooltips, cols),
+      (cols) => withTableVisualAnnotations(visibilityByColId, orderByColId, cols),
     ),
   ).map((lc) => ({ ...lc, path: annotateLinkerPath(derivedLabels, lc.path) }));
 
-  const labelColumnsAnnotated = withLabelAnnotations(derivedLabels, labelColumns);
+  const labelColumnsAnnotated = flow(
+    (cols: PColumn<PColumnDataUniversal>[]) => withHidenAxesAnnotations(cols),
+    (cols) => withLabelAnnotations(derivedLabels, cols),
+  )(labelColumns);
 
   return {
     direct: directAnnotated,
@@ -321,15 +326,15 @@ function annotateColumnGroups(params: {
   };
 }
 
-/** Apply a snapshot-array transformation to the inner `column` of each variant. */
-function withVariantColumns<V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId> }>(
+/** Lift a snapshot-array transform so it runs on the inner `column` of each variant. */
+function liftToVariantColumns<V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId> }>(
   variants: V[],
   fn: (cols: ColumnSnapshot<DiscoveredPColumnId>[]) => ColumnSnapshot<DiscoveredPColumnId>[],
 ): V[] {
   const cols = fn(variants.map((v) => v.column));
   if (cols.length !== variants.length)
     throw new Error(
-      `withVariantColumns: fn must preserve array length (got ${cols.length}, expected ${variants.length})`,
+      `liftToVariantColumns: fn must preserve array length (got ${cols.length}, expected ${variants.length})`,
     );
   return variants.map((v, i) => ({ ...v, column: cols[i] }));
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing `withHidenAxesAnnotations` call on label columns, so their axis columns are now hidden in the table just like linked columns. It also refactors the annotation pipelines from deeply-nested calls to flat `flow` compositions and renames `withVariantColumns` to the more descriptive `liftToVariantColumns`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is targeted and the refactored pipelines preserve identical semantics.

All annotation functions write to distinct keys/objects (`axesSpec[*].annotations[Visibility]` vs `axesSpec[*].annotations[Label]` vs column-level `annotations`), so the reordering within `flow` does not affect correctness. The new `withHidenAxesAnnotations` on label columns is the intentional fix. No logic bugs found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Applies `withHidenAxesAnnotations` to label columns (the fix), refactors annotation pipelines with `flow`, and renames `withVariantColumns` → `liftToVariantColumns`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/milaboratory/platforma/commit/84ab51dd5532a4f63ad32c8c6c54071a19811173) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30054123)</sub>

<!-- /greptile_comment -->