### PR TITLE
chore: make pl-cli tool to not spam with warnings in dev mode

### DIFF
--- a/.changeset/weak-buckets-count.md
+++ b/.changeset/weak-buckets-count.md
@@ -1,0 +1,10 @@
+---
+"@milaboratories/pl-error-like": patch
+"@milaboratories/pl-deployments": patch
+"@milaboratories/computable": patch
+"@milaboratories/pl-config": patch
+"@milaboratories/pl-errors": patch
+"@milaboratories/pl-tree": patch
+---
+
+mark node libs with type: module annotation in package.json

--- a/.changeset/wide-towns-own.md
+++ b/.changeset/wide-towns-own.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/pl-cli": patch
+---
+
+rename run.js to mjs to fix bunch of warnings in dev mode

--- a/lib/model/pl-error-like/package.json
+++ b/lib/model/pl-error-like/package.json
@@ -6,6 +6,7 @@
     "./dist/**/*",
     "./src/**/*"
   ],
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/node/computable/package.json
+++ b/lib/node/computable/package.json
@@ -6,6 +6,7 @@
     "./dist/**/*",
     "./src/**/*"
   ],
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/node/pl-config/package.json
+++ b/lib/node/pl-config/package.json
@@ -14,6 +14,7 @@
     "assets",
     "postinstall.js"
   ],
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/node/pl-deployments/package.json
+++ b/lib/node/pl-deployments/package.json
@@ -13,6 +13,7 @@
     "assets",
     "postinstall.js"
   ],
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/node/pl-errors/package.json
+++ b/lib/node/pl-errors/package.json
@@ -6,6 +6,7 @@
     "./dist/**/*",
     "./src/**/*"
   ],
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/lib/node/pl-tree/package.json
+++ b/lib/node/pl-tree/package.json
@@ -6,6 +6,7 @@
     "./dist/**/*",
     "./src/**/*"
   ],
+  "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/tools/pl-cli/bin/run.js
+++ b/tools/pl-cli/bin/run.js
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-
-import { execute } from "@oclif/core";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-await execute({ dir: __dirname });

--- a/tools/pl-cli/bin/run.mjs
+++ b/tools/pl-cli/bin/run.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { run, handle, flush } from "@oclif/core";
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+run(process.argv.slice(2), import.meta.url)
+  .catch(async (error) => {
+    return handle(error);
+  })
+  .finally(async () => flush());

--- a/tools/pl-cli/package.json
+++ b/tools/pl-cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for Platforma server state manipulation",
   "license": "UNLICENSED",
   "bin": {
-    "pl-cli": "./bin/run.js"
+    "pl-cli": "./bin/run.mjs"
   },
   "files": [
     "./bin/*",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR suppresses dev-mode warnings in `pl-cli` by renaming `bin/run.js` to `bin/run.mjs` (making the ESM nature explicit via file extension) and adds `"type": "module"` to six library `package.json` files. The library changes are safe because all packages already output `.cjs` for CommonJS consumers and `.js` for ESM, with the `exports` field correctly mapping both.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are narrow and low-risk; only a style nit found

All P2 findings only; the `"type": "module"` additions are safe because CJS outputs use explicit `.cjs` extensions and the `exports` field correctly handles both module types. The `bin/run.js`/`postinstall.js` files referenced in `pl-config` and `pl-deployments` don't exist in source, suggesting they're generated — worth a sanity check but not a blocker.

`lib/node/pl-config/package.json` and `lib/node/pl-deployments/package.json` — verify generated `bin/run.js` and `postinstall.js` artifacts are ESM-compatible after the `"type": "module"` addition
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/pl-cli/bin/run.mjs | Replaces `execute()` with explicit `run()`/`handle()`/`flush()` pattern; minor style nit with unnecessary async callbacks |
| tools/pl-cli/package.json | Binary entry updated from `run.js` to `run.mjs`; package already had `"type": "module"` pre-existing |
| lib/node/pl-config/package.json | Added `"type": "module"`; `files` array lists `bin/run.js` and `postinstall.js` which don't exist in the repo — worth verifying these generated artifacts will be ESM-compatible |
| lib/node/pl-deployments/package.json | Added `"type": "module"`; same situation as `pl-config` — `files` includes `bin/run.js`/`postinstall.js` not present in repo source |
| lib/model/pl-error-like/package.json | Added `"type": "module"`; `exports` field already maps both CJS (`.cjs`) and ESM (`.js`) correctly, so this is safe |
| lib/node/computable/package.json | Added `"type": "module"`; CJS/ESM outputs already use explicit extensions, change is safe |
| lib/node/pl-errors/package.json | Added `"type": "module"`; build outputs properly separated by extension, no issue |
| lib/node/pl-tree/package.json | Added `"type": "module"`; same pattern as the other libs, safe change |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tools/pl-cli/bin/run.mjs
Line: 7-10

Comment:
**Unnecessary `async` on `.catch`/`.finally` callbacks**

Neither callback needs to be `async`. The `.catch` handler returns the result of `handle(error)` directly (oclif's `handle` returns a `Promise`), and the `.finally` handler returns `flush()` which is also a `Promise`. Wrapping them in async functions is redundant; the Promise chain already handles both correctly.

```suggestion
  .catch((error) => handle(error))
  .finally(() => flush());
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: make pl-cli tool to not spam with..."](https://github.com/milaboratory/platforma/commit/7ca2af755b09f59ad12fece6e83af1b90e166401) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30141936)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->