### PR TITLE
Correct show label columns and simplify join for big projects

### DIFF
--- a/.changeset/cruel-vans-feel.md
+++ b/.changeset/cruel-vans-feel.md
@@ -1,5 +1,0 @@
----
-"@platforma-sdk/model": patch
----
-
-hide axes from label columns

--- a/.changeset/cruel-vans-feel.md
+++ b/.changeset/cruel-vans-feel.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+hide axes from label columns

--- a/.changeset/poor-dragons-kneel.md
+++ b/.changeset/poor-dragons-kneel.md
@@ -1,0 +1,20 @@
+---
+"@milaboratories/milaboratories.monetization-test": minor
+"@milaboratories/milaboratories.monetization-test.model": minor
+"@milaboratories/milaboratories.monetization-test.ui": minor
+"@milaboratories/milaboratories.pool-explorer": minor
+"@milaboratories/milaboratories.pool-explorer.model": minor
+"@milaboratories/milaboratories.ui-examples": minor
+"@milaboratories/milaboratories.ui-examples.model": minor
+"@milaboratories/milaboratories.pool-explorer.ui": minor
+"@milaboratories/milaboratories.ui-examples.ui": minor
+"@milaboratories/pl-middle-layer": minor
+"@milaboratories/pl-mcp-server": minor
+"@milaboratories/uikit": minor
+"@platforma-sdk/pl-cli": minor
+"@platforma-sdk/ui-vue": minor
+"@platforma-sdk/model": minor
+"@platforma-sdk/test": minor
+---
+
+Correct show label columns and simplify join for big projects

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -21,7 +21,6 @@ import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } 
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import type { ColumnSelector, ColumnSnapshot, ColumnVariant, MatchingMode } from "../../../columns";
-import { getAllLabelColumns, getMatchingLabelColumns } from "../labels";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
   deriveAllLabels,
@@ -97,11 +96,6 @@ export function createPlDataTableV3<A, U>(
 
   const splited = splitDiscoveredColumns(discovered);
 
-  const labelColumns = getMatchingLabelColumns(
-    [...splited.direct, ...splited.linked].map((v) => v.column),
-    getAllLabelColumns(ctx),
-  );
-
   const derivedLabels = deriveAllLabels({
     columns: discovered.map((dc) => ({
       id: dc.column.id,
@@ -109,7 +103,6 @@ export function createPlDataTableV3<A, U>(
       linkerPath: dc.path,
       qualifications: dc.qualifications,
     })),
-    labelColumns,
     deriveLabelsOptions: {
       includeNativeLabel: true,
       ...options.labelsOptions,
@@ -129,7 +122,6 @@ export function createPlDataTableV3<A, U>(
   const annotated = annotateColumnGroups({
     pframeSpec,
     ...splited,
-    labelColumns,
     derivedLabels,
     derivedTooltips,
     displayOptions: options.displayOptions,
@@ -143,7 +135,6 @@ export function createPlDataTableV3<A, U>(
   const columnIsAvailable = createColumnValidationById([
     ...annotated.direct.map((v) => v.column),
     ...annotated.linked.flatMap((lc) => [...lc.path.map((s) => s.linker), lc.column]),
-    ...annotated.labels,
   ]);
 
   const remapedDefaultFilters = remapFilterColumnIds(options.filters, discovered);
@@ -165,7 +156,6 @@ export function createPlDataTableV3<A, U>(
   const secondaryGroups: SecondaryGroup<undefined | PColumnDataUniversal>[] = buildSecondaryGroups(
     secondarySnapshots,
     annotated.linked,
-    annotated.labels,
   );
   const fullDef = createPTableDefV3({
     primaryJoinType,
@@ -181,7 +171,6 @@ export function createPlDataTableV3<A, U>(
   const pframeHandle = ctx.createPFrame([
     ...annotated.direct.map((v) => resolveSnapshot(v.column)),
     ...annotated.linked.map((v) => resolveSnapshot(v.column)),
-    ...annotated.labels,
     ...collectLinkerSnapshots(annotated.linked).map(resolveSnapshot),
   ]);
 
@@ -193,14 +182,13 @@ export function createPlDataTableV3<A, U>(
     hiddenSpecs,
   );
 
-  const visible = buildVisibleColumns(annotated, hiddenColumnIds, labelColumns);
+  const visible = buildVisibleColumns(annotated, hiddenColumnIds);
   const visibleDef = createPTableDefV3({
     primaryJoinType,
     primary: primaryEntries,
     secondary: buildSecondaryGroups(
       visible.direct.filter((c) => !c.isPrimary),
       visible.linked,
-      visible.labels,
     ),
     filters,
     sorting,
@@ -229,13 +217,11 @@ type SplitDiscoveredColumns = {
 type AnnotatedColumnGroups = {
   readonly direct: TableColumnVariant[];
   readonly linked: TableColumnVariant[];
-  readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 type VisibleColumns = {
   readonly direct: TableColumnVariant[];
   readonly linked: TableColumnVariant[];
-  readonly labels: PColumn<PColumnDataUniversal>[];
 };
 
 /** Split discovered columns into direct (no linker path) and linked (with linker path). */
@@ -262,26 +248,16 @@ function collectLinkerSnapshots(linked: TableColumnVariant[]): ColumnSnapshot<PO
 function annotateColumnGroups(params: {
   direct: TableColumnVariant[];
   linked: TableColumnVariant[];
-  labelColumns: PColumn<PColumnDataUniversal>[];
   derivedLabels: Record<string, string>;
   derivedTooltips: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
   pframeSpec: PFrameSpecDriver;
 }): AnnotatedColumnGroups {
-  const {
-    direct,
-    linked,
-    labelColumns,
-    derivedLabels,
-    derivedTooltips,
-    displayOptions,
-    pframeSpec,
-  } = params;
+  const { direct, linked, derivedLabels, derivedTooltips, displayOptions, pframeSpec } = params;
 
   const allColumnsForRules = [
     ...direct.map((v) => v.column),
     ...linked.map((v) => v.column),
-    ...labelColumns,
     ...collectLinkerSnapshots(linked),
   ];
   const visibilityByColId = evaluateRules(
@@ -314,15 +290,9 @@ function annotateColumnGroups(params: {
     ),
   ).map((lc) => ({ ...lc, path: annotateLinkerPath(derivedLabels, lc.path) }));
 
-  const labelColumnsAnnotated = flow(
-    (cols: PColumn<PColumnDataUniversal>[]) => withHidenAxesAnnotations(cols),
-    (cols) => withLabelAnnotations(derivedLabels, cols),
-  )(labelColumns);
-
   return {
     direct: directAnnotated,
     linked: linkedAnnotated,
-    labels: labelColumnsAnnotated,
   };
 }
 
@@ -422,7 +392,6 @@ function validateSorting(sorting: PTableSorting[], isValidColumnId: (id: string)
 function buildSecondaryGroups(
   direct: TableColumnVariant[],
   linked: TableColumnVariant[],
-  labels: PColumn<PColumnDataUniversal>[],
 ): SecondaryGroup<undefined | PColumnDataUniversal>[] {
   return [
     ...direct.map(
@@ -442,9 +411,6 @@ function buildSecondaryGroups(
         ],
         primaryQualifications: lc.qualifications.forQueries,
       }),
-    ),
-    ...labels.map(
-      (c): SecondaryGroup<undefined | PColumnDataUniversal> => ({ entries: [{ column: c }] }),
     ),
   ];
 }
@@ -490,15 +456,10 @@ function collectPreservedColumnIds(
 function buildVisibleColumns(
   annotated: AnnotatedColumnGroups,
   hiddenColumns: Set<PObjectId>,
-  originalLabelColumns: PColumn<PColumnDataUniversal>[],
 ): VisibleColumns {
   const direct = annotated.direct.filter((c) => !hiddenColumns.has(c.column.id));
   const linked = annotated.linked.filter((c) => !hiddenColumns.has(c.column.id));
-  const labels = getMatchingLabelColumns(
-    [...direct, ...linked].map((v) => v.column),
-    originalLabelColumns,
-  );
-  return { direct, linked, labels };
+  return { direct, linked };
 }
 
 /** Resolve a ColumnSnapshot to a PColumn with lazily-evaluated data. */

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -13,7 +13,6 @@ import { toColumnSnapshotProvider } from "../../../columns/column_snapshot_provi
 import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_sources";
 import { throwError } from "@milaboratories/helpers";
 import type { ColumnsSelectorConfig, TableColumnVariant } from "./createPlDataTableV3";
-import { isNil } from "es-toolkit";
 
 export type DiscoverTableColumnOptions = {
   sources?: ColumnSource[];
@@ -45,14 +44,6 @@ export function discoverTableColumnSnaphots(
   try {
     const variants = collection.findColumnVariants({
       ...(resolvedOptions.selector ?? {}),
-      exclude: [
-        ...(Array.isArray(resolvedOptions.selector?.exclude)
-          ? resolvedOptions.selector.exclude
-          : !isNil(resolvedOptions.selector.exclude)
-            ? [resolvedOptions.selector.exclude]
-            : []),
-        { name: "pl7.app/label" },
-      ],
     });
     const anchors = collection.getAnchors();
     return mapToTableColumnVariants(variants, anchors);

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -1,11 +1,4 @@
-import {
-  Annotation,
-  canonicalizeJson,
-  getAxisId,
-  type AxisId,
-  type PColumnSpec,
-  type PObjectId,
-} from "@milaboratories/pl-model-common";
+import { Annotation, type PColumnSpec, type PObjectId } from "@milaboratories/pl-model-common";
 import { SpecDriver } from "@milaboratories/pf-spec-driver";
 import { describe, expect, test } from "vitest";
 import { deriveAllLabels, evaluateRules, type LabelableColumn, type RuleColumn } from "./utils";
@@ -38,24 +31,6 @@ function makeLabelableColumn(
   };
 }
 
-function makeLabelColumn(
-  axisSpec: PColumnSpec["axesSpec"][0],
-  label: string,
-): { readonly spec: PColumnSpec } {
-  return {
-    spec: makeSpec({
-      name: "label-col",
-      valueType: "String",
-      annotations: { [Annotation.Label]: label },
-      axesSpec: [axisSpec],
-    }),
-  };
-}
-
-function axisKey(axis: PColumnSpec["axesSpec"][0]): string {
-  return canonicalizeJson<AxisId>(getAxisId(axis));
-}
-
 // ---------------------------------------------------------------------------
 // deriveAllLabels
 // ---------------------------------------------------------------------------
@@ -75,7 +50,6 @@ describe("deriveAllLabels", () => {
 
     const result = deriveAllLabels({
       columns,
-      labelColumns: [],
       deriveLabelsOptions: { includeNativeLabel: true },
     });
 
@@ -83,7 +57,7 @@ describe("deriveAllLabels", () => {
     expect(result["c2"]).toBe("Beta");
   });
 
-  test("returns axis labels from label columns when available", () => {
+  test("does not produce axis labels", () => {
     const axis = { type: "String", name: "sample" } as const;
     const columns: LabelableColumn[] = [
       makeLabelableColumn("c1", {
@@ -92,56 +66,17 @@ describe("deriveAllLabels", () => {
         annotations: { [Annotation.Label]: "Score" },
       }),
     ];
-    const labelColumns = [makeLabelColumn(axis, "Sample Name")];
 
     const result = deriveAllLabels({
       columns,
-      labelColumns,
       deriveLabelsOptions: { includeNativeLabel: true },
     });
 
-    expect(result[axisKey(axis)]).toBe("Sample Name");
+    expect(Object.keys(result)).toEqual(["c1"]);
+    expect(result["c1"]).toBe("Score");
   });
 
-  test("falls back to axis annotation when no label column matches", () => {
-    const axis = { type: "String", name: "gene" } as const;
-    const columns: LabelableColumn[] = [
-      makeLabelableColumn("c1", {
-        name: "expr",
-        axesSpec: [{ ...axis, annotations: { [Annotation.Label]: "Gene ID" } }],
-        annotations: { [Annotation.Label]: "Expression" },
-      }),
-    ];
-
-    const result = deriveAllLabels({
-      columns,
-      labelColumns: [],
-      deriveLabelsOptions: { includeNativeLabel: true },
-    });
-
-    expect(result[axisKey(axis)]).toBe("Gene ID");
-  });
-
-  test("axis with no label annotation and no label column gets 'Unlabeled'", () => {
-    const axis = { type: "Int", name: "idx" } as const;
-    const columns: LabelableColumn[] = [
-      makeLabelableColumn("c1", {
-        name: "val",
-        axesSpec: [axis],
-        annotations: { [Annotation.Label]: "Value" },
-      }),
-    ];
-
-    const result = deriveAllLabels({
-      columns,
-      labelColumns: [],
-      deriveLabelsOptions: { includeNativeLabel: true },
-    });
-
-    expect(result[axisKey(axis)]).toBe("Unlabeled");
-  });
-
-  test("deduplicates axes shared across columns", () => {
+  test("distinct labels for columns sharing an axis", () => {
     const sharedAxis = { type: "String", name: "sample" } as const;
     const columns: LabelableColumn[] = [
       makeLabelableColumn("c1", {
@@ -155,74 +90,14 @@ describe("deriveAllLabels", () => {
         annotations: { [Annotation.Label]: "Score 2" },
       }),
     ];
-    const labelColumns = [makeLabelColumn(sharedAxis, "Sample")];
 
     const result = deriveAllLabels({
       columns,
-      labelColumns,
       deriveLabelsOptions: { includeNativeLabel: true },
     });
 
-    // axis label appears once
-    expect(result[axisKey(sharedAxis)]).toBe("Sample");
-    // column labels are distinct
     expect(result["c1"]).toBe("Score 1");
     expect(result["c2"]).toBe("Score 2");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// deriveAxisLabels (tested through deriveAllLabels)
-// ---------------------------------------------------------------------------
-
-describe("deriveAxisLabels via deriveAllLabels", () => {
-  test("multiple axes each get their own label", () => {
-    const axis1 = { type: "String", name: "sample" } as const;
-    const axis2 = { type: "String", name: "chain" } as const;
-    const columns: LabelableColumn[] = [
-      makeLabelableColumn("c1", {
-        name: "value",
-        axesSpec: [axis1, axis2],
-        annotations: { [Annotation.Label]: "Value" },
-      }),
-    ];
-    const labelColumns = [
-      makeLabelColumn(axis1, "Sample ID"),
-      makeLabelColumn(axis2, "Chain Type"),
-    ];
-
-    const result = deriveAllLabels({
-      columns,
-      labelColumns,
-      deriveLabelsOptions: { includeNativeLabel: true },
-    });
-
-    expect(result[axisKey(axis1)]).toBe("Sample ID");
-    expect(result[axisKey(axis2)]).toBe("Chain Type");
-  });
-
-  test("label column overrides axis annotation", () => {
-    const axis = {
-      type: "String",
-      name: "sample",
-      annotations: { [Annotation.Label]: "Axis Annotation Label" },
-    } as const;
-    const columns: LabelableColumn[] = [
-      makeLabelableColumn("c1", {
-        name: "v",
-        axesSpec: [axis],
-        annotations: { [Annotation.Label]: "V" },
-      }),
-    ];
-    const labelColumns = [makeLabelColumn({ type: "String", name: "sample" }, "Label Col Label")];
-
-    const result = deriveAllLabels({
-      columns,
-      labelColumns,
-      deriveLabelsOptions: { includeNativeLabel: true },
-    });
-
-    expect(result[axisKey(axis)]).toBe("Label Col Label");
   });
 
   // Regression: LabelableColumn.linkerPath used to be `linkerPath` while
@@ -249,7 +124,6 @@ describe("deriveAxisLabels via deriveAllLabels", () => {
 
     const result = deriveAllLabels({
       columns,
-      labelColumns: [],
       deriveLabelsOptions: { includeNativeLabel: true },
     });
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -5,9 +5,7 @@ import {
   type PObjectId,
   Annotation,
   canonicalizeAxisId,
-  canonicalizeJson,
   DiscoveredPColumnId,
-  getAxisId,
   readAnnotation,
   readAnnotationJson,
 } from "@milaboratories/pl-model-common";
@@ -236,11 +234,9 @@ export type LabelableColumn = {
 /** Derive labels for all table elements: columns via deriveDistinctLabels, axes from label columns. */
 export function deriveAllLabels(options: {
   columns: LabelableColumn[];
-  labelColumns: { readonly spec: PColumnSpec }[];
   deriveLabelsOptions?: DeriveLabelsOptions;
 }): Record<string, string> {
-  const { columns, labelColumns, deriveLabelsOptions } = options;
-  const axisLabels = deriveAxisLabels(columns, labelColumns);
+  const { columns, deriveLabelsOptions } = options;
   const entries = columns.map((c) => ({
     spec: c.spec,
     linkerPath: c.linkerPath?.map((step) => ({
@@ -253,26 +249,7 @@ export function deriveAllLabels(options: {
     (acc, label, index) => ((acc[columns[index].id] = label), acc),
     {} as Record<string, string>,
   );
-  return { ...axisLabels, ...columnLabels };
-}
-
-/** Derive axis labels from matching label columns, falling back to axis spec annotations. */
-function deriveAxisLabels(
-  columns: { readonly spec: PColumnSpec }[],
-  labelColumns: { readonly spec: PColumnSpec }[],
-): Record<string, string> {
-  const axisSpecMap = new Map(
-    columns.flatMap((c) => c.spec.axesSpec).map((a) => [canonicalizeJson(getAxisId(a)), a]),
-  );
-  const result: Record<string, string> = {};
-  for (const axisKey of axisSpecMap.keys()) {
-    const labelCol = labelColumns.find(
-      (lc) => canonicalizeJson(getAxisId(lc.spec.axesSpec[0])) === axisKey,
-    );
-    const source = labelCol?.spec ?? axisSpecMap.get(axisKey);
-    result[axisKey] = readAnnotation(source ?? {}, Annotation.Label)?.trim() ?? "Unlabeled";
-  }
-  return result;
+  return columnLabels;
 }
 
 /** Column shape required by tooltip derivation. */

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -126,7 +126,7 @@ export async function calculateGridOptions({
 
   // displayable column indices ordered: axes first, then columns by OrderPriority
   const fields = sortIndicesByTypeAndPriority(
-    selectDisplayableIndices(tableSpecs, isPartitionedAxis),
+    selectDisplayableIndices(tableSpecs, isPartitionedAxis, getLabelColumnIndex),
     tableSpecs,
   );
 
@@ -337,8 +337,6 @@ export function makeColDef(
   };
 }
 
-type LabelColumnLookup = (axisId: AxisId) => number;
-
 /** Build index mapping from full tableSpecs to their position in visibleTableSpecs (missing → -1). */
 function buildSpecsToVisibleSpecsMapping(
   tableSpecs: PTableColumnSpec[],
@@ -370,7 +368,7 @@ function createPartitionedAxisPredicate(sheets: PlDataTableSheet[]): (axisId: Ax
 function collectLabelColumnsByAxis(
   tableSpecs: PTableColumnSpec[],
   isPartitionedAxis: (axisId: AxisId) => boolean,
-): LabelColumnLookup {
+): (axisId: AxisId) => number {
   const labelColumns: { axisId: AxisId; labelColumnIdx: number }[] = [];
   for (const [i, spec] of tableSpecs.entries()) {
     if (spec.type !== "column" || !isLabelColumnSpec(spec.spec)) continue;
@@ -390,16 +388,22 @@ function collectLabelColumnsByAxis(
 function selectDisplayableIndices(
   tableSpecs: PTableColumnSpec[],
   isPartitionedAxis: (axisId: AxisId) => boolean,
+  getLabelColumnIndex: (axisId: AxisId) => number,
 ): number[] {
   return tableSpecs
     .entries()
     .filter(([, spec]) => {
       switch (spec.type) {
         case "axis":
-          return !isColumnHidden(spec.spec) && !isPartitionedAxis(spec.id);
+          return (
+            // show axis if not hidden or if it has a label column
+            (!isColumnHidden(spec.spec) ? true : getLabelColumnIndex(spec.id) > -1) &&
+            !isPartitionedAxis(spec.id)
+          );
         case "column":
           return (
             !isColumnHidden(spec.spec) &&
+            // hide label columns (their labeled axes are shown instead)
             !isLabelColumnSpec(spec.spec) &&
             !isLinkerColumnSpec(spec.spec)
           );
@@ -429,7 +433,7 @@ function sortIndicesByTypeAndPriority(indices: number[], tableSpecs: PTableColum
 function replaceAxesWithLabelColumns(
   fields: number[],
   tableSpecs: PTableColumnSpec[],
-  getLabelColumnIndex: LabelColumnLookup,
+  getLabelColumnIndex: (axisId: AxisId) => number,
 ): number[] {
   return fields.map((i) => {
     const spec = tableSpecs[i];

--- a/sdk/ui-vue/src/components/PlAgGridColumnManager/PlAgGridColumnManager.vue
+++ b/sdk/ui-vue/src/components/PlAgGridColumnManager/PlAgGridColumnManager.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import {
   PlBtnGhost,
+  PlBtnSecondary,
   PlElementList,
+  PlIcon24,
   PlSearchField,
   PlSlideModal,
   usePlBlockPageTitleTeleportTarget,
@@ -45,6 +47,24 @@ const { filteredItems, segments } = useFilteredItems({
   query,
   getStrings: (item) => [item.label],
 });
+
+const toggleableFilteredItems = computed(() =>
+  filteredItems.value.filter((item) => item.id !== PlAgDataTableRowNumberColId),
+);
+
+const allFilteredHidden = computed(
+  () =>
+    toggleableFilteredItems.value.length > 0 &&
+    toggleableFilteredItems.value.every((item) => !item.column.isVisible()),
+);
+
+const toggleAllFiltered = () => {
+  if (props.api.isDestroyed()) return;
+  const nextVisible = allFilteredHidden.value;
+  const cols = toggleableFilteredItems.value.map((item) => item.column);
+  if (cols.length === 0) return;
+  props.api.setColumnsVisible(cols, nextVisible);
+};
 </script>
 
 <template>
@@ -54,7 +74,17 @@ const { filteredItems, segments } = useFilteredItems({
 
   <PlSlideModal v-model="slideModal" :width="width" close-on-outside-click>
     <template #title>Manage Columns</template>
-    <PlSearchField v-model="query" clearable />
+    <div :class="$style.searchRow">
+      <PlSearchField v-model="query" clearable />
+      <PlBtnSecondary
+        :class="$style.toogleAllBtn"
+        :disabled="toggleableFilteredItems.length === 0"
+        @click.stop="toggleAllFiltered"
+      >
+        <PlIcon24 v-if="allFilteredHidden" name="view-show" />
+        <PlIcon24 v-else name="view-hide" />
+      </PlBtnSecondary>
+    </div>
     <PlElementList
       :items="filteredItems"
       :get-item-key="(item) => item.id"
@@ -100,5 +130,25 @@ const { filteredItems, segments } = useFilteredItems({
 .match {
   background-color: var(--color-active-select);
   border-radius: 2px;
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.searchRow > :first-child {
+  flex: 1;
+}
+
+.toogleAllBtn {
+  min-width: unset;
+  opacity: 0.2;
+  transition: opacity 0.3s;
+
+  &:hover {
+    opacity: 1;
+  }
 }
 </style>

--- a/sdk/ui-vue/src/components/PlAgGridColumnManager/PlAgGridColumnManager.vue
+++ b/sdk/ui-vue/src/components/PlAgGridColumnManager/PlAgGridColumnManager.vue
@@ -77,7 +77,7 @@ const toggleAllFiltered = () => {
     <div :class="$style.searchRow">
       <PlSearchField v-model="query" clearable />
       <PlBtnSecondary
-        :class="$style.toogleAllBtn"
+        :class="$style.toggleAllBtn"
         :disabled="toggleableFilteredItems.length === 0"
         @click.stop="toggleAllFiltered"
       >
@@ -142,7 +142,7 @@ const toggleAllFiltered = () => {
   flex: 1;
 }
 
-.toogleAllBtn {
+.toggleAllBtn {
   min-width: unset;
   opacity: 0.2;
   transition: opacity 0.3s;


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors label column handling in `PlDataTable` by removing the separate label-column pipeline (discover → match → annotate → add to secondary groups) and instead including label columns in the standard column discovery flow. The UI layer in `table-source-v2.ts` now correctly shows hidden axes that have a corresponding label column (the core bug fix), hiding the raw label column and using it only to supply data for the axis display. It also adds a "toggle all" button to `PlAgGridColumnManager`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no P0 or P1 issues found; changes are a well-scoped refactoring and bug fix.

All changes are coherent: label columns now flow through standard discovery, the core display bug (hidden axes with label columns not showing) is correctly fixed in selectDisplayableIndices, and the toggle-all button is logically sound. No regressions identified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts | Core fix: getLabelColumnIndex is now passed to selectDisplayableIndices so hidden axes with label columns are correctly shown; label columns are explicitly hidden from the field list; LabelColumnLookup type alias inlined. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Removes the separate label-column pipeline (labelColumns var, annotated.labels, visible.labels) across all callers; the label columns now flow through normal discovery. |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts | Removes deriveAxisLabels and the labelColumns parameter from deriveAllLabels; axis labeling is now handled directly in the UI layer via replaceAxesWithLabelColumns. |
| sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts | Removes the hard-coded exclusion of pl7.app/label columns from discovery; user-supplied selector.exclude is now respected normally via the spread. |
| sdk/ui-vue/src/components/PlAgGridColumnManager/PlAgGridColumnManager.vue | Adds a toggle-all-filtered button (show/hide all visible filtered columns) excluding the row number column; logic is correct. |
| .changeset/poor-dragons-kneel.md | Changeset bumping affected packages to minor; no issues. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["typo"](https://github.com/milaboratory/platforma/commit/6f02bf2e941370c88e1adbf713e5a1d05a9813ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30146234)</sub>

<!-- /greptile_comment -->