### PR TITLE
feat(workflow-tengo): add feats.hasGpu

### DIFF
--- a/.changeset/gpu-flag-feats-has-gpu.md
+++ b/.changeset/gpu-flag-feats-has-gpu.md
@@ -1,0 +1,16 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+Add `feats.hasGpu` — true when the backend reports GPU availability via the `gpuAvailable` feature flag (driven by the new `--runner-gpu-available` CLI flag in the platforma backend). Use it to gate `.gpuMemory()` calls in blocks that have a CPU fallback path:
+
+```tengo
+feats := import("@platforma-sdk/workflow-tengo:feats")
+
+builder := exec.builder().software(sw).cpu(8).mem("24GiB")
+if feats.hasGpu {
+    builder = builder.gpuMemory("16GiB")
+}
+```
+
+Calling `.gpuMemory()` against a backend that reports no GPU now produces a permanent error from the runner driver, so blocks must guard with `feats.hasGpu` to remain compatible with both GPU and non-GPU backends.

--- a/sdk/workflow-tengo/src/feats.lib.tengo
+++ b/sdk/workflow-tengo/src/feats.lib.tengo
@@ -67,6 +67,12 @@ export ll.toStrict({
 	// true when backend supports docker packages
 	isDockerAvailable:        _isEnabled("dockerSupport"),
 
+	// true when at least one backend runner advertises GPU availability.
+	// Use to gate .gpuMemory() calls in blocks that have a CPU fallback path:
+	//   if feats.hasGpu { builder = builder.gpuMemory("16GiB") }
+	// Calling .gpuMemory() against a backend without GPU produces a permanent error.
+	hasGpu:                   _isEnabled("gpuAvailable"),
+
 	// true when backend supports 'secret' argType for environment variables
 	secretEnvSupport:         _isEnabled("secretEnvSupport"),
 

--- a/tests/workflow-tengo/src/exec/run/hello_gpu_limits.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/hello_gpu_limits.tpl.tengo
@@ -1,20 +1,30 @@
 self := import("@platforma-sdk/workflow-tengo:tpl")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 exec := import("@platforma-sdk/workflow-tengo:exec")
+feats := import("@platforma-sdk/workflow-tengo:feats")
 
 self.defineOutputs(["gpuMemory"])
 
 sw := assets.importSoftware("@platforma-open/milaboratories.software-test-utils:hello-world")
 
 self.body(func(inputs) {
-	/* Checks, that custom limits applied to the command do not
-	 * break anything in its execution. We can't check what _controller_ saw,
-	 * but we at least know SDK does not get broken when custom limits are applied. */
-	run := exec.builder().
+	/* Checks that the SDK builder chain does not break when .gpuMemory()
+	 * is wired in, mirroring what blocks like clonotype-space do.
+	 * Calling .gpuMemory() against a backend without GPU is a permanent error
+	 * from the runner driver, so we MUST gate with feats.hasGpu — same rule
+	 * blocks follow.
+	 * The hello-world echo of inputs.gpuMemory verifies the chain end-to-end
+	 * regardless of whether GPU was actually requested. */
+	builder := exec.builder().
 		software(sw).
 		cpu(1).
-		mem("2GiB").
-		gpuMemory(inputs.gpuMemory).
+		mem("2GiB")
+
+	if feats.hasGpu {
+		builder = builder.gpuMemory(inputs.gpuMemory)
+	}
+
+	run := builder.
 		arg(inputs.gpuMemory).
 		saveStdoutContent().
 		run()


### PR DESCRIPTION
## Summary

Adds `feats.hasGpu` to `@platforma-sdk/workflow-tengo`. It surfaces the new backend feature flag `gpuAvailable` (driven by `--runner-gpu-available` in the platforma backend) so blocks can gate `.gpuMemory()` calls:

\`\`\`tengo
feats := import(\"@platforma-sdk/workflow-tengo:feats\")

builder := exec.builder().software(sw).cpu(8).mem(\"24GiB\")
if feats.hasGpu {
    builder = builder.gpuMemory(\"16GiB\")
}
\`\`\`

Calling `.gpuMemory()` against a backend without GPU is a permanent error in the runner driver, so blocks with a CPU fallback path **must** guard with `feats.hasGpu` to remain compatible with both GPU and non-GPU backends.

Pairs with [milaboratory/pl#1800](https://github.com/milaboratory/pl/pull/1800) (backend flag) and [platforma-open/clonotype-space#TBD](https://github.com/platforma-open/clonotype-space) (block-level guard).

## Compatibility

Old backends without the `gpuAvailable` flag report `false` — safe default. Existing blocks unchanged.

## Test plan

- [x] `pnpm build` succeeds; `dist/tengo/lib/feats.lib.tengo` includes `hasGpu`
- [x] `pnpm test` (149 tests) passes
- [ ] Manual: import `@platforma-sdk/workflow-tengo:feats` from a block and confirm `feats.hasGpu` is `false` on a non-GPU backend, `true` on a GPU backend

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `feats.hasGpu` to the `@platforma-sdk/workflow-tengo` feature catalogue by wiring `_isEnabled("gpuAvailable")` — a single-line addition that follows the exact same pattern as every other feature flag in the file. The `_isEnabled` helper already returns `false` when `plapi.isFeatureEnabled` is absent, so old backends without the flag behave correctly with no code changes required.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, backward-compatible addition with no risky logic.

Single-line change following an established pattern; backward compatibility is guaranteed by the existing `_isEnabled` null-guard; changeset is correctly marked as minor.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/feats.lib.tengo | Adds `hasGpu: _isEnabled("gpuAvailable")` entry to the exported feature catalogue, following the exact same pattern as all other feature flags in the file; backward-compatible since `_isEnabled` returns `false` when the method is absent. |
| .changeset/gpu-flag-feats-has-gpu.md | Changeset file marking `@platforma-sdk/workflow-tengo` as a minor version bump with a clear description and usage example. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(workflow-tengo): add feats.hasGpu"](https://github.com/milaboratory/platforma/commit/2933ec22fd6f3954452ff99038b9fe28c072707e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30325252)</sub>

<!-- /greptile_comment -->