### PR TITLE
MILAB-6176: show table with partial data

### DIFF
--- a/.changeset/tiny-ads-mate.md
+++ b/.changeset/tiny-ads-mate.md
@@ -1,0 +1,13 @@
+---
+"@milaboratories/pl-middle-layer": minor
+"@milaboratories/pl-mcp-server": minor
+"@milaboratories/pl-drivers": minor
+"@platforma-sdk/workflow-tengo": minor
+"@milaboratories/pl-model-common": minor
+"@platforma-sdk/pl-cli": minor
+"@platforma-sdk/ui-vue": minor
+"@platforma-sdk/model": minor
+"@platforma-sdk/test": minor
+---
+
+Show table with partial data

--- a/lib/model/common/src/drivers/pframe/spec/spec.ts
+++ b/lib/model/common/src/drivers/pframe/spec/spec.ts
@@ -122,6 +122,7 @@ export const Annotation = {
   AxisNature: "pl7.app/axisNature",
   Alphabet: "pl7.app/alphabet",
   Description: "pl7.app/description",
+  DataStatus: "pl7.app/dataStatus",
   DiscreteValues: "pl7.app/discreteValues",
   Format: "pl7.app/format",
   Graph: {
@@ -178,6 +179,7 @@ export type Annotation = Metadata &
     [Annotation.Alphabet]: "nucleotide" | "aminoacid" | (string & {});
     [Annotation.AxisNature]: "homogeneous" | "heterogeneous" | "scaleCompatible" | (string & {});
     [Annotation.Description]: string;
+    [Annotation.DataStatus]: "computing" | "ready" | "error" | "absent";
     [Annotation.DiscreteValues]: StringifiedJson<number[]> | StringifiedJson<string[]>;
     [Annotation.Format]: string;
     [Annotation.Graph.Axis.HighCardinality]: StringifiedJson<boolean>;

--- a/lib/model/common/src/drivers/pframe/spec/spec.ts
+++ b/lib/model/common/src/drivers/pframe/spec/spec.ts
@@ -174,12 +174,14 @@ export const Annotation = {
   },
 } as const;
 
+export type AnnotationDataStatus = "computing" | "ready" | "error" | "absent";
+
 export type Annotation = Metadata &
   Partial<{
     [Annotation.Alphabet]: "nucleotide" | "aminoacid" | (string & {});
     [Annotation.AxisNature]: "homogeneous" | "heterogeneous" | "scaleCompatible" | (string & {});
     [Annotation.Description]: string;
-    [Annotation.DataStatus]: "computing" | "ready" | "error" | "absent";
+    [Annotation.DataStatus]: AnnotationDataStatus;
     [Annotation.DiscreteValues]: StringifiedJson<number[]> | StringifiedJson<string[]>;
     [Annotation.Format]: string;
     [Annotation.Graph.Axis.HighCardinality]: StringifiedJson<boolean>;

--- a/sdk/model/src/columns/column_snapshot_provider.ts
+++ b/sdk/model/src/columns/column_snapshot_provider.ts
@@ -46,6 +46,7 @@ export class ArrayColumnProvider implements ColumnSnapshotProvider {
     this.columns = columns.map((col) => ({
       id: col.id,
       spec: col.spec,
+      // @todo: is a lie
       dataStatus: "ready" as const,
       data: { get: () => col.data },
     }));

--- a/sdk/model/src/columns/column_snapshot_provider.ts
+++ b/sdk/model/src/columns/column_snapshot_provider.ts
@@ -1,10 +1,8 @@
 import type { PObjectId } from "@milaboratories/pl-model-common";
-import { PColumn } from "@milaboratories/pl-model-common";
+import { isDataInfo, PColumn, visitDataInfo } from "@milaboratories/pl-model-common";
 import { TreeNodeAccessor } from "../render/accessor";
 import type { PColumnDataUniversal } from "../render/internal";
 import type { ColumnDataStatus, ColumnSnapshot } from "./column_snapshot";
-
-// --- ColumnProvider ---
 
 /**
  * Data source interface for column enumeration.
@@ -22,8 +20,6 @@ export interface ColumnSnapshotProvider {
   isColumnListComplete(): boolean;
 }
 
-// --- ColumnSource ---
-
 /**
  * Union of types that can serve as column sources for helpers and builders.
  * Does NOT include TreeNodeAccessor — call `.toColumnSource()` on it first.
@@ -32,8 +28,6 @@ export type ColumnSource =
   | ColumnSnapshotProvider
   | ColumnSnapshot<PObjectId>[]
   | PColumn<PColumnDataUniversal | undefined>[];
-
-// --- ArrayColumnProvider ---
 
 /**
  * Simple provider wrapping an array of PColumns.
@@ -46,9 +40,8 @@ export class ArrayColumnProvider implements ColumnSnapshotProvider {
     this.columns = columns.map((col) => ({
       id: col.id,
       spec: col.spec,
-      // @todo: is a lie
-      dataStatus: "ready" as const,
       data: { get: () => col.data },
+      dataStatus: this.getStatus(col.data),
     }));
   }
 
@@ -59,9 +52,35 @@ export class ArrayColumnProvider implements ColumnSnapshotProvider {
   isColumnListComplete(): boolean {
     return true;
   }
-}
 
-// --- SnapshotColumnProvider ---
+  protected getStatus(
+    d: undefined | PColumnDataUniversal | (() => undefined | PColumnDataUniversal),
+  ): ColumnDataStatus {
+    if (d == null) {
+      return "absent";
+    }
+    if (typeof d === "function") {
+      return this.getStatus(d());
+    }
+    if (d instanceof TreeNodeAccessor) {
+      if (d.getIsReadyOrError()) return "ready";
+      if (d.getIsFinal()) return "absent";
+      return "computing";
+    }
+    if (isDataInfo(d)) {
+      let ready = true;
+      let final = true;
+      visitDataInfo(d, (v) => {
+        ready &&= v.getIsReadyOrError();
+        final &&= v.getIsFinal();
+      });
+      if (ready) return "ready";
+      if (final) return "absent";
+      return "computing";
+    }
+    return "ready";
+  }
+}
 
 /**
  * Provider wrapping an array of ColumnSnapshots.
@@ -78,8 +97,6 @@ export class SnapshotColumnProvider implements ColumnSnapshotProvider {
     return true;
   }
 }
-
-// --- OutputColumnProvider ---
 
 export interface OutputColumnProviderOpts {
   /** When true and the accessor is final, columns with no ready data get status 'absent'. */
@@ -133,8 +150,6 @@ export class OutputColumnProvider implements ColumnSnapshotProvider {
     });
   }
 }
-
-// --- Source normalization ---
 
 /** Checks if a value is a ColumnSnapshotProvider (duck-typing). */
 export function isColumnSnapshotProvider(source: unknown): source is ColumnSnapshotProvider {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -80,8 +80,6 @@ export type ColumnVisibilityRule = {
 
 export type ColumnMatcher = (spec: PColumnSpec) => boolean;
 
-// Main Function
-
 export function createPlDataTableV3<A, U>(
   ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
@@ -139,17 +137,18 @@ export function createPlDataTableV3<A, U>(
   ]);
 
   const remapedDefaultFilters = remapFilterColumnIds(options.filters, discovered);
-  const filters = concatFilters(
-    state.pTableParams.filters,
-    state.pTableParams.defaultFilters ?? remapedDefaultFilters,
+  const filters = filterFilters(
+    concatFilters(
+      state.pTableParams.filters,
+      state.pTableParams.defaultFilters ?? remapedDefaultFilters,
+    ),
+    columnIsAvailable,
   );
-  validateFilters(filters, columnIsAvailable);
 
-  const sorting = resolveSorting(
-    state.pTableParams.sorting,
-    remapSortingColumnIds(options.sorting, discovered),
+  const sorting = filterSorting(
+    resolveSorting(state.pTableParams.sorting, remapSortingColumnIds(options.sorting, discovered)),
+    columnIsAvailable,
   );
-  validateSorting(sorting, columnIsAvailable);
 
   const primaryEntries: PrimaryEntry<undefined | PColumnDataUniversal>[] = primarySnapshots.map(
     (v) => ({ column: resolveSnapshot(v.column) }),
@@ -347,19 +346,35 @@ function createColumnValidationById(
   };
 }
 
-/** Validate that all column references in filters exist in the table. */
-function validateFilters(
+/** Drop filter leaves whose column references are not available in the table. */
+function filterFilters(
   filters: Nil | PlDataTableFilters,
   isValidColumnId: (id: string) => boolean,
-): void {
-  if (filters == null) return;
-  const filterColumns = collectFilterSpecColumns(filters);
-  const firstInvalid = filterColumns.find((col) => !isValidColumnId(col));
-  if (firstInvalid !== undefined) {
-    throw new Error(
-      `Invalid filter column ${firstInvalid}: column reference does not match the table columns`,
-    );
-  }
+): Nil | PlDataTableFilters {
+  if (isNil(filters)) return filters;
+
+  const isLeafValid = (leaf: PlDataTableFilterSpecLeaf): boolean => {
+    if (leaf.type === undefined) return true;
+    if ("column" in leaf && !isValidColumnId(leaf.column)) return false;
+    if ("rhs" in leaf && !isValidColumnId(leaf.rhs)) return false;
+    return true;
+  };
+
+  const prune = (node: PlDataTableFilterNode): Nil | PlDataTableFilterNode => {
+    if (node.type === "and" || node.type === "or") {
+      const kept = node.filters
+        .map((f) => prune(f))
+        .filter((f): f is PlDataTableFilterNode => !isNil(f));
+      return { type: node.type, filters: kept };
+    }
+    if (node.type === "not") {
+      const inner = prune(node.filter);
+      return isNil(inner) ? undefined : { type: "not", filter: inner };
+    }
+    return isLeafValid(node) ? node : undefined;
+  };
+
+  return prune(filters) as Nil | PlDataTableFilters;
 }
 
 /** Merge two filter trees into one AND-combined tree. Returns the non-nil one if the other is nil. */
@@ -380,16 +395,12 @@ function resolveSorting(
   return (isEmpty(userSorting) ? defaultSorting : userSorting) ?? [];
 }
 
-/** Validate that all column references in sorting exist in the table. */
-function validateSorting(sorting: PTableSorting[], isValidColumnId: (id: string) => boolean): void {
-  const firstInvalid = sorting.find(
-    (s) => !isValidColumnId(canonicalizeJson<PTableColumnId>(s.column)),
-  );
-  if (firstInvalid !== undefined) {
-    throw new Error(
-      `Invalid sorting column ${JSON.stringify(firstInvalid.column)}: column reference does not match the table columns`,
-    );
-  }
+/** Drop sorting entries whose column is not available in the table. */
+function filterSorting(
+  sorting: PTableSorting[],
+  isValidColumnId: (id: string) => boolean,
+): PTableSorting[] {
+  return sorting.filter((s) => isValidColumnId(canonicalizeJson<PTableColumnId>(s.column)));
 }
 
 function buildSecondaryGroups(
@@ -477,21 +488,22 @@ function remapSortingColumnIds(
   sorting: Nil | PTableSorting[],
   columns: TableColumnVariant[],
 ): Nil | PTableSorting[] {
-  return sorting?.map((s) => {
-    if (s.column.type === "axis") return s; // Axis references are unaffected by column ID remapping
+  return sorting?.flatMap((s) => {
+    if (s.column.type === "axis") return [s]; // Axis references are unaffected by column ID remapping
 
     const id = s.column.id;
-    const column =
-      columns.find((c) => (c.originalId ?? c.column.id) === id) ??
-      throwError(`Column ID "${id}" in sorting does not match any discovered column`);
+    const column = columns.find((c) => (c.originalId ?? c.column.id) === id);
+    if (column === undefined) return [];
 
-    return {
-      ...s,
-      column: {
-        type: "column",
-        id: column.column.id,
+    return [
+      {
+        ...s,
+        column: {
+          type: "column" as const,
+          id: column.column.id,
+        },
       },
-    };
+    ];
   });
 }
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -32,6 +32,7 @@ import {
   withLabelAnnotations,
   withTableVisualAnnotations,
   withInfoAnnotations,
+  withDataStatusAnnotations,
 } from "./utils";
 import type { PrimaryEntry, SecondaryGroup } from "./createPTableDefV3";
 import { createPTableDefV3 } from "./createPTableDefV3";
@@ -274,6 +275,7 @@ function annotateColumnGroups(params: {
   const directAnnotated = liftToVariantColumns(
     direct,
     flow(
+      (cols) => withDataStatusAnnotations(cols),
       (cols) => withLabelAnnotations(derivedLabels, cols),
       (cols) => withInfoAnnotations(derivedTooltips, cols),
       (cols) => withTableVisualAnnotations(visibilityByColId, orderByColId, cols),
@@ -283,6 +285,7 @@ function annotateColumnGroups(params: {
   const linkedAnnotated = liftToVariantColumns(
     linked,
     flow(
+      (cols) => withDataStatusAnnotations(cols),
       (cols) => withHidenAxesAnnotations(cols),
       (cols) => withLabelAnnotations(derivedLabels, cols),
       (cols) => withInfoAnnotations(derivedTooltips, cols),

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -6,10 +6,8 @@ import {
   Annotation,
   canonicalizeAxisId,
   DiscoveredPColumnId,
-  isDataInfo,
   readAnnotation,
   readAnnotationJson,
-  visitDataInfo,
 } from "@milaboratories/pl-model-common";
 import {
   deriveDistinctLabels,
@@ -19,12 +17,11 @@ import {
   deriveDistinctTooltips,
   type TooltipEntry,
 } from "../../../labels/derive_distinct_tooltips";
-import type { ColumnData, MatchQualifications, MatchVariant } from "../../../columns";
+import type { ColumnDataStatus, MatchQualifications, MatchVariant } from "../../../columns";
 import type { ColumnMatcher, ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
 import type { ColumnSelector } from "../../../columns";
 import { ArrayColumnProvider, ColumnCollectionBuilder } from "../../../columns";
 import { isNil } from "es-toolkit";
-import { PColumnDataUniversal, TreeNodeAccessor } from "../../../render";
 
 /** Check if column should be omitted from the table */
 export function isColumnHidden(spec: { annotations?: Annotation }): boolean {
@@ -162,36 +159,9 @@ export function withLabelAnnotations<
 export function withDataStatusAnnotations<
   T extends {
     readonly spec: PColumnSpec;
-    readonly data: ColumnData<undefined | PColumnDataUniversal> | undefined;
+    readonly dataStatus: ColumnDataStatus;
   },
 >(columns: T[]): T[] {
-  const getStatus = (
-    d: undefined | PColumnDataUniversal | (() => undefined | PColumnDataUniversal),
-  ): "absent" | "computing" | "ready" => {
-    if (d == null) {
-      return "absent";
-    }
-    if (typeof d === "function") {
-      return getStatus(d());
-    }
-    if (d instanceof TreeNodeAccessor) {
-      if (d.getIsReadyOrError()) return "ready";
-      if (d.getIsFinal()) return "absent";
-      return "computing";
-    }
-    if (isDataInfo(d)) {
-      let ready = true;
-      let final = true;
-      visitDataInfo(d, (v) => {
-        ready &&= v.getIsReadyOrError();
-        final &&= v.getIsFinal();
-      });
-      if (ready) return "ready";
-      if (final) return "absent";
-      return "computing";
-    }
-    return "ready"; // PColumnValues
-  };
   return columns.map((col) => {
     return {
       ...col,
@@ -199,7 +169,7 @@ export function withDataStatusAnnotations<
         ...col.spec,
         annotations: {
           ...col.spec.annotations,
-          [Annotation.DataStatus]: getStatus(col.data?.get()),
+          [Annotation.DataStatus]: col.dataStatus,
         },
       },
     } as T;

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -6,8 +6,10 @@ import {
   Annotation,
   canonicalizeAxisId,
   DiscoveredPColumnId,
+  isDataInfo,
   readAnnotation,
   readAnnotationJson,
+  visitDataInfo,
 } from "@milaboratories/pl-model-common";
 import {
   deriveDistinctLabels,
@@ -17,11 +19,12 @@ import {
   deriveDistinctTooltips,
   type TooltipEntry,
 } from "../../../labels/derive_distinct_tooltips";
-import type { MatchQualifications, MatchVariant } from "../../../columns";
+import type { ColumnData, MatchQualifications, MatchVariant } from "../../../columns";
 import type { ColumnMatcher, ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
 import type { ColumnSelector } from "../../../columns";
 import { ArrayColumnProvider, ColumnCollectionBuilder } from "../../../columns";
 import { isNil } from "es-toolkit";
+import { PColumnDataUniversal, TreeNodeAccessor } from "../../../render";
 
 /** Check if column should be omitted from the table */
 export function isColumnHidden(spec: { annotations?: Annotation }): boolean {
@@ -130,7 +133,10 @@ function dedupeById(columns: RuleColumn[]): RuleColumn[] {
  * For each axis in column specs: writes derived axis label into AxisSpec annotations.
  */
 export function withLabelAnnotations<
-  T extends { readonly id: PObjectId; readonly spec: PColumnSpec },
+  T extends {
+    readonly id: PObjectId;
+    readonly spec: PColumnSpec;
+  },
 >(derivedLabels: undefined | Record<string, string>, columns: T[]): T[] {
   if (derivedLabels === undefined) return columns;
   return columns.map((col) => {
@@ -148,6 +154,53 @@ export function withLabelAnnotations<
             ? axis
             : { ...axis, annotations: { ...axis.annotations, [Annotation.Label]: label } };
         }),
+      },
+    } as T;
+  });
+}
+
+export function withDataStatusAnnotations<
+  T extends {
+    readonly spec: PColumnSpec;
+    readonly data: ColumnData<undefined | PColumnDataUniversal> | undefined;
+  },
+>(columns: T[]): T[] {
+  const getStatus = (
+    d: undefined | PColumnDataUniversal | (() => undefined | PColumnDataUniversal),
+  ): "absent" | "computing" | "ready" => {
+    if (d == null) {
+      return "absent";
+    }
+    if (typeof d === "function") {
+      return getStatus(d());
+    }
+    if (d instanceof TreeNodeAccessor) {
+      if (d.getIsReadyOrError()) return "ready";
+      if (d.getIsFinal()) return "absent";
+      return "computing";
+    }
+    if (isDataInfo(d)) {
+      let ready = true;
+      let final = true;
+      visitDataInfo(d, (v) => {
+        ready &&= v.getIsReadyOrError();
+        final &&= v.getIsFinal();
+      });
+      if (ready) return "ready";
+      if (final) return "absent";
+      return "computing";
+    }
+    return "ready"; // PColumnValues
+  };
+  return columns.map((col) => {
+    return {
+      ...col,
+      spec: {
+        ...col.spec,
+        annotations: {
+          ...col.spec.annotations,
+          [Annotation.DataStatus]: getStatus(col.data?.get()),
+        },
       },
     } as T;
   });

--- a/sdk/model/src/render/api.ts
+++ b/sdk/model/src/render/api.ts
@@ -29,10 +29,8 @@ import type {
 } from "@milaboratories/pl-model-common";
 import {
   AnchoredIdDeriver,
-  collectSpecQueryColumns,
   ensurePColumn,
   parseJson,
-  extractAllColumns,
   isDataInfo,
   isPColumn,
   isPColumnSpec,
@@ -46,6 +44,7 @@ import {
   readAnnotation,
   withEnrichments,
   legacyColumnSelectorsToPredicate,
+  extractAllColumns,
 } from "@milaboratories/pl-model-common";
 import canonicalize from "canonicalize";
 import type { Optional } from "utility-types";
@@ -70,9 +69,9 @@ import type { LabelDerivationOps } from "./util/label";
 import { deriveLabels } from "./util/label";
 import type { APColumnSelectorWithSplit } from "./util/split_selectors";
 import { patchInSetFilters } from "./util/pframe_upgraders";
-import { allPColumnsReady } from "./util/pcolumn_data";
 import type { PColumnDataUniversal } from "./internal";
 import { getService } from "../services";
+import { allPColumnsReady } from "./util";
 
 /**
  * Helper function to match domain objects
@@ -97,7 +96,7 @@ export type UniversalColumnOption = { label: string; value: SUniversalPColumnId 
  * @returns Transformed data compatible with platform API
  */
 function transformPColumnData(
-  data: PColumn<PColumnDataUniversal> | PColumnLazy<PColumnDataUniversal>,
+  data: PColumn<undefined | PColumnDataUniversal> | PColumnLazy<undefined | PColumnDataUniversal>,
 ): PColumn<PColumnValues | AccessorHandle | DataInfo<AccessorHandle>> {
   return mapPObjectData(data, (d) => {
     if (d instanceof TreeNodeAccessor) {
@@ -105,7 +104,7 @@ function transformPColumnData(
     } else if (isDataInfo(d)) {
       return mapDataInfo(d, (accessor) => accessor.handle);
     } else {
-      return d;
+      return d ?? [];
     }
   });
 }
@@ -663,8 +662,6 @@ export abstract class RenderCtxBase<Args = unknown, Data = unknown> {
       PColumn<undefined | PColumnDataUniversal> | PColumnLazy<undefined | PColumnDataUniversal>
     >,
   ): PFrameHandle | undefined {
-    if (!allPColumnsReady(def)) return undefined;
-    this.verifyInlineAndExplicitColumnsSupport(def);
     return this.ctx.createPFrame(def.map((c) => transformPColumnData(c)));
   }
 
@@ -709,16 +706,7 @@ export abstract class RenderCtxBase<Args = unknown, Data = unknown> {
   public createPTableV2(
     def: PTableDefV2<PColumn<undefined | PColumnDataUniversal>>,
   ): PTableHandle | undefined {
-    const columns = collectSpecQueryColumns(def.query);
-    if (!allPColumnsReady(columns)) return undefined;
-    this.verifyInlineAndExplicitColumnsSupport(columns);
-    return this.ctx.createPTableV2(
-      mapPTableDefV2(def, (po) => {
-        if (po.data === undefined)
-          throw new Error("unreachable: column data undefined after readiness check");
-        return transformPColumnData({ id: po.id, spec: po.spec, data: po.data });
-      }),
-    );
+    return this.ctx.createPTableV2(mapPTableDefV2(def, (po) => transformPColumnData(po)));
   }
 
   /** @deprecated scheduled for removal from SDK */

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/common.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/common.ts
@@ -1,8 +1,6 @@
-import type { PTableValue } from "@platforma-sdk/model";
-
 export const PTableHidden = { type: "hidden" } as const;
 export type PTableHidden = typeof PTableHidden;
 
-export function isPTableHidden(value: PTableValue | PTableHidden): value is PTableHidden {
-  return typeof value === "object" && value !== null && value.type === "hidden";
+export function isPTableHidden(value: unknown): value is PTableHidden {
+  return typeof value === "object" && value !== null && "type" in value && value.type === "hidden";
 }

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/value-rendering.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/value-rendering.ts
@@ -13,10 +13,15 @@ import * as d3 from "d3-format";
 import type { PlAgDataTableV2Row } from "../types";
 
 export function formatSpecialValues(
-  value: PTableValue | PTableHidden | undefined,
+  value: undefined | PTableValue | PTableHidden,
+  dataStatus: undefined | "absent" | "error" | "computing" | "ready",
 ): string | undefined {
-  if (value === undefined) {
-    return "undefined";
+  if (dataStatus === "absent") {
+    return "absent";
+  } else if (dataStatus === "error") {
+    return "error";
+  } else if (dataStatus === "computing") {
+    return "computing...";
   } else if (isPTableHidden(value)) {
     return "loading...";
   } else if (value === PTableNA) {
@@ -40,10 +45,11 @@ export function getColumnRenderingSpec(spec: PTableColumnSpec): ColumnRenderingS
     case ValueType.Float:
     case ValueType.Double: {
       const format = readAnnotation(spec.spec, Annotation.Format);
+      const dataStatus = readAnnotation(spec.spec, Annotation.DataStatus);
       const formatFn = format ? d3.format(format) : undefined;
       renderSpec = {
         valueFormatter: (params) => {
-          const formatted = formatSpecialValues(params.value);
+          const formatted = formatSpecialValues(params.value, dataStatus);
           if (formatted !== undefined) return formatted;
           return formatFn ? formatFn(Number(params.value)) : params.value!.toString();
         },
@@ -53,7 +59,10 @@ export function getColumnRenderingSpec(spec: PTableColumnSpec): ColumnRenderingS
     default:
       renderSpec = {
         valueFormatter: (params) => {
-          const formatted = formatSpecialValues(params.value);
+          const formatted = formatSpecialValues(
+            params.value,
+            readAnnotation(spec.spec, Annotation.DataStatus),
+          );
           if (formatted !== undefined) return formatted;
           return params.value!.toString();
         },

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/value-rendering.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/value-rendering.ts
@@ -51,7 +51,7 @@ export function getColumnRenderingSpec(spec: PTableColumnSpec): ColumnRenderingS
         valueFormatter: (params) => {
           const formatted = formatSpecialValues(params.value, dataStatus);
           if (formatted !== undefined) return formatted;
-          return formatFn ? formatFn(Number(params.value)) : params.value!.toString();
+          return formatFn ? formatFn(Number(params.value)) : (params.value?.toString() ?? "");
         },
       };
       break;
@@ -64,7 +64,7 @@ export function getColumnRenderingSpec(spec: PTableColumnSpec): ColumnRenderingS
             readAnnotation(spec.spec, Annotation.DataStatus),
           );
           if (formatted !== undefined) return formatted;
-          return params.value!.toString();
+          return params.value?.toString() ?? "";
         },
       };
       break;


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enables tables to render with partial data by removing the all-columns-ready guard, propagating a new `DataStatus` annotation through column specs, and updating cell renderers to display contextual status labels (`absent`, `error`, `computing...`) instead of blocking on full readiness. Filters and sorting are now silently dropped for unavailable columns rather than throwing.

- **P1**: `filterFilters` returns `{ type: "or", filters: [] }` when all leaves are pruned, which semantically means "nothing matches" and would produce an empty table — likely the opposite of the intended behavior for partial data.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe, but the empty filter node edge case in filterFilters can silently produce an empty table or a query error when all filter columns are unavailable.

One P1 finding in the filter pruning logic that can result in wrong data being shown (empty table) or a runtime error when a user has active filters on columns that aren't yet available. The rest of the changes are clean.

sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts — specifically the filterFilters prune function.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Switches from throwing on invalid filter/sort columns to silently dropping them; `filterFilters` can return empty `and`/`or` nodes that may break queries or produce empty tables. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/value-rendering.ts | Adds `dataStatus` rendering for absent/error/computing states; minor inconsistency where `readAnnotation` is cached for numeric columns but re-read per cell in the default branch. |
| sdk/model/src/columns/column_snapshot_provider.ts | Adds `getStatus` to `ArrayColumnProvider` to derive `dataStatus` from data readiness; logic correctly handles TreeNodeAccessor, DataInfo, functions, and undefined. |
| lib/model/common/src/drivers/pframe/spec/spec.ts | Adds `DataStatus` annotation key and `AnnotationDataStatus` type; clean, straightforward additions. |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts | Adds `withDataStatusAnnotations` helper to propagate column data status into spec annotations; straightforward and consistent with the existing annotation utilities. |
| sdk/model/src/render/api.ts | Removes the all-columns-ready guard, allowing partial data through; `transformPColumnData` now maps `undefined` data to an empty array `[]`. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/common.ts | Widens `isPTableHidden` parameter type from `PTableValue | PTableHidden` to `unknown` with safer property check; no issues. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts:363-377
**Empty `and`/`or` filter node returned instead of `nil`**

When all children of an `and` or `or` node are pruned, `prune` returns `{ type: "and"|"or", filters: [] }` rather than `nil`/`undefined`. An empty `or` node is semantically "false" (nothing matches), which would produce an empty table even when data is partially available — the opposite of the intent. An empty `and` node may cause a query-engine error. Returning `undefined` for empty logical nodes would be safer:

```suggestion
  const prune = (node: PlDataTableFilterNode): Nil | PlDataTableFilterNode => {
    if (node.type === "and" || node.type === "or") {
      const kept = node.filters
        .map((f) => prune(f))
        .filter((f): f is PlDataTableFilterNode => !isNil(f));
      if (kept.length === 0) return undefined;
      return { type: node.type, filters: kept };
    }
    if (node.type === "not") {
      const inner = prune(node.filter);
      return isNil(inner) ? undefined : { type: "not", filter: inner };
    }
    return isLeafValid(node) ? node : undefined;
  };
```

### Issue 2 of 2
sdk/ui-vue/src/components/PlAgDataTable/sources/value-rendering.ts:59-69
**`readAnnotation` called on every render in `default` branch**

The numeric branch caches `dataStatus` once (line 48), but the `default` branch re-reads the annotation inside the `valueFormatter` closure on every cell render. Since `getColumnRenderingSpec` is called once per column and `valueFormatter` runs per cell, this creates needless work. Cache it the same way as the numeric branch:

```suggestion
    default: {
      const dataStatus = readAnnotation(spec.spec, Annotation.DataStatus);
      renderSpec = {
        valueFormatter: (params) => {
          const formatted = formatSpecialValues(
            params.value,
            dataStatus,
          );
          if (formatted !== undefined) return formatted;
          return params.value?.toString() ?? "";
        },
      };
      break;
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset"](https://github.com/milaboratory/platforma/commit/5e4908cbb40ae14113444cd4be4147877ec3d8f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30332933)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->