### PR TITLE
feat(model): primaryColumns + enrichFromPool for createPlDataTableV3

### DIFF
--- a/.changeset/createpldatatablev3-primary-enrichment.md
+++ b/.changeset/createpldatatablev3-primary-enrichment.md
@@ -1,0 +1,27 @@
+---
+"@platforma-sdk/model": minor
+---
+
+`createPlDataTableV3`: add `primaryColumns` + `enrichFromPool` for the common case.
+
+The typical block table — "show columns from my workflow output, plus joinable columns from the result pool as optional extras" — now requires three lines instead of fifteen of `ColumnCollectionBuilder` plumbing:
+
+```ts
+.outputWithStatus('mainTable', (ctx) =>
+  createPlDataTableV3(ctx, {
+    tableState: ctx.data.tableState,
+    primaryColumns: ctx.outputs?.resolve('mainPf'),
+    enrichFromPool: 'optional',
+  }),
+)
+```
+
+`primaryColumns` accepts a `TreeNodeAccessor` (preserves per-column `dataStatus` for partial-data rendering), a `PColumn[]`, or a `TableColumnVariant[]`. `enrichFromPool` accepts `false` (default), `true`, a visibility shorthand (`'optional' | 'hidden' | 'default'`), or a full options object.
+
+Other changes:
+
+- `TableColumnVariant`'s `path`, `qualifications`, `originalId`, and `isPrimary` fields are now optional with sensible defaults (`[]`, `{ forHit: [], forQueries: {} }`, `column.id`, `true`). For the common case only `column` needs to be specified.
+- `primaryColumns` and `columns` are mutually exclusive — passing both throws.
+- Documentation: `createPlDataTableV3`, all of `createPlDataTableOptionsV3`, `ColumnsSelectorConfig`, `ColumnsDisplayOptions`, `DiscoverTableColumnOptions`, and the internal pipeline now have JSDoc explaining behavior, defaults, and edge cases.
+
+The advanced `columns: { sources, anchors, selector }` form is unchanged. `TooltipableColumn.id` widens from `DiscoveredPColumnId` to `PObjectId | DiscoveredPColumnId` (backward-compatible — `DiscoveredPColumnId` still assignable).

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts
@@ -1,0 +1,144 @@
+import type { PColumnSpec, PObjectId } from "@milaboratories/pl-model-common";
+import type { ColumnSnapshot, ColumnDataStatus } from "../../../columns";
+import { describe, expect, test } from "vitest";
+import {
+  normalizeEnrichmentConfig,
+  normalizeTableColumnVariant,
+  type TableColumnVariant,
+} from "./createPlDataTableV3";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpec(overrides: Partial<PColumnSpec> = {}): PColumnSpec {
+  return {
+    kind: "PColumn",
+    name: "col",
+    valueType: "Int",
+    annotations: {},
+    axesSpec: [],
+    ...overrides,
+  } as PColumnSpec;
+}
+
+function makeSnapshot(
+  id: string,
+  status: ColumnDataStatus = "ready",
+  spec: Partial<PColumnSpec> = {},
+): ColumnSnapshot<PObjectId> {
+  return {
+    id: id as PObjectId,
+    spec: makeSpec(spec),
+    dataStatus: status,
+    data: { get: () => undefined },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeEnrichmentConfig
+// ---------------------------------------------------------------------------
+
+describe("normalizeEnrichmentConfig", () => {
+  test("`true` shorthand expands to optional with default discovery params", () => {
+    expect(normalizeEnrichmentConfig(true)).toEqual({
+      visibility: "optional",
+      exclude: [],
+      maxHops: 4,
+      mode: "enrichment",
+    });
+  });
+
+  test("'optional' string shorthand", () => {
+    expect(normalizeEnrichmentConfig("optional")).toEqual({
+      visibility: "optional",
+      exclude: [],
+      maxHops: 4,
+      mode: "enrichment",
+    });
+  });
+
+  test("'hidden' string shorthand", () => {
+    expect(normalizeEnrichmentConfig("hidden").visibility).toBe("hidden");
+  });
+
+  test("'default' string shorthand", () => {
+    expect(normalizeEnrichmentConfig("default").visibility).toBe("default");
+  });
+
+  test("object form fills in missing fields with documented defaults", () => {
+    expect(normalizeEnrichmentConfig({})).toEqual({
+      visibility: "optional",
+      exclude: [],
+      maxHops: 4,
+      mode: "enrichment",
+    });
+  });
+
+  test("object form preserves explicit overrides", () => {
+    const exclude = [{ name: "x" }] as never;
+    expect(
+      normalizeEnrichmentConfig({
+        visibility: "hidden",
+        maxHops: 7,
+        mode: "exact",
+        exclude,
+      }),
+    ).toEqual({
+      visibility: "hidden",
+      maxHops: 7,
+      mode: "exact",
+      exclude,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeTableColumnVariant
+// ---------------------------------------------------------------------------
+
+describe("normalizeTableColumnVariant", () => {
+  test("fills in all defaults when only `column` is provided", () => {
+    const snap = makeSnapshot("c1");
+    const result = normalizeTableColumnVariant({ column: snap });
+
+    expect(result.column).toBe(snap);
+    expect(result.path).toEqual([]);
+    expect(result.qualifications).toEqual({ forHit: [], forQueries: {} });
+    expect(result.originalId).toBe("c1");
+    expect(result.isPrimary).toBe(true);
+  });
+
+  test("originalId defaults to column.id", () => {
+    const snap = makeSnapshot("c1");
+    const result = normalizeTableColumnVariant({ column: snap });
+    expect(result.originalId).toBe(snap.id);
+  });
+
+  test("explicit fields override defaults", () => {
+    const snap = makeSnapshot("c1");
+    const linker = makeSnapshot("linker1");
+    const variant: TableColumnVariant = {
+      column: snap,
+      path: [{ linker }],
+      qualifications: { forHit: [], forQueries: { ["q1" as PObjectId]: [] } },
+      originalId: "original-id" as PObjectId,
+      isPrimary: false,
+    };
+    const result = normalizeTableColumnVariant(variant);
+
+    expect(result.path).toHaveLength(1);
+    expect(result.path[0].linker).toBe(linker);
+    expect(result.qualifications.forQueries).toEqual({ ["q1" as PObjectId]: [] });
+    expect(result.originalId).toBe("original-id");
+    expect(result.isPrimary).toBe(false);
+  });
+
+  test("isPrimary explicitly set to false is preserved (not overridden by default true)", () => {
+    const variant: TableColumnVariant = {
+      column: makeSnapshot("c1"),
+      isPrimary: false,
+    };
+    expect(normalizeTableColumnVariant(variant).isPrimary).toBe(false);
+  });
+});

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -13,14 +13,35 @@ import type {
   PFrameSpecDriver,
   DiscoveredPColumnId,
 } from "@milaboratories/pl-model-common";
-import { canonicalizeJson, getAxisId, parseJson, uniqueBy } from "@milaboratories/pl-model-common";
+import {
+  Annotation,
+  canonicalizeJson,
+  createDiscoveredPColumnId,
+  getAxisId,
+  parseJson,
+  uniqueBy,
+} from "@milaboratories/pl-model-common";
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
+import { TreeNodeAccessor } from "../../../render/accessor";
 import type { RenderCtxBase, PColumnDataUniversal } from "../../../render";
 import { isEmpty } from "es-toolkit/compat";
 import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV5";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
-import type { ColumnSelector, ColumnSnapshot, ColumnVariant, MatchingMode } from "../../../columns";
+import type {
+  ColumnSelector,
+  ColumnSnapshot,
+  ColumnVariant,
+  MatchingMode,
+  MatchQualifications,
+} from "../../../columns";
+import {
+  ArrayColumnProvider,
+  ColumnCollectionBuilder,
+  OutputColumnProvider,
+  SnapshotColumnProvider,
+  collectCtxColumnSnapshotProviders,
+} from "../../../columns";
 import type { DeriveLabelsOptions } from "../../../labels/derive_distinct_labels";
 import {
   deriveAllLabels,
@@ -40,26 +61,171 @@ import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./
 import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/helpers";
 import { flow } from "es-toolkit";
 
+// ---------------------------------------------------------------------------
+// Public options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link createPlDataTableV3}.
+ *
+ * Two ways to specify columns:
+ *
+ * 1. **Simple case** (most blocks): `primaryColumns` + optional `enrichFromPool`.
+ *    Pass the workflow-output columns this block produces; optionally pull in
+ *    joinable columns from the result pool with a default visibility.
+ *
+ * 2. **Advanced case**: `columns: { sources, anchors, selector }` for explicit
+ *    discovery configuration (custom sources, specific anchor selection,
+ *    selector-mode tuning), or `columns: TableColumnVariant[]` for
+ *    pre-discovered variants.
+ *
+ * `primaryColumns` and `columns` are mutually exclusive.
+ */
 export type createPlDataTableOptionsV3 = {
+  /**
+   * Round-tripped UI state — sort, filters, hidden columns, fast search.
+   * Typically `ctx.data.tableState`.
+   */
   tableState?: PlDataTableStateV2;
 
-  columns: Nil | DiscoverTableColumnOptions | TableColumnVariant[];
+  /**
+   * Columns this block produces (always visible, drive the join row count).
+   *
+   * Accepts:
+   *  - `TreeNodeAccessor` — typically `ctx.outputs?.resolve('mainPf')`.
+   *    Preserves per-column `dataStatus` for partial-data rendering.
+   *  - `PColumn<PColumnDataUniversal>[]` — typically `accessor.getPColumns()`.
+   *  - `TableColumnVariant[]` — explicit variants, for power users.
+   *
+   * Mutually exclusive with `columns`. When neither is set or this resolves
+   * to an empty list, the function returns `undefined`.
+   */
+  primaryColumns?: TreeNodeAccessor | PColumn<PColumnDataUniversal>[] | TableColumnVariant[];
+
+  /**
+   * Pull joinable columns from the result pool (linker traversal supported).
+   * Discovered columns are tagged `isPrimary: false` and receive the
+   * configured visibility — the user can then toggle them in the column manager.
+   *
+   * Internally this anchors discovery against each primary column, so any pool
+   * column reachable from the primary axes (directly or via linkers) is included.
+   * Columns whose `NativePObjectId` matches a primary column are skipped — the
+   * primary version always wins.
+   *
+   * Shorthands:
+   *  - `false` (default) — no enrichment.
+   *  - `true` — equivalent to `'optional'`.
+   *  - `'optional' | 'hidden' | 'default'` — sets `visibility` to that value.
+   *  - object form for full control.
+   *
+   * Has no effect when `columns` is used instead of `primaryColumns`.
+   *
+   * @default false
+   */
+  enrichFromPool?: false | true | "optional" | "hidden" | "default" | EnrichFromPoolOptions;
+
+  /**
+   * Advanced column input — bypasses `primaryColumns` / `enrichFromPool`.
+   *
+   * Accepts:
+   *  - `DiscoverTableColumnOptions` — `{ sources, anchors, selector }` for
+   *    explicit discovery configuration.
+   *  - `TableColumnVariant[]` — pre-discovered variants.
+   *  - `Nil` — short-circuits the function to return `undefined`.
+   *
+   * Mutually exclusive with `primaryColumns`.
+   */
+  columns?: Nil | DiscoverTableColumnOptions | TableColumnVariant[];
+
+  /**
+   * Default filter applied on top of user filters; user can reset it from the UI.
+   * Stored separately from the user filters in the table state.
+   */
   filters?: PlDataTableFilters;
+
+  /**
+   * Default sort applied when the user has not chosen a sort.
+   * User-chosen sort (in `tableState.pTableParams.sorting`) takes precedence.
+   */
   sorting?: PTableSorting[];
+
+  /**
+   * Join semantics for primary columns.
+   *  - `"full"` (default) — outer join, rows from any primary column.
+   *  - `"inner"` — intersection only.
+   *
+   * @default "full"
+   */
   primaryJoinType?: "inner" | "full";
 
+  /**
+   * Tweaks for label derivation (e.g. `formatters.linker` to override
+   * the default "via X > Y" linker prefix).
+   */
   labelsOptions?: DeriveLabelsOptions;
+
+  /**
+   * Per-spec ordering and visibility rules. First matching rule wins;
+   * unmatched columns fall back to their own `pl7.app/table/orderPriority`
+   * and `pl7.app/table/visibility` annotations.
+   */
   displayOptions?: ColumnsDisplayOptions;
 };
 
-/** Structured source config — selectors/anchors instead of raw ColumnSource. */
-export type ColumnsSelectorConfig = {
-  include?: MultiColumnSelector | MultiColumnSelector[];
+/** Full-form configuration for {@link createPlDataTableOptionsV3.enrichFromPool}. */
+export type EnrichFromPoolOptions = {
+  /**
+   * Default visibility applied to enrichment columns.
+   *  - `"optional"` — hidden by default, user can toggle on in column manager (recommended).
+   *  - `"hidden"` — never shown anywhere (rare; usually means you don't want enrichment).
+   *  - `"default"` — visible alongside primary columns.
+   *
+   * User-supplied `displayOptions.visibility` rules still take precedence per
+   * the usual first-match-wins semantics.
+   *
+   * @default "optional"
+   */
+  visibility?: "optional" | "hidden" | "default";
+  /** Selector(s) excluding columns from enrichment discovery. */
   exclude?: MultiColumnSelector | MultiColumnSelector[];
+  /**
+   * Maximum linker hops when traversing from anchors.
+   * @default 4
+   */
+  maxHops?: number;
+  /**
+   * Axis matching strategy passed to the discovery engine.
+   * @default "enrichment"
+   */
   mode?: MatchingMode;
+};
+
+/**
+ * Selector configuration passed through to anchored discovery
+ * (`AnchoredColumnCollection.findColumnVariants`). All fields are optional —
+ * an empty config matches every column reachable from the anchors.
+ */
+export type ColumnsSelectorConfig = {
+  /** Include only columns matching these selector(s). */
+  include?: MultiColumnSelector | MultiColumnSelector[];
+  /** Exclude columns matching these selector(s) (applied after include). */
+  exclude?: MultiColumnSelector | MultiColumnSelector[];
+  /**
+   * Axis matching strategy. See `MatchingMode` for full semantics.
+   *  - `"enrichment"` (default) — columns whose axes are subsets of anchor axes.
+   *  - `"related"` — columns sharing at least one axis with an anchor.
+   *  - `"exact"` — columns with axes exactly matching an anchor.
+   * @default "enrichment"
+   */
+  mode?: MatchingMode;
+  /**
+   * Maximum number of linker hops when traversing across axis domains.
+   * @default 4
+   */
   maxHops?: number;
 };
 
+/** Per-spec ordering and visibility rules. */
 export type ColumnsDisplayOptions = {
   /** Column ordering rules. Higher priority = further left. First matching rule wins. */
   ordering?: ColumnOrderRule[];
@@ -67,34 +233,86 @@ export type ColumnsDisplayOptions = {
   visibility?: ColumnVisibilityRule[];
 };
 
+/** Single ordering rule. Match either by predicate (on `PColumnSpec`) or by selector. */
 export type ColumnOrderRule = {
   match: ColumnMatcher | ColumnSelector;
-  /** Higher number = further left in table */
+  /** Higher number = further left in table. */
   priority: number;
 };
 
+/** Single visibility rule. Match either by predicate (on `PColumnSpec`) or by selector. */
 export type ColumnVisibilityRule = {
   match: ColumnMatcher | ColumnSelector;
+  /**
+   *  - `"default"` — shown by default.
+   *  - `"optional"` — hidden by default, user can toggle on in column manager.
+   *  - `"hidden"` — never shown anywhere.
+   */
   visibility: "default" | "optional" | "hidden";
 };
 
+/** Predicate over a `PColumnSpec` used by display rules. */
 export type ColumnMatcher = (spec: PColumnSpec) => boolean;
 
+// ---------------------------------------------------------------------------
+// Public function
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a data-table model from block-generated columns and (optionally)
+ * joinable columns discovered in the result pool.
+ *
+ * Common usage (workflow output as primary columns, pool as optional extras):
+ *
+ * ```ts
+ * .outputWithStatus('mainTable', (ctx) =>
+ *   createPlDataTableV3(ctx, {
+ *     tableState: ctx.data.tableState,
+ *     primaryColumns: ctx.outputs?.resolve('mainPf'),
+ *     enrichFromPool: 'optional',
+ *   }),
+ * )
+ * ```
+ *
+ * Returns `undefined` when:
+ *  - `primaryColumns` resolves to an empty list (or `undefined`), and
+ *  - `columns` is `Nil` or resolves to an empty list.
+ *
+ * @param ctx - Block render context (provides driver, outputs, prerun, result pool).
+ * @param options - Column source, filters, sorting, display rules, etc.
+ *                  See {@link createPlDataTableOptionsV3}.
+ * @returns A `PlDataTableModel` consumable by `PlAgDataTableV2`, or `undefined`
+ *          when the table cannot be built yet.
+ */
 export function createPlDataTableV3<A, U>(
   ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
 ): PlDataTableModel | undefined {
+  // --- Mutual exclusion of high-level inputs ---
+  if (options.primaryColumns !== undefined && options.columns !== undefined) {
+    throw new Error(
+      "createPlDataTableV3: `primaryColumns` and `columns` are mutually exclusive — pass one or the other.",
+    );
+  }
+
   const pframeSpec = ctx.getService("pframeSpec");
   const state = upgradePlDataTableStateV2(options.tableState);
   const primaryJoinType = options.primaryJoinType ?? "full";
 
-  const discovered = isPlainObject(options.columns)
-    ? discoverTableColumnSnaphots(ctx, options.columns)
-    : options.columns;
+  // --- Resolve column input into a flat TableColumnVariant[] ---
+  // Three shapes feed in here; we normalize them all so the rest of the
+  // pipeline operates on a uniform list of variants with required fields.
+  const discovered = resolveColumns(ctx, options);
   if (isNil(discovered) || discovered.length === 0) return undefined;
 
-  const splited = splitDiscoveredColumns(discovered);
+  // Split into "direct" (no linker path) and "linked" (reached via linker hops).
+  // The two groups go through slightly different annotation pipelines below
+  // (linked columns also get hidden-axes annotations on linker steps).
+  const split = splitDiscoveredColumns(discovered);
 
+  // --- Derive display labels and tooltips from the discovered set ---
+  // Labels are computed jointly so that columns sharing names get
+  // distinguishing suffixes (handled by `deriveDistinctLabels` upstream).
   const derivedLabels = deriveAllLabels({
     columns: discovered.map((dc) => ({
       id: dc.column.id,
@@ -118,24 +336,32 @@ export function createPlDataTableV3<A, U>(
     })),
   });
 
+  // --- Annotate column groups with derived labels, tooltips, and display rules ---
   const annotated = annotateColumnGroups({
     pframeSpec,
-    ...splited,
+    ...split,
     derivedLabels,
     derivedTooltips,
     displayOptions: options.displayOptions,
   });
 
+  // Primary columns drive the join (one row per primary key tuple).
+  // Secondary columns are joined on top with their own qualification axes.
   const primarySnapshots = annotated.direct.filter((c) => c.isPrimary);
   const secondarySnapshots = annotated.direct.filter((c) => !c.isPrimary);
-
   if (primarySnapshots.length === 0) return undefined;
 
+  // --- Build column-id index for filter / sorting validation ---
+  // Includes axis IDs (from primary axesSpec) plus column IDs of every
+  // discovered direct + linked + linker column. References to non-existent
+  // columns are dropped from filters/sorting downstream.
   const columnIsAvailable = createColumnValidationById([
     ...annotated.direct.map((v) => v.column),
     ...annotated.linked.flatMap((lc) => [...lc.path.map((s) => s.linker), lc.column]),
   ]);
 
+  // --- Resolve filters: user filters AND-combined with default filters,
+  //     then prune leaves that reference columns no longer in the table ---
   const remapedDefaultFilters = remapFilterColumnIds(options.filters, discovered);
   const filters = filterFilters(
     concatFilters(
@@ -145,11 +371,16 @@ export function createPlDataTableV3<A, U>(
     columnIsAvailable,
   );
 
+  // --- Resolve sorting: user sort if non-empty else default sort,
+  //     remapped to discovered IDs, then pruned for missing columns ---
   const sorting = filterSorting(
     resolveSorting(state.pTableParams.sorting, remapSortingColumnIds(options.sorting, discovered)),
     columnIsAvailable,
   );
 
+  // --- Build the FULL-table handle (all discovered columns, hidden or not) ---
+  // The full handle is what the column manager uses to expose toggleable columns;
+  // the visible handle below is what actually drives row rendering.
   const primaryEntries: PrimaryEntry<undefined | PColumnDataUniversal>[] = primarySnapshots.map(
     (v) => ({ column: resolveSnapshot(v.column) }),
   );
@@ -166,14 +397,19 @@ export function createPlDataTableV3<A, U>(
   });
 
   const fullHandle = ctx.createPTableV2(fullDef);
-  // TODO: is workaround for dropdown suggestions.
-  // Pframe have not equivalent data for columns relativly to Ptable
+  // PFrame handle exposed alongside the table (used by filter UI for value
+  // suggestions / autocomplete — PTable doesn't expose per-column data the
+  // same way PFrame does, so we ship a parallel PFrame).
   const pframeHandle = ctx.createPFrame([
     ...annotated.direct.map((v) => resolveSnapshot(v.column)),
     ...annotated.linked.map((v) => resolveSnapshot(v.column)),
     ...collectLinkerSnapshots(annotated.linked).map(resolveSnapshot),
   ]);
 
+  // --- Determine which columns are hidden, then build the VISIBLE-table handle ---
+  // The visible handle excludes hidden/optional columns the user has not
+  // explicitly enabled, but preserves any columns referenced by sort/filter
+  // (those must remain in the join for the predicate to evaluate).
   const hiddenSpecs = state.pTableParams.hiddenColIds;
   const hiddenColumnIds = computeHiddenColumns(
     [...annotated.direct, ...annotated.linked].map((v) => v.column),
@@ -204,35 +440,298 @@ export function createPlDataTableV3<A, U>(
   } satisfies PlDataTableModel;
 }
 
-export type TableColumnVariant = ColumnVariant<DiscoveredPColumnId> & {
-  readonly originalId: PObjectId;
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A column entry consumable by {@link createPlDataTableV3}.
+ *
+ * Most fields are optional with sensible defaults — for the common case
+ * (a column from a workflow output, no linker path, primary), only `column`
+ * needs to be specified and the rest are filled in.
+ *
+ * @see normalizeTableColumnVariant for the defaults applied at function entry.
+ */
+export type TableColumnVariant = {
+  /** Column snapshot (id + spec + lazy data + dataStatus). Required. */
+  readonly column: ColumnSnapshot<DiscoveredPColumnId | PObjectId>;
+  /**
+   * Linker path traversed to reach this column from an anchor. Empty for
+   * direct columns (the typical case).
+   * @default []
+   */
+  readonly path?: { linker: ColumnSnapshot<PObjectId> }[];
+  /**
+   * Match qualifications collected during anchored discovery — used by the
+   * join engine to disambiguate when a column matches an anchor in multiple ways.
+   * @default { forHit: [], forQueries: {} }
+   */
+  readonly qualifications?: MatchQualifications;
+  /**
+   * Original (pre-discovery) PObjectId, used to remap filter/sorting column
+   * references the user passed in via `options.filters` / `options.sorting`.
+   * @default column.id (cast to PObjectId)
+   */
+  readonly originalId?: PObjectId;
+  /**
+   * Whether this column is part of the primary join key set. Primary columns
+   * drive row generation; non-primary columns are joined on top.
+   * @default true
+   */
   readonly isPrimary?: boolean;
 };
 
+/** Internal shape after default-filling — every field guaranteed present. */
+type NormalizedTableColumnVariant = Required<TableColumnVariant>;
+
 type SplitDiscoveredColumns = {
-  readonly direct: TableColumnVariant[];
-  readonly linked: TableColumnVariant[];
+  readonly direct: NormalizedTableColumnVariant[];
+  readonly linked: NormalizedTableColumnVariant[];
 };
 
 type AnnotatedColumnGroups = {
-  readonly direct: TableColumnVariant[];
-  readonly linked: TableColumnVariant[];
+  readonly direct: NormalizedTableColumnVariant[];
+  readonly linked: NormalizedTableColumnVariant[];
 };
 
 type VisibleColumns = {
-  readonly direct: TableColumnVariant[];
-  readonly linked: TableColumnVariant[];
+  readonly direct: NormalizedTableColumnVariant[];
+  readonly linked: NormalizedTableColumnVariant[];
 };
 
+// ---------------------------------------------------------------------------
+// Column resolution: primaryColumns + enrichFromPool, or columns
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve `options.primaryColumns` / `options.columns` / `options.enrichFromPool`
+ * into a single flat list of normalized variants.
+ *
+ * Returns `undefined` if no input was provided or if everything resolved to empty.
+ */
+function resolveColumns<A, U>(
+  ctx: RenderCtxBase<A, U>,
+  options: createPlDataTableOptionsV3,
+): NormalizedTableColumnVariant[] | undefined {
+  // Path A: simple-case sugar — primaryColumns + optional enrichFromPool.
+  if (options.primaryColumns !== undefined) {
+    const primary = normalizePrimaryColumns(options.primaryColumns);
+    if (primary === undefined || primary.length === 0) return undefined;
+
+    if (!options.enrichFromPool) return primary;
+
+    const enrichment = normalizeEnrichmentConfig(options.enrichFromPool);
+    const enriched = discoverEnrichmentColumns(ctx, primary, enrichment);
+    return [...primary, ...enriched];
+  }
+
+  // Path B: advanced — columns is either a discovery config or pre-built variants.
+  if (options.columns === undefined) return undefined;
+
+  const variants = isPlainObject(options.columns)
+    ? discoverTableColumnSnaphots(ctx, options.columns)
+    : options.columns;
+
+  if (isNil(variants)) return undefined;
+  return variants.map(normalizeTableColumnVariant);
+}
+
+/**
+ * Fill in defaults on a user-supplied `TableColumnVariant`. Existing values
+ * pass through; missing optional fields receive the documented defaults.
+ *
+ * @internal Exposed for unit testing; not part of the stable public surface.
+ */
+export function normalizeTableColumnVariant(v: TableColumnVariant): NormalizedTableColumnVariant {
+  return {
+    column: v.column,
+    path: v.path ?? [],
+    qualifications: v.qualifications ?? { forHit: [], forQueries: {} },
+    originalId: v.originalId ?? (v.column.id as PObjectId),
+    isPrimary: v.isPrimary ?? true,
+  };
+}
+
+/**
+ * Normalize the three accepted shapes of `primaryColumns` into variant form.
+ *
+ *  - `TreeNodeAccessor` → `OutputColumnProvider` (preserves per-column
+ *    `dataStatus` so the table can render partial data).
+ *  - `PColumn[]` → `ArrayColumnProvider` (status derived from accessor readiness).
+ *  - `TableColumnVariant[]` → variants with defaults filled in.
+ *
+ * All produced variants get `isPrimary: true` and an empty linker `path`.
+ * Returns `undefined` only when input is `undefined`; an empty array stays empty.
+ */
+function normalizePrimaryColumns(
+  input: NonNullable<createPlDataTableOptionsV3["primaryColumns"]>,
+): NormalizedTableColumnVariant[] | undefined {
+  if (input instanceof TreeNodeAccessor) {
+    return new OutputColumnProvider(input).getAllColumns().map(snapshotToPrimaryVariant);
+  }
+
+  if (!Array.isArray(input)) {
+    throw new Error(
+      "createPlDataTableV3: `primaryColumns` must be a TreeNodeAccessor, a PColumn[], or a TableColumnVariant[].",
+    );
+  }
+
+  if (input.length === 0) return [];
+
+  // Distinguish PColumn[] from TableColumnVariant[] by shape: variants
+  // wrap their column under a `column` field; PColumns expose `id`/`spec`/`data` directly.
+  const first = input[0] as object;
+  if ("column" in first) {
+    return (input as TableColumnVariant[]).map(normalizeTableColumnVariant);
+  }
+  return new ArrayColumnProvider(input as PColumn<PColumnDataUniversal>[])
+    .getAllColumns()
+    .map(snapshotToPrimaryVariant);
+}
+
+/** Wrap a `ColumnSnapshot` as a primary variant (no linker path, no qualifications). */
+function snapshotToPrimaryVariant(snap: ColumnSnapshot<PObjectId>): NormalizedTableColumnVariant {
+  return {
+    column: snap,
+    path: [],
+    qualifications: { forHit: [], forQueries: {} },
+    originalId: snap.id,
+    isPrimary: true,
+  };
+}
+
+/**
+ * Coerce the various shorthand forms of `enrichFromPool` to a normalized
+ * options object with all defaults filled in. Caller must have already
+ * filtered out the falsy forms (`undefined`, `false`).
+ *
+ * @internal Exposed for unit testing; not part of the stable public surface.
+ */
+export function normalizeEnrichmentConfig(
+  config: Exclude<NonNullable<createPlDataTableOptionsV3["enrichFromPool"]>, false>,
+): Required<EnrichFromPoolOptions> {
+  if (config === true) {
+    return { visibility: "optional", exclude: [], maxHops: 4, mode: "enrichment" };
+  }
+  if (typeof config === "string") {
+    return { visibility: config, exclude: [], maxHops: 4, mode: "enrichment" };
+  }
+  return {
+    visibility: config.visibility ?? "optional",
+    exclude: config.exclude ?? [],
+    maxHops: config.maxHops ?? 4,
+    mode: config.mode ?? "enrichment",
+  };
+}
+
+/**
+ * Discover columns in the result pool joinable to the primary columns and
+ * convert them into non-primary variants with the configured default visibility.
+ *
+ * Source order is `[primary, ...ctx providers]`; the builder dedups by
+ * `NativePObjectId` (first source wins), so primary columns naturally take
+ * precedence over their pool-published siblings (block published columns
+ * via `exports`). Discovery results are then post-filtered to drop any
+ * variant whose original ID matches a primary column — that case happens
+ * when a primary column also matches the enrichment selector.
+ *
+ * The configured visibility is applied as a `pl7.app/table/visibility`
+ * annotation on each enriched column's spec. User-supplied
+ * `displayOptions.visibility` rules still take precedence per the usual
+ * first-match-wins semantics in `evaluateRules`.
+ */
+function discoverEnrichmentColumns<A, U>(
+  ctx: RenderCtxBase<A, U>,
+  primary: NormalizedTableColumnVariant[],
+  config: Required<EnrichFromPoolOptions>,
+): NormalizedTableColumnVariant[] {
+  const primarySnapshots = primary.map((v) => v.column as ColumnSnapshot<PObjectId>);
+  const primaryIds = new Set(primarySnapshots.map((s) => s.id));
+
+  const builder = new ColumnCollectionBuilder(ctx.getService("pframeSpec"))
+    .addSource(new SnapshotColumnProvider(primarySnapshots))
+    .addSources(collectCtxColumnSnapshotProviders(ctx));
+
+  // One anchor entry per primary column — discovery satisfies queries via any
+  // anchor, so any pool column joinable to *any* primary axis is reachable.
+  const anchors = Object.fromEntries(primary.map((v, i) => [`primary_${i}`, v.column.id]));
+
+  const collection = builder.build({ anchors });
+  if (collection === undefined) return [];
+
+  try {
+    const variants = collection.findColumnVariants({
+      mode: config.mode,
+      maxHops: config.maxHops,
+      exclude: config.exclude,
+    });
+
+    return variants
+      .filter((v) => !primaryIds.has(v.column.id))
+      .map((v) => enrichmentVariantFromMatch(v, config.visibility));
+  } finally {
+    collection.dispose();
+  }
+}
+
+/**
+ * Convert a discovered `ColumnVariant` into our normalized form, applying the
+ * configured default visibility as an annotation on the spec.
+ */
+function enrichmentVariantFromMatch(
+  v: ColumnVariant<PObjectId>,
+  visibility: Required<EnrichFromPoolOptions>["visibility"],
+): NormalizedTableColumnVariant {
+  const discoveredId = createDiscoveredPColumnId({
+    column: v.column.id,
+    path: v.path.map((s) => ({ type: "linker" as const, column: s.linker.id })),
+    columnQualifications: v.qualifications.forHit,
+    queriesQualifications: v.qualifications.forQueries,
+  });
+  return {
+    column: {
+      id: discoveredId,
+      spec: withVisibilityAnnotation(v.column.spec, visibility),
+      data: v.column.data,
+      dataStatus: v.column.dataStatus,
+    },
+    path: v.path,
+    qualifications: v.qualifications,
+    originalId: v.column.id,
+    isPrimary: false,
+  };
+}
+
+/** Set the table-visibility annotation on a column spec without mutating the input. */
+function withVisibilityAnnotation(
+  spec: PColumnSpec,
+  visibility: Required<EnrichFromPoolOptions>["visibility"],
+): PColumnSpec {
+  return {
+    ...spec,
+    annotations: {
+      ...spec.annotations,
+      [Annotation.Table.Visibility]: visibility,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal pipeline (split / annotate / build defs / etc.)
+// ---------------------------------------------------------------------------
+
 /** Split discovered columns into direct (no linker path) and linked (with linker path). */
-function splitDiscoveredColumns(columns: TableColumnVariant[]): SplitDiscoveredColumns {
+function splitDiscoveredColumns(columns: NormalizedTableColumnVariant[]): SplitDiscoveredColumns {
   const direct = columns.filter((dc) => dc.path.length === 0);
   const linked = columns.filter((dc) => dc.path.length > 0);
   return { direct, linked };
 }
 
 /** All linker snapshots across the given linked columns, deduped by id. */
-function collectLinkerSnapshots(linked: TableColumnVariant[]): ColumnSnapshot<PObjectId>[] {
+function collectLinkerSnapshots(
+  linked: NormalizedTableColumnVariant[],
+): ColumnSnapshot<PObjectId>[] {
   return uniqueBy(
     linked.flatMap((lc) => lc.path.map((s) => s.linker)),
     (c) => c.id,
@@ -246,8 +745,8 @@ function collectLinkerSnapshots(linked: TableColumnVariant[]): ColumnSnapshot<PO
  * column annotations via `withTableVisualAnnotations`.
  */
 function annotateColumnGroups(params: {
-  direct: TableColumnVariant[];
-  linked: TableColumnVariant[];
+  direct: NormalizedTableColumnVariant[];
+  linked: NormalizedTableColumnVariant[];
   derivedLabels: Record<string, string>;
   derivedTooltips: Record<string, string>;
   displayOptions?: ColumnsDisplayOptions;
@@ -255,6 +754,8 @@ function annotateColumnGroups(params: {
 }): AnnotatedColumnGroups {
   const { direct, linked, derivedLabels, derivedTooltips, displayOptions, pframeSpec } = params;
 
+  // Evaluate user rules over the union of all columns (direct, linked, linkers)
+  // since rules can target any discovered column regardless of role.
   const allColumnsForRules = [
     ...direct.map((v) => v.column),
     ...linked.map((v) => v.column),
@@ -299,9 +800,13 @@ function annotateColumnGroups(params: {
 }
 
 /** Lift a snapshot-array transform so it runs on the inner `column` of each variant. */
-function liftToVariantColumns<V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId> }>(
+function liftToVariantColumns<
+  V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId | PObjectId> },
+>(
   variants: V[],
-  fn: (cols: ColumnSnapshot<DiscoveredPColumnId>[]) => ColumnSnapshot<DiscoveredPColumnId>[],
+  fn: (
+    cols: ColumnSnapshot<DiscoveredPColumnId | PObjectId>[],
+  ) => ColumnSnapshot<DiscoveredPColumnId | PObjectId>[],
 ): V[] {
   const cols = fn(variants.map((v) => v.column));
   if (cols.length !== variants.length)
@@ -311,10 +816,15 @@ function liftToVariantColumns<V extends { readonly column: ColumnSnapshot<Discov
   return variants.map((v, i) => ({ ...v, column: cols[i] }));
 }
 
+/**
+ * Annotate the linker steps of a linked column's path with derived labels and
+ * mark their axes as hidden — linkers participate in the join but their cells
+ * are not displayed in the table.
+ */
 function annotateLinkerPath(
   derivedLabels: Record<string, string>,
-  path: TableColumnVariant["path"],
-): TableColumnVariant["path"] {
+  path: NormalizedTableColumnVariant["path"],
+): NormalizedTableColumnVariant["path"] {
   if (path.length === 0) return path;
   const annotatedLinkers = withHidenAxesAnnotations(
     withLabelAnnotations(
@@ -325,9 +835,13 @@ function annotateLinkerPath(
   return path.map((s, i) => ({ ...s, linker: annotatedLinkers[i] }));
 }
 
-/** Build an index of all valid column IDs (axes + columns) for filter/sorting validation. */
+/**
+ * Build an index of all valid column IDs (axes + columns) for filter/sorting validation.
+ * Returns a predicate that takes a canonicalized `PTableColumnId` JSON string
+ * and reports whether it refers to a column or axis present in the discovered set.
+ */
 function createColumnValidationById(
-  fullColumns: { readonly id: PObjectId; readonly spec: PColumnSpec }[],
+  fullColumns: { readonly id: PObjectId | DiscoveredPColumnId; readonly spec: PColumnSpec }[],
 ) {
   const axisIds = uniqueBy(
     fullColumns.flatMap((c) => c.spec.axesSpec.map(getAxisId)),
@@ -403,9 +917,15 @@ function filterSorting(
   return sorting.filter((s) => isValidColumnId(canonicalizeJson<PTableColumnId>(s.column)));
 }
 
+/**
+ * Build the secondary-group list passed to `createPTableDefV3`. Each direct
+ * non-primary column becomes a single-entry group; each linked column becomes
+ * a multi-entry group (linker steps followed by the hit column). Primary
+ * qualifications travel along to disambiguate the join.
+ */
 function buildSecondaryGroups(
-  direct: TableColumnVariant[],
-  linked: TableColumnVariant[],
+  direct: NormalizedTableColumnVariant[],
+  linked: NormalizedTableColumnVariant[],
 ): SecondaryGroup<undefined | PColumnDataUniversal>[] {
   return [
     ...direct.map(
@@ -428,13 +948,24 @@ function buildSecondaryGroups(
   ];
 }
 
-/** Determine which columns should be hidden based on state or optional-column defaults. */
+/**
+ * Determine which columns should be hidden in the visible-table handle.
+ *
+ * Two sources contribute:
+ *  - Always-hidden columns (annotation `Visibility = 'hidden'`).
+ *  - Optionally-hidden columns: either the user's saved selection
+ *    (`hiddenSpecs` from `tableState.pTableParams.hiddenColIds`) when present,
+ *    or the default set (annotation `Visibility = 'optional'`) when not.
+ *
+ * Columns referenced by active sort or filter are *un-hidden* — they must
+ * remain in the join for the predicate to evaluate.
+ */
 function computeHiddenColumns(
-  columns: { readonly id: PObjectId; readonly spec: PColumnSpec }[],
+  columns: { readonly id: PObjectId | DiscoveredPColumnId; readonly spec: PColumnSpec }[],
   sorting: Nil | PTableSorting[],
   filters: Nil | PlDataTableFilters,
   hiddenSpecs: Nil | PTableColumnId[],
-): Set<PObjectId> {
+): Set<PObjectId | DiscoveredPColumnId> {
   const alwaysHidden = columns.filter((c) => isColumnHidden(c.spec)).map((c) => c.id);
   const optionalHidden = !isNil(hiddenSpecs)
     ? hiddenSpecs.filter((s): s is PTableColumnIdColumn => s.type === "column").map((s) => s.id)
@@ -442,7 +973,7 @@ function computeHiddenColumns(
   const initial = [...alwaysHidden, ...optionalHidden];
   const preserved = collectPreservedColumnIds(sorting, filters);
 
-  return new Set(initial.filter((id) => !preserved.has(id)));
+  return new Set(initial.filter((id) => !preserved.has(id as PObjectId)));
 }
 
 /** Collect IDs of columns that must remain visible (sorted, filtered). */
@@ -465,10 +996,10 @@ function collectPreservedColumnIds(
   return new Set<PObjectId>([...sortedIds, ...filterIds]);
 }
 
-/** Filter annotated columns to only visible ones, re-matching label columns for the visible subset. */
+/** Filter annotated columns to only visible ones. */
 function buildVisibleColumns(
   annotated: AnnotatedColumnGroups,
-  hiddenColumns: Set<PObjectId>,
+  hiddenColumns: Set<PObjectId | DiscoveredPColumnId>,
 ): VisibleColumns {
   const direct = annotated.direct.filter((c) => !hiddenColumns.has(c.column.id));
   const linked = annotated.linked.filter((c) => !hiddenColumns.has(c.column.id));
@@ -477,15 +1008,19 @@ function buildVisibleColumns(
 
 /** Resolve a ColumnSnapshot to a PColumn with lazily-evaluated data. */
 function resolveSnapshot(
-  snap: ColumnSnapshot<PObjectId>,
+  snap: ColumnSnapshot<PObjectId | DiscoveredPColumnId>,
 ): PColumn<undefined | PColumnDataUniversal> {
-  return { id: snap.id, spec: snap.spec, data: snap.data?.get() };
+  return { id: snap.id as PObjectId, spec: snap.spec, data: snap.data?.get() };
 }
 
-/** Remap column references in sorting entries. */
+/**
+ * Remap column references in sorting entries from user-facing `originalId`s
+ * to the post-discovery `DiscoveredPColumnId`s actually used inside the table.
+ * Sorting entries referencing columns no longer in the discovered set are dropped.
+ */
 function remapSortingColumnIds(
   sorting: Nil | PTableSorting[],
-  columns: TableColumnVariant[],
+  columns: NormalizedTableColumnVariant[],
 ): Nil | PTableSorting[] {
   return sorting?.flatMap((s) => {
     if (s.column.type === "axis") return [s]; // Axis references are unaffected by column ID remapping
@@ -499,7 +1034,7 @@ function remapSortingColumnIds(
         ...s,
         column: {
           type: "column" as const,
-          id: column.column.id,
+          id: column.column.id as PObjectId,
         },
       },
     ];
@@ -508,10 +1043,15 @@ function remapSortingColumnIds(
 
 type PlDataTableFilterNode = FilterSpecNode<PlDataTableFilterSpecLeaf>;
 
-/** Remap column references in a filter tree. */
+/**
+ * Remap column references in a filter tree from user-facing `originalId`s
+ * to the post-discovery `DiscoveredPColumnId`s actually used inside the table.
+ * Throws if a referenced column is not present in the discovered set —
+ * filter validity is the caller's contract.
+ */
 function remapFilterColumnIds(
   filters: Nil | PlDataTableFilters,
-  columns: TableColumnVariant[],
+  columns: NormalizedTableColumnVariant[],
 ): Nil | PlDataTableFilters {
   if (isNil(filters)) return filters;
 
@@ -528,7 +1068,7 @@ function remapFilterColumnIds(
 
     return canonicalizeJson<PTableColumnId>({
       type: "column",
-      id: column.column.id,
+      id: column.column.id as PObjectId,
     });
   };
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -640,6 +640,13 @@ export function normalizeEnrichmentConfig(
  * annotation on each enriched column's spec. User-supplied
  * `displayOptions.visibility` rules still take precedence per the usual
  * first-match-wins semantics in `evaluateRules`.
+ *
+ * Failure handling: any error thrown by the underlying spec-frame engine
+ * (e.g. WASM traps in `pframes-rs-wasm` when the result pool produces an
+ * unsupported shape) is caught here. The function logs the failure and
+ * returns an empty enrichment list, so the table still renders with its
+ * primary columns. The block is responsible for surfacing the warning to
+ * the user if needed.
  */
 function discoverEnrichmentColumns<A, U>(
   ctx: RenderCtxBase<A, U>,
@@ -649,18 +656,19 @@ function discoverEnrichmentColumns<A, U>(
   const primarySnapshots = primary.map((v) => v.column as ColumnSnapshot<PObjectId>);
   const primaryIds = new Set(primarySnapshots.map((s) => s.id));
 
-  const builder = new ColumnCollectionBuilder(ctx.getService("pframeSpec"))
-    .addSource(new SnapshotColumnProvider(primarySnapshots))
-    .addSources(collectCtxColumnSnapshotProviders(ctx));
-
-  // One anchor entry per primary column — discovery satisfies queries via any
-  // anchor, so any pool column joinable to *any* primary axis is reachable.
-  const anchors = Object.fromEntries(primary.map((v, i) => [`primary_${i}`, v.column.id]));
-
-  const collection = builder.build({ anchors });
-  if (collection === undefined) return [];
-
+  let collection: ReturnType<ColumnCollectionBuilder["build"]> | undefined;
   try {
+    const builder = new ColumnCollectionBuilder(ctx.getService("pframeSpec"))
+      .addSource(new SnapshotColumnProvider(primarySnapshots))
+      .addSources(collectCtxColumnSnapshotProviders(ctx));
+
+    // One anchor entry per primary column — discovery satisfies queries via any
+    // anchor, so any pool column joinable to *any* primary axis is reachable.
+    const anchors = Object.fromEntries(primary.map((v, i) => [`primary_${i}`, v.column.id]));
+
+    collection = builder.build({ anchors });
+    if (collection === undefined) return [];
+
     const variants = collection.findColumnVariants({
       mode: config.mode,
       maxHops: config.maxHops,
@@ -670,8 +678,17 @@ function discoverEnrichmentColumns<A, U>(
     return variants
       .filter((v) => !primaryIds.has(v.column.id))
       .map((v) => enrichmentVariantFromMatch(v, config.visibility));
+  } catch (err) {
+    // Discovery failed — most commonly a WASM trap in pframes-rs-wasm when
+    // the column set changes between evaluations. Degrade gracefully: skip
+    // enrichment and render the table with primary columns only.
+    console.warn(
+      "createPlDataTableV3: enrichFromPool discovery failed, falling back to primary-only",
+      err,
+    );
+    return [];
   } finally {
-    collection.dispose();
+    collection?.dispose();
   }
 }
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -14,13 +14,47 @@ import { collectCtxColumnSnapshotProviders } from "../../../columns/ctx_column_s
 import { throwError } from "@milaboratories/helpers";
 import type { ColumnsSelectorConfig, TableColumnVariant } from "./createPlDataTableV3";
 
+/**
+ * Configuration for the advanced `columns: { sources, anchors, selector }`
+ * form of {@link createPlDataTableV3}. Use this when you need explicit control
+ * over which providers participate in discovery (e.g. filtering the result
+ * pool, adding extra workflow outputs) or when the anchor must be a specific
+ * column rather than the default "every primary column" set used by
+ * `primaryColumns` + `enrichFromPool`.
+ */
 export type DiscoverTableColumnOptions = {
+  /**
+   * Column sources to search. When omitted, discovery falls back to the
+   * default ctx providers (`outputs → prerun → resultPool`, deduped by
+   * `NativePObjectId` with first-source-wins).
+   *
+   * Order matters for dedup — sources earlier in the list take precedence
+   * when multiple sources expose the same column (same `NativePObjectId`).
+   */
   sources?: ColumnSource[];
+  /**
+   * Named anchors against which discovery resolves axes. Each entry can be:
+   *  - `PlRef` — resolved against the result pool to a `PColumnSpec`.
+   *  - `PObjectId` — looked up in the collected columns.
+   *  - `PColumnSpec` — used directly (matched by `NativePObjectId`).
+   *  - `RelaxedColumnSelector` — selector that must resolve to a unique column.
+   *
+   * Anchors define the join "frame" — discovery only returns columns whose
+   * axes are reachable from at least one anchor (per the `selector.mode`).
+   */
   anchors: Record<string, PlRef | PObjectId | PColumnSpec | RelaxedColumnSelector>;
+  /** Selector configuration controlling which columns are discovered. */
   selector: ColumnsSelectorConfig;
 };
 
-/** Discover columns from sources/anchors and normalize into a flat TableColumnVariant list. */
+/**
+ * Discover columns from sources/anchors and normalize into a flat
+ * `TableColumnVariant[]`. Used internally by {@link createPlDataTableV3}
+ * when the user passes the advanced `columns: { ... }` form.
+ *
+ * Returns `undefined` when there are no sources, no collection could be built,
+ * or no variants matched.
+ */
 export function discoverTableColumnSnaphots(
   ctx: RenderCtxBase,
   options: DiscoverTableColumnOptions,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -276,7 +276,9 @@ export function deriveAllLabels(options: {
 
 /** Column shape required by tooltip derivation. */
 export type TooltipableColumn = {
-  readonly id: DiscoveredPColumnId;
+  // `DiscoveredPColumnId` extends `PObjectId` via branding — both are accepted.
+  // The id is used as a Record key in the result map; semantically identical.
+  readonly id: PObjectId | DiscoveredPColumnId;
   readonly spec: PColumnSpec;
   readonly originalId: PObjectId;
   readonly linkerPath?: MatchVariant["path"];


### PR DESCRIPTION
## Summary

Adds a simple-case sugar for the most common table pattern in blocks — _show columns from my workflow output, plus joinable columns from the result pool as optional extras_:

```ts
.outputWithStatus('mainTable', (ctx) =>
  createPlDataTableV3(ctx, {
    tableState: ctx.data.tableState,
    primaryColumns: ctx.outputs?.resolve('mainPf'),
    enrichFromPool: 'optional',
  }),
)
```

Three lines instead of the ~15 lines of `ColumnCollectionBuilder` plumbing this case currently requires. The advanced `columns: { sources, anchors, selector }` form is untouched and stays available for cases like `antibody-tcr-lead-selection` that need explicit anchor selection or custom-filtered sources.

## Why

Today, blocks that just want to display their workflow output in a data table have two unappealing options:

1. **Use `createPlDataTableV2`** — flickers when result-pool label columns transition between "ready" and "not ready", because V2 returns `undefined` if any single label column isn't ready (see `allPColumnsReady` gate). This causes column headers to mount/unmount rapidly when the user adds metadata + re-runs upstream blocks.
2. **Use `createPlDataTableV3` with `columns: TableColumnVariant[]`** — works, but requires constructing variants with `path`, `qualifications`, `originalId`, `isPrimary` for every column. Bulk of the code is wrapping `OutputColumnProvider(accessor).getAllColumns().map(snap => ({ column: ..., path: [], qualifications: { forHit: [], forQueries: {} }, originalId: snap.id, isPrimary: true }))`.

Neither matches the user's actual mental model: _here are MY columns; please attach anything else from the pool that joins to them, optionally hideable_.

## What

### New options on `createPlDataTableOptionsV3`

```ts
type createPlDataTableOptionsV3 = {
  tableState?: PlDataTableStateV2;

  // NEW
  primaryColumns?:
    | TreeNodeAccessor                                   // ctx.outputs?.resolve('mainPf')
    | PColumn<PColumnDataUniversal>[]                    // accessor.getPColumns()
    | TableColumnVariant[];                              // power-user explicit form
  enrichFromPool?:
    | false | true
    | 'optional' | 'hidden' | 'default'
    | { visibility?, exclude?, maxHops?, mode? };

  // EXISTING — unchanged
  columns?: Nil | DiscoverTableColumnOptions | TableColumnVariant[];
  filters?: PlDataTableFilters;
  sorting?: PTableSorting[];
  primaryJoinType?: 'inner' | 'full';
  labelsOptions?: DeriveLabelsOptions;
  displayOptions?: ColumnsDisplayOptions;
};
```

`primaryColumns` and `columns` are **mutually exclusive** — passing both throws.

### Relaxation on `TableColumnVariant`

`path`, `qualifications`, `originalId`, and `isPrimary` are now all optional with documented defaults (`[]`, `{ forHit: [], forQueries: {} }`, `column.id`, `true`). For the common case only `column` is required.

### Implementation strategy

- `primaryColumns` is normalized to variants tagged `isPrimary: true`. `TreeNodeAccessor` is wrapped via `OutputColumnProvider` (preserves per-column `dataStatus` for partial-data rendering).
- `enrichFromPool` runs anchored discovery via `ColumnCollectionBuilder`, with primary columns registered as the FIRST source. The builder's existing `NativePObjectId` dedup (first-source-wins) handles the case where the workflow output is also re-published to the result pool — no manual exclusion needed.
- Each enriched variant gets the configured `visibility` set as a `pl7.app/table/visibility` annotation on its spec. User-supplied `displayOptions.visibility` rules still take precedence per the existing first-match-wins evaluation in `evaluateRules`.

### Documentation

- JSDoc with `@default` on every option.
- Top-of-function block for `createPlDataTableV3` showing common usage.
- Documented `ColumnsSelectorConfig`, `ColumnsDisplayOptions`, `ColumnOrderRule`, `ColumnVisibilityRule`, `ColumnMatcher`, `DiscoverTableColumnOptions`, and the internal pipeline functions (`splitDiscoveredColumns`, `annotateColumnGroups`, `buildSecondaryGroups`, etc.).

## Backward compatibility

Verified clean. Every change is either additive (new optional fields), a relaxation (required → optional), or a type widening (DiscoveredPColumnId → DiscoveredPColumnId | PObjectId, where DiscoveredPColumnId still assignable). All existing callers in the monorepo compile and run unchanged. Specifically:

- `clonotype-browser` (uses `columns: { ... }` discovery and `columns: TableColumnVariant[]`) — untouched.
- `antibody-tcr-lead-selection` (uses `columns: { sources, anchors, selector }` with custom-filtered pool sources, custom anchor selection, multi-rule visibility/ordering, `labelsOptions.formatters.linker`) — every advanced lever they use is preserved.
- `etc/blocks/table-test` — uses `columns: { ... }` form, untouched.

`TooltipableColumn.id` widened from `DiscoveredPColumnId` to `PObjectId | DiscoveredPColumnId`. Backward-compatible because `DiscoveredPColumnId` extends `PObjectId` via branding — both still accepted.

## Test plan

- [x] `pnpm types:check` clean for `@platforma-sdk/model`.
- [x] `pnpm test` — 384 passed (374 existing + 10 new).
- [x] `pnpm build` clean (declaration generation works).
- [ ] Local block validation: building the dev SDK in `clonotype-distribution`, `clonotype-browser`, and `antibody-tcr-lead-selection` (in progress separately).
- [ ] Manual UI verification once dev blocks are loaded into desktop app.

## Files changed

- `sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts` — main implementation + extensive JSDoc.
- `sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts` — JSDoc only.
- `sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts` — single-field type widening on `TooltipableColumn.id`.
- `sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts` — new test file (10 tests).
- `.changeset/createpldatatablev3-primary-enrichment.md` — minor bump for `@platforma-sdk/model`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `primaryColumns` and `enrichFromPool` as ergonomic sugar on `createPlDataTableV3`, reducing the typical "show my workflow output + joinable pool extras" pattern from ~15 lines of `ColumnCollectionBuilder` plumbing to 3. All existing callers are unaffected; `TableColumnVariant` fields are relaxed to optional with sensible defaults, and the advanced `columns: { sources, anchors, selector }` form is preserved unchanged.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — no P0/P1 findings; two P2 issues are low-impact edge cases.

Only P2 findings present: a fragile duck-typing check to distinguish PColumn[] from TableColumnVariant[], and a mutual-exclusion guard that incorrectly fires when columns: null (a valid Nil value) is combined with primaryColumns. Neither affects the primary happy-path flows, which are covered by 10 new tests.

createPlDataTableV3.ts — the normalizePrimaryColumns array-type discriminant and the mutual-exclusion null check.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Main implementation — adds primaryColumns + enrichFromPool sugar with well-structured normalization pipeline; two minor issues: fragile duck-typing to distinguish input array types, and mutual-exclusion guard fires on columns: null (valid Nil value). |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts | New test file — 10 unit tests covering normalizeEnrichmentConfig shorthands and normalizeTableColumnVariant defaults; well-structured and thorough for the targeted units. |
| sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts | JSDoc additions only — no logic changes; docs accurately describe the advanced columns: { sources, anchors, selector } form. |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts | Single backward-compatible type widening on TooltipableColumn.id from DiscoveredPColumnId to PObjectId | DiscoveredPColumnId; no logic changes. |
| .changeset/createpldatatablev3-primary-enrichment.md | Changeset file — correctly marked as minor bump for @platforma-sdk/model, with accurate description of all changes. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts:719-721
**Fragile duck-typing to distinguish `PColumn[]` from `TableColumnVariant[]`**

The heuristic `"column" in first` relies on `PColumn` not having a `column` property. If `PColumn` ever gains such a field, this silently misclassifies the input — treating a `PColumn[]` as a `TableColumnVariant[]` and wrapping it incorrectly. Consider using `"spec" in first && "data" in first` instead, which targets structural requirements of `PColumn` that are absent from `TableColumnVariant`.

```suggestion
  const first = input[0] as object;
  if ("spec" in first && "data" in first) {
    return new ArrayColumnProvider(input as PColumn<PColumnDataUniversal>[])
      .getAllColumns()
      .map(snapshotToPrimaryVariant);
  }
  return (input as TableColumnVariant[]).map(normalizeTableColumnVariant);
```

### Issue 2 of 2
sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts:461-465
**Mutual-exclusion check fires on `columns: null`**

`Nil` is `undefined | null`, and `columns` is typed as `Nil | DiscoverTableColumnOptions | TableColumnVariant[]`. Passing `{ primaryColumns: ..., columns: null }` trips the guard (`null !== undefined` is `true`) and throws — even though `null` is a documented valid value meaning "no columns". Using `!isNil(options.columns)` would let `null` fall through correctly.

```suggestion
  if (options.primaryColumns !== undefined && !isNil(options.columns)) {
    throw new Error(
      "createPlDataTableV3: `primaryColumns` and `columns` are mutually exclusive — pass one or the other.",
    );
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(model): primaryColumns + enrichFrom..."](https://github.com/milaboratory/platforma/commit/2d6f493d9c54e20d67c86e54bd1668f34e95c167) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30614602)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->