### PR TITLE
feat(model): add requiresLinkerJoin feature flag

### DIFF
--- a/.changeset/requires-linker-join-flag.md
+++ b/.changeset/requires-linker-join-flag.md
@@ -1,0 +1,7 @@
+---
+"@platforma-sdk/model": minor
+"@milaboratories/pl-model-common": minor
+"@milaboratories/pl-middle-layer": minor
+---
+
+Add `requiresLinkerJoin` block feature flag. Blocks that depend on linker-join support can declare this requirement; the middle layer registers it as a supported runtime capability.

--- a/.changeset/requires-linker-join-flag.md
+++ b/.changeset/requires-linker-join-flag.md
@@ -1,7 +1,0 @@
----
-"@platforma-sdk/model": minor
-"@milaboratories/pl-model-common": minor
-"@milaboratories/pl-middle-layer": minor
----
-
-Add `requiresLinkerJoin` block feature flag. Blocks that depend on linker-join support can declare this requirement; the middle layer registers it as a supported runtime capability.

--- a/.changeset/requires-pframes-version-flag.md
+++ b/.changeset/requires-pframes-version-flag.md
@@ -1,0 +1,7 @@
+---
+"@platforma-sdk/model": minor
+"@milaboratories/pl-model-common": minor
+"@milaboratories/pl-middle-layer": minor
+---
+
+Add `requiresPFramesVersion` block feature flag. Blocks can declare a minimum PFrames version requirement; the middle layer registers the supported version as a runtime capability.

--- a/lib/model/common/src/flags/block_flags.ts
+++ b/lib/model/common/src/flags/block_flags.ts
@@ -21,6 +21,7 @@ export type BlockCodeKnownFeatureFlags = {
   readonly requiresModelAPIVersion?: number;
   readonly requiresUIAPIVersion?: number;
   readonly requiresCreatePTable?: number;
+  readonly requiresLinkerJoin?: boolean;
 } & ServiceRequireFlags;
 
 export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQueryRanking"] as const;
@@ -28,6 +29,7 @@ export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQuer
 export const AllRequiresFeatureFlags = [
   "requiresUIAPIVersion",
   "requiresCreatePTable",
+  "requiresLinkerJoin",
   "requiresModelAPIVersion",
 ] as const;
 

--- a/lib/model/common/src/flags/block_flags.ts
+++ b/lib/model/common/src/flags/block_flags.ts
@@ -21,7 +21,7 @@ export type BlockCodeKnownFeatureFlags = {
   readonly requiresModelAPIVersion?: number;
   readonly requiresUIAPIVersion?: number;
   readonly requiresCreatePTable?: number;
-  readonly requiresLinkerJoin?: boolean;
+  readonly requiresPFramesVersion?: number;
 } & ServiceRequireFlags;
 
 export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQueryRanking"] as const;
@@ -29,7 +29,7 @@ export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQuer
 export const AllRequiresFeatureFlags = [
   "requiresUIAPIVersion",
   "requiresCreatePTable",
-  "requiresLinkerJoin",
+  "requiresPFramesVersion",
   "requiresModelAPIVersion",
 ] as const;
 

--- a/lib/model/common/src/flags/block_flags.ts
+++ b/lib/model/common/src/flags/block_flags.ts
@@ -24,6 +24,13 @@ export type BlockCodeKnownFeatureFlags = {
   readonly requiresPFramesVersion?: number;
 } & ServiceRequireFlags;
 
+/**
+ * Required PFrames version. Bump this in lockstep with the `@milaboratories/pframes-rs-*`
+ * version in `pnpm-workspace.yaml` so blocks built against the new SDK refuse to load on
+ * older desktop apps.
+ */
+export const REQUIRES_PFRAMES_VERSION = 1_001_031;
+
 export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQueryRanking"] as const;
 
 export const AllRequiresFeatureFlags = [

--- a/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
@@ -346,6 +346,7 @@ export class MiddleLayer {
     runtimeCapabilities.addSupportedRequirement("requiresModelAPIVersion", 1);
     runtimeCapabilities.addSupportedRequirement("requiresModelAPIVersion", 2);
     runtimeCapabilities.addSupportedRequirement("requiresCreatePTable", 2);
+    runtimeCapabilities.addSupportedRequirement("requiresLinkerJoin", true);
     registerServiceCapabilities((flag, value) =>
       runtimeCapabilities.addSupportedRequirement(flag, value),
     );

--- a/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
@@ -346,7 +346,7 @@ export class MiddleLayer {
     runtimeCapabilities.addSupportedRequirement("requiresModelAPIVersion", 1);
     runtimeCapabilities.addSupportedRequirement("requiresModelAPIVersion", 2);
     runtimeCapabilities.addSupportedRequirement("requiresCreatePTable", 2);
-    runtimeCapabilities.addSupportedRequirement("requiresLinkerJoin", true);
+    runtimeCapabilities.addSupportedRequirement("requiresPFramesVersion", 1_001_031);
     registerServiceCapabilities((flag, value) =>
       runtimeCapabilities.addSupportedRequirement(flag, value),
     );

--- a/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
@@ -35,6 +35,7 @@ import { RuntimeCapabilities } from "@platforma-sdk/model";
 import {
   type ModelServiceRegistry,
   registerServiceCapabilities,
+  REQUIRES_PFRAMES_VERSION,
 } from "@milaboratories/pl-model-common";
 import { createModelServiceRegistry } from "../service_factories";
 import type { DownloadUrlDriver } from "@milaboratories/pl-drivers";
@@ -346,7 +347,7 @@ export class MiddleLayer {
     runtimeCapabilities.addSupportedRequirement("requiresModelAPIVersion", 1);
     runtimeCapabilities.addSupportedRequirement("requiresModelAPIVersion", 2);
     runtimeCapabilities.addSupportedRequirement("requiresCreatePTable", 2);
-    runtimeCapabilities.addSupportedRequirement("requiresPFramesVersion", 1_001_031);
+    runtimeCapabilities.addSupportedRequirement("requiresPFramesVersion", REQUIRES_PFRAMES_VERSION);
     registerServiceCapabilities((flag, value) =>
       runtimeCapabilities.addSupportedRequirement(flag, value),
     );

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -248,7 +248,7 @@ catalog:
   "winston": ^3.17.0
 
   "@milaboratories/tengo-tester": ^1.6.4
-  # When bumping, also update `requiresPFramesVersion` in sdk/model and lib/node/pl-middle-layer.
+  # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
   "@milaboratories/pframes-rs-node": 1.1.31
   "@milaboratories/pframes-rs-wasm": 1.1.31
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -248,6 +248,7 @@ catalog:
   "winston": ^3.17.0
 
   "@milaboratories/tengo-tester": ^1.6.4
+  # When bumping, also update `requiresPFramesVersion` in sdk/model and lib/node/pl-middle-layer.
   "@milaboratories/pframes-rs-node": 1.1.31
   "@milaboratories/pframes-rs-wasm": 1.1.31
 

--- a/sdk/model/src/block_model.ts
+++ b/sdk/model/src/block_model.ts
@@ -138,7 +138,7 @@ export class BlockModelV3<
     requiresUIAPIVersion: 3,
     requiresModelAPIVersion: BLOCK_STORAGE_FACADE_VERSION,
     requiresCreatePTable: 2,
-    requiresLinkerJoin: true,
+    requiresPFramesVersion: 1_001_031,
     ...BLOCK_SERVICE_FLAGS,
   } satisfies BlockCodeKnownFeatureFlags;
 

--- a/sdk/model/src/block_model.ts
+++ b/sdk/model/src/block_model.ts
@@ -6,6 +6,7 @@ import type {
   BlockCodeKnownFeatureFlags,
   BlockConfigContainer,
 } from "@milaboratories/pl-model-common";
+import { REQUIRES_PFRAMES_VERSION } from "@milaboratories/pl-model-common";
 import { getPlatformaInstance, isInUI, createAndRegisterRenderLambda } from "./internal";
 import type { DataModel } from "./block_migrations";
 import type { PlatformaV3 } from "./platforma";
@@ -138,7 +139,7 @@ export class BlockModelV3<
     requiresUIAPIVersion: 3,
     requiresModelAPIVersion: BLOCK_STORAGE_FACADE_VERSION,
     requiresCreatePTable: 2,
-    requiresPFramesVersion: 1_001_031,
+    requiresPFramesVersion: REQUIRES_PFRAMES_VERSION,
     ...BLOCK_SERVICE_FLAGS,
   } satisfies BlockCodeKnownFeatureFlags;
 

--- a/sdk/model/src/block_model.ts
+++ b/sdk/model/src/block_model.ts
@@ -138,6 +138,7 @@ export class BlockModelV3<
     requiresUIAPIVersion: 3,
     requiresModelAPIVersion: BLOCK_STORAGE_FACADE_VERSION,
     requiresCreatePTable: 2,
+    requiresLinkerJoin: true,
     ...BLOCK_SERVICE_FLAGS,
   } satisfies BlockCodeKnownFeatureFlags;
 

--- a/sdk/model/src/block_model_legacy.ts
+++ b/sdk/model/src/block_model_legacy.ts
@@ -72,7 +72,7 @@ export class BlockModel<
       requiresUIAPIVersion: 1,
       requiresModelAPIVersion: 1,
       requiresCreatePTable: 2,
-      requiresLinkerJoin: true,
+      requiresPFramesVersion: 1_001_031,
     };
   }
 

--- a/sdk/model/src/block_model_legacy.ts
+++ b/sdk/model/src/block_model_legacy.ts
@@ -72,6 +72,7 @@ export class BlockModel<
       requiresUIAPIVersion: 1,
       requiresModelAPIVersion: 1,
       requiresCreatePTable: 2,
+      requiresLinkerJoin: true,
     };
   }
 

--- a/sdk/model/src/block_model_legacy.ts
+++ b/sdk/model/src/block_model_legacy.ts
@@ -6,6 +6,7 @@ import type {
   BlockCodeKnownFeatureFlags,
   BlockConfigContainer,
 } from "@milaboratories/pl-model-common";
+import { REQUIRES_PFRAMES_VERSION } from "@milaboratories/pl-model-common";
 import type { Checked, ConfigResult, TypedConfig } from "./config";
 import { getImmediate } from "./config";
 import { getPlatformaInstance, isInUI, tryRegisterCallback } from "./internal";
@@ -72,7 +73,7 @@ export class BlockModel<
       requiresUIAPIVersion: 1,
       requiresModelAPIVersion: 1,
       requiresCreatePTable: 2,
-      requiresPFramesVersion: 1_001_031,
+      requiresPFramesVersion: REQUIRES_PFRAMES_VERSION,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `requiresLinkerJoin` boolean feature flag mirroring the pattern of `requiresCreatePTable`
- Wire it into both V3 and legacy block model defaults, the known flags type/list, and the middle layer's runtime capabilities

## Test plan
- [ ] Type-check passes
- [ ] Existing flag tests still pass

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `requiresLinkerJoin` as a new boolean feature flag, wired into the type system, the `AllRequiresFeatureFlags` registry, the middle layer's runtime capabilities, and both V3 and legacy block model defaults — mirroring the established `requiresCreatePTable` pattern. The implementation is type-safe and consistent, but the flag is set as a hard default in every block model, making it opt-out rather than opt-in.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge if the intent is for all blocks to universally require linker-join support from the runtime.

Only P2 findings; the code is internally consistent and follows established patterns. The one concern (mandatory default) is a design question rather than a bug.

sdk/model/src/block_model.ts and sdk/model/src/block_model_legacy.ts — both set requiresLinkerJoin: true as a universal block default.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/flags/block_flags.ts | Adds requiresLinkerJoin?: boolean to BlockCodeKnownFeatureFlags and AllRequiresFeatureFlags; type-safe and consistent with existing patterns. |
| lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts | Declares runtime support for requiresLinkerJoin via addSupportedRequirement; follows existing capability registration pattern correctly. |
| sdk/model/src/block_model.ts | Adds requiresLinkerJoin: true to BlockModelV3 static FEATURE_FLAGS default; makes it mandatory for all V3 blocks (opt-out rather than opt-in). |
| sdk/model/src/block_model_legacy.ts | Adds requiresLinkerJoin: true to legacy BlockModel default flags; same opt-out concern as block_model.ts. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/model/src/block_model.ts:141
**Mandatory default makes the flag opt-out rather than opt-in**

`requiresLinkerJoin: true` is baked into the default flags for every block compiled with this SDK (both `BlockModelV3.FEATURE_FLAGS` here and `BlockModel.INITIAL_BLOCK_FEATURE_FLAGS` in the legacy model). Any block deployed to a runtime that doesn't declare `addSupportedRequirement("requiresLinkerJoin", true)` will be refused by `getIncompatibleFlags`. If only a subset of blocks actually needs the linker-join capability, making it a universal default unnecessarily narrows runtime compatibility. Consider whether this flag should instead be set explicitly only by the blocks that use it, leaving the default as `undefined`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add changeset"](https://github.com/milaboratory/platforma/commit/45eaee9bc404e39f2378c2123b3af18e64b23881) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30660250)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->