### PR TITLE
feat(model): scope filter discovery to result pool, add filter predicate

### DIFF
--- a/.changeset/dataset-selector-filter-predicate.md
+++ b/.changeset/dataset-selector-filter-predicate.md
@@ -1,5 +1,11 @@
 ---
 "@platforma-sdk/model": minor
+"@platforma-sdk/workflow-tengo": patch
+"@platforma-sdk/ui-vue": patch
 ---
 
 `buildDatasetOptions`: scope filter discovery to the result pool only (block outputs and prerun no longer pollute the filter dropdown), add a `filter` predicate to restrict eligible filter columns, and skip filter matches without a PlRef instead of throwing. Removes the need for callers to wrap `buildDatasetOptions` in try/catch.
+
+`tableBuilder.addPrimary`: drop a `PrimaryRef.filter` whose `resolveColumn` produced no spec, so a stale or malformed filter ref no longer causes `pframes.build-table` to panic with `field "spec" not found and inputs locked`.
+
+`PlDatasetSelector`: always render the filter dropdown; disable it when the selected dataset has no compatible filters, instead of hiding it entirely.

--- a/.changeset/dataset-selector-filter-predicate.md
+++ b/.changeset/dataset-selector-filter-predicate.md
@@ -8,4 +8,4 @@
 
 `tableBuilder.addPrimary`: drop a `PrimaryRef.filter` whose `resolveColumn` produced no spec, so a stale or malformed filter ref no longer causes `pframes.build-table` to panic with `field "spec" not found and inputs locked`.
 
-`PlDatasetSelector`: always render the filter dropdown, regardless of whether the selected dataset has compatible filters. When there are none the dropdown shows an empty option list instead of being hidden.
+`PlDatasetSelector`: always render the filter dropdown, regardless of whether the selected dataset has compatible filters; the dropdown is clearable and uses an empty selection (instead of a synthetic "No filter" entry) to mean "no filter applied". Removed the `noFilterLabel` prop.

--- a/.changeset/dataset-selector-filter-predicate.md
+++ b/.changeset/dataset-selector-filter-predicate.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": minor
+---
+
+`buildDatasetOptions`: scope filter discovery to the result pool only (block outputs and prerun no longer pollute the filter dropdown), add a `filter` predicate to restrict eligible filter columns, and skip filter matches without a PlRef instead of throwing. Removes the need for callers to wrap `buildDatasetOptions` in try/catch.

--- a/.changeset/dataset-selector-filter-predicate.md
+++ b/.changeset/dataset-selector-filter-predicate.md
@@ -8,4 +8,4 @@
 
 `tableBuilder.addPrimary`: drop a `PrimaryRef.filter` whose `resolveColumn` produced no spec, so a stale or malformed filter ref no longer causes `pframes.build-table` to panic with `field "spec" not found and inputs locked`.
 
-`PlDatasetSelector`: always render the filter dropdown; disable it when the selected dataset has no compatible filters, instead of hiding it entirely.
+`PlDatasetSelector`: always render the filter dropdown, regardless of whether the selected dataset has compatible filters. When there are none the dropdown shows an empty option list instead of being hidden.

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -31,6 +31,18 @@ export type BuildDatasetOptions = {
   enrichmentMaxHops?: number;
 };
 
+type SpecPredicateOption =
+  | MultiColumnSelector
+  | MultiColumnSelector[]
+  | ((spec: PObjectSpec) => boolean);
+
+function toPredicate(
+  opt: SpecPredicateOption | undefined,
+): ((spec: PObjectSpec) => boolean) | undefined {
+  if (opt === undefined) return undefined;
+  return typeof opt === "function" ? opt : multiColumnSelectorsToPredicate(opt);
+}
+
 /**
  * Usage:
  * ```ts
@@ -41,13 +53,7 @@ export function buildDatasetOptions(
   ctx: RenderCtxBase,
   opts?: BuildDatasetOptions,
 ): DatasetOption[] | undefined {
-  const primary = opts?.primary;
-  const primaryPredicate =
-    primary === undefined
-      ? () => true
-      : typeof primary === "function"
-        ? primary
-        : multiColumnSelectorsToPredicate(primary);
+  const primaryPredicate = toPredicate(opts?.primary) ?? (() => true);
   const options = ctx.resultPool.getOptions(primaryPredicate, { refsWithEnrichments: true });
   if (options.length === 0) return [];
 
@@ -56,13 +62,7 @@ export function buildDatasetOptions(
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
 
-  const filterOpt = opts?.filter;
-  const filterPredicate =
-    filterOpt === undefined
-      ? undefined
-      : typeof filterOpt === "function"
-        ? filterOpt
-        : multiColumnSelectorsToPredicate(filterOpt);
+  const filterPredicate = toPredicate(opts?.filter);
 
   return options.map((primary: Option): DatasetOption => {
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -2,6 +2,7 @@ import type { MultiColumnSelector, Option, PObjectSpec } from "@milaboratories/p
 import { multiColumnSelectorsToPredicate } from "@milaboratories/pl-model-common";
 import type { DeriveLabelsOptions } from "../../labels/derive_distinct_labels";
 import type { RenderCtxBase } from "../../render";
+import type { AnchoredColumnCollection } from "../../columns/column_collection_builder";
 import { ColumnCollectionBuilder } from "../../columns/column_collection_builder";
 import {
   ResultPoolColumnSnapshotProvider,
@@ -71,20 +72,24 @@ export function buildDatasetOptions(
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
     if (!datasetSpec) return { primary };
 
-    // ResultPoolColumnSnapshotProvider is always complete; allowPartialColumnList
-    // narrows the return type to non-undefined.
-    const filterCollection = new ColumnCollectionBuilder(pframeSpec)
-      .addSource(filterSource)
-      .build({ anchors: { main: datasetSpec }, allowPartialColumnList: true });
-
-    const enrichmentCollection =
-      enrichmentSources !== undefined
-        ? new ColumnCollectionBuilder(pframeSpec)
-            .addSources(enrichmentSources)
-            .build({ anchors: { main: datasetSpec } })
-        : undefined;
-
+    // Allocations happen inside try so a throw on the second build()
+    // still disposes the first collection.
+    let filterCollection: AnchoredColumnCollection | undefined;
+    let enrichmentCollection: AnchoredColumnCollection | undefined;
     try {
+      // ResultPoolColumnSnapshotProvider is always complete;
+      // allowPartialColumnList narrows the return type to non-undefined.
+      filterCollection = new ColumnCollectionBuilder(pframeSpec)
+        .addSource(filterSource)
+        .build({ anchors: { main: datasetSpec }, allowPartialColumnList: true });
+
+      enrichmentCollection =
+        enrichmentSources !== undefined
+          ? new ColumnCollectionBuilder(pframeSpec)
+              .addSources(enrichmentSources)
+              .build({ anchors: { main: datasetSpec } })
+          : undefined;
+
       const filterMatches = findFilterColumns(filterCollection).filter((m) =>
         filterPredicate(m.column.spec),
       );
@@ -112,7 +117,7 @@ export function buildDatasetOptions(
         ...(enrichments !== undefined && enrichments.length > 0 ? { enrichments } : {}),
       };
     } finally {
-      filterCollection.dispose();
+      filterCollection?.dispose();
       enrichmentCollection?.dispose();
     }
   });

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -16,10 +16,8 @@ type SpecPredicateOption =
   | MultiColumnSelector[]
   | ((spec: PObjectSpec) => boolean);
 
-function toPredicate(
-  opt: SpecPredicateOption | undefined,
-): ((spec: PObjectSpec) => boolean) | undefined {
-  if (opt === undefined) return undefined;
+function toPredicate(opt: SpecPredicateOption | undefined): (spec: PObjectSpec) => boolean {
+  if (opt === undefined) return () => true;
   return typeof opt === "function" ? opt : multiColumnSelectorsToPredicate(opt);
 }
 
@@ -53,7 +51,9 @@ export function buildDatasetOptions(
   ctx: RenderCtxBase,
   opts?: BuildDatasetOptions,
 ): DatasetOption[] | undefined {
-  const primaryPredicate = toPredicate(opts?.primary) ?? (() => true);
+  const primaryPredicate = toPredicate(opts?.primary);
+  const filterPredicate = toPredicate(opts?.filter);
+
   const options = ctx.resultPool.getOptions(primaryPredicate, { refsWithEnrichments: true });
   if (options.length === 0) return [];
 
@@ -61,8 +61,6 @@ export function buildDatasetOptions(
   const filterSource = new ResultPoolColumnSnapshotProvider(ctx.resultPool);
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
-
-  const filterPredicate = toPredicate(opts?.filter);
 
   return options.map((primary: Option): DatasetOption => {
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
@@ -80,10 +78,9 @@ export function buildDatasetOptions(
     try {
       let filters: Option[] | undefined;
       if (filterCollection) {
-        let filterMatches = findFilterColumns(filterCollection);
-        if (filterPredicate !== undefined) {
-          filterMatches = filterMatches.filter((m) => filterPredicate(m.column.spec));
-        }
+        const filterMatches = findFilterColumns(filterCollection).filter((m) =>
+          filterPredicate(m.column.spec),
+        );
         filters =
           filterMatches.length === 0
             ? undefined

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -64,14 +64,16 @@ export function buildDatasetOptions(
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
     if (!datasetSpec) return { primary };
 
-    const enrichmentCollection = new ColumnCollectionBuilder(pframeSpec)
-      .addSources(collectCtxColumnSnapshotProviders(ctx))
-      .build({ anchors: { main: datasetSpec } });
-    if (!enrichmentCollection) return { primary };
-
     const filterCollection = new ColumnCollectionBuilder(pframeSpec)
       .addSource(new ResultPoolColumnSnapshotProvider(ctx.resultPool))
       .build({ anchors: { main: datasetSpec } });
+
+    const enrichmentCollection =
+      opts?.withEnrichments !== undefined
+        ? new ColumnCollectionBuilder(pframeSpec)
+            .addSources(collectCtxColumnSnapshotProviders(ctx))
+            .build({ anchors: { main: datasetSpec } })
+        : undefined;
 
     try {
       let filters: Option[] | undefined;
@@ -86,7 +88,7 @@ export function buildDatasetOptions(
       }
 
       let enrichments;
-      if (opts?.withEnrichments !== undefined) {
+      if (enrichmentCollection && opts?.withEnrichments !== undefined) {
         const enrichmentVariants = findEnrichmentColumns(enrichmentCollection, {
           maxHops: opts.enrichmentMaxHops,
           ...(typeof opts.withEnrichments === "function"
@@ -104,8 +106,8 @@ export function buildDatasetOptions(
         ...(enrichments !== undefined && enrichments.length > 0 ? { enrichments } : {}),
       };
     } finally {
-      enrichmentCollection.dispose();
       filterCollection?.dispose();
+      enrichmentCollection?.dispose();
     }
   });
 }

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -61,21 +61,27 @@ export function buildDatasetOptions(
   const pframeSpec = ctx.getService("pframeSpec");
 
   const withEnrichments = opts?.withEnrichments;
+  const filterSource = new ResultPoolColumnSnapshotProvider(ctx.resultPool);
+  // Hoisted out of the per-option loop: collectCtxColumnSnapshotProviders
+  // walks the entire output tree, so calling it once per dataset option would
+  // be O(N × tree).
+  const enrichmentSources =
+    withEnrichments !== undefined ? collectCtxColumnSnapshotProviders(ctx) : undefined;
 
   return options.map((primary: Option): DatasetOption => {
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
     if (!datasetSpec) return { primary };
 
-    // ResultPoolColumnSnapshotProvider is always complete, so build() never
-    // returns undefined here.
+    // ResultPoolColumnSnapshotProvider is always complete; allowPartialColumnList
+    // narrows the return type to non-undefined.
     const filterCollection = new ColumnCollectionBuilder(pframeSpec)
-      .addSource(new ResultPoolColumnSnapshotProvider(ctx.resultPool))
-      .build({ anchors: { main: datasetSpec } })!;
+      .addSource(filterSource)
+      .build({ anchors: { main: datasetSpec }, allowPartialColumnList: true });
 
     const enrichmentCollection =
-      withEnrichments !== undefined
+      enrichmentSources !== undefined
         ? new ColumnCollectionBuilder(pframeSpec)
-            .addSources(collectCtxColumnSnapshotProviders(ctx))
+            .addSources(enrichmentSources)
             .build({ anchors: { main: datasetSpec } })
         : undefined;
 

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -60,43 +60,44 @@ export function buildDatasetOptions(
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
 
+  const withEnrichments = opts?.withEnrichments;
+
   return options.map((primary: Option): DatasetOption => {
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
     if (!datasetSpec) return { primary };
 
+    // ResultPoolColumnSnapshotProvider is always complete, so build() never
+    // returns undefined here.
     const filterCollection = new ColumnCollectionBuilder(pframeSpec)
       .addSource(new ResultPoolColumnSnapshotProvider(ctx.resultPool))
-      .build({ anchors: { main: datasetSpec } });
+      .build({ anchors: { main: datasetSpec } })!;
 
     const enrichmentCollection =
-      opts?.withEnrichments !== undefined
+      withEnrichments !== undefined
         ? new ColumnCollectionBuilder(pframeSpec)
             .addSources(collectCtxColumnSnapshotProviders(ctx))
             .build({ anchors: { main: datasetSpec } })
         : undefined;
 
     try {
-      let filters: Option[] | undefined;
-      if (filterCollection) {
-        const filterMatches = findFilterColumns(filterCollection).filter((m) =>
-          filterPredicate(m.column.spec),
-        );
-        filters =
-          filterMatches.length === 0
-            ? undefined
-            : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
-      }
+      const filterMatches = findFilterColumns(filterCollection).filter((m) =>
+        filterPredicate(m.column.spec),
+      );
+      const filters =
+        filterMatches.length === 0
+          ? undefined
+          : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
 
       let enrichments;
-      if (enrichmentCollection && opts?.withEnrichments !== undefined) {
+      if (enrichmentCollection && withEnrichments !== undefined) {
         const enrichmentVariants = findEnrichmentColumns(enrichmentCollection, {
-          maxHops: opts.enrichmentMaxHops,
-          ...(typeof opts.withEnrichments === "function"
-            ? { predicate: opts.withEnrichments }
-            : { include: opts.withEnrichments }),
+          maxHops: opts?.enrichmentMaxHops,
+          ...(typeof withEnrichments === "function"
+            ? { predicate: withEnrichments }
+            : { include: withEnrichments }),
         });
         if (enrichmentVariants.length > 0) {
-          enrichments = enrichmentVariantsToRefs(enrichmentVariants, opts.labelOptions);
+          enrichments = enrichmentVariantsToRefs(enrichmentVariants, opts?.labelOptions);
         }
       }
 
@@ -106,7 +107,7 @@ export function buildDatasetOptions(
         ...(enrichments !== undefined && enrichments.length > 0 ? { enrichments } : {}),
       };
     } finally {
-      filterCollection?.dispose();
+      filterCollection.dispose();
       enrichmentCollection?.dispose();
     }
   });

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -3,7 +3,10 @@ import { multiColumnSelectorsToPredicate } from "@milaboratories/pl-model-common
 import type { DeriveLabelsOptions } from "../../labels/derive_distinct_labels";
 import type { RenderCtxBase } from "../../render";
 import { ColumnCollectionBuilder } from "../../columns/column_collection_builder";
-import { collectCtxColumnSnapshotProviders } from "../../columns/ctx_column_sources";
+import {
+  ResultPoolColumnSnapshotProvider,
+  collectCtxColumnSnapshotProviders,
+} from "../../columns/ctx_column_sources";
 import type { DatasetOption } from "./dataset_selection";
 import { buildRefMap, filterMatchesToOptions, findFilterColumns } from "./filter_discovery";
 import { enrichmentVariantsToRefs, findEnrichmentColumns } from "./enrichment_discovery";
@@ -11,6 +14,12 @@ import { enrichmentVariantsToRefs, findEnrichmentColumns } from "./enrichment_di
 export type BuildDatasetOptions = {
   /** Which result pool columns qualify as datasets. Defaults to all. */
   primary?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
+  /**
+   * Restricts which result pool columns are considered as filters. Intersected
+   * with the built-in `pl7.app/isSubset: "true"` constraint. Defaults to
+   * accept-all.
+   */
+  filter?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
   /** Formatting options for filter labels. */
   labelOptions?: DeriveLabelsOptions;
   /**
@@ -42,29 +51,48 @@ export function buildDatasetOptions(
   const options = ctx.resultPool.getOptions(primaryPredicate, { refsWithEnrichments: true });
   if (options.length === 0) return [];
 
-  const columnSources = collectCtxColumnSnapshotProviders(ctx);
+  const enrichmentSources = collectCtxColumnSnapshotProviders(ctx);
+  const filterSource = new ResultPoolColumnSnapshotProvider(ctx.resultPool);
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
+
+  const filterOpt = opts?.filter;
+  const filterPredicate =
+    filterOpt === undefined
+      ? undefined
+      : typeof filterOpt === "function"
+        ? filterOpt
+        : multiColumnSelectorsToPredicate(filterOpt);
 
   return options.map((primary: Option): DatasetOption => {
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
     if (!datasetSpec) return { primary };
 
-    const builder = new ColumnCollectionBuilder(pframeSpec);
-    for (const src of columnSources) builder.addSource(src);
-    const collection = builder.build({ anchors: { main: datasetSpec } });
-    if (!collection) return { primary };
+    const enrichmentBuilder = new ColumnCollectionBuilder(pframeSpec);
+    for (const src of enrichmentSources) enrichmentBuilder.addSource(src);
+    const enrichmentCollection = enrichmentBuilder.build({ anchors: { main: datasetSpec } });
+    if (!enrichmentCollection) return { primary };
+
+    const filterBuilder = new ColumnCollectionBuilder(pframeSpec);
+    filterBuilder.addSource(filterSource);
+    const filterCollection = filterBuilder.build({ anchors: { main: datasetSpec } });
 
     try {
-      const filterMatches = findFilterColumns(collection);
-      const filters =
-        filterMatches.length === 0
-          ? undefined
-          : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
+      let filters: Option[] | undefined;
+      if (filterCollection) {
+        let filterMatches = findFilterColumns(filterCollection);
+        if (filterPredicate !== undefined) {
+          filterMatches = filterMatches.filter((m) => filterPredicate(m.column.spec));
+        }
+        filters =
+          filterMatches.length === 0
+            ? undefined
+            : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
+      }
 
       let enrichments;
       if (opts?.withEnrichments !== undefined) {
-        const enrichmentVariants = findEnrichmentColumns(collection, {
+        const enrichmentVariants = findEnrichmentColumns(enrichmentCollection, {
           maxHops: opts.enrichmentMaxHops,
           ...(typeof opts.withEnrichments === "function"
             ? { predicate: opts.withEnrichments }
@@ -81,7 +109,8 @@ export function buildDatasetOptions(
         ...(enrichments !== undefined && enrichments.length > 0 ? { enrichments } : {}),
       };
     } finally {
-      collection.dispose();
+      enrichmentCollection.dispose();
+      filterCollection?.dispose();
     }
   });
 }

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -11,26 +11,6 @@ import type { DatasetOption } from "./dataset_selection";
 import { buildRefMap, filterMatchesToOptions, findFilterColumns } from "./filter_discovery";
 import { enrichmentVariantsToRefs, findEnrichmentColumns } from "./enrichment_discovery";
 
-export type BuildDatasetOptions = {
-  /** Which result pool columns qualify as datasets. Defaults to all. */
-  primary?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
-  /**
-   * Restricts which result pool columns are considered as filters. Intersected
-   * with the built-in `pl7.app/isSubset: "true"` constraint. Defaults to
-   * accept-all.
-   */
-  filter?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
-  /** Formatting options for filter labels. */
-  labelOptions?: DeriveLabelsOptions;
-  /**
-   * Enables enrichment discovery and filters hits attached to
-   * `DatasetOption.enrichments`. Use `() => true` to accept all; omit to disable.
-   */
-  withEnrichments?: MultiColumnSelector | MultiColumnSelector[] | ((spec: PObjectSpec) => boolean);
-  /** Maximum linker hops considered. Only used when `withEnrichments` is set. */
-  enrichmentMaxHops?: number;
-};
-
 type SpecPredicateOption =
   | MultiColumnSelector
   | MultiColumnSelector[]
@@ -42,6 +22,26 @@ function toPredicate(
   if (opt === undefined) return undefined;
   return typeof opt === "function" ? opt : multiColumnSelectorsToPredicate(opt);
 }
+
+export type BuildDatasetOptions = {
+  /** Which result pool columns qualify as datasets. Defaults to all. */
+  primary?: SpecPredicateOption;
+  /**
+   * Restricts which result pool columns are considered as filters. Intersected
+   * with the built-in `pl7.app/isSubset: "true"` constraint. Defaults to
+   * accept-all.
+   */
+  filter?: SpecPredicateOption;
+  /** Formatting options for filter labels. */
+  labelOptions?: DeriveLabelsOptions;
+  /**
+   * Enables enrichment discovery and filters hits attached to
+   * `DatasetOption.enrichments`. Use `() => true` to accept all; omit to disable.
+   */
+  withEnrichments?: SpecPredicateOption;
+  /** Maximum linker hops considered. Only used when `withEnrichments` is set. */
+  enrichmentMaxHops?: number;
+};
 
 /**
  * Usage:

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -57,8 +57,6 @@ export function buildDatasetOptions(
   const options = ctx.resultPool.getOptions(primaryPredicate, { refsWithEnrichments: true });
   if (options.length === 0) return [];
 
-  const enrichmentSources = collectCtxColumnSnapshotProviders(ctx);
-  const filterSource = new ResultPoolColumnSnapshotProvider(ctx.resultPool);
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
 
@@ -66,14 +64,14 @@ export function buildDatasetOptions(
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
     if (!datasetSpec) return { primary };
 
-    const enrichmentBuilder = new ColumnCollectionBuilder(pframeSpec);
-    for (const src of enrichmentSources) enrichmentBuilder.addSource(src);
-    const enrichmentCollection = enrichmentBuilder.build({ anchors: { main: datasetSpec } });
+    const enrichmentCollection = new ColumnCollectionBuilder(pframeSpec)
+      .addSources(collectCtxColumnSnapshotProviders(ctx))
+      .build({ anchors: { main: datasetSpec } });
     if (!enrichmentCollection) return { primary };
 
-    const filterBuilder = new ColumnCollectionBuilder(pframeSpec);
-    filterBuilder.addSource(filterSource);
-    const filterCollection = filterBuilder.build({ anchors: { main: datasetSpec } });
+    const filterCollection = new ColumnCollectionBuilder(pframeSpec)
+      .addSource(new ResultPoolColumnSnapshotProvider(ctx.resultPool))
+      .build({ anchors: { main: datasetSpec } });
 
     try {
       let filters: Option[] | undefined;

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -60,13 +60,12 @@ export function buildDatasetOptions(
   const refMap = buildRefMap(ctx.resultPool.getSpecs().entries);
   const pframeSpec = ctx.getService("pframeSpec");
 
-  const withEnrichments = opts?.withEnrichments;
+  const withEnrichments = opts?.withEnrichments ?? false;
   const filterSource = new ResultPoolColumnSnapshotProvider(ctx.resultPool);
   // Hoisted out of the per-option loop: collectCtxColumnSnapshotProviders
   // walks the entire output tree, so calling it once per dataset option would
   // be O(N × tree).
-  const enrichmentSources =
-    withEnrichments !== undefined ? collectCtxColumnSnapshotProviders(ctx) : undefined;
+  const enrichmentSources = withEnrichments ? collectCtxColumnSnapshotProviders(ctx) : undefined;
 
   return options.map((primary: Option): DatasetOption => {
     const datasetSpec = ctx.resultPool.getPColumnSpecByRef(primary.ref);
@@ -95,7 +94,7 @@ export function buildDatasetOptions(
           : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
 
       let enrichments;
-      if (enrichmentCollection && withEnrichments !== undefined) {
+      if (enrichmentCollection && withEnrichments) {
         const enrichmentVariants = findEnrichmentColumns(enrichmentCollection, {
           maxHops: opts?.enrichmentMaxHops,
           ...(typeof withEnrichments === "function"

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts
@@ -140,17 +140,23 @@ describe("filterMatchesToOptions", () => {
     expect(filterMatchesToOptions([], new Map())).toEqual([]);
   });
 
-  test("throws when ref not found in map", () => {
-    const filterSpec1 = spec("orphan", [axis("sample")], { [Annotation.IsSubset]: "true" });
-    const f1Snap = snap("orphan-id", filterSpec1);
+  test("skips entries whose ref is not found in map", () => {
+    const knownRef = createPlRef("b1", "known");
+    const knownSpec = spec("known", [axis("sample")], { [Annotation.IsSubset]: "true" });
+    const orphanSpec = spec("orphan", [axis("sample")], { [Annotation.IsSubset]: "true" });
+    const knownSnap = snap(canonicalize(knownRef)! as string, knownSpec);
+    const orphanSnap = snap("orphan-id", orphanSpec);
 
     const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
-    builder.addSource([f1Snap, anchorSnap]);
+    builder.addSource([knownSnap, orphanSnap, anchorSnap]);
     const collection = builder.build({ anchors: { main: anchorSpec } })!;
 
     const matches = findFilterColumns(collection);
-    expect(matches.length).toBe(1);
+    expect(matches.length).toBe(2);
 
-    expect(() => filterMatchesToOptions(matches, new Map())).toThrow(/no PlRef found/);
+    const refMap = buildRefMap([{ ref: knownRef }]);
+    const options = filterMatchesToOptions(matches, refMap);
+    expect(options).toHaveLength(1);
+    expect(options[0].ref).toBe(knownRef);
   });
 });

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
@@ -48,11 +48,13 @@ export function filterMatchesToOptions(
   // Each ColumnMatch can be reached via multiple variants (different linker
   // paths / qualifications). We emit one Option per variant so the user can
   // pick a specific path — `deriveDistinctLabels` disambiguates labels by
-  // path.
-  const flattened = matches
-    .flatMap((m) => m.variants.map((v) => ({ match: m, variant: v })))
-    .map((item) => ({ ...item, ref: refsByObjectId.get(item.match.column.id) }))
-    .filter((item): item is typeof item & { ref: PlRef } => item.ref !== undefined);
+  // path. All variants of a match share a column id, so the ref lookup
+  // happens once per match.
+  const flattened = matches.flatMap((match) => {
+    const ref = refsByObjectId.get(match.column.id);
+    if (ref === undefined) return [];
+    return match.variants.map((variant) => ({ match, variant, ref }));
+  });
 
   const entries: Entry[] = flattened.map(({ match, variant }) => ({
     spec: match.column.spec,

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
@@ -31,6 +31,9 @@ export function findFilterColumns(collection: AnchoredColumnCollection): ColumnM
 /**
  * Derive labeled options from filter column matches, for use in DatasetOption.filters.
  *
+ * Entries whose column id has no PlRef in `refsByObjectId` are silently
+ * skipped — they cannot be exposed as user-selectable options.
+ *
  * @param matches - from findFilterColumns()
  * @param refsByObjectId - from {@link buildRefMap}
  * @param labelOptions - forwarded to deriveDistinctLabels()
@@ -46,7 +49,10 @@ export function filterMatchesToOptions(
   // paths / qualifications). We emit one Option per variant so the user can
   // pick a specific path — `deriveDistinctLabels` disambiguates labels by
   // path.
-  const flattened = matches.flatMap((m) => m.variants.map((v) => ({ match: m, variant: v })));
+  const flattened = matches
+    .flatMap((m) => m.variants.map((v) => ({ match: m, variant: v })))
+    .map((item) => ({ ...item, ref: refsByObjectId.get(item.match.column.id) }))
+    .filter((item): item is typeof item & { ref: PlRef } => item.ref !== undefined);
 
   const entries: Entry[] = flattened.map(({ match, variant }) => ({
     spec: match.column.spec,
@@ -55,14 +61,7 @@ export function filterMatchesToOptions(
 
   const labels = deriveDistinctLabels(entries, labelOptions);
 
-  return flattened.map(({ match }, i) => {
-    const ref = refsByObjectId.get(match.column.id);
-    if (ref === undefined)
-      throw new Error(
-        `no PlRef found for filter column ${match.column.spec.name} (id: ${match.column.id})`,
-      );
-    return { ref, label: labels[i] };
-  });
+  return flattened.map(({ ref }, i) => ({ ref, label: labels[i] }));
 }
 
 /**

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -145,12 +145,11 @@ function onFilterChange(value: PlRef | null | undefined) {
       </template>
     </PlDropdownRef>
     <PlDropdown
-      v-if="hasFilters"
       :model-value="filterValue"
       :options="filterOptions"
       :label="filterLabel"
       :placeholder="filterPlaceholder"
-      :disabled="disabled"
+      :disabled="disabled || !hasFilters"
       @update:model-value="onFilterChange"
     />
   </div>

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -87,25 +87,27 @@ const filterOptions = computed<ListOption<PlRef>[]>(
   () => currentDatasetOption.value?.filters?.map((f) => ({ label: f.label, value: f.ref })) ?? [],
 );
 
-function emitValue(dataset: PlRef | undefined, filter: PlRef | undefined) {
+// Resolve from `props.options` directly — `currentDatasetOption` may not have
+// recomputed yet when this runs synchronously inside a change handler.
+function findOption(dataset: PlRef): DatasetOption | undefined {
+  return props.options?.find((o) => plRefsEqual(o.primary.ref, dataset, true));
+}
+
+function onDatasetChange(dataset: PlRef | undefined) {
   if (dataset === undefined) {
     model.value = undefined;
     return;
   }
-  // Resolve from `props.options` directly — `currentDatasetOption` may not
-  // have recomputed yet when this runs synchronously inside a change handler.
-  const option = props.options?.find((o) => plRefsEqual(o.primary.ref, dataset, true));
-  model.value = createDatasetSelection(createPrimaryRef(dataset, filter), option?.enrichments);
+  model.value = createDatasetSelection(createPrimaryRef(dataset), findOption(dataset)?.enrichments);
 }
 
-function onDatasetChange(dataset: PlRef | undefined) {
-  emitValue(dataset, undefined);
-}
-
-function onFilterChange(value: PlRef | undefined) {
+function onFilterChange(filter: PlRef | undefined) {
   const dataset = selectedDataset.value;
   if (!dataset) return;
-  emitValue(dataset, value);
+  model.value = createDatasetSelection(
+    createPrimaryRef(dataset, filter),
+    findOption(dataset)?.enrichments,
+  );
 }
 </script>
 

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -86,8 +86,6 @@ const primaryOptions = computed<readonly { ref: PlRef; label: string }[] | undef
   props.options?.map((o) => o.primary),
 );
 
-const hasFilters = computed(() => (currentDatasetOption.value?.filters?.length ?? 0) > 0);
-
 /**
  * Filter dropdown options. The first entry (`null`) is the "No filter" choice —
  * null distinguishes it from `undefined` (dropdown clear button, disabled here).
@@ -149,7 +147,7 @@ function onFilterChange(value: PlRef | null | undefined) {
       :options="filterOptions"
       :label="filterLabel"
       :placeholder="filterPlaceholder"
-      :disabled="disabled || !hasFilters"
+      :disabled="disabled"
       @update:model-value="onFilterChange"
     />
   </div>

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -2,9 +2,9 @@
 /**
  * Select a dataset and (optionally) a filter column, emitting a {@link DatasetSelection}.
  *
- * Behaves like {@link PlDropdownRef} when none of the offered datasets carry
- * filter options. When the selected dataset has compatible filters, a second
- * dropdown appears with the filters plus a "No filter" entry.
+ * The filter dropdown is always rendered and is clearable — leaving it empty
+ * means "no filter". When the selected dataset has no compatible filters, the
+ * dropdown opens to an empty option list.
  *
  * The emitted value bundles the user's pick (`primary`) with the auto-attached
  * `enrichments` payload from the matching `DatasetOption`. Enrichments are
@@ -46,8 +46,6 @@ const props = withDefaults(
     filterLabel?: string;
     /** Placeholder for the filter dropdown. */
     filterPlaceholder?: string;
-    /** Label of the "no filter" entry prepended to the filter options. */
-    noFilterLabel?: string;
     /** Show a clear button on the dataset dropdown. */
     clearable?: boolean;
     /** Mark the dataset dropdown as required. */
@@ -64,7 +62,6 @@ const props = withDefaults(
     placeholder: "...",
     filterLabel: "",
     filterPlaceholder: "...",
-    noFilterLabel: "No filter",
     clearable: false,
     required: false,
     disabled: false,
@@ -86,20 +83,9 @@ const primaryOptions = computed<readonly { ref: PlRef; label: string }[] | undef
   props.options?.map((o) => o.primary),
 );
 
-/**
- * Filter dropdown options. The first entry (`null`) is the "No filter" choice —
- * null distinguishes it from `undefined` (dropdown clear button, disabled here).
- */
-const filterOptions = computed<ListOption<PlRef | null>[]>(() => {
-  const filters = currentDatasetOption.value?.filters;
-  if (!filters) return [];
-  return [
-    { label: props.noFilterLabel, value: null } as ListOption<PlRef | null>,
-    ...filters.map((f) => ({ label: f.label, value: f.ref }) as ListOption<PlRef | null>),
-  ];
-});
-
-const filterValue = computed<PlRef | null>(() => selectedFilter.value ?? null);
+const filterOptions = computed<ListOption<PlRef>[]>(
+  () => currentDatasetOption.value?.filters?.map((f) => ({ label: f.label, value: f.ref })) ?? [],
+);
 
 function emitValue(dataset: PlRef | undefined, filter: PlRef | undefined) {
   if (dataset === undefined) {
@@ -116,10 +102,10 @@ function onDatasetChange(dataset: PlRef | undefined) {
   emitValue(dataset, undefined);
 }
 
-function onFilterChange(value: PlRef | null | undefined) {
+function onFilterChange(value: PlRef | undefined) {
   const dataset = selectedDataset.value;
   if (!dataset) return;
-  emitValue(dataset, value ?? undefined);
+  emitValue(dataset, value);
 }
 </script>
 
@@ -143,11 +129,12 @@ function onFilterChange(value: PlRef | null | undefined) {
       </template>
     </PlDropdownRef>
     <PlDropdown
-      :model-value="filterValue"
+      :model-value="selectedFilter"
       :options="filterOptions"
       :label="filterLabel"
       :placeholder="filterPlaceholder"
       :disabled="disabled"
+      clearable
       @update:model-value="onFilterChange"
     />
   </div>

--- a/sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts
@@ -24,7 +24,7 @@ const optionsWithFilters: DatasetOption[] = [
     ],
     enrichments: enrichmentsA,
   },
-  // Dataset B has no filters — filter dropdown must stay hidden.
+  // Dataset B has no filters — filter dropdown is rendered but with no options.
   { primary: { label: "Dataset B", ref: datasetB } },
 ];
 
@@ -51,7 +51,7 @@ async function pickOption(index: number) {
 }
 
 describe("PlDatasetSelector", () => {
-  it("renders a single dropdown when no dataset has filters", async () => {
+  it("always renders both dataset and filter dropdowns", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: { modelValue: undefined, options: optionsNoFilters },
       attachTo: document.body,
@@ -60,12 +60,11 @@ describe("PlDatasetSelector", () => {
 
     const selector = wrapper.find(".pl-dataset-selector");
     expect(selector.exists()).toBe(true);
-    // Only PlDropdownRef is rendered — no filter dropdown.
-    expect(selector.element.children.length).toBe(1);
+    expect(selector.element.children.length).toBe(2);
     wrapper.unmount();
   });
 
-  it("shows the filter dropdown when the selected dataset has filters", async () => {
+  it("filter dropdown is rendered when the selected dataset has filters", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: { modelValue: selection(datasetA), options: optionsWithFilters },
       attachTo: document.body,
@@ -76,14 +75,20 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("hides the filter dropdown when the selected dataset has no filters", async () => {
+  it("filter dropdown is still rendered (with no options) when the selected dataset has no filters", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: { modelValue: selection(datasetB), options: optionsWithFilters },
       attachTo: document.body,
     });
     await flushPromises();
 
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(1);
+    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(2);
+
+    // Opening the filter dropdown shows no options.
+    const inputs = wrapper.findAll("input");
+    expect(inputs.length).toBe(2);
+    await inputs[1].trigger("focus");
+    expect(document.body.querySelectorAll(".dropdown-list-item").length).toBe(0);
     wrapper.unmount();
   });
 
@@ -129,8 +134,8 @@ describe("PlDatasetSelector", () => {
     const inputs = wrapper.findAll("input");
     expect(inputs.length).toBe(2);
     await inputs[1].trigger("focus");
-    // Options: [No filter, Top 1000, High quality]. Pick "Top 1000".
-    await pickOption(1);
+    // Options: [Top 1000, High quality]. Pick "Top 1000".
+    await pickOption(0);
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
@@ -143,7 +148,7 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("emits DatasetSelection with no filter key when 'No filter' is picked", async () => {
+  it("emits DatasetSelection with no filter key when the filter dropdown is cleared", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
         modelValue: selection(datasetA, filterA1, enrichmentsA),
@@ -155,9 +160,12 @@ describe("PlDatasetSelector", () => {
     });
     await flushPromises();
 
-    const inputs = wrapper.findAll("input");
-    await inputs[1].trigger("focus");
-    await pickOption(0); // "No filter"
+    // The filter dropdown is the second .clear button (the first belongs to
+    // the dataset dropdown, but it's only present when the dataset selector
+    // itself is clearable; here only the filter is clearable by default).
+    const clearBtns = wrapper.findAll(".clear");
+    expect(clearBtns.length).toBeGreaterThan(0);
+    await clearBtns[clearBtns.length - 1].trigger("click");
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
@@ -168,14 +176,18 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("hides filter dropdown when dataset has filters: [] (empty array)", async () => {
+  it("filter dropdown is still rendered (with no options) when dataset has filters: [] (empty array)", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: { modelValue: selection(datasetC), options: optionsWithEmptyFilters },
       attachTo: document.body,
     });
     await flushPromises();
 
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(1);
+    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(2);
+
+    const inputs = wrapper.findAll("input");
+    await inputs[1].trigger("focus");
+    expect(document.body.querySelectorAll(".dropdown-list-item").length).toBe(0);
     wrapper.unmount();
   });
 
@@ -197,8 +209,7 @@ describe("PlDatasetSelector", () => {
     expect(inputs.length).toBe(2);
     await inputs[1].trigger("focus");
     const items = document.body.querySelectorAll(".dropdown-list-item");
-    expect(items.length).toBe(3); // No filter, Top 1000, High quality
-    expect(items[0].textContent).toContain("No filter");
+    expect(items.length).toBe(2); // Top 1000, High quality — no synthetic "No filter"
     wrapper.unmount();
   });
 
@@ -242,9 +253,10 @@ describe("PlDatasetSelector", () => {
     });
     await flushPromises();
 
-    const clearBtn = wrapper.find(".clear");
-    expect(clearBtn.exists()).toBe(true);
-    await clearBtn.trigger("click");
+    // First .clear button is on the dataset dropdown (clearable: true).
+    const clearBtns = wrapper.findAll(".clear");
+    expect(clearBtns.length).toBeGreaterThan(0);
+    await clearBtns[0].trigger("click");
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();

--- a/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
@@ -410,6 +410,15 @@ tableBuilder := func(format, ...ctxArg) {
 
 				for _, rawFlt in rawFilters {
 					resolvedFlt := resolveColumn(rawFlt)
+					// A malformed or unresolvable filter ref produces no spec —
+					// silently dropping it here keeps build-table's
+					// PrimarySpecsReady awaitState from panicking on a
+					// locked-but-fieldless `filter` sub-resource. Same
+					// rationale as filterMatchesToOptions skipping ref-less
+					// entries on the model side.
+					if is_undefined(resolvedFlt.spec) {
+						continue
+					}
 					entry.filters = append(entry.filters, {
 						spec: resolvedFlt.spec,
 						data: resolvedFlt.data

--- a/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
@@ -410,12 +410,6 @@ tableBuilder := func(format, ...ctxArg) {
 
 				for _, rawFlt in rawFilters {
 					resolvedFlt := resolveColumn(rawFlt)
-					// A malformed or unresolvable filter ref produces no spec —
-					// silently dropping it here keeps build-table's
-					// PrimarySpecsReady awaitState from panicking on a
-					// locked-but-fieldless `filter` sub-resource. Same
-					// rationale as filterMatchesToOptions skipping ref-less
-					// entries on the model side.
 					if is_undefined(resolvedFlt.spec) {
 						continue
 					}

--- a/sdk/workflow-tengo/src/tpl/base.lib.tengo
+++ b/sdk/workflow-tengo/src/tpl/base.lib.tengo
@@ -100,12 +100,15 @@ AWAIT_TEMPLATES := {
 	],
 	// Matches a v1 ResolvedPrimaryRef shape: { __isPrimaryRef: "v1",
 	// column: {spec, data}, filter?: {spec, data} }. Awaits the column's
-	// spec (required) and filter's spec (optional, regex-matched so the
-	// absence of `filter` is fine). The `__isPrimaryRef` marker is
-	// ignored — we never descend into it.
+	// spec (required) and filter's spec (optional). Both `filter` and
+	// `filter.spec` are regex-matched: the parent `filter` field may be
+	// absent (no filter selected), and the `spec` sub-field may be absent
+	// when the filter ref resolved to a "no result" sentinel that never
+	// populated the spec input. The `__isPrimaryRef` marker is ignored —
+	// we never descend into it.
 	"PrimarySpecsReady": [
 		["column", "spec", "ResourceReady"],
-		[{ match: "^filter$" }, "spec", "ResourceReady"]
+		[{ match: "^filter$" }, { match: "^spec$" }, "ResourceReady"]
 	]
 }
 


### PR DESCRIPTION
## Summary

Fixes three issues in `buildDatasetOptions` surfaced by the 3D-structure-prediction block (filters from the block itself appearing in the dropdown, no API to restrict filter eligibility, dropdown disappearing post-run because `buildDatasetOptions` threw).

- **A.** Build a separate `ColumnCollection` for filter discovery sourced from the result pool only (`ResultPoolColumnSnapshotProvider`). Block outputs and prerun no longer leak into the filter dropdown. Enrichment discovery keeps the unioned collection.
- **B.** New `filter?: SpecPredicateOption` on `BuildDatasetOptions`, intersected with the built-in `pl7.app/isSubset: "true"` constraint via post-filter on matches. Default = accept all.
- **C.** `filterMatchesToOptions` skips entries without a PlRef instead of throwing — callers no longer need try/catch around `buildDatasetOptions`.
- Extracted `SpecPredicateOption` alias and `toPredicate()` helper used by `primary`, `filter`, and `withEnrichments`.

Block-side migration of the 3D block is intentionally out of scope — will follow once the SDK update lands.

## Test plan

- [x] `pnpm exec vitest run` in `sdk/model` (374 passed, including updated `filterMatchesToOptions` skip-behavior test)
- [x] `pnpm exec tsc --noEmit` in `sdk/model`
- [x] `pnpm run build:local --filter @platforma-sdk/model`
- [ ] Verify in 3D-structure-prediction block that the filter dropdown stays populated after a run (block-side change in a follow-up PR)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three bugs in `buildDatasetOptions`: filter discovery is now scoped to the result pool only (via a new `ResultPoolColumnSnapshotProvider`), a `filter` predicate option lets callers restrict eligible filter columns, and `filterMatchesToOptions` silently skips entries without a `PlRef` instead of throwing. The `SpecPredicateOption` alias and `toPredicate()` helper clean up the repeated predicate-coercion pattern across `primary`, `filter`, and `withEnrichments`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; one minor resource-management edge case in build_dataset_options.ts.

Only P2 findings — the `filterCollection` build sitting outside the `try` block could theoretically leak `enrichmentCollection` if `build()` throws, but `build()` returning `null` (not throwing) is the normal failure mode. All other logic is sound and test coverage is updated.

sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts — `filterCollection` build placement relative to the try/finally block.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts | Splits collection building into separate enrichment and filter paths; adds `SpecPredicateOption` alias and `toPredicate()` helper; `filterCollection` is built outside the try/finally block, risking an `enrichmentCollection` leak on throw. |
| sdk/model/src/components/PlDatasetSelector/filter_discovery.ts | Replaces throw-on-missing-ref with silent skip; label index alignment is preserved correctly after filtering. |
| sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts | Test updated to verify skip-behavior: a known ref is returned, an orphan entry is silently dropped. Correct coverage. |
| .changeset/dataset-selector-filter-predicate.md | Minor-bump changeset accurately describes all three fixes. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts:76-78
**`enrichmentCollection` may leak if `filterBuilder.build()` throws**

`filterCollection` is built outside the `try` block. If `filterBuilder.build()` throws, the `finally` clause is never reached and the already-allocated `enrichmentCollection` is never disposed. Moving the `filterBuilder.build()` call inside the `try` block would close the gap.

```ts
    const filterBuilder = new ColumnCollectionBuilder(pframeSpec);
    filterBuilder.addSource(filterSource);

    try {
      const filterCollection = filterBuilder.build({ anchors: { main: datasetSpec } });
      let filters: Option[] | undefined;
      if (filterCollection) {
        // ... existing filter logic ...
      }
      // ... enrichment logic ...
    } finally {
      enrichmentCollection.dispose();
      filterCollection?.dispose();
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(model): use SpecPredicateOption..."](https://github.com/milaboratory/platforma/commit/e8a08b148792dcb0601a244d4a733d6e3410fd7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30666211)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->