### PR TITLE
fix(pl-middle-layer): decouple PFrame blob pool from originating tree

### DIFF
--- a/.changeset/decouple-blob-pool-from-tree.md
+++ b/.changeset/decouple-blob-pool-from-tree.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Fix PFrame errors in duplicated projects when the original is recalculated. The blob pools deduplicated entries by rid but resolved through the first acquirer's `PlTreeEntry`; once that tree dropped the resource, other projects sharing the entry started failing with "resource not found in the tree" and parquet HTTP 500s. Snapshots are now captured at parse time and the pools resolve via the snapshot directly, keeping cross-project dedup intact.

--- a/lib/node/pl-middle-layer/src/pool/data.ts
+++ b/lib/node/pl-middle-layer/src/pool/data.ts
@@ -9,17 +9,57 @@ import {
   type PObjectId,
   type PObjectSpec,
 } from "@platforma-sdk/model";
-import type { PlTreeEntry, PlTreeNodeAccessor } from "@milaboratories/pl-tree";
+import { makeResourceSnapshot, type PlTreeNodeAccessor } from "@milaboratories/pl-tree";
 import canonicalize from "canonicalize";
 import {
   isNullResourceId,
+  resourceIdToString,
   resourceType,
   resourceTypeToString,
   resourceTypesEqual,
+  type ResourceId,
+  type ResourceType,
 } from "@milaboratories/pl-client";
 import type { Writable } from "utility-types";
 import { createHash } from "node:crypto";
 import type { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
+import { OnDemandBlobResourceSnapshot } from "@milaboratories/pl-drivers";
+
+/**
+ * Tree-independent reference to a blob resource used by the PFrame data flow.
+ *
+ * The earlier design carried a {@link PlTreeEntry} all the way into the blob pools;
+ * resolution then went back through the originating tree, so when that tree dropped
+ * the resource (e.g., a project recalculated with new settings), shared pool entries
+ * — held alive by other projects — would start failing with "resource not found in
+ * the tree" even though the underlying blob was still valid backend-side.
+ *
+ * BlobResourceRef captures the snapshot at parse time, where the tree is guaranteed
+ * to resolve. The pools then key by rid (`resourceInfo.id`) and call into the
+ * download driver with the snapshot directly — independent of any specific tree.
+ */
+export class BlobResourceRef {
+  constructor(
+    public readonly resourceInfo: { readonly id: ResourceId; readonly type: ResourceType },
+    /** Present only for on-demand (remote) blobs; needed for size and signed handle. */
+    public readonly onDemandSnapshot: OnDemandBlobResourceSnapshot | undefined,
+  ) {}
+
+  toJSON(): string {
+    return resourceIdToString(this.resourceInfo.id);
+  }
+}
+
+function makeLocalBlobRef(accessor: PlTreeNodeAccessor): BlobResourceRef {
+  return new BlobResourceRef(accessor.resourceInfo, undefined);
+}
+
+function makeRemoteBlobRef(accessor: PlTreeNodeAccessor): BlobResourceRef {
+  return new BlobResourceRef(
+    accessor.resourceInfo,
+    makeResourceSnapshot(accessor, OnDemandBlobResourceSnapshot),
+  );
+}
 
 export const PColumnDataJsonPartitioned = resourceType("PColumnData/JsonPartitioned", "1");
 export const PColumnDataJsonSuperPartitioned = resourceType(
@@ -59,7 +99,7 @@ const BinaryPartitionedValuesFieldSuffix = ".values";
 
 export function parseDataInfoResource(
   data: PlTreeNodeAccessor,
-): PFrameInternal.DataInfo<PlTreeEntry> {
+): PFrameInternal.DataInfo<BlobResourceRef> {
   if (!data.getIsReadyOrError()) throw new PFrameDriverError("Data not ready.");
 
   const resourceData = data.getDataAsJson();
@@ -80,7 +120,10 @@ export function parseDataInfoResource(
     const parts = Object.fromEntries(
       data
         .listInputFields()
-        .map((field) => [field, data.traverse({ field, errorIfFieldNotSet: true }).persist()]),
+        .map((field) => [
+          field,
+          makeLocalBlobRef(data.traverse({ field, errorIfFieldNotSet: true })),
+        ]),
     );
 
     return {
@@ -91,7 +134,7 @@ export function parseDataInfoResource(
   } else if (resourceTypesEqual(data.resourceType, PColumnDataJsonSuperPartitioned)) {
     const meta = resourceData as PColumnDataSuperPartitionedResourceValue;
 
-    const parts: Record<string, PlTreeEntry> = {};
+    const parts: Record<string, BlobResourceRef> = {};
     for (const superKey of data.listInputFields()) {
       const superPart = data.traverse({ field: superKey, errorIfFieldNotSet: true });
       const keys = superPart.listInputFields();
@@ -103,7 +146,9 @@ export function parseDataInfoResource(
           ...(JSON.parse(superKey) as PColumnValue[]),
           ...(JSON.parse(key) as PColumnValue[]),
         ]);
-        parts[partKey] = superPart.traverse({ field: key, errorIfFieldNotSet: true }).persist();
+        parts[partKey] = makeLocalBlobRef(
+          superPart.traverse({ field: key, errorIfFieldNotSet: true }),
+        );
       }
     }
 
@@ -115,7 +160,7 @@ export function parseDataInfoResource(
   } else if (resourceTypesEqual(data.resourceType, PColumnDataBinaryPartitioned)) {
     const meta = resourceData as PColumnDataPartitionedResourceValue;
 
-    const parts: Record<string, Partial<Writable<BinaryChunk<PlTreeEntry>>>> = {};
+    const parts: Record<string, Partial<Writable<BinaryChunk<BlobResourceRef>>>> = {};
 
     // parsing the structure
     for (const field of data.listInputFields()) {
@@ -126,7 +171,7 @@ export function parseDataInfoResource(
           part = {};
           parts[partKey] = part;
         }
-        part.index = data.traverse({ field, errorIfFieldNotSet: true }).persist();
+        part.index = makeLocalBlobRef(data.traverse({ field, errorIfFieldNotSet: true }));
       } else if (field.endsWith(BinaryPartitionedValuesFieldSuffix)) {
         const partKey = field.slice(0, -BinaryPartitionedValuesFieldSuffix.length);
         let part = parts[partKey];
@@ -134,7 +179,7 @@ export function parseDataInfoResource(
           part = {};
           parts[partKey] = part;
         }
-        part.values = data.traverse({ field, errorIfFieldNotSet: true }).persist();
+        part.values = makeLocalBlobRef(data.traverse({ field, errorIfFieldNotSet: true }));
       } else throw new PFrameDriverError(`unrecognized part field name: ${field}`);
     }
 
@@ -147,12 +192,12 @@ export function parseDataInfoResource(
     return {
       type: "BinaryPartitioned",
       partitionKeyLength: meta.partitionKeyLength,
-      parts: parts as Record<string, BinaryChunk<PlTreeEntry>>,
+      parts: parts as Record<string, BinaryChunk<BlobResourceRef>>,
     };
   } else if (resourceTypesEqual(data.resourceType, PColumnDataBinarySuperPartitioned)) {
     const meta = resourceData as PColumnDataSuperPartitionedResourceValue;
 
-    const parts: Record<string, Partial<Writable<BinaryChunk<PlTreeEntry>>>> = {};
+    const parts: Record<string, Partial<Writable<BinaryChunk<BlobResourceRef>>>> = {};
     for (const superKey of data.listInputFields()) {
       const superData = data.traverse({ field: superKey, errorIfFieldNotSet: true });
       const keys = superData.listInputFields();
@@ -172,12 +217,9 @@ export function parseDataInfoResource(
             part = {};
             parts[partKey] = part;
           }
-          parts[partKey].index = superData
-            .traverse({
-              field,
-              errorIfFieldNotSet: true,
-            })
-            .persist();
+          parts[partKey].index = makeLocalBlobRef(
+            superData.traverse({ field, errorIfFieldNotSet: true }),
+          );
         } else if (field.endsWith(BinaryPartitionedValuesFieldSuffix)) {
           const key = field.slice(0, -BinaryPartitionedValuesFieldSuffix.length);
 
@@ -190,12 +232,9 @@ export function parseDataInfoResource(
             part = {};
             parts[partKey] = part;
           }
-          parts[partKey].values = superData
-            .traverse({
-              field,
-              errorIfFieldNotSet: true,
-            })
-            .persist();
+          parts[partKey].values = makeLocalBlobRef(
+            superData.traverse({ field, errorIfFieldNotSet: true }),
+          );
         } else throw new PFrameDriverError(`unrecognized part field name: ${field}`);
       }
     }
@@ -203,12 +242,12 @@ export function parseDataInfoResource(
     return {
       type: "BinaryPartitioned",
       partitionKeyLength: meta.superPartitionKeyLength + meta.partitionKeyLength,
-      parts: parts as Record<string, BinaryChunk<PlTreeEntry>>,
+      parts: parts as Record<string, BinaryChunk<BlobResourceRef>>,
     };
   } else if (resourceTypesEqual(data.resourceType, PColumnDataParquetPartitioned)) {
     const meta = resourceData as PColumnDataPartitionedResourceValue;
 
-    const parts: Record<string, ParquetChunk<PlTreeEntry>> = {};
+    const parts: Record<string, ParquetChunk<BlobResourceRef>> = {};
     for (const key of data.listInputFields()) {
       const resource = data.traverse({
         field: key,
@@ -227,7 +266,7 @@ export function parseDataInfoResource(
   } else if (resourceTypesEqual(data.resourceType, PColumnDataParquetSuperPartitioned)) {
     const meta = resourceData as PColumnDataSuperPartitionedResourceValue;
 
-    const parts: Record<string, ParquetChunk<PlTreeEntry>> = {};
+    const parts: Record<string, ParquetChunk<BlobResourceRef>> = {};
     for (const superKey of data.listInputFields()) {
       const superPart = data.traverse({ field: superKey, errorIfFieldNotSet: true });
       const keys = superPart.listInputFields();
@@ -259,7 +298,7 @@ export function parseDataInfoResource(
 
 export function traverseParquetChunkResource(
   resource: PlTreeNodeAccessor,
-): ParquetChunk<PlTreeEntry> {
+): ParquetChunk<BlobResourceRef> {
   if (!resourceTypesEqual(resource.resourceType, ParquetChunkResourceType)) {
     throw new PFrameDriverError(
       `unknown resource type: ${resourceTypeToString(resource.resourceType)}, ` +
@@ -267,9 +306,9 @@ export function traverseParquetChunkResource(
     );
   }
 
-  const blob = resource
-    .traverse({ field: "blob", assertFieldType: "Service", errorIfFieldNotSet: true })
-    .persist();
+  const blob = makeRemoteBlobRef(
+    resource.traverse({ field: "blob", assertFieldType: "Service", errorIfFieldNotSet: true }),
+  );
   const partInfo = resource.getDataAsJson() as ParquetChunkMetadata;
   const mapping = resource
     .traverse({ field: "mapping", assertFieldType: "Service", errorIfFieldNotSet: true })

--- a/lib/node/pl-middle-layer/src/pool/data.ts
+++ b/lib/node/pl-middle-layer/src/pool/data.ts
@@ -50,7 +50,7 @@ export class BlobResourceRef {
   }
 }
 
-function makeLocalBlobRef(accessor: PlTreeNodeAccessor): BlobResourceRef {
+export function makeLocalBlobRef(accessor: PlTreeNodeAccessor): BlobResourceRef {
   return new BlobResourceRef(accessor.resourceInfo, undefined);
 }
 

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -29,7 +29,12 @@ import {
 import { HttpHelpers } from "@milaboratories/pframes-rs-node";
 import path from "node:path";
 import { Readable } from "node:stream";
-import { BlobResourceRef, parseDataInfoResource, traverseParquetChunkResource } from "./data";
+import {
+  BlobResourceRef,
+  makeLocalBlobRef,
+  parseDataInfoResource,
+  traverseParquetChunkResource,
+} from "./data";
 import { isDownloadNetworkError400 } from "@milaboratories/pl-drivers";
 
 function makeBlobId(res: BlobResourceRef): PFrameInternal.PFrameBlobId {
@@ -310,7 +315,7 @@ export async function createPFrameDriver(params: {
       : isDataInfo(data)
         ? data.type === "ParquetPartitioned"
           ? mapDataInfo(data, (a) => traverseParquetChunkResource(a))
-          : mapDataInfo(data, (a) => new BlobResourceRef(a.resourceInfo, undefined))
+          : mapDataInfo(data, (a) => makeLocalBlobRef(a))
         : makeJsonDataInfo(spec, data);
   };
 

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -15,11 +15,7 @@ import { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
 import { emptyDir } from "@milaboratories/ts-helpers";
 import { RefCountPoolBase, type PoolEntry, type MiLogger } from "@milaboratories/helpers";
 import type { DownloadDriver } from "@milaboratories/pl-drivers";
-import {
-  isPlTreeNodeAccessor,
-  type PlTreeEntry,
-  type PlTreeNodeAccessor,
-} from "@milaboratories/pl-tree";
+import { isPlTreeNodeAccessor, type PlTreeNodeAccessor } from "@milaboratories/pl-tree";
 import type { Computable, ComputableStableDefined } from "@milaboratories/computable";
 import {
   makeJsonDataInfo,
@@ -33,17 +29,17 @@ import {
 import { HttpHelpers } from "@milaboratories/pframes-rs-node";
 import path from "node:path";
 import { Readable } from "node:stream";
-import { parseDataInfoResource, traverseParquetChunkResource } from "./data";
+import { BlobResourceRef, parseDataInfoResource, traverseParquetChunkResource } from "./data";
 import { isDownloadNetworkError400 } from "@milaboratories/pl-drivers";
 
-function makeBlobId(res: PlTreeEntry): PFrameInternal.PFrameBlobId {
-  return String(res.rid) as PFrameInternal.PFrameBlobId;
+function makeBlobId(res: BlobResourceRef): PFrameInternal.PFrameBlobId {
+  return String(res.resourceInfo.id) as PFrameInternal.PFrameBlobId;
 }
 
 type LocalBlob = ComputableStableDefined<LocalBlobHandleAndSize>;
 class LocalBlobProviderImpl
-  extends RefCountPoolBase<PlTreeEntry, PFrameInternal.PFrameBlobId, LocalBlob>
-  implements LocalBlobProvider<PlTreeEntry>
+  extends RefCountPoolBase<BlobResourceRef, PFrameInternal.PFrameBlobId, LocalBlob>
+  implements LocalBlobProvider<BlobResourceRef>
 {
   constructor(
     private readonly blobDriver: DownloadDriver,
@@ -52,12 +48,15 @@ class LocalBlobProviderImpl
     super();
   }
 
-  protected calculateParamsKey(params: PlTreeEntry): PFrameInternal.PFrameBlobId {
+  protected calculateParamsKey(params: BlobResourceRef): PFrameInternal.PFrameBlobId {
     return makeBlobId(params);
   }
 
-  protected createNewResource(params: PlTreeEntry, _key: PFrameInternal.PFrameBlobId): LocalBlob {
-    return this.blobDriver.getDownloadedBlob(params);
+  protected createNewResource(
+    params: BlobResourceRef,
+    _key: PFrameInternal.PFrameBlobId,
+  ): LocalBlob {
+    return this.blobDriver.getDownloadedBlob(params.resourceInfo);
   }
 
   public getByKey(blobId: PFrameInternal.PFrameBlobId): LocalBlob {
@@ -90,7 +89,7 @@ class LocalBlobProviderImpl
 
 type RemoteBlob = Computable<RemoteBlobHandleAndSize>;
 class RemoteBlobPool extends RefCountPoolBase<
-  PlTreeEntry,
+  BlobResourceRef,
   PFrameInternal.PFrameBlobId,
   RemoteBlob
 > {
@@ -101,12 +100,21 @@ class RemoteBlobPool extends RefCountPoolBase<
     super();
   }
 
-  protected calculateParamsKey(params: PlTreeEntry): PFrameInternal.PFrameBlobId {
+  protected calculateParamsKey(params: BlobResourceRef): PFrameInternal.PFrameBlobId {
     return makeBlobId(params);
   }
 
-  protected createNewResource(params: PlTreeEntry, _key: PFrameInternal.PFrameBlobId): RemoteBlob {
-    return this.blobDriver.getOnDemandBlob(params);
+  protected createNewResource(
+    params: BlobResourceRef,
+    _key: PFrameInternal.PFrameBlobId,
+  ): RemoteBlob {
+    if (params.onDemandSnapshot === undefined) {
+      throw new PFrameDriverError(
+        `BlobResourceRef for rid ${params.toJSON()} is missing the on-demand snapshot; ` +
+          `remote (parquet) blobs must be captured via makeRemoteBlobRef.`,
+      );
+    }
+    return this.blobDriver.getOnDemandBlob(params.onDemandSnapshot);
   }
 
   public getByKey(blobId: PFrameInternal.PFrameBlobId): RemoteBlob {
@@ -232,7 +240,7 @@ class BlobStore extends PFrameInternal.BaseObjectStore {
   }
 }
 
-class RemoteBlobProviderImpl implements RemoteBlobProvider<PlTreeEntry> {
+class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
   constructor(
     private readonly pool: RemoteBlobPool,
     private readonly server: PFrameInternal.HttpServer,
@@ -253,7 +261,7 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<PlTreeEntry> {
     return new RemoteBlobProviderImpl(pool, server);
   }
 
-  public acquire(params: PlTreeEntry): PoolEntry<PFrameInternal.PFrameBlobId> {
+  public acquire(params: BlobResourceRef): PoolEntry<PFrameInternal.PFrameBlobId> {
     return this.pool.acquire(params);
   }
 
@@ -302,7 +310,7 @@ export async function createPFrameDriver(params: {
       : isDataInfo(data)
         ? data.type === "ParquetPartitioned"
           ? mapDataInfo(data, (a) => traverseParquetChunkResource(a))
-          : mapDataInfo(data, (a) => a.persist())
+          : mapDataInfo(data, (a) => new BlobResourceRef(a.resourceInfo, undefined))
         : makeJsonDataInfo(spec, data);
   };
 


### PR DESCRIPTION
## Summary

Fixes PFrame errors that surface in a duplicated project when the original project's block is recalculated with new settings.

## Root cause

`LocalBlobProviderImpl` and `RemoteBlobPool` in `lib/node/pl-middle-layer/src/pool/driver.ts` deduplicate entries by `rid` (correct, content-addressed), but `createNewResource` calls `blobDriver.getOnDemandBlob(plTreeEntry)` / `getDownloadedBlob(plTreeEntry)` with the *first acquirer's* `PlTreeEntry`. The resulting `Computable` is bound to that originating tree.

When two projects (e.g., a duplicate) reference the same blob `rid`, both share the pool entry. If the originating project recalculates and its tree drops the old resource, the shared computable starts failing with `resource <rid> not found in the tree` — even though the backend blob is alive and the *other* project's tree still references it. Symptom in logs: parquet HTTP server 500s and cascading `getUniqueValues` / `getData` failures.

## Fix

Capture the tree-independent snapshot at parse time (in `pool/data.ts`, where the tree is guaranteed to resolve) and plumb it through the pool as a new `BlobResourceRef` class:

- `resourceInfo: { id, type }` — sufficient for `getDownloadedBlob` (local).
- `onDemandSnapshot: OnDemandBlobResourceSnapshot | undefined` — captured for parquet/remote blobs; needed for size and signed-handle synthesis.

The pools still key by rid (`String(resourceInfo.id)`) so cross-project deduplication is preserved. Resolution calls into `DownloadDriver` with the captured snapshot — no tree in the loop. The `DownloadDriver`'s internal caches (`keyToDownload`, `keyToOnDemand`) are already keyed by rid, so this aligns the middle-layer pool with the driver's existing invariants.

## Files

- `lib/node/pl-middle-layer/src/pool/data.ts` — new `BlobResourceRef` class; every `.persist()` call replaced with `makeLocalBlobRef` / `makeRemoteBlobRef`.
- `lib/node/pl-middle-layer/src/pool/driver.ts` — pool generic param `PlTreeEntry` → `BlobResourceRef`; `createNewResource` calls drivers with the snapshot.

No public API surface change.

## Test plan

- [ ] `tsc --noEmit` passes (verified locally).
- [ ] Reproduce original scenario: calculate Antibody TCR Leads Selection block in project A, duplicate to project B, recalculate A with different settings (e.g., ranking column), open cdr3 / V-J usage in B. Expected: graphs render, no `resource ... not found in the tree` errors, no parquet 500s.
- [ ] Regression check: open the same block in a single project — dedup still works (only one parquet HTTP request per rid).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR decouples the PFrame blob pools from the originating `PlTreeEntry` by capturing a tree-independent snapshot (`BlobResourceRef`) at parse time, fixing "resource not found in the tree" failures when a duplicated project's blobs were held via an entry from the original (now-invalidated) tree. The approach is sound: pool deduplication is preserved by keying on `resourceInfo.id`, and `DownloadDriver`'s internal caches already key by rid, so snapshot staleness is self-correcting.

- A pre-existing logic bug was spotted in `data.ts`: the `PColumnDataParquetSuperPartitioned` inner loop traverses `data` with `key` (a sub-field of `superPart`) instead of `superPart` — this can throw or resolve the wrong chunk resource.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core fix is correct, but a pre-existing wrong traversal node in `PColumnDataParquetSuperPartitioned` should be addressed while this file is open.

One P1 logic bug found (pre-existing wrong traversal: `data.traverse` instead of `superPart.traverse` in the parquet super-partitioned path). The P1 ceiling is 4/5; the bug is in a path that is plausibly exercised and the PR author is already modifying this file, pulling the score to 3.

lib/node/pl-middle-layer/src/pool/data.ts — specifically the `PColumnDataParquetSuperPartitioned` branch at line 277.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/pool/data.ts | Introduces `BlobResourceRef` and replaces all `.persist()` calls with `makeLocalBlobRef`/`makeRemoteBlobRef` to decouple pool entries from originating trees. Pre-existing bug found: in the `PColumnDataParquetSuperPartitioned` branch (line 277), `data.traverse({ field: key })` should be `superPart.traverse({ field: key })`. |
| lib/node/pl-middle-layer/src/pool/driver.ts | Swaps pool generic param from `PlTreeEntry` to `BlobResourceRef`; `createNewResource` now calls `getDownloadedBlob(params.resourceInfo)` and `getOnDemandBlob(params.onDemandSnapshot)` directly. Guard added for missing snapshot in `RemoteBlobPool`. Changes are clean and correct. |
| .changeset/decouple-blob-pool-from-tree.md | Changeset entry correctly marks this as a patch-level fix for `@milaboratories/pl-middle-layer`. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pl-middle-layer/src/pool/data.ts`, line 277 ([link](https://github.com/milaboratory/platforma/blob/27d8d4f21f432442e292592f4ab19b98aeacb347/lib/node/pl-middle-layer/src/pool/data.ts#L277)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Wrong traversal node in `PColumnDataParquetSuperPartitioned` loop**

   `key` comes from `superPart.listInputFields()`, but the resource is fetched with `data.traverse({ field: key })` — traversing the top-level node instead of `superPart`. Since `key` is a sub-field of `superPart` and not a direct field of `data`, this will either throw (`errorIfFieldNotSet: true`) or resolve the wrong chunk resource. The parallel `PColumnDataBinarySuperPartitioned` block (lines 220–237) correctly uses `superData.traverse(...)`. This is a pre-existing bug uncovered while reviewing this file; the fix should mirror the binary-super-partitioned pattern:

   ```typescript
   const resource = superPart.traverse({ field: key, errorIfFieldNotSet: true });
   ```

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-middle-layer/src/pool/data.ts
   Line: 277

   Comment:
   **Wrong traversal node in `PColumnDataParquetSuperPartitioned` loop**

   `key` comes from `superPart.listInputFields()`, but the resource is fetched with `data.traverse({ field: key })` — traversing the top-level node instead of `superPart`. Since `key` is a sub-field of `superPart` and not a direct field of `data`, this will either throw (`errorIfFieldNotSet: true`) or resolve the wrong chunk resource. The parallel `PColumnDataBinarySuperPartitioned` block (lines 220–237) correctly uses `superData.traverse(...)`. This is a pre-existing bug uncovered while reviewing this file; the fix should mirror the binary-super-partitioned pattern:

   ```typescript
   const resource = superPart.traverse({ field: key, errorIfFieldNotSet: true });
   ```

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/node/pl-middle-layer/src/pool/data.ts:277
**Wrong traversal node in `PColumnDataParquetSuperPartitioned` loop**

`key` comes from `superPart.listInputFields()`, but the resource is fetched with `data.traverse({ field: key })` — traversing the top-level node instead of `superPart`. Since `key` is a sub-field of `superPart` and not a direct field of `data`, this will either throw (`errorIfFieldNotSet: true`) or resolve the wrong chunk resource. The parallel `PColumnDataBinarySuperPartitioned` block (lines 220–237) correctly uses `superData.traverse(...)`. This is a pre-existing bug uncovered while reviewing this file; the fix should mirror the binary-super-partitioned pattern:

```typescript
const resource = superPart.traverse({ field: key, errorIfFieldNotSet: true });
```

```suggestion
        const resource = superPart.traverse({ field: key, errorIfFieldNotSet: true });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add changeset for blob pool tree-..."](https://github.com/milaboratory/platforma/commit/27d8d4f21f432442e292592f4ab19b98aeacb347) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30685316)</sub>

<!-- /greptile_comment -->