### PR TITLE
Disable linker info tooltips in table

### DIFF
--- a/.changeset/good-pots-invite.md
+++ b/.changeset/good-pots-invite.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/ui-vue": patch
+---
+
+Disable linker tooltips

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -316,9 +316,9 @@ export function makeColDef(
       tooltip:
         readAnnotation(spec.spec, Annotation.Description)?.trim() ??
         readAnnotation(labeledSpec.spec, Annotation.Description)?.trim(),
-      info:
-        readAnnotation(spec.spec, Annotation.Table.Info)?.trim() ??
-        readAnnotation(labeledSpec.spec, Annotation.Table.Info)?.trim(),
+      // info:
+      //   readAnnotation(spec.spec, Annotation.Table.Info)?.trim() ??
+      //   readAnnotation(labeledSpec.spec, Annotation.Table.Info)?.trim(),
     } satisfies PlAgHeaderComponentParams,
     cellDataType: (() => {
       switch (valueType) {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR disables the linker info tooltips in the `PlAgDataTable` column headers by commenting out the `info` property read from `Annotation.Table.Info` in `makeColDef`. A corresponding patch changeset is included. The only notable point is that the code is commented out rather than deleted.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a simple property omission with no logic errors or security implications.

Only P2 (style) finding present: commented-out code should be deleted or given a TODO. No functional, logic, or security issues.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts | Comments out the `info` property in `headerComponentParams` to disable linker info tooltips; logic is correct but leaves dead commented-out code. |
| .changeset/good-pots-invite.md | Adds a patch-level changeset entry for `@platforma-sdk/ui-vue` describing the tooltip disable. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts:319-321
**Commented-out code instead of deletion**

The `info` property is commented out rather than removed. If this is a permanent or long-term disable, the dead code should be deleted — it's recoverable from git history. If it's a temporary workaround, a `// TODO:` comment explaining the reason and ticket reference would help future contributors understand when/why to re-enable it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Disable linker info tooltips in table"](https://github.com/milaboratory/platforma/commit/02a03624e07663a6382c4e58f353e79b70c7c338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30695840)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->