### PR TITLE
fix: Correct join secondary columns

### DIFF
--- a/.changeset/fix-incorrect-linker-join.md
+++ b/.changeset/fix-incorrect-linker-join.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Fix `createPlDataTableV3` collapsing linker variants that share axis name + domain. Linked columns are now emitted as nested `linkerJoin` `SpecQueryJoinEntry`s instead of flat sibling leaves under one `outerJoin`, binding each hit column to its own linker chain.

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -22,11 +22,19 @@ export type PrimaryEntry<Data> = {
   column: PColumn<Data>;
 };
 
-/** Secondary side leaf — the hit column, a linker step, or a label column. */
+/** Secondary side leaf — the hit column or a label column, optionally reached via a linker chain. */
 export type SecondaryEntry<Data> = {
   column: PColumn<Data>;
-  /** For hit: `forHit`. For linker step k: `path[k].qualifications`. For label/direct: omit. */
+  /** For hit: `forHit`. For label/direct: omit. Applied to the outermost emitted join entry. */
   qualifications?: AxisQualification[];
+  /**
+   * Linker chain leading to `column`, ordered from outermost to innermost.
+   * When present, the entry is emitted as nested `linkerJoin` operators —
+   * one per linker — wrapping the hit column. Binds this hit to this exact
+   * chain so the engine cannot reuse a sibling chain that happens to share
+   * axis name + domain.
+   */
+  linkers?: PColumn<Data>[];
 };
 
 /** Secondary group — one join subtree outer-joined onto primary. */
@@ -58,9 +66,7 @@ export function createPTableDefV3<Data = PColumnDataUniversal>(params: {
           params.primary.flatMap((p) => g.primaryQualifications?.[p.column.id] ?? []),
         ),
       },
-      secondary: params.secondary.flatMap((g) =>
-        g.entries.map((e) => toLeaf(e.column, e.qualifications ?? [])),
-      ),
+      secondary: params.secondary.flatMap((g) => g.entries.map((e) => toJoinEntry(e))),
     };
   }
 
@@ -111,4 +117,18 @@ function toLeaf<Data>(
     entry: { type: "column", column: col },
     qualifications: qs,
   };
+}
+
+function toJoinEntry<Data>(e: SecondaryEntry<Data>): SpecQueryJoinEntry<PColumn<Data>> {
+  const qs = e.qualifications ?? [];
+  if (isNil(e.linkers) || e.linkers.length === 0) return toLeaf(e.column, qs);
+
+  const folded = e.linkers.reduceRight<SpecQueryJoinEntry<PColumn<Data>>>(
+    (inner, linker) => ({
+      entry: { type: "linkerJoin", linker: { column: linker }, secondary: [inner] },
+      qualifications: [],
+    }),
+    toLeaf(e.column, []),
+  );
+  return { ...folded, qualifications: qs };
 }

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -417,10 +417,11 @@ function buildSecondaryGroups(
     ...linked.map(
       (lc): SecondaryGroup<undefined | PColumnDataUniversal> => ({
         entries: [
-          ...lc.path.map((s) => ({
-            column: resolveSnapshot(s.linker),
-          })),
-          { column: resolveSnapshot(lc.column), qualifications: lc.qualifications.forHit },
+          {
+            column: resolveSnapshot(lc.column),
+            qualifications: lc.qualifications.forHit,
+            linkers: lc.path.map((s) => resolveSnapshot(s.linker)),
+          },
         ],
         primaryQualifications: lc.qualifications.forQueries,
       }),


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where linked columns sharing the same axis name + domain were incorrectly collapsed by the engine when multiple linker variants contributed to the same `outerJoin` secondary list. The fix replaces the old flat-sibling approach (emitting each linker and hit column as independent `SecondaryEntry` leaves) with a single entry that carries a `linkers` chain, which `toJoinEntry` then folds into nested `linkerJoin` nodes via `reduceRight` — binding each hit column to its exact linker chain.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic is a focused, well-scoped fix with no new surface area or regressions apparent.

No P0 or P1 issues found. The `reduceRight` fold correctly places `linkers[0]` as outermost and applies `qualifications` only to the top-level entry as documented. A small score deduction reflects that the semantic contract of `SpecQueryJoinEntry.qualifications` on a `linkerJoin` node (vs. on the leaf) cannot be fully verified without the engine type definitions, and there are no tests in the diff to confirm the runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fix-incorrect-linker-join.md | Changeset entry documenting the patch to createPlDataTableV3; description is accurate and clear. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts | Adds `linkers` field to SecondaryEntry and a new `toJoinEntry` helper that folds a linker chain into nested `linkerJoin` SpecQueryJoinEntry nodes using reduceRight; logic and qualifications placement look correct. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | buildSecondaryGroups now emits a single SecondaryEntry per linked column (with the linker path encoded in `linkers`) instead of flat sibling entries; change is consistent with the new createPTableDefV3 API. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(model): bind linker variants to thei..."](https://github.com/milaboratory/platforma/commit/d7d5321c2c2b9cabcd9eed30cae628dc0eda4c3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30711382)</sub>

<!-- /greptile_comment -->