### PR TITLE
fix(pf-spec-driver): re-emit empty qualifications on linker steps

### DIFF
--- a/.changeset/fix-discover-columns-linker-qualifications-shim.md
+++ b/.changeset/fix-discover-columns-linker-qualifications-shim.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pf-spec-driver": patch
+---
+
+Re-emit empty `qualifications: []` on linker steps in `discoverColumns` responses. pframes-rs >= 1.1.31 dropped the field from the wire shape, breaking older block bundles (e.g. clonotype-browser v1.1.11) that read `step.qualifications.length` without guarding. The shim restores compatibility until all blocks rebuild against an SDK that tolerates the absent field.

--- a/lib/model/pf-spec-driver/src/spec_driver.ts
+++ b/lib/model/pf-spec-driver/src/spec_driver.ts
@@ -107,7 +107,16 @@ export class SpecDriver implements PFrameSpecDriver, AsyncDisposable {
         );
       }
       const result = pframe.discoverColumns(request);
-      return result;
+      // Backward-compat shim: pframes-rs >= 1.1.31 dropped the `qualifications`
+      return {
+        ...result,
+        hits: result.hits.map((hit) => ({
+          ...hit,
+          path: hit.path.map((step) =>
+            step.type === "linker" ? { ...step, qualifications: [] } : step,
+          ),
+        })),
+      };
     } catch (err: unknown) {
       const error = new PFrameSpecDriverError(`discoverColumns failed`);
       error.cause = new Error(


### PR DESCRIPTION
## Summary

- pframes-rs >= 1.1.31 (PR pframes-rs#245) dropped the `qualifications` field from linker steps in the `discoverColumns` wire shape.
- Older block bundles — e.g. `clonotype-browser` v1.1.11 — read `step.qualifications.length` without guarding and crash with `TypeError: cannot read property 'length' of undefined`, rendering `ErrorRepo` instead of the data table.
- Reassemble the response in `SpecDriver.discoverColumns` and inject `qualifications: []` on every linker step. Empty array suffices because the legacy formatter shorts on `length === 0`.

The shim can be dropped once all shipped blocks rebuild against an SDK that tolerates the absent field.

## Test plan

- [ ] `pnpm -F @milaboratories/pf-spec-driver test`
- [ ] Smoke-test: in `platforma-desktop-app` with `pframes-rs-{node,wasm}: 1.1.31`, open `clonotype-browser` v1.1.11 and confirm the table renders instead of `ErrorRepo`.
- [ ] Confirm newer blocks (built against a guarded SDK) are unaffected.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This patch adds a backward-compatibility shim in `SpecDriver.discoverColumns` that re-injects `qualifications: []` on every linker step in the response, restoring a field that pframes-rs ≥ 1.1.31 removed from the wire shape and that older block bundles (e.g. clonotype-browser v1.1.11) access without a null guard.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the shim correctly restores the missing field for legacy blocks and does not affect the main data path.

The logic change is small and targeted. The only concerns are that the unconditional overwrite would silently discard real qualifications if pframes-rs ever re-adds them, and the comment is cut off before explaining the full context and the removal condition.

lib/model/pf-spec-driver/src/spec_driver.ts — the shim logic and its truncated comment.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/pf-spec-driver/src/spec_driver.ts | Adds a backward-compat shim in `discoverColumns` that injects `qualifications: []` on all linker path steps; the comment is truncated mid-sentence and the unconditional overwrite could silently discard the field if pframes-rs re-adds it with real data. |
| .changeset/fix-discover-columns-linker-qualifications-shim.md | Changeset entry correctly describes the patch as a `@milaboratories/pf-spec-driver` patch bump with a clear explanation of the compatibility shim. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/model/pf-spec-driver/src/spec_driver.ts:110
The comment ends mid-sentence, cutting off before explaining what field was dropped and why that matters. The full context — that legacy blocks crash on `step.qualifications.length` — is in the PR description but not in the code, where it matters most for future maintainers deciding when to remove the shim.

```suggestion
      // Backward-compat shim: pframes-rs >= 1.1.31 dropped the `qualifications`
      // field from linker steps. Older block bundles (e.g. clonotype-browser v1.1.11)
      // read `step.qualifications.length` without guarding and crash with a TypeError.
      // Drop this shim once all shipped blocks rebuild against an SDK that tolerates the absent field.
```

### Issue 2 of 2
lib/model/pf-spec-driver/src/spec_driver.ts:116
The shim unconditionally overwrites `qualifications` with `[]` via trailing spread placement. If a future pframes-rs release re-adds the field with non-empty data (e.g. during a rollback or a revised API contract), this silently discards the real values and newer blocks that use them would receive incorrect empty arrays. Using `??` instead preserves the field when it is actually present.

```suggestion
            step.type === "linker" ? { ...step, qualifications: (step as any).qualifications ?? [] } : step,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pf-spec-driver): re-emit empty quali..."](https://github.com/milaboratory/platforma/commit/963fa23851b6c7a31fc59cc26ab33b2055de969e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30815919)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->