### PR TITLE
Fix: add labels for predefined columns

### DIFF
--- a/.changeset/many-comics-sleep.md
+++ b/.changeset/many-comics-sleep.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-model-common": minor
+"@platforma-sdk/ui-vue": minor
+"@platforma-sdk/model": minor
+---
+
+Label columns for predefined columns and show in table label columns always

--- a/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
+++ b/lib/model/common/src/drivers/pframe/spec/discovered_column.ts
@@ -4,10 +4,10 @@ import { AxisQualification } from "./selectors";
 import { canonicalizeJson } from "../../../json";
 
 export type DiscoveredPColumn = {
-  path: PathItem[];
   column: PObjectId;
-  columnQualifications: AxisQualification[];
-  queriesQualifications: Record<PObjectId, AxisQualification[]>;
+  path?: PathItem[];
+  columnQualifications?: AxisQualification[];
+  queriesQualifications?: Record<PObjectId, AxisQualification[]>;
 };
 
 export type DiscoveredPColumnId = Branded<PObjectId, "DiscoveredPColumnId">; // CanonicalizedJson<DiscoveredPColumn>;
@@ -28,22 +28,28 @@ export function isDiscoveredPColumn(obj: unknown): obj is DiscoveredPColumn {
   );
 }
 
-export function createDiscoveredPColumn(props: {
-  column: PObjectId;
-  path: PathItem[];
-  columnQualifications: AxisQualification[];
-  queriesQualifications: Record<PObjectId, AxisQualification[]>;
-}): DiscoveredPColumn {
-  return JSON.parse(JSON.stringify(props));
+export function distillDiscoveredPColumn(props: DiscoveredPColumn): DiscoveredPColumn {
+  return {
+    column: props.column,
+    path: Array.isArray(props.path) && props.path.length > 0 ? props.path : undefined,
+    columnQualifications:
+      Array.isArray(props.columnQualifications) && props.columnQualifications.length > 0
+        ? props.columnQualifications
+        : undefined,
+    queriesQualifications:
+      props.queriesQualifications && Object.keys(props.queriesQualifications).length > 0
+        ? props.queriesQualifications
+        : undefined,
+  };
 }
 
 export function createDiscoveredPColumnId(props: {
   column: PObjectId;
-  path: PathItem[];
-  columnQualifications: AxisQualification[];
-  queriesQualifications: Record<PObjectId, AxisQualification[]>;
+  path?: PathItem[];
+  columnQualifications?: AxisQualification[];
+  queriesQualifications?: Record<PObjectId, AxisQualification[]>;
 }): DiscoveredPColumnId {
-  return stringifyDiscoveredPColumnId(createDiscoveredPColumn(props));
+  return stringifyDiscoveredPColumnId(props);
 }
 
 export function parseDiscoveredPColumnId(id: DiscoveredPColumnId): DiscoveredPColumn {
@@ -60,5 +66,7 @@ export function parseDiscoveredPColumnId(id: DiscoveredPColumnId): DiscoveredPCo
 }
 
 export function stringifyDiscoveredPColumnId(id: DiscoveredPColumn) {
-  return canonicalizeJson<DiscoveredPColumn>(id) as string as DiscoveredPColumnId;
+  return canonicalizeJson<DiscoveredPColumn>(
+    distillDiscoveredPColumn(id),
+  ) as string as DiscoveredPColumnId;
 }

--- a/sdk/model/src/columns/column_collection_builder.test.ts
+++ b/sdk/model/src/columns/column_collection_builder.test.ts
@@ -402,12 +402,8 @@ describe("AnchoredColumnCollection", () => {
 
     expect(col1Match.variants.length).toBeGreaterThan(0);
     for (const v of col1Match.variants) {
-      expect(v.qualifications.forQueries).toBeDefined();
-      expect(v.qualifications.forHit).toBeDefined();
-      // forQueries keys are a subset of anchor ids
-      for (const key of Object.keys(v.qualifications.forQueries)) {
-        expect([anchorSnap.id]).toContain(key);
-      }
+      expect(v.qualifications.forQueries).toBeUndefined();
+      expect(v.qualifications.forHit).toBeUndefined();
     }
   });
 
@@ -432,7 +428,7 @@ describe("AnchoredColumnCollection", () => {
 
     for (const v of c1.variants) {
       const forQueries = v.qualifications.forQueries;
-      if (anchorASnap.id in forQueries && anchorBSnap.id in forQueries) {
+      if (forQueries && anchorASnap.id in forQueries && anchorBSnap.id in forQueries) {
         // Shared axes group → equal qualifications for both anchor keys.
         expect(forQueries[anchorASnap.id]).toStrictEqual(forQueries[anchorBSnap.id]);
       }

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -20,8 +20,6 @@ import type { PFrameSpecDriver, PoolEntry, SpecFrameHandle } from "@milaboratori
 import { throwError } from "@milaboratories/helpers";
 import { getService } from "../services";
 
-// --- FindColumnsOptions ---
-
 /** Options for plain collection findColumns. */
 export interface FindColumnsOptions {
   /** Include columns matching these selectors. If omitted, includes all columns. */
@@ -29,8 +27,6 @@ export interface FindColumnsOptions {
   /** Exclude columns matching these selectors. */
   exclude?: ColumnSelector;
 }
-
-// --- ColumnCollection ---
 
 /** Plain collection — no axis context, selector-based filtering only. */
 export interface ColumnCollection extends Disposable {
@@ -42,8 +38,6 @@ export interface ColumnCollection extends Disposable {
    *  Never returns undefined — the "not ready" state was absorbed by the builder. */
   findColumns(options?: FindColumnsOptions): ColumnSnapshot<PObjectId>[];
 }
-
-// --- AnchoredColumnCollection ---
 
 /** Axis-aware column collection with anchored identity derivation. */
 export interface AnchoredColumnCollection extends Disposable {
@@ -82,12 +76,10 @@ export interface ColumnMatch {
 export interface ColumnVariant<Id extends PObjectId = PObjectId> {
   /** Column snapshot with anchored SUniversalPColumnId. */
   readonly column: ColumnSnapshot<Id>;
-  /** Full qualifications needed for integration. */
-  readonly qualifications: MatchQualifications;
   /** Linker steps traversed to reach this hit; empty for direct matches. */
-  readonly path: {
-    linker: ColumnSnapshot<PObjectId>;
-  }[];
+  readonly path?: { linker: ColumnSnapshot<PObjectId> }[];
+  /** Full qualifications needed for integration. */
+  readonly qualifications?: MatchQualifications;
 }
 
 /** A single mapping variant describing how a hit column can be integrated. */
@@ -95,20 +87,16 @@ export interface MatchVariant {
   /** Full qualifications needed for integration. */
   readonly qualifications: MatchQualifications;
   /** Linker steps traversed to reach this hit; empty for direct matches. */
-  readonly path: {
-    linker: ColumnSnapshot<PObjectId>;
-  }[];
+  readonly path: { linker: ColumnSnapshot<PObjectId> }[];
 }
 
 /** Qualifications needed for both already-integrated anchor columns and the hit column. */
 export interface MatchQualifications {
   /** Qualifications for already-integrated anchor columns */
-  readonly forQueries: Record<PObjectId, AxisQualification[]>;
+  readonly forQueries?: Record<PObjectId, AxisQualification[]>;
   /** Qualifications for the hit column. */
-  readonly forHit: AxisQualification[];
+  readonly forHit?: AxisQualification[];
 }
-
-// --- Build options ---
 
 export interface BuildOptions {
   allowPartialColumnList?: true;
@@ -119,8 +107,6 @@ export type AnchorEntry = PObjectId | PColumnSpec | RelaxedColumnSelector;
 export interface AnchoredBuildOptions extends BuildOptions {
   anchors: Record<string, AnchorEntry>;
 }
-
-// --- ColumnCollectionBuilder ---
 
 /**
  * Mutable builder that accumulates column sources, then produces
@@ -197,8 +183,6 @@ export class ColumnCollectionBuilder {
   }
 }
 
-// --- ColumnCollectionImpl ---
-
 interface ColumnCollectionImplOptions {
   readonly columns: ColumnSnapshot<PObjectId>[];
 }
@@ -245,8 +229,6 @@ class ColumnCollectionImpl implements ColumnCollection, Disposable {
     return results;
   }
 }
-
-// --- AnchoredColumnCollectionImpl ---
 
 interface AnchoredColumnCollectionImplOptions extends ColumnCollectionImplOptions {
   readonly anchors: Record<string, AnchorEntry>;
@@ -368,14 +350,10 @@ function collectColumns(providers: ColumnSnapshotProvider[]): ColumnSnapshot<POb
   return result;
 }
 
-// --- Shared snapshot helpers ---
-
 /** Normalize ColumnSelector (relaxed, single or array) to MultiColumnSelector[]. */
 function toMultiColumnSelectors(input: ColumnSelector): MultiColumnSelector[] {
   return convertColumnSelectorToMultiColumnSelector(input);
 }
-
-// --- Anchor resolution ---
 
 /**
  * Resolve each anchor entry to a ColumnSnapshot from the collected columns.
@@ -423,7 +401,7 @@ function resolveAnchorMap(
         excludeColumns: undefined,
         axes: [],
         maxHops: 0,
-        constraints: matchingModeToConstraints("exact"),
+        constraints: matchingModeToConstraints("related"),
       });
 
       if (matched.hits.length === 0) {
@@ -461,14 +439,15 @@ function remapFromIdxToId(
   },
   anchors: ColumnSnapshot<PObjectId>[],
 ): MatchQualifications {
-  const forQueries = qualifications.forQueries.reduce<Record<PObjectId, AxisQualification[]>>(
-    (acc, qs, i) => (anchors[i] ? ((acc[anchors[i].id] = qs), acc) : acc),
-    {},
+  const forQueries = qualifications.forQueries.reduce(
+    (acc, qs, i) => (anchors[i] && qs.length > 0 ? acc.set(anchors[i].id, qs) : acc),
+    new Map<PObjectId, AxisQualification[]>(),
   );
-  return { forQueries, forHit: qualifications.forHit };
+  return {
+    forQueries: forQueries.size > 0 ? Object.fromEntries(forQueries) : undefined,
+    forHit: qualifications.forHit.length > 0 ? qualifications.forHit : undefined,
+  };
 }
-
-// --- MatchingMode → DiscoverColumnsConstraints ---
 
 function matchingModeToConstraints(mode: MatchingMode): DiscoverColumnsConstraints {
   switch (mode) {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
@@ -9,7 +9,7 @@ import type {
 import { getColumnIdAndSpec } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal, TreeNodeAccessor } from "../../../render";
 import { isFunction } from "es-toolkit";
-import type { PlDataTableFilters } from "../typesV5";
+import type { PlDataTableFilters } from "../typesV6";
 import { createPTableDefV3 } from "./createPTableDefV3";
 
 export function createPTableDefV2(params: {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -13,7 +13,7 @@ import type {
 import { isBooleanExpression } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal } from "../../../render";
 import { isNil } from "es-toolkit";
-import type { PlDataTableFilters } from "../typesV5";
+import type { PlDataTableFilters } from "../typesV6";
 import { distillFilterSpec, filterSpecToSpecQueryExpr } from "../../../filters";
 import type { Nil } from "@milaboratories/helpers";
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
@@ -25,7 +25,7 @@ import type {
 } from "../../../render";
 import { allPColumnsReady, deriveLabels, PColumnCollection } from "../../../render";
 import { identity } from "es-toolkit";
-import type { CreatePlDataTableOps, PlDataTableModel } from "../typesV5";
+import type { CreatePlDataTableOps, PlDataTableModel } from "../typesV6";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import { getMatchingLabelColumns } from "../labels";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -36,8 +36,12 @@ import {
 } from "./utils";
 import type { PrimaryEntry, SecondaryGroup } from "./createPTableDefV3";
 import { createPTableDefV3 } from "./createPTableDefV3";
-import { discoverTableColumnSnaphots, type DiscoverTableColumnOptions } from "./discoverColumns";
-import { isNil, isPlainObject, throwError, type Nil } from "@milaboratories/helpers";
+import {
+  discoverLabelColumnVariants,
+  discoverTableColumnSnaphots,
+  type DiscoverTableColumnOptions,
+} from "./discoverColumns";
+import { getField, isNil, isPlainObject, throwError, type Nil } from "@milaboratories/helpers";
 import { flow } from "es-toolkit";
 
 export type createPlDataTableOptionsV3 = {
@@ -90,7 +94,12 @@ export function createPlDataTableV3<A, U>(
 
   const discovered = isPlainObject(options.columns)
     ? discoverTableColumnSnaphots(ctx, options.columns)
-    : options.columns;
+    : isNil(options.columns)
+      ? options.columns
+      : uniqueBy(
+          [...options.columns, ...discoverLabelColumnVariants(ctx, options.columns)],
+          (c) => c.column.id,
+        );
   if (isNil(discovered) || discovered.length === 0) return undefined;
 
   const splited = splitDiscoveredColumns(discovered);
@@ -111,7 +120,7 @@ export function createPlDataTableV3<A, U>(
   const derivedTooltips = deriveAllTooltips({
     columns: discovered.map((dc) => ({
       id: dc.column.id,
-      originalId: dc.originalId,
+      originalId: getField(dc, "originalId"),
       spec: dc.column.spec,
       linkerPath: dc.path,
       qualifications: dc.qualifications,
@@ -133,7 +142,7 @@ export function createPlDataTableV3<A, U>(
 
   const columnIsAvailable = createColumnValidationById([
     ...annotated.direct.map((v) => v.column),
-    ...annotated.linked.flatMap((lc) => [...lc.path.map((s) => s.linker), lc.column]),
+    ...annotated.linked.flatMap((lc) => [...(lc.path ?? []).map((s) => s.linker), lc.column]),
   ]);
 
   const remapedDefaultFilters = remapFilterColumnIds(options.filters, discovered);
@@ -204,8 +213,10 @@ export function createPlDataTableV3<A, U>(
   } satisfies PlDataTableModel;
 }
 
-export type TableColumnVariant = ColumnVariant<DiscoveredPColumnId> & {
-  readonly originalId: PObjectId;
+export type TableColumnVariant = (
+  | ColumnVariant<PObjectId>
+  | (ColumnVariant<DiscoveredPColumnId> & { readonly originalId: PObjectId })
+) & {
   readonly isPrimary?: boolean;
 };
 
@@ -226,15 +237,15 @@ type VisibleColumns = {
 
 /** Split discovered columns into direct (no linker path) and linked (with linker path). */
 function splitDiscoveredColumns(columns: TableColumnVariant[]): SplitDiscoveredColumns {
-  const direct = columns.filter((dc) => dc.path.length === 0);
-  const linked = columns.filter((dc) => dc.path.length > 0);
+  const direct = columns.filter((dc) => (dc.path?.length ?? 0) === 0);
+  const linked = columns.filter((dc) => (dc.path?.length ?? 0) > 0);
   return { direct, linked };
 }
 
 /** All linker snapshots across the given linked columns, deduped by id. */
 function collectLinkerSnapshots(linked: TableColumnVariant[]): ColumnSnapshot<PObjectId>[] {
   return uniqueBy(
-    linked.flatMap((lc) => lc.path.map((s) => s.linker)),
+    linked.flatMap((lc) => (lc.path ?? []).map((s) => s.linker)),
     (c) => c.id,
   );
 }
@@ -299,9 +310,13 @@ function annotateColumnGroups(params: {
 }
 
 /** Lift a snapshot-array transform so it runs on the inner `column` of each variant. */
-function liftToVariantColumns<V extends { readonly column: ColumnSnapshot<DiscoveredPColumnId> }>(
+function liftToVariantColumns<
+  V extends { readonly column: ColumnSnapshot<PObjectId | DiscoveredPColumnId> },
+>(
   variants: V[],
-  fn: (cols: ColumnSnapshot<DiscoveredPColumnId>[]) => ColumnSnapshot<DiscoveredPColumnId>[],
+  fn: (
+    cols: ColumnSnapshot<PObjectId | DiscoveredPColumnId>[],
+  ) => ColumnSnapshot<PObjectId | DiscoveredPColumnId>[],
 ): V[] {
   const cols = fn(variants.map((v) => v.column));
   if (cols.length !== variants.length)
@@ -315,7 +330,7 @@ function annotateLinkerPath(
   derivedLabels: Record<string, string>,
   path: TableColumnVariant["path"],
 ): TableColumnVariant["path"] {
-  if (path.length === 0) return path;
+  if (isNil(path) || path.length === 0) return path;
   const annotatedLinkers = withHidenAxesAnnotations(
     withLabelAnnotations(
       derivedLabels,
@@ -410,8 +425,8 @@ function buildSecondaryGroups(
   return [
     ...direct.map(
       (c): SecondaryGroup<undefined | PColumnDataUniversal> => ({
-        entries: [{ column: resolveSnapshot(c.column), qualifications: c.qualifications.forHit }],
-        primaryQualifications: c.qualifications.forQueries,
+        entries: [{ column: resolveSnapshot(c.column), qualifications: c.qualifications?.forHit }],
+        primaryQualifications: c.qualifications?.forQueries,
       }),
     ),
     ...linked.map(
@@ -419,11 +434,11 @@ function buildSecondaryGroups(
         entries: [
           {
             column: resolveSnapshot(lc.column),
-            qualifications: lc.qualifications.forHit,
-            linkers: lc.path.map((s) => resolveSnapshot(s.linker)),
+            linkers: lc.path?.map((s) => resolveSnapshot(s.linker)),
+            qualifications: lc.qualifications?.forHit,
           },
         ],
-        primaryQualifications: lc.qualifications.forQueries,
+        primaryQualifications: lc.qualifications?.forQueries,
       }),
     ),
   ];
@@ -492,7 +507,7 @@ function remapSortingColumnIds(
     if (s.column.type === "axis") return [s]; // Axis references are unaffected by column ID remapping
 
     const id = s.column.id;
-    const column = columns.find((c) => (c.originalId ?? c.column.id) === id);
+    const column = columns.find((c) => (getField(c, "originalId") ?? c.column.id) === id);
     if (column === undefined) return [];
 
     return [
@@ -524,7 +539,7 @@ function remapFilterColumnIds(
 
     const originalId = parsed.id;
     const column =
-      columns.find((c) => (c.originalId ?? c.column.id) === originalId) ??
+      columns.find((c) => (getField(c, "originalId") ?? c.column.id) === originalId) ??
       throwError(`Column ID "${parsed.id}" in filters does not match any discovered column`);
 
     return canonicalizeJson<PTableColumnId>({

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -17,7 +17,7 @@ import { canonicalizeJson, getAxisId, parseJson, uniqueBy } from "@milaboratorie
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
 import type { RenderCtxBase, PColumnDataUniversal } from "../../../render";
 import { isEmpty } from "es-toolkit/compat";
-import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV5";
+import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV6";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import type { ColumnSelector, ColumnSnapshot, ColumnVariant, MatchingMode } from "../../../columns";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -1,5 +1,5 @@
 import type { PColumnSpec, PlRef, PObjectId } from "@milaboratories/pl-model-common";
-import { createDiscoveredPColumnId, isPlRef } from "@milaboratories/pl-model-common";
+import { createDiscoveredPColumnId, isPlRef, PColumnName } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
 import type {
   ColumnSource,
@@ -42,11 +42,62 @@ export function discoverTableColumnSnaphots(
   if (collection === undefined) return undefined;
 
   try {
-    const variants = collection.findColumnVariants({
-      ...(resolvedOptions.selector ?? {}),
-    });
+    const variants = collection.findColumnVariants(resolvedOptions.selector);
     const anchors = collection.getAnchors();
     return mapToTableColumnVariants(variants, anchors);
+  } finally {
+    collection.dispose();
+  }
+}
+
+/**
+ * Discover label columns matching the axes of the given value columns from
+ * ctx providers. Returns label snapshots wrapped as direct TableColumnVariants
+ * (path: [], empty qualifications, isPrimary: false).
+ */
+export function discoverLabelColumnVariants<A, U>(
+  ctx: RenderCtxBase<A, U>,
+  columns: TableColumnVariant[],
+): TableColumnVariant[] {
+  if (columns.length === 0) return [];
+  const collection = new ColumnCollectionBuilder(ctx.getService("pframeSpec"))
+    .addSources(collectCtxColumnSnapshotProviders(ctx))
+    .addSource(columns.map((c) => c.column))
+    .build({
+      allowPartialColumnList: true,
+      anchors: Object.fromEntries(
+        columns
+          .filter((col) => (col.path?.length ?? 0) === 0 && col.isPrimary)
+          .map((col, i) => [`anchor_${i}`, col.column.spec]),
+      ),
+    });
+
+  try {
+    const axes = columns.flatMap((col) => col.column.spec.axesSpec);
+    return collection
+      .findColumnVariants({
+        include: axes.map((a) => ({
+          name: { type: "exact", value: PColumnName.Label },
+          axes: [{ name: { type: "exact", value: a.name } }],
+        })),
+        maxHops: columns.reduce((acc, c) => Math.max(acc, c.path?.length ?? 0), 0),
+      })
+      .map((variant) => ({
+        ...variant,
+        column: {
+          ...variant.column,
+          id: createDiscoveredPColumnId({
+            column: variant.column.id,
+            path: variant.path?.map((p) => ({
+              type: "linker",
+              column: p.linker.id,
+            })),
+            columnQualifications: variant.qualifications?.forHit,
+            queriesQualifications: variant.qualifications?.forQueries,
+          }),
+          originalId: variant.column.id,
+        },
+      }));
   } finally {
     collection.dispose();
   }
@@ -99,12 +150,12 @@ function mapToTableColumnVariants(
 
     const discoveredId = createDiscoveredPColumnId({
       column: snap.id,
-      path: variant.path.map((p) => ({
+      path: variant.path?.map((p) => ({
         type: "linker",
         column: p.linker.id,
       })),
-      columnQualifications: variant.qualifications.forHit,
-      queriesQualifications: variant.qualifications.forQueries,
+      columnQualifications: variant.qualifications?.forHit,
+      queriesQualifications: variant.qualifications?.forQueries,
     });
     return {
       column: {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -103,8 +103,6 @@ export function discoverLabelColumnVariants<A, U>(
   }
 }
 
-// --- Pure helper functions ---
-
 /** Resolve PlRef values in anchors to PColumnSpec via the result pool. */
 function resolveAnchors(
   ctx: RenderCtxBase,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/index.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/index.ts
@@ -1,5 +1,5 @@
 import type { RenderCtxBase } from "../../../render";
-import type { PlDataTableModel } from "../typesV5";
+import type { PlDataTableModel } from "../typesV6";
 import { createPlDataTableOptionsV2, createPlDataTableV2 } from "./createPlDataTableV2";
 import { createPlDataTableV3 } from "./createPlDataTableV3";
 import type { createPlDataTableOptionsV3 } from "./createPlDataTableV3";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -114,7 +114,7 @@ describe("deriveAllLabels", () => {
       makeLabelableColumn(
         "c1",
         { name: "shared", annotations: { [Annotation.Label]: "Cluster size" } },
-        [{ linker: { id: "lk" as PObjectId, spec: linkerSpec } as never, qualifications: [] }],
+        [{ linker: { id: "lk" as PObjectId, spec: linkerSpec } as never }],
       ),
       makeLabelableColumn("c2", {
         name: "shared",

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -6,9 +6,7 @@ import {
   Annotation,
   canonicalizeAxisId,
   DiscoveredPColumnId,
-  isLabelColumn,
   readAnnotation,
-  readAnnotationJson,
 } from "@milaboratories/pl-model-common";
 import {
   deriveDistinctLabels,
@@ -56,12 +54,9 @@ export function getOrderPriority(
   orderByColId?: Map<PObjectId, ColumnOrderRule>,
 ): undefined | number {
   const rule = orderByColId?.get(col.id);
-  return (
-    rule?.priority ??
-    readAnnotationJson(col.spec, Annotation.Table.OrderPriority) ??
-    // Label columns for axes get highest priority to keep them leftmost;
-    (isLabelColumn(col.spec) && col.spec.axesSpec.length === 1 ? 110000 : undefined)
-  );
+  if (rule !== undefined) return rule.priority;
+  const annotation = Number(readAnnotation(col.spec, Annotation.Table.OrderPriority));
+  return isNaN(annotation) ? undefined : annotation;
 }
 
 /**

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -6,6 +6,7 @@ import {
   Annotation,
   canonicalizeAxisId,
   DiscoveredPColumnId,
+  isLabelColumn,
   readAnnotation,
   readAnnotationJson,
 } from "@milaboratories/pl-model-common";
@@ -22,6 +23,7 @@ import type { ColumnMatcher, ColumnOrderRule, ColumnVisibilityRule } from "./cre
 import type { ColumnSelector } from "../../../columns";
 import { ArrayColumnProvider, ColumnCollectionBuilder } from "../../../columns";
 import { isNil } from "es-toolkit";
+import { getField } from "@milaboratories/helpers";
 
 /** Check if column should be omitted from the table */
 export function isColumnHidden(spec: { annotations?: Annotation }): boolean {
@@ -54,8 +56,12 @@ export function getOrderPriority(
   orderByColId?: Map<PObjectId, ColumnOrderRule>,
 ): undefined | number {
   const rule = orderByColId?.get(col.id);
-  if (rule !== undefined) return rule.priority;
-  return readAnnotationJson(col.spec, Annotation.Table.OrderPriority);
+  return (
+    rule?.priority ??
+    readAnnotationJson(col.spec, Annotation.Table.OrderPriority) ??
+    // Label columns for axes get highest priority to keep them leftmost;
+    (isLabelColumn(col.spec) && col.spec.axesSpec.length === 1 ? 110000 : undefined)
+  );
 }
 
 /**
@@ -276,9 +282,9 @@ export function deriveAllLabels(options: {
 
 /** Column shape required by tooltip derivation. */
 export type TooltipableColumn = {
-  readonly id: DiscoveredPColumnId;
+  readonly id: PObjectId | DiscoveredPColumnId;
   readonly spec: PColumnSpec;
-  readonly originalId: PObjectId;
+  readonly originalId?: PObjectId;
   readonly linkerPath?: MatchVariant["path"];
   readonly qualifications?: MatchQualifications;
 };
@@ -290,15 +296,15 @@ export function deriveAllTooltips(options: {
   const { columns } = options;
 
   const variantCountByOriginal = columns.reduce<Map<PObjectId, number>>((acc, c) => {
-    return acc.set(c.originalId, (acc.get(c.originalId) ?? 0) + 1);
+    return acc.set(getField(c, "originalId") ?? c.id, (acc.get(c.originalId ?? c.id) ?? 0) + 1);
   }, new Map());
 
   const { entries } = columns.reduce(
     ({ entries, variantSeen }, c) => {
-      const variantCount = variantCountByOriginal.get(c.originalId);
+      const id = getField(c, "originalId") ?? c.id;
+      const variantCount = variantCountByOriginal.get(id);
       const variantIndex =
-        (variantSeen.set(c.originalId, (variantSeen.get(c.originalId) ?? 0) + 1),
-        variantSeen.get(c.originalId));
+        (variantSeen.set(id, (variantSeen.get(id) ?? 0) + 1), variantSeen.get(id));
 
       entries.push({
         spec: c.spec,

--- a/sdk/model/src/components/PlDataTable/createPlDataTableSheet.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTableSheet.ts
@@ -1,6 +1,6 @@
 import type { AxisSpec } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../render";
-import type { PlDataTableSheet } from "./typesV5";
+import type { PlDataTableSheet } from "./typesV6";
 
 /** Create sheet entries for PlDataTable */
 export function createPlDataTableSheet<A, U>(

--- a/sdk/model/src/components/PlDataTable/index.ts
+++ b/sdk/model/src/components/PlDataTable/index.ts
@@ -13,7 +13,7 @@ export type {
   PlDataTableFilterMeta,
   PlDataTableFilters,
   PlDataTableFiltersWithMeta,
-} from "./typesV5";
+} from "./typesV6";
 
 export type { PlDataTableStateV2 } from "./state-migration";
 export {

--- a/sdk/model/src/components/PlDataTable/index.ts
+++ b/sdk/model/src/components/PlDataTable/index.ts
@@ -1,7 +1,6 @@
 // If you need to export something from previous versions,
 // that mean you don't forget update deps to the latest version of the package.
 export type {
-  PlTableColumnId,
   PlTableColumnIdJson,
   PlDataTableGridStateCore,
   PlDataTableSheet,

--- a/sdk/model/src/components/PlDataTable/state-migration.ts
+++ b/sdk/model/src/components/PlDataTable/state-migration.ts
@@ -7,7 +7,7 @@ import type {
   PTableRecordFilter,
   PTableSorting,
 } from "@milaboratories/pl-model-common";
-import { canonicalizeJson } from "@milaboratories/pl-model-common";
+import { canonicalizeJson, parseJson } from "@milaboratories/pl-model-common";
 import { distillFilterSpec } from "../../filters";
 import type { PlDataTableFilterState, PlTableFilter } from "./typesV4";
 import type {
@@ -17,7 +17,8 @@ import type {
   PlDataTableStateV2CacheEntry,
   PlDataTableStateV2Normalized,
   PTableParamsV2,
-} from "./typesV5";
+} from "./typesV6";
+import type { PlDataTableGridStateV5, PlDataTableV5ColIdJson } from "./typesV5";
 
 /**
  * PlDataTableV2 persisted state
@@ -111,6 +112,19 @@ export type PlDataTableStateV2 =
         sorting: PTableSorting[];
       };
     }
+  // v5 stored colIds as `{source, labeled}` wrappers; only the gridState shape differs.
+  | {
+      version: 5;
+      stateCache: {
+        sourceId: string;
+        gridState: PlDataTableGridStateV5;
+        sheetsState: PlDataTableSheetState[];
+        filtersState: null | PlDataTableFiltersWithMeta;
+        defaultFiltersState: null | PlDataTableFiltersWithMeta;
+        searchString?: string;
+      }[];
+      pTableParams: PTableParamsV2;
+    }
   // Normalized state
   | PlDataTableStateV2Normalized;
 
@@ -143,15 +157,59 @@ export function upgradePlDataTableStateV2(
     // Non upgradeable as column ids calculation algorithm has changed, resetting state to default
     state = createPlDataTableStateV2();
   }
-  // v4 -> v5: migrate per-column filters to tree-based format
+  // v4 -> v6: migrate per-column filters to tree-based format (skips v5).
+  // v4 gridState already used bare PTableColumnSpec colIds, so we jump
+  // straight to v6 without going through the v5 wrapper format.
   if (state.version === 4) {
-    state = migrateV4toV5(state);
+    state = migrateV4toV6(state);
+  }
+  // v5 -> v6: unwrap `{source, labeled}` colIds in gridState back to bare PTableColumnSpec.
+  if (state.version === 5) {
+    state = migrateV5toV6(state);
   }
   return state;
 }
 
-/** Migrate v4 state to v5: convert per-column filters to tree-based format */
-function migrateV4toV5(
+/** Migrate v5 to v6: unwrap `{source, labeled}` colIds in gridState. */
+function migrateV5toV6(
+  state: Extract<PlDataTableStateV2, { version: 5 }>,
+): PlDataTableStateV2Normalized {
+  return {
+    version: 6,
+    stateCache: state.stateCache.map((entry) => ({
+      ...entry,
+      gridState: unwrapV5GridState(entry.gridState),
+    })),
+    pTableParams: state.pTableParams,
+  };
+}
+
+/** Convert v5 wrapped colId JSON to bare PTableColumnSpec JSON, taking `.source`. */
+function unwrapV5ColId(json: PlDataTableV5ColIdJson): CanonicalizedJson<PTableColumnSpec> {
+  return canonicalizeJson(parseJson(json).source);
+}
+
+function unwrapV5GridState(gridState: PlDataTableGridStateV5): PlDataTableGridStateCore {
+  return {
+    columnOrder: gridState.columnOrder
+      ? { orderedColIds: gridState.columnOrder.orderedColIds.map(unwrapV5ColId) }
+      : undefined,
+    sort: gridState.sort
+      ? {
+          sortModel: gridState.sort.sortModel.map((s) => ({
+            colId: unwrapV5ColId(s.colId),
+            sort: s.sort,
+          })),
+        }
+      : undefined,
+    columnVisibility: gridState.columnVisibility
+      ? { hiddenColIds: gridState.columnVisibility.hiddenColIds.map(unwrapV5ColId) }
+      : undefined,
+  };
+}
+
+/** Migrate v4 state to v6: convert per-column filters to tree-based format (skips v5). */
+function migrateV4toV6(
   state: Extract<PlDataTableStateV2, { version: 4 }>,
 ): PlDataTableStateV2Normalized {
   let idCounter = 0;
@@ -183,7 +241,7 @@ function migrateV4toV5(
     : undefined;
 
   return {
-    version: 5,
+    version: 6,
     stateCache: migratedCache,
     pTableParams:
       currentCache && oldSourceId
@@ -283,7 +341,7 @@ export function createDefaultPTableParams(): PTableParamsV2 {
 
 export function createPlDataTableStateV2(): PlDataTableStateV2Normalized {
   return {
-    version: 5,
+    version: 6,
     stateCache: [],
     pTableParams: createDefaultPTableParams(),
   };

--- a/sdk/model/src/components/PlDataTable/state-migration.ts
+++ b/sdk/model/src/components/PlDataTable/state-migration.ts
@@ -174,13 +174,18 @@ export function upgradePlDataTableStateV2(
 function migrateV5toV6(
   state: Extract<PlDataTableStateV2, { version: 5 }>,
 ): PlDataTableStateV2Normalized {
+  // pTableParams reset: v5 stored DiscoveredPColumnId-based hiddenColIds with
+  // empty-array fields (e.g. `{column, path: [], columnQualifications: [], ...}`).
+  // v6 distills empty fields, so the same logical column serialises differently
+  // and lookups would silently miss every previously-hidden discovered column.
+  // gridState colIds are derived from PTableColumnSpec and unaffected.
   return {
     version: 6,
     stateCache: state.stateCache.map((entry) => ({
       ...entry,
       gridState: unwrapV5GridState(entry.gridState),
     })),
-    pTableParams: state.pTableParams,
+    pTableParams: createDefaultPTableParams(),
   };
 }
 

--- a/sdk/model/src/components/PlDataTable/typesV5.ts
+++ b/sdk/model/src/components/PlDataTable/typesV5.ts
@@ -14,14 +14,7 @@ import type {
 import type { FilterSpecLeaf } from "../../filters";
 import { Nil } from "@milaboratories/helpers";
 
-export type PlTableColumnId = {
-  /** Original column spec */
-  source: PTableColumnSpec;
-  /** Column spec with labeled axes replaced by label columns */
-  labeled: PTableColumnSpec;
-};
-
-export type PlTableColumnIdJson = CanonicalizedJson<PlTableColumnId>;
+export type PlTableColumnIdJson = CanonicalizedJson<PTableColumnSpec>;
 
 export type PlDataTableGridStateCore = {
   /** Includes column ordering */

--- a/sdk/model/src/components/PlDataTable/typesV5.ts
+++ b/sdk/model/src/components/PlDataTable/typesV5.ts
@@ -1,152 +1,20 @@
-import type {
-  AxisId,
-  AxisSpec,
-  CanonicalizedJson,
-  ListOptionBase,
-  PTableColumnSpec,
-  PTableSorting,
-  PColumnIdAndSpec,
-  PTableHandle,
-  RootFilterSpec,
-  PTableColumnId,
-  PFrameHandle,
-} from "@milaboratories/pl-model-common";
-import type { FilterSpecLeaf } from "../../filters";
-import { Nil } from "@milaboratories/helpers";
+import type { CanonicalizedJson, PTableColumnSpec } from "@milaboratories/pl-model-common";
 
-export type PlTableColumnIdJson = CanonicalizedJson<PTableColumnSpec>;
-
-export type PlDataTableGridStateCore = {
-  /** Includes column ordering */
-  columnOrder?: {
-    /** All colIds in order */
-    orderedColIds: PlTableColumnIdJson[];
-  };
-  /** Includes current sort columns and direction */
-  sort?: {
-    /** Sorted columns and directions in order */
-    sortModel: {
-      /** Column Id to apply the sort to. */
-      colId: PlTableColumnIdJson;
-      /** Sort direction */
-      sort: "asc" | "desc";
-    }[];
-  };
-  /** Includes column visibility */
-  columnVisibility?: {
-    /** All colIds which were hidden */
-    hiddenColIds: PlTableColumnIdJson[];
-  };
+/**
+ * v5 colId wrapper. v5 stored every grid colId as `{ source, labeled }` —
+ * `source` was the original column spec, `labeled` was the spec with
+ * labeled axes substituted by their label columns. v6 dropped the wrapper
+ * and stores bare `PTableColumnSpec`. Kept here for the v5→v6 migration.
+ */
+export type PlDataTableV5ColIdWrapper = {
+  source: PTableColumnSpec;
+  labeled: PTableColumnSpec;
 };
 
-export type PlDataTableSheet = {
-  /** spec of the axis to use */
-  axis: AxisSpec;
-  /** options to show in the filter dropdown */
-  options: ListOptionBase<string | number>[];
-  /** default (selected) value */
-  defaultValue?: string | number;
-};
+export type PlDataTableV5ColIdJson = CanonicalizedJson<PlDataTableV5ColIdWrapper>;
 
-export type PlDataTableSheetState = {
-  /** id of the axis */
-  axisId: AxisId;
-  /** selected value */
-  value: string | number;
-};
-
-/** Tree-based filter state compatible with PlAdvancedFilter's RootFilter */
-export type PlDataTableFilterMeta = {
-  id: number;
-  source?: "table-filter" | "table-search";
-  isExpanded?: boolean;
-  isSuppressed?: boolean;
-};
-export type PlDataTableFilterSpecLeaf = FilterSpecLeaf<CanonicalizedJson<PTableColumnId>>;
-export type PlDataTableFilters = RootFilterSpec<PlDataTableFilterSpecLeaf>;
-export type PlDataTableFiltersWithMeta = RootFilterSpec<
-  PlDataTableFilterSpecLeaf,
-  PlDataTableFilterMeta
->;
-
-export type PlDataTableStateV2CacheEntry = {
-  /** DataSource identifier for state management */
-  sourceId: string;
-  /** Internal ag-grid state */
-  gridState: PlDataTableGridStateCore;
-  /** Sheets state */
-  sheetsState: PlDataTableSheetState[];
-  /** User filters state (tree-based, compatible with PlAdvancedFilter) */
-  filtersState: null | PlDataTableFiltersWithMeta;
-  /** Default filters state from model (snapshot of defaults) */
-  defaultFiltersState: null | PlDataTableFiltersWithMeta;
-  /** Fast search string */
-  searchString?: string;
-};
-
-export type PTableParamsV2 =
-  | {
-      sourceId: null;
-      hiddenColIds: null;
-      sorting: [];
-      filters: null;
-      defaultFilters: null;
-    }
-  | {
-      sourceId: string;
-      hiddenColIds: null | PTableColumnId[];
-      sorting: PTableSorting[];
-      filters: null | PlDataTableFilters;
-      defaultFilters: null | PlDataTableFilters;
-    };
-
-export type PlDataTableStateV2Normalized = {
-  /** Version for upgrades */
-  version: 5;
-  /** Internal states, LRU cache for 5 sourceId-s */
-  stateCache: PlDataTableStateV2CacheEntry[];
-  /** PTable params derived from the cache state for the current sourceId */
-  pTableParams: PTableParamsV2;
-};
-
-/** PlAgDataTable model */
-export type PlDataTableModel = {
-  /** DataSource identifier for state management */
-  sourceId: null | string;
-  /** p-table including all columns, used to show the full specification of the table */
-  fullTableHandle?: PTableHandle;
-  /** p-frame handle */
-  fullPframeHandle?: PFrameHandle;
-  /** p-table including only visible columns, used to get the data */
-  visibleTableHandle?: PTableHandle;
-  /** Default filters from model options, surfaced for UI display */
-  defaultFilters?: Nil | PlDataTableFilters;
-};
-
-export type CreatePlDataTableOps = {
-  /** Filters for columns and non-partitioned axes */
-  filters?: PlDataTableFilters;
-
-  /** Sorting to columns hidden from user */
-  sorting?: PTableSorting[];
-
-  /**
-   * Selects columns for which will be inner-joined to the table.
-   *
-   * Default behaviour: all columns are considered to be core
-   */
-  coreColumnPredicate?: (spec: PColumnIdAndSpec) => boolean;
-
-  /**
-   * Determines how core columns should be joined together:
-   *   inner - so user will only see records present in all core columns
-   *   full - so user will only see records present in any of the core columns
-   *
-   * All non-core columns will be left joined to the table produced by the core
-   * columns, in other words records form the pool of non-core columns will only
-   * make their way into the final table if core table contains corresponding key.
-   *
-   * Default: 'full'
-   */
-  coreJoinType?: "inner" | "full";
+export type PlDataTableGridStateV5 = {
+  columnOrder?: { orderedColIds: PlDataTableV5ColIdJson[] };
+  sort?: { sortModel: { colId: PlDataTableV5ColIdJson; sort: "asc" | "desc" }[] };
+  columnVisibility?: { hiddenColIds: PlDataTableV5ColIdJson[] };
 };

--- a/sdk/model/src/components/PlDataTable/typesV6.ts
+++ b/sdk/model/src/components/PlDataTable/typesV6.ts
@@ -1,0 +1,152 @@
+import type {
+  AxisId,
+  AxisSpec,
+  CanonicalizedJson,
+  ListOptionBase,
+  PTableColumnSpec,
+  PTableSorting,
+  PColumnIdAndSpec,
+  PTableHandle,
+  RootFilterSpec,
+  PTableColumnId,
+  PFrameHandle,
+} from "@milaboratories/pl-model-common";
+import type { FilterSpecLeaf } from "../../filters";
+import { Nil } from "@milaboratories/helpers";
+
+export type PlTableColumnIdJson = CanonicalizedJson<PTableColumnSpec>;
+
+export type PlDataTableGridStateCore = {
+  /** Includes column ordering */
+  columnOrder?: {
+    /** All colIds in order */
+    orderedColIds: PlTableColumnIdJson[];
+  };
+  /** Includes current sort columns and direction */
+  sort?: {
+    /** Sorted columns and directions in order */
+    sortModel: {
+      /** Column Id to apply the sort to. */
+      colId: PlTableColumnIdJson;
+      /** Sort direction */
+      sort: "asc" | "desc";
+    }[];
+  };
+  /** Includes column visibility */
+  columnVisibility?: {
+    /** All colIds which were hidden */
+    hiddenColIds: PlTableColumnIdJson[];
+  };
+};
+
+export type PlDataTableSheet = {
+  /** spec of the axis to use */
+  axis: AxisSpec;
+  /** options to show in the filter dropdown */
+  options: ListOptionBase<string | number>[];
+  /** default (selected) value */
+  defaultValue?: string | number;
+};
+
+export type PlDataTableSheetState = {
+  /** id of the axis */
+  axisId: AxisId;
+  /** selected value */
+  value: string | number;
+};
+
+/** Tree-based filter state compatible with PlAdvancedFilter's RootFilter */
+export type PlDataTableFilterMeta = {
+  id: number;
+  source?: "table-filter" | "table-search";
+  isExpanded?: boolean;
+  isSuppressed?: boolean;
+};
+export type PlDataTableFilterSpecLeaf = FilterSpecLeaf<CanonicalizedJson<PTableColumnId>>;
+export type PlDataTableFilters = RootFilterSpec<PlDataTableFilterSpecLeaf>;
+export type PlDataTableFiltersWithMeta = RootFilterSpec<
+  PlDataTableFilterSpecLeaf,
+  PlDataTableFilterMeta
+>;
+
+export type PlDataTableStateV2CacheEntry = {
+  /** DataSource identifier for state management */
+  sourceId: string;
+  /** Internal ag-grid state */
+  gridState: PlDataTableGridStateCore;
+  /** Sheets state */
+  sheetsState: PlDataTableSheetState[];
+  /** User filters state (tree-based, compatible with PlAdvancedFilter) */
+  filtersState: null | PlDataTableFiltersWithMeta;
+  /** Default filters state from model (snapshot of defaults) */
+  defaultFiltersState: null | PlDataTableFiltersWithMeta;
+  /** Fast search string */
+  searchString?: string;
+};
+
+export type PTableParamsV2 =
+  | {
+      sourceId: null;
+      hiddenColIds: null;
+      sorting: [];
+      filters: null;
+      defaultFilters: null;
+    }
+  | {
+      sourceId: string;
+      hiddenColIds: null | PTableColumnId[];
+      sorting: PTableSorting[];
+      filters: null | PlDataTableFilters;
+      defaultFilters: null | PlDataTableFilters;
+    };
+
+export type PlDataTableStateV2Normalized = {
+  /** Version for upgrades */
+  version: 6;
+  /** Internal states, LRU cache for 5 sourceId-s */
+  stateCache: PlDataTableStateV2CacheEntry[];
+  /** PTable params derived from the cache state for the current sourceId */
+  pTableParams: PTableParamsV2;
+};
+
+/** PlAgDataTable model */
+export type PlDataTableModel = {
+  /** DataSource identifier for state management */
+  sourceId: null | string;
+  /** p-table including all columns, used to show the full specification of the table */
+  fullTableHandle?: PTableHandle;
+  /** p-frame handle */
+  fullPframeHandle?: PFrameHandle;
+  /** p-table including only visible columns, used to get the data */
+  visibleTableHandle?: PTableHandle;
+  /** Default filters from model options, surfaced for UI display */
+  defaultFilters?: Nil | PlDataTableFilters;
+};
+
+export type CreatePlDataTableOps = {
+  /** Filters for columns and non-partitioned axes */
+  filters?: PlDataTableFilters;
+
+  /** Sorting to columns hidden from user */
+  sorting?: PTableSorting[];
+
+  /**
+   * Selects columns for which will be inner-joined to the table.
+   *
+   * Default behaviour: all columns are considered to be core
+   */
+  coreColumnPredicate?: (spec: PColumnIdAndSpec) => boolean;
+
+  /**
+   * Determines how core columns should be joined together:
+   *   inner - so user will only see records present in all core columns
+   *   full - so user will only see records present in any of the core columns
+   *
+   * All non-core columns will be left joined to the table produced by the core
+   * columns, in other words records form the pool of non-core columns will only
+   * make their way into the final table if core table contains corresponding key.
+   *
+   * Default: 'full'
+   */
+  coreJoinType?: "inner" | "full";
+};

--- a/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
@@ -69,10 +69,10 @@ export function findEnrichmentColumns(
   });
   const predicate = options?.predicate;
   return variants.filter((v) => {
-    if (v.path.length === 0) return false;
+    if ((v.path?.length ?? 0) === 0) return false;
     if (predicate !== undefined && !predicate(v.column.spec)) return false;
     if (!isGloballyAddressable(v.column.id)) return false;
-    if (v.path.some((p) => !isGloballyAddressable(p.linker.id))) return false;
+    if (v.path?.some((p) => !isGloballyAddressable(p.linker.id))) return false;
     return true;
   });
 }
@@ -90,20 +90,20 @@ export function enrichmentVariantsToRefs(
 
   const entries: Entry[] = variants.map((variant) => ({
     spec: variant.column.spec,
-    linkerPath: variant.path.map((p) => ({ spec: p.linker.spec })),
+    linkerPath: variant.path?.map((p) => ({ spec: p.linker.spec })),
     qualifications: variant.qualifications,
   }));
   const labels = deriveDistinctLabels(entries, labelOptions);
 
   return variants.map((variant, i): LabeledEnrichmentRef => {
-    const path: EnrichmentStep[] = variant.path.map((step) => ({
+    const path: undefined | EnrichmentStep[] = variant.path?.map((step) => ({
       type: "linker",
       linker: step.linker.id,
     }));
     return {
       ref: createEnrichmentRef(variant.column.id, {
         path,
-        qualifications: variant.qualifications.forHit,
+        qualifications: variant.qualifications?.forHit,
       }),
       label: labels[i],
     };

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -289,7 +289,7 @@ function enrichRecord(value: Entry, index: number, options: DeriveLabelsOptions)
     }
   }
 
-  if (qualifications !== undefined) {
+  if (qualifications !== undefined && qualifications.forQueries !== undefined) {
     for (const [anchorId, qs] of Object.entries(qualifications.forQueries)) {
       if (qs.length === 0) continue;
       const anchorText = isFunction(formatters?.anchorQualification)
@@ -302,7 +302,7 @@ function enrichRecord(value: Entry, index: number, options: DeriveLabelsOptions)
         importance: -11,
       });
     }
-    if (qualifications.forHit.length > 0) {
+    if (qualifications.forHit !== undefined && qualifications.forHit.length > 0) {
       const hitText = isFunction(formatters?.hitQualification)
         ? formatters.hitQualification(qualifications.forHit, spec, index)
         : `[${formatQualifications(qualifications.forHit)}]`;

--- a/sdk/model/src/labels/derive_distinct_tooltips.ts
+++ b/sdk/model/src/labels/derive_distinct_tooltips.ts
@@ -74,6 +74,7 @@ function formatOriginPath(entry: TooltipEntry): undefined | string {
 
 function formatAnchors(q: undefined | MatchQualifications): undefined | string {
   if (isNil(q)) return undefined;
+  if (isNil(q.forQueries)) return undefined;
   const ids = Object.keys(q.forQueries);
   if (ids.length === 0) return undefined;
 
@@ -90,7 +91,7 @@ function formatAnchors(q: undefined | MatchQualifications): undefined | string {
 }
 
 function formatHit(q: undefined | MatchQualifications): undefined | string {
-  if (isNil(q) || q.forHit.length === 0) return undefined;
+  if (isNil(q) || isNil(q.forHit) || q.forHit.length === 0) return undefined;
   const rendered = formatAxisQualifications(q.forHit);
   if (rendered === undefined) return undefined;
   return ["Hit column qualifications", `${BULLET_1}${rendered}`].join("\n");

--- a/sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts
+++ b/sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts
@@ -90,11 +90,6 @@ export function isCsvExportAvailable(): boolean {
  * ag-grid column defs, remapped onto the provided PTable spec array so the
  * indices match the current table handle (ColDef.field indices may be stale
  * or diverge from the spec order).
- *
- * Each grid column carries a `PlTableColumnId` ({ source, labeled }). When
- * the labeled spec differs from the source (axis replaced by a label
- * column), both indices are emitted so the export contains the raw axis
- * value alongside its human-readable label.
  */
 export function collectVisibleColumnIndices(
   gridApi: GridApi,
@@ -114,8 +109,7 @@ export function collectVisibleColumnIndices(
     if (def.hide === true) return [];
     if (isNil(def.colId)) return [];
     if (def.colId === PlAgDataTableRowNumberColId) return [];
-    const { labeled } = parseJson(def.colId as PlTableColumnIdJson);
-    return [labeled];
+    return [parseJson(def.colId as PlTableColumnIdJson)];
   };
 
   return [...new Set(columnDefs.flatMap(specsForDef).map(findIndex))].filter((idx) => idx !== -1);

--- a/sdk/ui-vue/src/components/PlAgDataTable/compositions/useFilterableColumns.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/compositions/useFilterableColumns.ts
@@ -33,7 +33,7 @@ export function useFilterableColumns(
       const cols = dataColDefs
         .filter((def): def is typeof def & { colId: string } => !isNil(def.colId))
         .map((def) => ({
-          item: parseJson(def.colId satisfies string as PlTableColumnIdJson).labeled,
+          item: parseJson(def.colId satisfies string as PlTableColumnIdJson),
           hide: def.hide,
         }));
 

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -16,7 +16,6 @@ import {
   type AxisId,
   type PTableColumnSpec,
   type PTableKey,
-  type PlTableColumnId,
   type PlTableColumnIdJson,
   isLabelColumn as isLabelColumnSpec,
   isLinkerColumn as isLinkerColumnSpec,
@@ -121,7 +120,7 @@ export async function calculateGridOptions({
 
   const isPartitionedAxis = createPartitionedAxisPredicate(sheets);
 
-  // label columns indexed by labeled axis (for axis→label replacement later)
+  // label columns indexed by labeled axis (used for displayability filter)
   const getLabelColumnIndex = collectLabelColumnsByAxis(tableSpecs, isPartitionedAxis);
 
   // displayable column indices ordered: axes first, then columns by OrderPriority
@@ -130,34 +129,22 @@ export async function calculateGridOptions({
     tableSpecs,
   );
 
-  // same as fields, but each axis replaced by its label column index when available
-  const indices = replaceAxesWithLabelColumns(fields, tableSpecs, getLabelColumnIndex);
-
   // default hidden columns derived from Optional annotation when no saved state
-  const resolvedHiddenColIds =
-    hiddenColIds ?? computeDefaultHiddenColIds(fields, indices, tableSpecs);
+  const resolvedHiddenColIds = hiddenColIds ?? computeDefaultHiddenColIds(fields, tableSpecs);
 
   const columnDefs: ColDef<PlAgDataTableV2Row, PTableValue | PTableHidden>[] = [
     makeRowNumberColDef(),
-    ...fields.map((field, index) =>
-      makeColDef(
-        field,
-        tableSpecs[field],
-        tableSpecs[indices[index]],
-        resolvedHiddenColIds,
-        cellButtonAxisParams,
-      ),
+    ...fields.map((field) =>
+      makeColDef(field, tableSpecs[field], resolvedHiddenColIds, cellButtonAxisParams),
     ),
   ];
 
   // axes — taken directly from visible table (always present as part of join)
   const visibleAxes = collectVisibleAxes(visibleTableSpecs);
 
-  // request indices: non-hidden display fields + visible axes for row selection keys.
-  // Axes replaced by label columns request label data (display); original axis values
-  // are fetched via visibleAxes (row keys).
+  // request indices: display fields + visible axes for row selection keys.
   const { requestIndices, axesResultIndices, fieldResultMapping } = buildRequestIndices(
-    indices,
+    fields,
     visibleAxes.map(([idx]) => idx),
     specsToVisibleSpecsMapping,
   );
@@ -245,14 +232,10 @@ export type PlAgCellButtonAxisParams = {
 export function makeColDef(
   iCol: number,
   spec: PTableColumnSpec,
-  labeledSpec: PTableColumnSpec,
   hiddenColIds: PlTableColumnIdJson[] | undefined,
   cellButtonAxisParams?: PlAgCellButtonAxisParams,
 ): ColDef<PlAgDataTableV2Row, PTableValue | PTableHidden> {
-  const colId = canonicalizeJson<PlTableColumnId>({
-    source: spec,
-    labeled: labeledSpec,
-  });
+  const colId = canonicalizeJson<PTableColumnSpec>(spec);
   const valueType = spec.type === "axis" ? spec.spec.type : spec.spec.valueType;
   const columnRenderingSpec = getColumnRenderingSpec(spec);
   const cellStyle: CellStyle = {};
@@ -265,9 +248,7 @@ export function makeColDef(
     }
   }
   const headerName =
-    readAnnotation(labeledSpec.spec, Annotation.Label)?.trim() ??
-    readAnnotation(spec.spec, Annotation.Label)?.trim() ??
-    `Unlabeled ${spec.type} ${iCol}`;
+    readAnnotation(spec.spec, Annotation.Label)?.trim() ?? `Unlabeled ${spec.type} ${iCol}`;
 
   return {
     colId,
@@ -314,12 +295,8 @@ export function makeColDef(
             throw Error(`unsupported data type: ${valueType}`);
         }
       })(),
-      tooltip:
-        readAnnotation(spec.spec, Annotation.Description)?.trim() ??
-        readAnnotation(labeledSpec.spec, Annotation.Description)?.trim(),
-      // info:
-      //   readAnnotation(spec.spec, Annotation.Table.Info)?.trim() ??
-      //   readAnnotation(labeledSpec.spec, Annotation.Table.Info)?.trim(),
+      tooltip: readAnnotation(spec.spec, Annotation.Description)?.trim(),
+      // info: readAnnotation(spec.spec, Annotation.Table.Info)?.trim(),
     } satisfies PlAgHeaderComponentParams,
     cellDataType: (() => {
       switch (valueType) {
@@ -422,30 +399,16 @@ function sortIndicesByTypeAndPriority(indices: number[], tableSpecs: PTableColum
   return [...indices].sort((a, b) => priorityOf(b) - priorityOf(a));
 }
 
-// /** For each axis entry substitute the index of its matching label column when one exists. */
-// function replaceAxesWithLabelColumns(
-//   fields: number[],
-//   tableSpecs: PTableColumnSpec[],
-//   getLabelColumnIndex: (axisId: AxisId) => number,
-// ): number[] {
-//   return fields.map((i) => {
-//     const spec = tableSpecs[i];
-//     const labelIdx = spec.type === "axis" ? getLabelColumnIndex(spec.id) : -1;
-//     return labelIdx === -1 ? i : labelIdx;
-//   });
-// }
-
 /** Default hidden col ids built from columns marked with the Optional annotation. */
 function computeDefaultHiddenColIds(
   fields: number[],
-  indices: number[],
   tableSpecs: PTableColumnSpec[],
 ): PlTableColumnIdJson[] {
-  return fields.reduce<PlTableColumnIdJson[]>((acc, field, i) => {
+  return fields.reduce<PlTableColumnIdJson[]>((acc, field) => {
     const spec = tableSpecs[field];
-    if (spec.type !== "column" || !isColumnOptional(spec.spec)) return acc;
-    const labeledSpec = tableSpecs[indices[i]];
-    return [...acc, canonicalizeJson<PlTableColumnId>({ source: spec, labeled: labeledSpec })];
+    return spec.type === "column" && isColumnOptional(spec.spec)
+      ? [...acc, canonicalizeJson<PTableColumnSpec>(spec)]
+      : acc;
   }, []);
 }
 

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -275,7 +275,8 @@ export function makeColDef(
     context: spec,
     field: `${iCol}`,
     headerName,
-    lockPosition: spec.type === "axis",
+    lockPosition:
+      spec.type === "axis" || (isLabelColumnSpec(spec.spec) && spec.spec.axesSpec.length === 1),
     hide: hiddenColIds !== undefined && hiddenColIds.includes(colId),
     valueFormatter: columnRenderingSpec.valueFormatter,
     headerComponent: PlAgColumnHeader,
@@ -396,17 +397,11 @@ function selectDisplayableIndices(
       switch (spec.type) {
         case "axis":
           return (
-            // show axis if not hidden or if it has a label column
-            (!isColumnHidden(spec.spec) ? true : getLabelColumnIndex(spec.id) > -1) &&
+            !(getLabelColumnIndex(spec.id) > -1 ? true : isColumnHidden(spec.spec)) &&
             !isPartitionedAxis(spec.id)
           );
         case "column":
-          return (
-            !isColumnHidden(spec.spec) &&
-            // hide label columns (their labeled axes are shown instead)
-            !isLabelColumnSpec(spec.spec) &&
-            !isLinkerColumnSpec(spec.spec)
-          );
+          return !isColumnHidden(spec.spec) && !isLinkerColumnSpec(spec.spec);
       }
     })
     .map(([i]) => i)
@@ -417,30 +412,28 @@ function selectDisplayableIndices(
 function sortIndicesByTypeAndPriority(indices: number[], tableSpecs: PTableColumnSpec[]): number[] {
   const priorityOf = (i: number): number => {
     const spec = tableSpecs[i];
-    return spec.type === "column"
-      ? (readAnnotationJson(spec.spec, Annotation.Table.OrderPriority) ?? 0)
-      : 0;
+    const prior =
+      spec.type === "axis" || isLabelColumnSpec(spec.spec)
+        ? Infinity
+        : Number(readAnnotationJson(spec.spec, Annotation.Table.OrderPriority));
+
+    return isNaN(prior) ? 0 : prior;
   };
-  return [...indices].sort((a, b) => {
-    if (tableSpecs[a].type !== tableSpecs[b].type) {
-      return tableSpecs[a].type === "axis" ? -1 : 1;
-    }
-    return priorityOf(b) - priorityOf(a);
-  });
+  return [...indices].sort((a, b) => priorityOf(b) - priorityOf(a));
 }
 
-/** For each axis entry substitute the index of its matching label column when one exists. */
-function replaceAxesWithLabelColumns(
-  fields: number[],
-  tableSpecs: PTableColumnSpec[],
-  getLabelColumnIndex: (axisId: AxisId) => number,
-): number[] {
-  return fields.map((i) => {
-    const spec = tableSpecs[i];
-    const labelIdx = spec.type === "axis" ? getLabelColumnIndex(spec.id) : -1;
-    return labelIdx === -1 ? i : labelIdx;
-  });
-}
+// /** For each axis entry substitute the index of its matching label column when one exists. */
+// function replaceAxesWithLabelColumns(
+//   fields: number[],
+//   tableSpecs: PTableColumnSpec[],
+//   getLabelColumnIndex: (axisId: AxisId) => number,
+// ): number[] {
+//   return fields.map((i) => {
+//     const spec = tableSpecs[i];
+//     const labelIdx = spec.type === "axis" ? getLabelColumnIndex(spec.id) : -1;
+//     return labelIdx === -1 ? i : labelIdx;
+//   });
+// }
 
 /** Default hidden col ids built from columns marked with the Optional annotation. */
 function computeDefaultHiddenColIds(

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
@@ -417,7 +417,7 @@ function convertPartitionFiltersToFilterSpec(
 function convertAgSortingToPTableSorting(state: PlDataTableGridStateCore["sort"]): PTableSorting[] {
   return (
     state?.sortModel.map((item) => {
-      const { spec: _, ...column } = parseJson(item.colId).labeled;
+      const { spec: _, ...column } = parseJson(item.colId);
       return {
         column,
         ascending: item.sort === "asc",
@@ -430,7 +430,7 @@ function convertAgSortingToPTableSorting(state: PlDataTableGridStateCore["sort"]
 function getHiddenColIds(
   state: PlDataTableGridStateCore["columnVisibility"],
 ): PTableColumnId[] | null {
-  return state?.hiddenColIds?.map((json) => getPTableColumnId(parseJson(json).source)) ?? null;
+  return state?.hiddenColIds?.map((json) => getPTableColumnId(parseJson(json))) ?? null;
 }
 
 function makeDefaultState(): PlDataTableStateV2CacheEntryNullable {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds label column discovery for predefined (user-supplied) column lists in `createPlDataTableV3`, introduces a v5→v6 state migration to handle the `{source, labeled}` colId wrapper format, and stabilises `DiscoveredPColumnId` by stripping empty arrays/objects via the new `distillDiscoveredPColumn` helper. The previously-flagged issue around silently broken `getHiddenColIds` / `convertAgSortingToPTableSorting` parsing is resolved by the new migration.

- `discoverLabelColumnVariants` discovers and appends label columns for predefined `TableColumnVariant[]` inputs; wired into the predefined-columns branch of `createPlDataTableV3`.
- `DiscoveredPColumn` fields become optional and `distillDiscoveredPColumn` canonicalises IDs by omitting empty path/qualification fields, changing the on-wire ID format for previously-serialised columns.
- State migration v5→v6 correctly unwraps `{source, labeled}` gridState colIds but forwards `pTableParams` unchanged, leaving stale `DiscoveredPColumnId` values that mismatch the new format on first model render after upgrade.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Two defects in the new label-discovery path need fixing before merge: a runtime throw on empty anchors and a stale-ID mismatch after state migration.

The `discoverLabelColumnVariants` function will throw when the caller provides a `TableColumnVariant[]` with no direct-path primary columns — a valid state since `isPrimary` is optional. The v5→v6 migration forwards `pTableParams` unchanged; `distillDiscoveredPColumn` changes `DiscoveredPColumnId` serialisation (removing empty arrays), so hidden-column IDs persisted under the old format silently fail to match on first model render after upgrade.

`discoverColumns.ts` (empty-anchors guard) and `state-migration.ts` (reset `pTableParams` on v5→v6).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts | Adds `discoverLabelColumnVariants` to discover label columns for predefined column lists; throws when no primary direct-path column exists in the input (empty anchors issue). |
| sdk/model/src/components/PlDataTable/state-migration.ts | Adds v5→v6 migration (unwraps `{source,labeled}` colId wrappers in gridState), but forwards stale `pTableParams` with old-format `DiscoveredPColumnId` values that silently mismatch after the `distillDiscoveredPColumn` format change. |
| lib/model/common/src/drivers/pframe/spec/discovered_column.ts | Makes `path`, `columnQualifications`, and `queriesQualifications` optional; renames `createDiscoveredPColumn` → `distillDiscoveredPColumn` which strips empty arrays/objects, changing the canonical ID format. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Wires `discoverLabelColumnVariants` for predefined column lists; correct but inherits the empty-anchors vulnerability from the callee. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts | Previously-flagged silently-broken hidden/sort state issue is resolved by the new v5→v6 migration; `getHiddenColIds` and `convertAgSortingToPTableSorting` now receive properly migrated v6 colIds. |
| sdk/model/src/components/PlDataTable/typesV5.ts | New file defining v5 state types needed by the v5→v6 migration; correct. |
| sdk/model/src/components/PlDataTable/typesV6.ts | Extracts current v6 PlDataTable type definitions into their own file; no logic changes. |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts | Utility helpers for label/annotation derivation; no substantive changes beyond import updates. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts`, line 430-434 ([link](https://github.com/milaboratory/platforma/blob/1dd92ee0f2195e6b27205b076290e59a6855c30d/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts#L430-L434)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silently broken parsing of persisted hidden-column state**

   Any session that saved `hiddenColIds` under the old `PlTableColumnId` format (`{"source":{...},"labeled":{...}}`) will silently malfunction here. `parseJson(json)` returns `{ source, labeled }`, which is passed to `getPTableColumnId()`. That function switches on `spec.type`, finds no match for the old object shape, and returns `undefined` (implicit fall-through). The resulting `null` array means the table ignores the user's saved visibility choices without any error or warning. The same applies to `convertAgSortingToPTableSorting` at line 420, where `const { spec: _, ...column } = parseJson(item.colId)` produces `column = { source: {...}, labeled: {...} }` — an invalid `PTableColumnId` — so saved sort state also silently reverts to default. If persisted UI state is not explicitly invalidated on upgrade, users will see their hidden-column and sort preferences disappear.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
   Line: 430-434

   Comment:
   **Silently broken parsing of persisted hidden-column state**

   Any session that saved `hiddenColIds` under the old `PlTableColumnId` format (`{"source":{...},"labeled":{...}}`) will silently malfunction here. `parseJson(json)` returns `{ source, labeled }`, which is passed to `getPTableColumnId()`. That function switches on `spec.type`, finds no match for the old object shape, and returns `undefined` (implicit fall-through). The resulting `null` array means the table ignores the user's saved visibility choices without any error or warning. The same applies to `convertAgSortingToPTableSorting` at line 420, where `const { spec: _, ...column } = parseJson(item.colId)` produces `column = { source: {...}, labeled: {...} }` — an invalid `PTableColumnId` — so saved sort state also silently reverts to default. If persisted UI state is not explicitly invalidated on upgrade, users will see their hidden-column and sort preferences disappear.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts`, line 63-73 ([link](https://github.com/milaboratory/platforma/blob/c283b24c55aa73834945f0ee27d6edbda8797bc1/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts#L63-L73)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Unchecked empty-anchors case throws at runtime**

   When every entry in `columns` has either `path.length > 0` or `isPrimary` falsy (e.g., a caller who builds `TableColumnVariant[]` without setting the optional `isPrimary` flag), the `Object.fromEntries(...)` call produces `{}`. `ColumnCollectionBuilder.build()` still sees `"anchors" in options` as `true` and instantiates `AnchoredColumnCollectionImpl`, whose constructor calls `resolveAnchorMap({}, ...)`. That function iterates zero anchor entries, leaving `resolvedIds.size === 0`, and throws `"At least one anchor must be resolved to a valid column"`.

   A guard is needed before calling `.build()`: if no primary, path-zero columns exist, return `[]` early — there are no anchors, so no label columns can be resolved.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
   Line: 63-73

   Comment:
   **Unchecked empty-anchors case throws at runtime**

   When every entry in `columns` has either `path.length > 0` or `isPrimary` falsy (e.g., a caller who builds `TableColumnVariant[]` without setting the optional `isPrimary` flag), the `Object.fromEntries(...)` call produces `{}`. `ColumnCollectionBuilder.build()` still sees `"anchors" in options` as `true` and instantiates `AnchoredColumnCollectionImpl`, whose constructor calls `resolveAnchorMap({}, ...)`. That function iterates zero anchor entries, leaving `resolvedIds.size === 0`, and throws `"At least one anchor must be resolved to a valid column"`.

   A guard is needed before calling `.build()`: if no primary, path-zero columns exist, return `[]` early — there are no anchors, so no label columns can be resolved.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `sdk/model/src/components/PlDataTable/state-migration.ts`, line 177-185 ([link](https://github.com/milaboratory/platforma/blob/c283b24c55aa73834945f0ee27d6edbda8797bc1/sdk/model/src/components/PlDataTable/state-migration.ts#L177-L185)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **v5→v6 migration silently preserves stale `pTableParams` with mismatched column IDs**

   `pTableParams` is forwarded unchanged from the v5 state. In v5, `pTableParams.hiddenColIds` contains `DiscoveredPColumnId` values produced by the old `createDiscoveredPColumn`, which always serialised empty arrays — e.g., `{"column":"…","path":[],"columnQualifications":[],"queriesQualifications":{}}`.

   After this PR, `distillDiscoveredPColumn` strips empty fields, so the same logical column now generates `{"column":"…"}`. Because the IDs don't match, `computeHiddenColumns` in `createPlDataTableV3` will ignore every previously-hidden discovered column on the first model render after the upgrade — they silently reappear.

   The safest fix is to reset `pTableParams` to `createDefaultPTableParams()` during migration, accepting a one-time loss of the cached visible-table preference, instead of silently applying wrong state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/model/src/components/PlDataTable/state-migration.ts
   Line: 177-185

   Comment:
   **v5→v6 migration silently preserves stale `pTableParams` with mismatched column IDs**

   `pTableParams` is forwarded unchanged from the v5 state. In v5, `pTableParams.hiddenColIds` contains `DiscoveredPColumnId` values produced by the old `createDiscoveredPColumn`, which always serialised empty arrays — e.g., `{"column":"…","path":[],"columnQualifications":[],"queriesQualifications":{}}`.

   After this PR, `distillDiscoveredPColumn` strips empty fields, so the same logical column now generates `{"column":"…"}`. Because the IDs don't match, `computeHiddenColumns` in `createPlDataTableV3` will ignore every previously-hidden discovered column on the first model render after the upgrade — they silently reappear.

   The safest fix is to reset `pTableParams` to `createDefaultPTableParams()` during migration, accepting a one-time loss of the cached visible-table preference, instead of silently applying wrong state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts:63-73
**Unchecked empty-anchors case throws at runtime**

When every entry in `columns` has either `path.length > 0` or `isPrimary` falsy (e.g., a caller who builds `TableColumnVariant[]` without setting the optional `isPrimary` flag), the `Object.fromEntries(...)` call produces `{}`. `ColumnCollectionBuilder.build()` still sees `"anchors" in options` as `true` and instantiates `AnchoredColumnCollectionImpl`, whose constructor calls `resolveAnchorMap({}, ...)`. That function iterates zero anchor entries, leaving `resolvedIds.size === 0`, and throws `"At least one anchor must be resolved to a valid column"`.

A guard is needed before calling `.build()`: if no primary, path-zero columns exist, return `[]` early — there are no anchors, so no label columns can be resolved.

### Issue 2 of 2
sdk/model/src/components/PlDataTable/state-migration.ts:177-185
**v5→v6 migration silently preserves stale `pTableParams` with mismatched column IDs**

`pTableParams` is forwarded unchanged from the v5 state. In v5, `pTableParams.hiddenColIds` contains `DiscoveredPColumnId` values produced by the old `createDiscoveredPColumn`, which always serialised empty arrays — e.g., `{"column":"…","path":[],"columnQualifications":[],"queriesQualifications":{}}`.

After this PR, `distillDiscoveredPColumn` strips empty fields, so the same logical column now generates `{"column":"…"}`. Because the IDs don't match, `computeHiddenColumns` in `createPlDataTableV3` will ignore every previously-hidden discovered column on the first model render after the upgrade — they silently reappear.

The safest fix is to reset `pTableParams` to `createDefaultPTableParams()` during migration, accepting a one-time loss of the cached visible-table preference, instead of silently applying wrong state.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: update imports to use types from v6..."](https://github.com/milaboratory/platforma/commit/c283b24c55aa73834945f0ee27d6edbda8797bc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31020719)</sub>

<!-- /greptile_comment -->