### PR TITLE
fix(helpers): release missing getField export

### DIFF
--- a/.changeset/helpers-getfield-export.md
+++ b/.changeset/helpers-getfield-export.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/helpers": minor
+---
+
+Publish the `getField` export. The function was added to the source in #1564 and consumed by `@platforma-sdk/model@1.75.0`, but that PR's changeset bumped only `model`, `uikit`, and `ui-vue`, leaving `helpers` unreleased. Result: `model@1.75.0` shipped with `"@milaboratories/helpers": "1.14.1"`, a version that does not export `getField`, causing `SyntaxError: The requested module '@milaboratories/helpers' does not provide an export named 'getField'` at runtime in any consumer that resolves model 1.75.0 (e.g. transitively via `pl-middle-layer >= 1.59.1`). Bumping `helpers` cascades a patch bump to `model` via `updateInternalDependencies`, which republishes model with a working `helpers` dep.


### PR DESCRIPTION
## Summary

- Adds a missing minor changeset for `@milaboratories/helpers` so the `getField` export ships to npm.
- `updateInternalDependencies: patch` (in `.changeset/config.json`) cascades a patch bump to `@platforma-sdk/model`, which republishes it with a `helpers` dep version that actually exports `getField`.

## Why

PR #1564 added `getField()` to `lib/util/helpers/src/objects.ts` and consumed it from `sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts`, but the changeset in that PR (`.changeset/deep-geese-turn.md`) bumped only `@milaboratories/uikit`, `@platforma-sdk/ui-vue`, and `@platforma-sdk/model` — `@milaboratories/helpers` was not included.

As a result:

- `@milaboratories/helpers@1.14.1` (latest published) does **not** export `getField`.
- `@platforma-sdk/model@1.75.0` was published with `"@milaboratories/helpers": "1.14.1"` and an `import { getField } from "@milaboratories/helpers"` in the compiled output.
- Any consumer that resolves `@platforma-sdk/model@1.75.0` (e.g. transitively via `@milaboratories/pl-middle-layer >= 1.59.1`, whose peer dep is `'@platforma-sdk/model': '>=1.75.0'`) blows up at startup with:

  ```
  SyntaxError: The requested module '@milaboratories/helpers' does not provide an export named 'getField'
      at .../@platforma-sdk+model@1.75.0/.../createPlDataTable/utils.js:7
  ```

This was reproducible from `platforma-desktop-app` via `pnpm dev` after a routine deps update.

## Test plan

- [ ] CI green on this branch
- [ ] After merge & release: verify a fresh `@milaboratories/helpers` published with `getField` in its exported surface
- [ ] After merge & release: verify the auto-cascaded `@platforma-sdk/model` patch release pins the new helpers version
- [ ] Re-run `pnpm install && pnpm dev` in `core/platforma-desktop-app` against the new releases — Electron main process should boot without the `SyntaxError`