### PR TITLE
fix: correct table migration to v6

### DIFF
--- a/.changeset/lucky-cobras-exist.md
+++ b/.changeset/lucky-cobras-exist.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-model-common": patch
+"@platforma-sdk/model": patch
+---
+
+Fix table migration to v6

--- a/lib/model/common/src/json.ts
+++ b/lib/model/common/src/json.ts
@@ -56,7 +56,7 @@ export function parseJson<T>(value: StringifiedJson<T> | CanonicalizedJson<T>): 
   return JSON.parse(value) as T;
 }
 
-export function safeParseJson<T, F = undefined>(value: string, fallback?: F): T | F {
+export function parseJsonSafely<T, F = undefined>(value: string, fallback?: F): T | F {
   try {
     return JSON.parse(value) as T;
   } catch {

--- a/lib/model/common/src/json.ts
+++ b/lib/model/common/src/json.ts
@@ -10,7 +10,6 @@ export type JsonSerializable =
   | { [key: string]: JsonSerializable }
   | { toJSON(): JsonValue };
 
-//
 type NotAssignableToJson = bigint | symbol | Function;
 
 export type JsonCompatible<T> = unknown extends T

--- a/lib/model/common/src/json.ts
+++ b/lib/model/common/src/json.ts
@@ -10,7 +10,7 @@ export type JsonSerializable =
   | { [key: string]: JsonSerializable }
   | { toJSON(): JsonValue };
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+//
 type NotAssignableToJson = bigint | symbol | Function;
 
 export type JsonCompatible<T> = unknown extends T
@@ -55,6 +55,14 @@ export function canonicalizeJson(value: unknown): string {
 
 export function parseJson<T>(value: StringifiedJson<T> | CanonicalizedJson<T>): T {
   return JSON.parse(value) as T;
+}
+
+export function safeParseJson<T, F = undefined>(value: string, fallback?: F): T | F {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback as F;
+  }
 }
 
 export function bigintReplacer(_key: string, value: unknown): unknown {

--- a/sdk/model/src/components/PlDataTable/state-migration.ts
+++ b/sdk/model/src/components/PlDataTable/state-migration.ts
@@ -7,7 +7,7 @@ import type {
   PTableRecordFilter,
   PTableSorting,
 } from "@milaboratories/pl-model-common";
-import { canonicalizeJson, parseJson } from "@milaboratories/pl-model-common";
+import { canonicalizeJson, safeParseJson } from "@milaboratories/pl-model-common";
 import { distillFilterSpec } from "../../filters";
 import type { PlDataTableFilterState, PlTableFilter } from "./typesV4";
 import type {
@@ -18,7 +18,12 @@ import type {
   PlDataTableStateV2Normalized,
   PTableParamsV2,
 } from "./typesV6";
-import type { PlDataTableGridStateV5, PlDataTableV5ColIdJson } from "./typesV5";
+import type {
+  PlDataTableGridStateV5,
+  PlDataTableV5ColIdJson,
+  PlDataTableV5ColIdWrapper,
+} from "./typesV5";
+import { isNil } from "es-toolkit";
 
 /**
  * PlDataTableV2 persisted state
@@ -189,26 +194,33 @@ function migrateV5toV6(
   };
 }
 
-/** Convert v5 wrapped colId JSON to bare PTableColumnSpec JSON, taking `.source`. */
-function unwrapV5ColId(json: PlDataTableV5ColIdJson): CanonicalizedJson<PTableColumnSpec> {
-  return canonicalizeJson(parseJson(json).source);
+/** Convert v5 wrapped colId JSON to bare PTableColumnSpec JSON, taking `.source`.
+ * gridState colIds may include the row-number sentinel (a JSON-stringified
+ * literal, not a wrapped spec) — those pass through unchanged. */
+function unwrapV5ColId(json: string): string {
+  const parsed: unknown = safeParseJson(json as CanonicalizedJson<unknown>);
+  return !isNil(parsed) && typeof parsed === "object" && "source" in parsed
+    ? canonicalizeJson((parsed as PlDataTableV5ColIdWrapper).source)
+    : json;
 }
 
 function unwrapV5GridState(gridState: PlDataTableGridStateV5): PlDataTableGridStateCore {
+  const unwrapAs = (json: PlDataTableV5ColIdJson) =>
+    unwrapV5ColId(json) as CanonicalizedJson<PTableColumnSpec>;
   return {
     columnOrder: gridState.columnOrder
-      ? { orderedColIds: gridState.columnOrder.orderedColIds.map(unwrapV5ColId) }
+      ? { orderedColIds: gridState.columnOrder.orderedColIds.map(unwrapAs) }
       : undefined,
     sort: gridState.sort
       ? {
           sortModel: gridState.sort.sortModel.map((s) => ({
-            colId: unwrapV5ColId(s.colId),
+            colId: unwrapAs(s.colId),
             sort: s.sort,
           })),
         }
       : undefined,
     columnVisibility: gridState.columnVisibility
-      ? { hiddenColIds: gridState.columnVisibility.hiddenColIds.map(unwrapV5ColId) }
+      ? { hiddenColIds: gridState.columnVisibility.hiddenColIds.map(unwrapAs) }
       : undefined,
   };
 }

--- a/sdk/model/src/components/PlDataTable/state-migration.ts
+++ b/sdk/model/src/components/PlDataTable/state-migration.ts
@@ -7,7 +7,7 @@ import type {
   PTableRecordFilter,
   PTableSorting,
 } from "@milaboratories/pl-model-common";
-import { canonicalizeJson, safeParseJson } from "@milaboratories/pl-model-common";
+import { canonicalizeJson, parseJsonSafely } from "@milaboratories/pl-model-common";
 import { distillFilterSpec } from "../../filters";
 import type { PlDataTableFilterState, PlTableFilter } from "./typesV4";
 import type {
@@ -198,7 +198,7 @@ function migrateV5toV6(
  * gridState colIds may include the row-number sentinel (a JSON-stringified
  * literal, not a wrapped spec) — those pass through unchanged. */
 function unwrapV5ColId(json: string): string {
-  const parsed: unknown = safeParseJson(json as CanonicalizedJson<unknown>);
+  const parsed: unknown = parseJsonSafely(json as CanonicalizedJson<unknown>);
   return !isNil(parsed) && typeof parsed === "object" && "source" in parsed
     ? canonicalizeJson((parsed as PlDataTableV5ColIdWrapper).source)
     : json;


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the v5→v6 table state migration by making `unwrapV5ColId` tolerant of row-number sentinel values that are stored as plain JSON literals rather than `{source, labeled}` wrapper objects — the previous `parseJson` call would throw on these, breaking migration for any user whose grid state included such a sentinel. A new `safeParseJson` utility is added to `@milaboratories/pl-model-common` to enable the graceful fallback.

- `unwrapV5ColId` now uses `safeParseJson` + a runtime shape-check (`"source" in parsed`) to distinguish real v5 wrappers from pass-through sentinels, and a `PlDataTableV5ColIdWrapper` type cast replaces the former unsafe assertion.
- `safeParseJson<T, F>` is introduced in `json.ts` as a reusable utility that returns a typed fallback (`undefined` by default) on parse failure.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the migration fix is correctly scoped and the new utility is straightforward.

The core migration logic in `state-migration.ts` is sound and the `safeParseJson` addition is well-typed. The only nit is an accidental `//` placeholder left in `json.ts` where the `eslint-disable-next-line` comment was — if the lint rule is still active, CI would surface this.

`lib/model/common/src/json.ts` — verify the empty `//` comment doesn't leave the `Function` type unguarded under the active lint config.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/json.ts | Adds `safeParseJson` utility; incidentally replaces an eslint-disable comment with a bare `//` that no longer suppresses the lint warning on `Function`. |
| sdk/model/src/components/PlDataTable/state-migration.ts | Fixes `unwrapV5ColId` to gracefully pass through row-number sentinel values (non-wrapper colIds) instead of throwing on `parseJson`; logic and typing look correct. |
| .changeset/lucky-cobras-exist.md | Standard changeset entry marking a patch release for both affected packages. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/common/src/json.ts:13-14
The eslint-disable comment was replaced with a bare `//` that has no effect. If `@typescript-eslint/no-unsafe-function-type` is still enabled in the project's lint config, this line will trigger a lint error on the `Function` type reference below it. The comment should either be restored or removed entirely if the rule is now globally disabled.

```suggestion
// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
type NotAssignableToJson = bigint | symbol | Function;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: correct table migration to v6"](https://github.com/milaboratory/platforma/commit/54b2272ad470f036f32bdaaf975458e2327520fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31137125)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->