### PR TITLE
MILAB-5815: optional user creation contract update

### DIFF
--- a/.changeset/whole-birds-cry.md
+++ b/.changeset/whole-birds-cry.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-client": minor
+"@platforma-sdk/pl-cli": minor
+---
+
+Support fresh contract of user root creation

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -1604,7 +1604,9 @@ message AuthAPI {
   message GetUserRoot {
     message Request {
       string login = 1;
-      bool do_not_create = 2;
+      bool create_if_not_exists = 3;
+
+      // next free: 4;
     }
 
     message Response {

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -792,7 +792,7 @@ components:
       properties:
         login:
           type: string
-        doNotCreate:
+        createIfNotExists:
           type: boolean
     AuthAPI_GetUserRoot_Response:
       type: object

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -184,8 +184,16 @@ export class PlClient {
    * @returns SignedResourceId of the user root, or undefined if the server returned no userRoot entry.
    * @throws if the backend does not implement ListUserResources (callers should catch with isUnimplementedError).
    */
+  public async getUserRoot(opts: {
+    login?: string;
+    createIfNotExists: true;
+  }): Promise<SignedResourceId>;
+  public async getUserRoot(opts?: {
+    login?: string;
+    createIfNotExists?: boolean;
+  }): Promise<SignedResourceId | undefined>;
   public async getUserRoot(
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     return this.userResources.getUserRoot(opts);
   }
@@ -251,7 +259,7 @@ export class PlClient {
       this._ll = await this.buildLLPlClient(true, wireProtocol);
     }
 
-    const userRoot = await this.userResources.getUserRoot();
+    const userRoot = await this.userResources.getUserRoot({ createIfNotExists: true });
 
     if (this.conf.alternativeRoot === undefined) {
       this._clientRoot = userRoot;

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -593,14 +593,14 @@ export class LLPlClient implements WireClientProviderFactory {
   }
 
   public async getUserRoot(
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<grpcTypes.AuthAPI_GetUserRoot_Response> {
     const cl = this.clientProvider.get();
     if (cl instanceof GrpcPlApiClient) {
       return (
         await cl.getUserRoot({
           login: opts.login ?? "",
-          doNotCreate: opts.doNotCreate ?? false,
+          createIfNotExists: opts.createIfNotExists ?? false,
         })
       ).response;
     } else {
@@ -609,7 +609,7 @@ export class LLPlClient implements WireClientProviderFactory {
           await cl.POST("/v1/auth/user-root", {
             body: {
               login: opts.login ?? "",
-              doNotCreate: opts.doNotCreate ?? false,
+              createIfNotExists: opts.createIfNotExists ?? false,
             },
           })
         ).data,

--- a/lib/node/pl-client/src/core/user_resources.ts
+++ b/lib/node/pl-client/src/core/user_resources.ts
@@ -52,7 +52,7 @@ type BackendCapability = "getUserRoot" | "listUserResources" | "legacy";
  *
  * Detects backend capability on the first getUserRoot() call and remembers
  * the result. Three-tier fallback:
- * 1. getUserRoot RPC (newest, supports doNotCreate)
+ * 1. getUserRoot RPC (newest, supports createIfNotExists)
  * 2. listUserResources RPC (streams all resources, picks userRoot)
  * 3. Named resource lookup/creation via transaction (legacy)
  */
@@ -73,15 +73,13 @@ export class UserResources {
    * 2. listUserResources RPC
    * 3. Named resource lookup/creation via transaction (legacy)
    */
-  async getUserRoot(): Promise<SignedResourceId>;
-  async getUserRoot(opts: { login?: string }): Promise<SignedResourceId>;
-  async getUserRoot(opts: { login?: string; doNotCreate: false }): Promise<SignedResourceId>;
-  async getUserRoot(opts: {
+  async getUserRoot(opts: { login?: string; createIfNotExists: true }): Promise<SignedResourceId>;
+  async getUserRoot(opts?: {
     login?: string;
-    doNotCreate: true;
+    createIfNotExists?: boolean;
   }): Promise<SignedResourceId | undefined>;
   async getUserRoot(
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     if (this.backendCapability === undefined) {
       return await this.detectAndGetUserRoot(opts);
@@ -89,8 +87,16 @@ export class UserResources {
     return await this.getUserRootWith(this.backendCapability, opts);
   }
 
+  private async detectAndGetUserRoot(opts: {
+    login?: string;
+    createIfNotExists: true;
+  }): Promise<SignedResourceId>;
+  private async detectAndGetUserRoot(opts?: {
+    login?: string;
+    createIfNotExists?: boolean;
+  }): Promise<SignedResourceId | undefined>;
   private async detectAndGetUserRoot(
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     // 1. Try getUserRoot RPC
     try {
@@ -117,7 +123,15 @@ export class UserResources {
 
   private async getUserRootWith(
     capability: BackendCapability,
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists: true },
+  ): Promise<SignedResourceId>;
+  private async getUserRootWith(
+    capability: BackendCapability,
+    opts?: { login?: string; createIfNotExists?: boolean },
+  ): Promise<SignedResourceId | undefined>;
+  private async getUserRootWith(
+    capability: BackendCapability,
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     switch (capability) {
       case "getUserRoot":
@@ -134,7 +148,7 @@ export class UserResources {
    * Always fetches fresh from the server (no caching).
    */
   async getDataLibraries(
-    opts: { login?: string; doNotCreateUserRoot?: boolean } = {},
+    opts: { login?: string; createUserRootIfNotExists?: boolean } = {},
   ): Promise<ReadonlyMap<string, StorageInfo>> {
     if (this.backendCapability === undefined) {
       // First call — detect backend capability
@@ -158,24 +172,23 @@ export class UserResources {
     return await this.getDataLibrariesViaLegacy();
   }
 
-  private async getUserRootViaRpc(opts: { login?: string }): Promise<SignedResourceId>;
   private async getUserRootViaRpc(opts: {
     login?: string;
-    doNotCreate: false;
+    createIfNotExists: true;
   }): Promise<SignedResourceId>;
-  private async getUserRootViaRpc(opts: {
+  private async getUserRootViaRpc(opts?: {
     login?: string;
-    doNotCreate: true;
+    createIfNotExists?: boolean;
   }): Promise<SignedResourceId | undefined>;
   private async getUserRootViaRpc(
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     const resp = await this.ll.getUserRoot({
       login: opts.login,
-      doNotCreate: opts.doNotCreate,
+      createIfNotExists: opts.createIfNotExists,
     });
     if (resp.userRoot === undefined) {
-      if (opts.doNotCreate) return undefined;
+      if (!opts.createIfNotExists) return undefined;
       throw new Error("getUserRoot returned no userRoot entry");
     }
     return createSignedResourceId(
@@ -184,17 +197,16 @@ export class UserResources {
     );
   }
 
-  private async getUserRootViaList(opts: { login?: string }): Promise<SignedResourceId>;
   private async getUserRootViaList(opts: {
     login?: string;
-    doNotCreate: false;
+    createIfNotExists: true;
   }): Promise<SignedResourceId>;
-  private async getUserRootViaList(opts: {
+  private async getUserRootViaList(opts?: {
     login?: string;
-    doNotCreate: true;
+    createIfNotExists?: boolean;
   }): Promise<SignedResourceId | undefined>;
   private async getUserRootViaList(
-    opts: { login?: string; doNotCreate?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     const responses = await this.ll.listUserResources({ login: opts.login, limit: 1 });
     for (const msg of responses) {
@@ -205,7 +217,12 @@ export class UserResources {
         );
       }
     }
-    throw new Error("listUserResources returned no userRoot entry");
+
+    if (opts.createIfNotExists) {
+      throw new Error("listUserResources returned no userRoot entry");
+    }
+
+    return undefined;
   }
 
   private async getDataLibrariesViaList(
@@ -276,17 +293,16 @@ export class UserResources {
     return result;
   }
 
-  private async getUserRootViaLegacy(opts: { login?: string }): Promise<SignedResourceId>;
   private async getUserRootViaLegacy(opts: {
     login?: string;
-    doNotCreateUserRoot: false;
+    createIfNotExists: true;
   }): Promise<SignedResourceId>;
-  private async getUserRootViaLegacy(opts: {
+  private async getUserRootViaLegacy(opts?: {
     login?: string;
-    doNotCreateUserRoot: true;
+    createIfNotExists?: boolean;
   }): Promise<SignedResourceId | undefined>;
   private async getUserRootViaLegacy(
-    opts: { login?: string; doNotCreateUserRoot?: boolean } = {},
+    opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<SignedResourceId | undefined> {
     const login = opts.login ?? this.authUser;
     const mainRootName =
@@ -297,7 +313,7 @@ export class UserResources {
         return await tx.getResourceByName(mainRootName);
       }
 
-      if (opts.doNotCreateUserRoot) {
+      if (!opts.createIfNotExists) {
         return undefined;
       }
 

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -3520,9 +3520,9 @@ export interface AuthAPI_GetUserRoot_Request {
      */
     login: string;
     /**
-     * @generated from protobuf field: bool do_not_create = 2
+     * @generated from protobuf field: bool create_if_not_exists = 3
      */
-    doNotCreate: boolean;
+    createIfNotExists: boolean;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.GetUserRoot.Response
@@ -17635,13 +17635,13 @@ class AuthAPI_GetUserRoot_Request$Type extends MessageType<AuthAPI_GetUserRoot_R
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.GetUserRoot.Request", [
             { no: 1, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "do_not_create", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 3, name: "create_if_not_exists", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_GetUserRoot_Request>): AuthAPI_GetUserRoot_Request {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.login = "";
-        message.doNotCreate = false;
+        message.createIfNotExists = false;
         if (value !== undefined)
             reflectionMergePartial<AuthAPI_GetUserRoot_Request>(this, message, value);
         return message;
@@ -17654,8 +17654,8 @@ class AuthAPI_GetUserRoot_Request$Type extends MessageType<AuthAPI_GetUserRoot_R
                 case /* string login */ 1:
                     message.login = reader.string();
                     break;
-                case /* bool do_not_create */ 2:
-                    message.doNotCreate = reader.bool();
+                case /* bool create_if_not_exists */ 3:
+                    message.createIfNotExists = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -17672,9 +17672,9 @@ class AuthAPI_GetUserRoot_Request$Type extends MessageType<AuthAPI_GetUserRoot_R
         /* string login = 1; */
         if (message.login !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.login);
-        /* bool do_not_create = 2; */
-        if (message.doNotCreate !== false)
-            writer.tag(2, WireType.Varint).bool(message.doNotCreate);
+        /* bool create_if_not_exists = 3; */
+        if (message.createIfNotExists !== false)
+            writer.tag(3, WireType.Varint).bool(message.createIfNotExists);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -527,7 +527,7 @@ export interface components {
     };
     AuthAPI_GetUserRoot_Request: {
       login: string;
-      doNotCreate: boolean;
+      createIfNotExists: boolean;
     };
     AuthAPI_GetUserRoot_Response: {
       userRoot: components["schemas"]["AuthAPI_UserRoot"];

--- a/tools/pl-cli/src/project_ops.ts
+++ b/tools/pl-cli/src/project_ops.ts
@@ -235,7 +235,7 @@ export async function navigateToUserRoot(
 ): Promise<{ userRoot: SignedResourceId; projectListRid: SignedResourceId }> {
   let userRootRid: SignedResourceId | undefined;
 
-  userRootRid = await pl.getUserRoot({ login: username, doNotCreate: true });
+  userRootRid = await pl.getUserRoot({ login: username });
   if (userRootRid === undefined) {
     throw new Error(`User "${username}" not found on this server (no root resource).`);
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the `GetUserRoot` API contract, inverting the semantics of the creation flag from `doNotCreate` (opt-out) to `createIfNotExists` (opt-in), and bumping the protobuf field number from 2 to 3. All call sites, generated TypeScript types, OpenAPI schema, and gRPC/REST transport layers are updated consistently.

- The protobuf message drops `do_not_create = 2` and introduces `create_if_not_exists = 3`; old field 2 is not marked `reserved`, which leaves a gap in the wire-format history.
- `getUserRootViaRpc` and `getUserRootViaLegacy` correctly gate creation on `createIfNotExists`, but `getUserRootViaList` always throws when no user root is found, regardless of `createIfNotExists` — callers on a `listUserResources` backend expecting `undefined` will get an exception instead.
- `navigateToUserRoot` in `pl-cli` drops the now-redundant explicit flag; the default (no `createIfNotExists`) correctly means "don't create".
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The rename and logic inversion are applied correctly in most paths, but getUserRootViaList never returns undefined, which can surface as an unexpected exception for callers on a listUserResources backend.

The core rename and inverted flag logic are consistently applied across gRPC, REST, proto, and generated types. The one gap is getUserRootViaList, which unconditionally throws when no user root is found — unlike its sibling methods that honour the createIfNotExists flag and return undefined. Any client whose detected backend capability is listUserResources and that calls getUserRoot without createIfNotExists: true (e.g. navigateToUserRoot) will receive a thrown error rather than the undefined the overload contract promises.

lib/node/pl-client/src/core/user_resources.ts — specifically the getUserRootViaList implementation which does not respect the createIfNotExists flag.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/user_resources.ts | Renames doNotCreate → createIfNotExists throughout all overloads and implementations; getUserRootViaList still throws unconditionally when no root is found, breaking the undefined-return contract for the listUserResources backend path. |
| lib/node/pl-client/proto/plapi/plapiproto/api.proto | Replaces do_not_create (field 2) with create_if_not_exists (field 3); old field 2 is abandoned without a reserved statement. |
| lib/node/pl-client/src/core/client.ts | Adds overloads to getUserRoot mirroring the new createIfNotExists semantics; init() now passes createIfNotExists: true explicitly — correct. |
| lib/node/pl-client/src/core/ll_client.ts | Straightforward rename of doNotCreate → createIfNotExists in both gRPC and REST call sites. |
| tools/pl-cli/src/project_ops.ts | Drops the explicit doNotCreate: true; default behaviour (no createIfNotExists) now means "don't create", which preserves the original intent. |
| lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts | Generated protobuf TypeScript file updated to reflect field number 3 and renamed createIfNotExists; serialization/deserialization logic is consistent. |
| lib/node/pl-client/src/proto-rest/plapi.ts | REST schema type updated from doNotCreate to createIfNotExists — simple rename, no logic changes. |
| lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml | OpenAPI schema property renamed from doNotCreate to createIfNotExists to match the updated contract. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pl-client/src/core/user_resources.ts`, line 208-221 ([link](https://github.com/milaboratory/platforma/blob/c159efef8ea29ac6ea93c46e8fb4f161b3b86f9c/lib/node/pl-client/src/core/user_resources.ts#L208-L221)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`getUserRootViaList` ignores `createIfNotExists` and always throws**

   The new overload (line 204–206) declares that when `createIfNotExists` is absent the method returns `Promise<SignedResourceId | undefined>`, but the implementation body always throws `"listUserResources returned no userRoot entry"` when no entry is found — it never returns `undefined`. This breaks the contract for any caller on a `listUserResources` backend that omits `createIfNotExists: true` (e.g. `navigateToUserRoot` at `project_ops.ts:238`), which will receive an exception instead of the promised `undefined`. The sibling methods `getUserRootViaRpc` (line 191) and `getUserRootViaLegacy` (line 311) both gate creation on `createIfNotExists`, but `getUserRootViaList` has no such guard. A `if (!opts.createIfNotExists) return undefined;` branch is needed before the throw.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-client/src/core/user_resources.ts
   Line: 208-221

   Comment:
   **`getUserRootViaList` ignores `createIfNotExists` and always throws**

   The new overload (line 204–206) declares that when `createIfNotExists` is absent the method returns `Promise<SignedResourceId | undefined>`, but the implementation body always throws `"listUserResources returned no userRoot entry"` when no entry is found — it never returns `undefined`. This breaks the contract for any caller on a `listUserResources` backend that omits `createIfNotExists: true` (e.g. `navigateToUserRoot` at `project_ops.ts:238`), which will receive an exception instead of the promised `undefined`. The sibling methods `getUserRootViaRpc` (line 191) and `getUserRootViaLegacy` (line 311) both gate creation on `createIfNotExists`, but `getUserRootViaList` has no such guard. A `if (!opts.createIfNotExists) return undefined;` branch is needed before the throw.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pl-client/src/core/user_resources.ts:208-221
**`getUserRootViaList` ignores `createIfNotExists` and always throws**

The new overload (line 204–206) declares that when `createIfNotExists` is absent the method returns `Promise<SignedResourceId | undefined>`, but the implementation body always throws `"listUserResources returned no userRoot entry"` when no entry is found — it never returns `undefined`. This breaks the contract for any caller on a `listUserResources` backend that omits `createIfNotExists: true` (e.g. `navigateToUserRoot` at `project_ops.ts:238`), which will receive an exception instead of the promised `undefined`. The sibling methods `getUserRootViaRpc` (line 191) and `getUserRootViaLegacy` (line 311) both gate creation on `createIfNotExists`, but `getUserRootViaList` has no such guard. A `if (!opts.createIfNotExists) return undefined;` branch is needed before the throw.

### Issue 2 of 2
lib/node/pl-client/proto/plapi/plapiproto/api.proto:1605-1610
The old field 2 (`do_not_create`) is abandoned but not explicitly reserved. Proto3 best practice is to add a `reserved` statement so the field number can never be accidentally reused in the future, which would cause silent wire-format corruption or misinterpretation for clients that still hold old messages with field 2 set.

```suggestion
    message Request {
      string login = 1;
      reserved 2; // was: bool do_not_create = 2
      bool create_if_not_exists = 3;

      // next free: 4;
    }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-5815: optional user creation contr..."](https://github.com/milaboratory/platforma/commit/c159efef8ea29ac6ea93c46e8fb4f161b3b86f9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31163795)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->