### PR TITLE
Filter out hidden columns when deriving labels in createPlDataTableV3

### DIFF
--- a/.changeset/gentle-ants-help.md
+++ b/.changeset/gentle-ants-help.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Filter out hidden columns when deriving labels in createPlDataTableV3

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -105,12 +105,14 @@ export function createPlDataTableV3<A, U>(
   const splited = splitDiscoveredColumns(discovered);
 
   const derivedLabels = deriveAllLabels({
-    columns: discovered.map((dc) => ({
-      id: dc.column.id,
-      spec: dc.column.spec,
-      linkerPath: dc.path,
-      qualifications: dc.qualifications,
-    })),
+    columns: discovered
+      .map((dc) => ({
+        id: dc.column.id,
+        spec: dc.column.spec,
+        linkerPath: dc.path,
+        qualifications: dc.qualifications,
+      }))
+      .filter((v) => !isColumnHidden(v.spec)),
     deriveLabelsOptions: {
       includeNativeLabel: true,
       ...options.labelsOptions,


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR filters out annotation-hidden columns (those whose spec carries `Annotation.Table.Visibility = "hidden"`) from the column list passed to `deriveAllLabels`, so they no longer participate in the label-uniqueness computation and won't receive entries in the `derivedLabels` record.

- **Label derivation fix**: hidden columns were previously included in `deriveDistinctLabels`, which could cause visible-column labels to be over-qualified to disambiguate from columns that will never be shown.
- **Scope of filter**: the filter uses `isColumnHidden(v.spec)`, which checks annotation-based visibility only; columns hidden dynamically via `displayOptions.visibility` rules are still included, since those rules are evaluated later in `annotateColumnGroups`. This is consistent with the current architecture.
- **Tooltips unaffected**: `deriveAllTooltips` continues to receive the full unfiltered column list, which is fine because hidden columns have no visible tooltip surface.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a small, targeted one-liner that correctly excludes annotation-hidden columns from label derivation without touching any other data flow.

The change is minimal and self-contained: it adds a single `.filter` call on the column list before passing it to `deriveAllLabels`. The filtered-out columns still flow through every other pipeline stage unchanged (`splited`, `derivedTooltips`, `annotateColumnGroups`), so there is no risk of columns going missing from the table, filter validation, or sorting logic. The behaviour is consistent with how `computeHiddenColumns` already treats the same hidden columns downstream.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Adds `.filter((v) => !isColumnHidden(v.spec))` to the column list passed to `deriveAllLabels`, excluding annotation-hidden columns from the label uniqueness computation. |
| .changeset/gentle-ants-help.md | Standard changeset entry correctly marking the fix as a patch for `@platforma-sdk/model`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Filter out hidden columns when deriving ..."](https://github.com/milaboratory/platforma/commit/08fea2cd988ea9b5c79082e328b94e87e209831b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31297915)</sub>

<!-- /greptile_comment -->