### PR TITLE
PFrames update - fixed bug in PColumn combination

### DIFF
--- a/.changeset/full-socks-create.md
+++ b/.changeset/full-socks-create.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+---
+
+PFrames update - fixed bug in PColumn combination

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,11 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.31
-      version: 1.1.31
+      specifier: 1.1.34
+      version: 1.1.34
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.31
-      version: 1.1.31
+      specifier: 1.1.34
+      version: 1.1.34
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1856,7 +1856,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1976,10 +1976,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.31(encoding@0.1.13)
+        version: 1.1.34(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2413,10 +2413,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.31(encoding@0.1.13)
+        version: 1.1.34(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -4988,18 +4988,18 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.31':
-    resolution: {integrity: sha512-TZkCDFrNiCH+1oRrpCzmD8GvlNky0W70YgGmIDJ/4Vi/Z0bMQQPlsB1OHOz7hfoySD9a0Djc1Q7lhnLmAtnPDA==}
+  '@milaboratories/pframes-rs-node@1.1.34':
+    resolution: {integrity: sha512-ir2xi+8HcZWy2t98beRP9MUd7ng5gvmos3lALj5rgUg0SAUnN8fBvJ0gAI5AtqhgsjGLRcpr5cGBg12JXJ3Img==}
 
-  '@milaboratories/pframes-rs-serv@1.1.31':
-    resolution: {integrity: sha512-Cq/Q4H40bG4xYXNR9oJcDPZE+osMBJVdBnthxbZ0haYspoz7GWegEBW3EeeP/Aetp6G2jwMmPu/CGu/02O8X8g==}
+  '@milaboratories/pframes-rs-serv@1.1.34':
+    resolution: {integrity: sha512-Wm8LunSZIwi2B66KUVIkzTZgBUQgv4A/sBXeq3u+CDeYptU4ouCY6tpgvJsLo97IUgVtIhsM6+7/X+UGOg0Gjg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasi@1.1.31':
-    resolution: {integrity: sha512-pueH0fOgiCusD2YzlvZAD6FL1Qo2AvFc6+Jmxms+ymADgpTcd0ABYeaxGZih4hfgyJc5Zcnkea9dy+pemju8TA==}
+  '@milaboratories/pframes-rs-wasip2@1.1.34':
+    resolution: {integrity: sha512-OgmExo52JzdFdY+jJ4+75zwBBfgO8QLoosY/RN4r8cvwxZHo0PJ8Pcmw+N54/eoDCocDkuUFDmRnlCGcRzB7TQ==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.31':
-    resolution: {integrity: sha512-tLUf8FkRvrWOV6uSP1rwFlpNl0DUXkSNrrlTp5qFNFzHZSBtcVlw8bjfrJS7aCWuSMvKHQd49aNitEXF7aNbKw==}
+  '@milaboratories/pframes-rs-wasm@1.1.34':
+    resolution: {integrity: sha512-Lg4DeeoipPYMFJf8bvPIgafXurGUCoW17eRhO7+yab9mCPnM9UgoJEzQ35O46vtNywFRlOT4Op1oey2VyGehGw==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.36.0
@@ -11228,18 +11228,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/pframes-rs-node@1.1.31(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.34(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-serv': 1.1.31
+      '@milaboratories/pframes-rs-serv': 1.1.34
       '@milaboratories/pl-model-common': 1.36.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.31':
+  '@milaboratories/pframes-rs-serv@1.1.34':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-model-common': 1.36.0
@@ -11247,12 +11247,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasi@1.1.31': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.34': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasi': 1.1.31
+      '@milaboratories/pframes-rs-wasip2': 1.1.34
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -249,8 +249,8 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.31
-  "@milaboratories/pframes-rs-wasm": 1.1.31
+  "@milaboratories/pframes-rs-node": 1.1.34
+  "@milaboratories/pframes-rs-wasm": 1.1.34
 
   "quickjs-emscripten": 0.31.0
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps `@milaboratories/pframes-rs-node` and `@milaboratories/pframes-rs-wasm` from `1.1.31` to `1.1.34` to pick up a bug fix in PColumn combination, also renaming the internal `pframes-rs-wasi` sub-package to `pframes-rs-wasip2`.

- The catalog versions and lockfile are updated consistently across all importing packages.
- The `REQUIRES_PFRAMES_VERSION` constant in `lib/model/common/src/flags/block_flags.ts` was not updated from `1_001_031` to `1_001_034`; the workspace comment explicitly requires this to be done in lockstep with any version bump.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The package version bump is internally consistent, but the companion runtime version flag was not updated, meaning the compatibility guard will not reflect the new minimum version.

The REQUIRES_PFRAMES_VERSION constant in block_flags.ts is the mechanism by which blocks signal their minimum required PFrames version to the desktop app. It was not bumped from 1_001_031 to 1_001_034 alongside the package upgrade, so blocks built after this change would not enforce the 1.1.34 minimum and could silently load on older desktop apps that still carry the PColumn combination bug.

lib/model/common/src/flags/block_flags.ts — REQUIRES_PFRAMES_VERSION needs to be updated to 1_001_034.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/full-socks-create.md | New changeset entry marking patch bumps for pf-spec-driver and pf-driver for the PColumn combination bug fix. |
| pnpm-workspace.yaml | Catalog versions for pframes-rs-node and pframes-rs-wasm bumped from 1.1.31 to 1.1.34; comment reminds to update REQUIRES_PFRAMES_VERSION which was not done in this PR. |
| pnpm-lock.yaml | Lockfile updated to reflect the version bump; pframes-rs-wasi package renamed to pframes-rs-wasip2 at 1.1.34. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/model/common/src/flags/block_flags.ts`, line 32 ([link](https://github.com/milaboratory/platforma/blob/6363fde35b78330126fa30e4fde85ddffb86008c/lib/model/common/src/flags/block_flags.ts#L32)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `pframes-rs-*` packages were bumped from `1.1.31` to `1.1.34` in this PR, but `REQUIRES_PFRAMES_VERSION` still encodes `1.1.31` (`1_001_031`). The comment in `pnpm-workspace.yaml` explicitly states this constant must be updated in lockstep with the package bump. Without this update, blocks built against the new SDK will not correctly signal their minimum required PFrames version, so they could silently load on older desktop apps that lack the bug fix.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/common/src/flags/block_flags.ts
   Line: 32

   Comment:
   The `pframes-rs-*` packages were bumped from `1.1.31` to `1.1.34` in this PR, but `REQUIRES_PFRAMES_VERSION` still encodes `1.1.31` (`1_001_031`). The comment in `pnpm-workspace.yaml` explicitly states this constant must be updated in lockstep with the package bump. Without this update, blocks built against the new SDK will not correctly signal their minimum required PFrames version, so they could silently load on older desktop apps that lack the bug fix.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/common/src/flags/block_flags.ts:32
The `pframes-rs-*` packages were bumped from `1.1.31` to `1.1.34` in this PR, but `REQUIRES_PFRAMES_VERSION` still encodes `1.1.31` (`1_001_031`). The comment in `pnpm-workspace.yaml` explicitly states this constant must be updated in lockstep with the package bump. Without this update, blocks built against the new SDK will not correctly signal their minimum required PFrames version, so they could silently load on older desktop apps that lack the bug fix.

```suggestion
export const REQUIRES_PFRAMES_VERSION = 1_001_034;
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames update - fixed bug in PColumn co..."](https://github.com/milaboratory/platforma/commit/6363fde35b78330126fa30e4fde85ddffb86008c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31312654)</sub>

<!-- /greptile_comment -->