### PR TITLE
Cell button for labelled-axis cols

### DIFF
--- a/.changeset/cell-button-labelled-axis.md
+++ b/.changeset/cell-button-labelled-axis.md
@@ -1,0 +1,6 @@
+---
+"@platforma-sdk/ui-vue": patch
+"@milaboratories/uikit": patch
+---
+
+Fix `@cell-button-clicked` not firing on PlAgDataTableV2 when the configured axis has a label column. Since the predefined-label change in 1.75.0, labelled axes are replaced in the grid by their label column, so the cell-button cellRendererSelector — which only matched `type:"axis"` ColDefs — never installed. Now also resolve the axis on single-axis label columns whose labeled axis equals `showCellButtonForAxisId`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ catalogs:
       specifier: ^4.1.3
       version: 4.1.3
     vue:
-      specifier: ^3.5.24
+      specifier: 3.5.24
       version: 3.5.24
     vue-tsc:
       specifier: ^3.2.6
@@ -4343,11 +4343,6 @@ packages:
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
@@ -4368,10 +4363,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -8435,10 +8426,6 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -10531,10 +10518,6 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
-
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
@@ -10564,11 +10547,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -12795,7 +12773,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.24':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.5.24
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -12808,14 +12786,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.24':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/compiler-core': 3.5.24
       '@vue/compiler-dom': 3.5.24
       '@vue/compiler-ssr': 3.5.24
       '@vue/shared': 3.5.24
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.8
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.24':
@@ -14957,12 +14935,6 @@ snapshots:
       tslib: 2.8.1
 
   pluralize@8.0.0: {}
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -256,7 +256,7 @@ catalog:
 
   # UI
 
-  "vue": ^3.5.24
+  "vue": 3.5.24
   "@vueuse/core": ^13.3.0
   "@vueuse/integrations": ^13.3.0
   "vue-tsc": ^3.2.6

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -262,11 +262,14 @@ export function makeColDef(
     valueFormatter: columnRenderingSpec.valueFormatter,
     headerComponent: PlAgColumnHeader,
     cellRendererSelector: cellButtonAxisParams?.showCellButtonForAxisId
-      ? (params: ICellRendererParams) => {
-          if (spec.type !== "axis") return;
-
-          const axisId = (params.colDef?.context as PTableColumnSpec)?.id as AxisId;
-          if (isJsonEqual(axisId, cellButtonAxisParams.showCellButtonForAxisId)) {
+      ? () => {
+          const axisId =
+            spec.type === "axis"
+              ? spec.id
+              : isLabelColumnSpec(spec.spec) && spec.spec.axesSpec.length === 1
+                ? getAxisId(spec.spec.axesSpec[0])
+                : undefined;
+          if (axisId && isJsonEqual(axisId, cellButtonAxisParams.showCellButtonForAxisId)) {
             return {
               component: PlAgTextAndButtonCell,
               params: {


### PR DESCRIPTION
PlAgDataTableV2's cellRendererSelector matched
`showCellButtonForAxisId` only against type:"axis" ColDefs. Since the predefined-label change in 1.75.0, axes that have a label column are dropped from the grid and the label column is shown in their place — so the configured axis no longer has a ColDef to attach the button to and `@cell-button-clicked` never fires.

Resolve the axis on single-axis label columns too (mirroring the existing lockPosition loosening), so the button surfaces on whichever ColDef substitutes for the labelled axis.

Also pin Vue to 3.5.24 exactly; the @babel/parser and postcss bumps in the lockfile are fallout from the reinstall.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `@cell-button-clicked` never firing on `PlAgDataTableV2` when the target axis has a label column. Since v1.75.0, labelled axes are replaced in the grid by their label column, so the old `cellRendererSelector` — which only matched `type:"axis"` ColDefs — had no ColDef to attach to.

- In `table-source-v2.ts`, `cellRendererSelector` now reads `params.colDef?.context` and resolves the axis ID from either a direct axis column or a single-axis label column (mirroring the existing `lockPosition` logic), so the cell button surfaces on whichever ColDef substitutes for the labelled axis.
- Vue is pinned to exactly `3.5.24` in `pnpm-workspace.yaml` (was `^3.5.24`), with the resulting `@babel/parser` and `postcss` lockfile churn as noted in the PR description.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the fix is a narrow, well-scoped extension to the cellRendererSelector that mirrors the already-correct lockPosition logic.

The core TypeScript change is straightforward: it reads axis identity from the ColDef context and resolves it from either an axis column or a single-axis label column, exactly mirroring the existing lockPosition condition. The only open question is whether the @milaboratories/uikit entry in the changeset is intentional (likely a re-export relationship), which is worth a quick confirm but does not affect runtime correctness. The lockfile churn is mechanical and expected.

.changeset/cell-button-labelled-axis.md — confirm the @milaboratories/uikit bump is intentional.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts | Core fix: cellRendererSelector now resolves the axis ID from both direct axis ColDefs and single-axis label column ColDefs, matching the existing lockPosition condition exactly. |
| .changeset/cell-button-labelled-axis.md | Changeset lists both @platforma-sdk/ui-vue and @milaboratories/uikit as patch bumps, but no uikit source files are changed in this PR; may be correct if uikit re-exports the component. |
| pnpm-workspace.yaml | Vue version specifier tightened from ^3.5.24 to exact 3.5.24 to prevent unintended minor/patch upgrades. |
| pnpm-lock.yaml | Lockfile-only changes: removes older @babel/parser@7.28.5 and postcss@8.5.6 snapshots, updates Vue SFC compiler dependencies to @babel/parser@7.29.2 and postcss@8.5.8 as a side-effect of the reinstall. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cellRendererSelector called"] --> B["Read colSpec from params.colDef?.context"]
    B --> C{colSpec exists?}
    C -- No --> Z["return undefined - default renderer"]
    C -- Yes --> D{colSpec.type is axis?}
    D -- Yes --> E["axisId = colSpec.id"]
    D -- No --> F{isLabelColumnSpec AND axesSpec.length === 1?}
    F -- Yes --> G["axisId = getAxisId of axesSpec at 0"]
    F -- No --> Z
    E --> H{axisId matches showCellButtonForAxisId?}
    G --> H
    H -- No --> Z
    H -- Yes --> I["Return PlAgTextAndButtonCell with onClick trigger"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/cell-button-labelled-axis.md:2-3
**`@milaboratories/uikit` listed but no uikit files changed**

The changeset bumps `@milaboratories/uikit` as a patch alongside `@platforma-sdk/ui-vue`, but no uikit source files appear in this PR's diff. If uikit re-exports `PlAgDataTableV2` (or otherwise bundles ui-vue's output), the entry is correct and this is fine — just worth confirming the bump is intentional and not a leftover from a previous changeset draft.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6014: cell button for labelled-axi..."](https://github.com/milaboratory/platforma/commit/89fc3adf7f61595a4eb66ebc8aeefff4ceb5b6d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31335088)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->