### PR TITLE
PlDatasetSelector: single dropdown for datasets and filters

### DIFF
--- a/.changeset/pl-dataset-selector-single-dropdown.md
+++ b/.changeset/pl-dataset-selector-single-dropdown.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/ui-vue": minor
+---
+
+`PlDatasetSelector` now renders datasets and their filters in a single dropdown — each dataset row is followed by its filter rows, with the parent dataset label shown as the row description. Removed the `filterLabel` and `filterPlaceholder` props (no longer applicable).

--- a/etc/blocks/ui-examples/ui/src/pages/PlDatasetSelectorPage.vue
+++ b/etc/blocks/ui-examples/ui/src/pages/PlDatasetSelectorPage.vue
@@ -37,7 +37,7 @@ const optionsBase: DatasetOption[] = [
       { label: "High confidence", ref: filterHighConfidence },
     ],
   },
-  // No `filters` — component hides the filter dropdown when this is picked.
+  // No filters — only the primary row is rendered.
   { primary: { label: "Raw — Clonotypes", ref: datasetWithoutFilters } },
 ];
 
@@ -68,8 +68,7 @@ const emptyOptions = computed<readonly DatasetOption[] | undefined>(() =>
             :disabled="data.disabled"
             :clearable="data.clearable"
             :required="data.required"
-            label="Dataset with filters"
-            filter-label="Filter"
+            label="Dataset"
             loading-options-helper="Loading datasets…"
           />
 

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -1,10 +1,13 @@
 <script lang="ts">
 /**
- * Select a dataset and (optionally) a filter column, emitting a {@link DatasetSelection}.
+ * Select a dataset or one of its filters in a single dropdown, emitting a
+ * {@link DatasetSelection}.
  *
- * The filter dropdown is always rendered and is clearable — leaving it empty
- * means "no filter". When the selected dataset has no compatible filters, the
- * dropdown opens to an empty option list.
+ * Each `DatasetOption` contributes one row for its primary plus one row per
+ * filter — filters are listed directly underneath their parent dataset and
+ * carry the parent's primary label as the row description. Filter labels are
+ * derived by `buildDatasetOptions` from each filter column's latest
+ * `pl7.app/trace` step (the producing block's self-description).
  *
  * The emitted value bundles the user's pick (`primary`) with the auto-attached
  * `enrichments` payload from the matching `DatasetOption`. Enrichments are
@@ -19,7 +22,7 @@ export default {
 import type { DatasetOption, DatasetSelection, PlRef } from "@platforma-sdk/model";
 import { createDatasetSelection, createPrimaryRef, plRefsEqual } from "@platforma-sdk/model";
 import type { ListOption } from "@milaboratories/uikit";
-import { PlDropdown, PlDropdownRef } from "@milaboratories/uikit";
+import { PlDropdown } from "@milaboratories/uikit";
 import { computed } from "vue";
 
 const slots = defineSlots<{
@@ -32,25 +35,21 @@ const props = withDefaults(
   defineProps<{
     /** Available datasets, each optionally carrying compatible filter choices. */
     options?: Readonly<DatasetOption[]>;
-    /** Label above the dataset dropdown. */
+    /** Label above the dropdown. */
     label?: string;
-    /** Helper text below the dataset dropdown (shown when there is no error). */
+    /** Helper text below the dropdown (shown when there is no error). */
     helper?: string;
     /** Helper text shown while `options` is undefined (loading). */
     loadingOptionsHelper?: string;
-    /** Error message displayed below the dataset dropdown. */
+    /** Error message displayed below the dropdown. */
     error?: unknown;
-    /** Placeholder when no dataset is selected. */
+    /** Placeholder when nothing is selected. */
     placeholder?: string;
-    /** Label above the filter dropdown. */
-    filterLabel?: string;
-    /** Placeholder for the filter dropdown. */
-    filterPlaceholder?: string;
-    /** Show a clear button on the dataset dropdown. */
+    /** Show a clear button. */
     clearable?: boolean;
-    /** Mark the dataset dropdown as required. */
+    /** Mark the dropdown as required. */
     required?: boolean;
-    /** Disable all interaction. */
+    /** Disable interaction. */
     disabled?: boolean;
   }>(),
   {
@@ -60,92 +59,73 @@ const props = withDefaults(
     loadingOptionsHelper: undefined,
     error: undefined,
     placeholder: "...",
-    filterLabel: "",
-    filterPlaceholder: "...",
     clearable: false,
     required: false,
     disabled: false,
   },
 );
 
-const selectedDataset = computed<PlRef | undefined>(() => model.value?.primary.column);
+type Selection = { primary: PlRef; filter?: PlRef };
 
-const selectedFilter = computed<PlRef | undefined>(() => model.value?.primary.filter);
-
-const currentDatasetOption = computed<DatasetOption | undefined>(() => {
-  const dataset = selectedDataset.value;
-  if (!dataset) return undefined;
-  return props.options?.find((o) => plRefsEqual(o.primary.ref, dataset, true));
+const selectionValue = computed<Selection | undefined>(() => {
+  const primary = model.value?.primary;
+  if (primary === undefined) return undefined;
+  return primary.filter === undefined
+    ? { primary: primary.column }
+    : { primary: primary.column, filter: primary.filter };
 });
 
-// PlDropdownRef expects `Option[]`; project the primary out of each entry.
-const primaryOptions = computed<readonly { ref: PlRef; label: string }[] | undefined>(() =>
-  props.options?.map((o) => o.primary),
-);
+// `deepEqual` (used by PlDropdown for matching) treats `{a, b: undefined}` and
+// `{a}` as different shapes, so the option list and the selection value must
+// agree on filter-key presence.
+const dropdownOptions = computed<ListOption<Selection>[] | undefined>(() => {
+  if (props.options === undefined) return undefined;
+  const out: ListOption<Selection>[] = [];
+  for (const o of props.options) {
+    out.push({ label: o.primary.label, value: { primary: o.primary.ref } });
+    for (const filter of o.filters ?? []) {
+      out.push({
+        label: filter.label,
+        description: o.primary.label,
+        value: { primary: o.primary.ref, filter: filter.ref },
+      });
+    }
+  }
+  return out;
+});
 
-const filterOptions = computed<ListOption<PlRef>[]>(
-  () => currentDatasetOption.value?.filters?.map((f) => ({ label: f.label, value: f.ref })) ?? [],
-);
-
-// Resolve from `props.options` directly — `currentDatasetOption` may not have
-// recomputed yet when this runs synchronously inside a change handler.
-function findOption(dataset: PlRef): DatasetOption | undefined {
-  return props.options?.find((o) => plRefsEqual(o.primary.ref, dataset, true));
+function findOption(primary: PlRef): DatasetOption | undefined {
+  return props.options?.find((o) => plRefsEqual(o.primary.ref, primary, true));
 }
 
-function onDatasetChange(dataset: PlRef | undefined) {
-  if (dataset === undefined) {
+function onChange(selection: Selection | undefined) {
+  if (selection === undefined) {
     model.value = undefined;
     return;
   }
-  model.value = createDatasetSelection(createPrimaryRef(dataset), findOption(dataset)?.enrichments);
-}
-
-function onFilterChange(filter: PlRef | undefined) {
-  const dataset = selectedDataset.value;
-  if (!dataset) return;
   model.value = createDatasetSelection(
-    createPrimaryRef(dataset, filter),
-    findOption(dataset)?.enrichments,
+    createPrimaryRef(selection.primary, selection.filter),
+    findOption(selection.primary)?.enrichments,
   );
 }
 </script>
 
 <template>
-  <div class="pl-dataset-selector">
-    <PlDropdownRef
-      :model-value="selectedDataset"
-      :options="primaryOptions"
-      :label="label"
-      :helper="helper"
-      :loading-options-helper="loadingOptionsHelper"
-      :error="error"
-      :placeholder="placeholder"
-      :clearable="clearable"
-      :required="required"
-      :disabled="disabled"
-      @update:model-value="onDatasetChange"
-    >
-      <template v-if="slots.tooltip" #tooltip>
-        <slot name="tooltip" />
-      </template>
-    </PlDropdownRef>
-    <PlDropdown
-      :model-value="selectedFilter"
-      :options="filterOptions"
-      :label="filterLabel"
-      :placeholder="filterPlaceholder"
-      :disabled="disabled"
-      clearable
-      @update:model-value="onFilterChange"
-    />
-  </div>
+  <PlDropdown
+    :model-value="selectionValue"
+    :options="dropdownOptions"
+    :label="label"
+    :helper="helper"
+    :loading-options-helper="loadingOptionsHelper"
+    :error="error"
+    :placeholder="placeholder"
+    :clearable="clearable"
+    :required="required"
+    :disabled="disabled"
+    @update:model-value="onChange"
+  >
+    <template v-if="slots.tooltip" #tooltip>
+      <slot name="tooltip" />
+    </template>
+  </PlDropdown>
 </template>
-
-<style scoped>
-.pl-dataset-selector {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-</style>

--- a/sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts
@@ -24,17 +24,11 @@ const optionsWithFilters: DatasetOption[] = [
     ],
     enrichments: enrichmentsA,
   },
-  // Dataset B has no filters — filter dropdown is rendered but with no options.
+  // Dataset B has no filters — it appears as a single row with no children.
   { primary: { label: "Dataset B", ref: datasetB } },
 ];
 
-const datasetC = createPlRef("3", "out-c", true);
-
 const optionsNoFilters: DatasetOption[] = [{ primary: { label: "Dataset B", ref: datasetB } }];
-
-const optionsWithEmptyFilters: DatasetOption[] = [
-  { primary: { label: "Dataset C", ref: datasetC }, filters: [] },
-];
 
 function selection(
   ref: typeof datasetA,
@@ -45,57 +39,46 @@ function selection(
 }
 
 async function pickOption(index: number) {
-  const options = [...document.body.querySelectorAll(".dropdown-list-item")] as HTMLElement[];
-  options[index].click();
+  const items = [...document.body.querySelectorAll(".dropdown-list-item")] as HTMLElement[];
+  items[index].click();
   await flushPromises();
 }
 
 describe("PlDatasetSelector", () => {
-  it("always renders both dataset and filter dropdowns", async () => {
+  it("renders a single dropdown that lists datasets and filters together", async () => {
     const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: undefined, options: optionsNoFilters },
+      props: { modelValue: undefined, options: optionsWithFilters },
       attachTo: document.body,
     });
     await flushPromises();
 
-    const selector = wrapper.find(".pl-dataset-selector");
-    expect(selector.exists()).toBe(true);
-    expect(selector.element.children.length).toBe(2);
+    expect(wrapper.findAll("input").length).toBe(1);
+    await wrapper.find("input").trigger("focus");
+
+    const items = document.body.querySelectorAll(".dropdown-list-item");
+    // Dataset A + 2 filters under it + Dataset B.
+    expect(items.length).toBe(4);
     wrapper.unmount();
   });
 
-  it("filter dropdown is rendered when the selected dataset has filters", async () => {
+  it("uses the filter option's label as the row's display label", async () => {
     const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: selection(datasetA), options: optionsWithFilters },
+      props: { modelValue: undefined, options: optionsWithFilters },
       attachTo: document.body,
     });
     await flushPromises();
 
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(2);
+    await wrapper.find("input").trigger("focus");
+    const items = [...document.body.querySelectorAll(".dropdown-list-item")] as HTMLElement[];
+    expect(items[1].textContent).toContain("Top 1000");
+    expect(items[2].textContent).toContain("High quality");
     wrapper.unmount();
   });
 
-  it("filter dropdown is still rendered (with no options) when the selected dataset has no filters", async () => {
-    const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: selection(datasetB), options: optionsWithFilters },
-      attachTo: document.body,
-    });
-    await flushPromises();
-
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(2);
-
-    // Opening the filter dropdown shows no options.
-    const inputs = wrapper.findAll("input");
-    expect(inputs.length).toBe(2);
-    await inputs[1].trigger("focus");
-    expect(document.body.querySelectorAll(".dropdown-list-item").length).toBe(0);
-    wrapper.unmount();
-  });
-
-  it("emits DatasetSelection bundling primary + enrichments when dataset changes", async () => {
+  it("emits DatasetSelection bundling primary + enrichments when a dataset is picked", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: selection(datasetA, filterA1, enrichmentsA),
+        modelValue: undefined,
         options: optionsWithFilters,
         "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
           wrapper.setProps({ modelValue: e }),
@@ -104,25 +87,25 @@ describe("PlDatasetSelector", () => {
     });
     await flushPromises();
 
-    const inputs = wrapper.findAll("input");
-    await inputs[0].trigger("focus");
-    // Dataset A is index 0; pick Dataset B (index 1) — has no enrichments.
-    await pickOption(1);
+    await wrapper.find("input").trigger("focus");
+    // Items in order: Dataset A, filterA1, filterA2, Dataset B.
+    await pickOption(0);
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
     const last = emitted![emitted!.length - 1][0] as DatasetSelection;
     expect(last).toEqual({
       __isDatasetSelection: "v1",
-      primary: { __isPrimaryRef: "v1", column: datasetB },
+      primary: { __isPrimaryRef: "v1", column: datasetA },
+      enrichments: enrichmentsA,
     });
     wrapper.unmount();
   });
 
-  it("emits DatasetSelection with filter set when a filter is picked", async () => {
+  it("emits DatasetSelection with filter set when a filter row is picked", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
-        modelValue: selection(datasetA, undefined, enrichmentsA),
+        modelValue: undefined,
         options: optionsWithFilters,
         "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
           wrapper.setProps({ modelValue: e }),
@@ -131,11 +114,9 @@ describe("PlDatasetSelector", () => {
     });
     await flushPromises();
 
-    const inputs = wrapper.findAll("input");
-    expect(inputs.length).toBe(2);
-    await inputs[1].trigger("focus");
-    // Options: [Top 1000, High quality]. Pick "Top 1000".
-    await pickOption(0);
+    await wrapper.find("input").trigger("focus");
+    // Pick filterA1 — index 1 in the flat list.
+    await pickOption(1);
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
@@ -148,72 +129,7 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("emits DatasetSelection with no filter key when the filter dropdown is cleared", async () => {
-    const wrapper = mount(PlDatasetSelector, {
-      props: {
-        modelValue: selection(datasetA, filterA1, enrichmentsA),
-        options: optionsWithFilters,
-        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
-          wrapper.setProps({ modelValue: e }),
-      },
-      attachTo: document.body,
-    });
-    await flushPromises();
-
-    // The filter dropdown is the second .clear button (the first belongs to
-    // the dataset dropdown, but it's only present when the dataset selector
-    // itself is clearable; here only the filter is clearable by default).
-    const clearBtns = wrapper.findAll(".clear");
-    expect(clearBtns.length).toBeGreaterThan(0);
-    await clearBtns[clearBtns.length - 1].trigger("click");
-
-    const emitted = wrapper.emitted("update:modelValue");
-    expect(emitted).toBeDefined();
-    const last = emitted![emitted!.length - 1][0] as DatasetSelection;
-    expect(last.primary).toEqual({ __isPrimaryRef: "v1", column: datasetA });
-    expect("filter" in last.primary).toBe(false);
-    expect(last.enrichments).toEqual(enrichmentsA);
-    wrapper.unmount();
-  });
-
-  it("filter dropdown is still rendered (with no options) when dataset has filters: [] (empty array)", async () => {
-    const wrapper = mount(PlDatasetSelector, {
-      props: { modelValue: selection(datasetC), options: optionsWithEmptyFilters },
-      attachTo: document.body,
-    });
-    await flushPromises();
-
-    expect(wrapper.find(".pl-dataset-selector").element.children.length).toBe(2);
-
-    const inputs = wrapper.findAll("input");
-    await inputs[1].trigger("focus");
-    expect(document.body.querySelectorAll(".dropdown-list-item").length).toBe(0);
-    wrapper.unmount();
-  });
-
-  it("does not emit on mount when no filter is selected", async () => {
-    const wrapper = mount(PlDatasetSelector, {
-      props: {
-        modelValue: selection(datasetA),
-        options: optionsWithFilters,
-        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
-          wrapper.setProps({ modelValue: e }),
-      },
-      attachTo: document.body,
-    });
-    await flushPromises();
-
-    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
-
-    const inputs = wrapper.findAll("input");
-    expect(inputs.length).toBe(2);
-    await inputs[1].trigger("focus");
-    const items = document.body.querySelectorAll(".dropdown-list-item");
-    expect(items.length).toBe(2); // Top 1000, High quality — no synthetic "No filter"
-    wrapper.unmount();
-  });
-
-  it("emits DatasetSelection without enrichments when the option carries none", async () => {
+  it("emits DatasetSelection without enrichments when the picked option carries none", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
         modelValue: undefined,
@@ -225,8 +141,7 @@ describe("PlDatasetSelector", () => {
     });
     await flushPromises();
 
-    const inputs = wrapper.findAll("input");
-    await inputs[0].trigger("focus");
+    await wrapper.find("input").trigger("focus");
     await pickOption(0);
 
     const emitted = wrapper.emitted("update:modelValue");
@@ -240,7 +155,7 @@ describe("PlDatasetSelector", () => {
     wrapper.unmount();
   });
 
-  it("emits undefined when cleared via the dataset dropdown", async () => {
+  it("emits undefined when cleared", async () => {
     const wrapper = mount(PlDatasetSelector, {
       props: {
         modelValue: selection(datasetA, filterA1, enrichmentsA),
@@ -253,15 +168,30 @@ describe("PlDatasetSelector", () => {
     });
     await flushPromises();
 
-    // First .clear button is on the dataset dropdown (clearable: true).
-    const clearBtns = wrapper.findAll(".clear");
-    expect(clearBtns.length).toBeGreaterThan(0);
-    await clearBtns[0].trigger("click");
+    const clearBtn = wrapper.find(".clear");
+    expect(clearBtn.exists()).toBe(true);
+    await clearBtn.trigger("click");
 
     const emitted = wrapper.emitted("update:modelValue");
     expect(emitted).toBeDefined();
     const last = emitted![emitted!.length - 1][0];
     expect(last).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("does not emit on mount when a value is provided", async () => {
+    const wrapper = mount(PlDatasetSelector, {
+      props: {
+        modelValue: selection(datasetA),
+        options: optionsWithFilters,
+        "onUpdate:modelValue": (e: DatasetSelection | undefined) =>
+          wrapper.setProps({ modelValue: e }),
+      },
+      attachTo: document.body,
+    });
+    await flushPromises();
+
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Summary

- `PlDatasetSelector` collapses its previous two-dropdown layout (dataset + filter) into a single dropdown. Each dataset row is followed by its filter rows directly underneath, with the parent dataset label shown as the row description so the user can tell which dataset a filter belongs to.
- Removed the now-irrelevant `filterLabel` and `filterPlaceholder` props.
- Filter labels continue to be derived by `buildDatasetOptions` via `deriveDistinctLabels` — no behavior change there.
- `DatasetSelection` shape is unchanged, so block authors using the picker need no model/workflow updates.

The example page (`etc/blocks/ui-examples`) and tests are updated to match.

## Test plan

- [ ] `pnpm --filter @platforma-sdk/ui-vue test` — 7 jsdom tests pass
- [ ] `pnpm --filter @platforma-sdk/model --filter @platforma-sdk/ui-vue check` — tsc + lint + fmt clean
- [ ] Open `ui-examples` PlDatasetSelector page, verify single-dropdown rendering, dataset/filter selection, clear, and disabled/loading states

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR collapses `PlDatasetSelector` from a two-dropdown (dataset + filter) layout into a single flat dropdown where each dataset row is immediately followed by its filter rows (with the parent dataset name shown as the row description). The `filterLabel` and `filterPlaceholder` props are removed, and `PlDropdownRef` is replaced with `PlDropdown` backed by a new `Selection` value type.

- **Component refactor**: `dropdownOptions` builds a flat `ListOption<Selection>[]` with dataset primaries interleaved with their filters; `selectionValue` reconstructs a `Selection` from `model.value`, deliberately omitting the `filter` key when absent to match `PlDropdown`'s `deepEqual` comparator.
- **API surface change**: `filterLabel` and `filterPlaceholder` are removed as public props — this is a breaking change for any consumer currently passing them, but the changeset is bumped `minor` rather than `major`.
- **Tests**: All 7 tests are rewritten to target the new single-dropdown behavior; old two-dropdown scenarios (stale/empty filter lists) are dropped.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge once the changeset version bump is corrected from `minor` to `major`.

The refactor is well-executed — the `deepEqual` key-presence edge case is handled, enrichments flow through correctly, and all 7 tests exercise the new behavior end-to-end. The one issue is the changeset marking: removing `filterLabel` and `filterPlaceholder` from the public prop surface is a breaking change for any caller that currently passes them, so the version bump should be `major` rather than `minor`. Everything else — the component, tests, and example page — is safe to ship once that label is corrected.

`.changeset/pl-dataset-selector-single-dropdown.md` needs the version bump corrected from `minor` to `major`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue | Core component refactored from two dropdowns to one; logic is clean and the deepEqual key-presence concern is correctly handled. No functional bugs found. |
| sdk/ui-vue/src/components/PlDatasetSelector/__tests__/PlDatasetSelector.jsdomtest.ts | Tests are fully rewritten for the new layout; all relevant scenarios (render count, label display, dataset pick, filter pick, clear, no-spurious-emit) are covered. |
| .changeset/pl-dataset-selector-single-dropdown.md | Changeset is bumped `minor` despite removing public props (`filterLabel`, `filterPlaceholder`), which is a semver-breaking change that should be `major`. |
| etc/blocks/ui-examples/ui/src/pages/PlDatasetSelectorPage.vue | Example page updated to remove removed props and update label; straightforward cleanup with no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens PlDatasetSelector] --> B[Single PlDropdown opens]
    B --> C[dropdownOptions: flat list]
    C --> D[Dataset A row value: primary only]
    C --> E[Filter 1 row value: primary + filter description: Dataset A]
    C --> F[Filter 2 row value: primary + filter description: Dataset A]
    C --> G[Dataset B row value: primary only]
    D --> H{User picks option}
    E --> H
    F --> H
    G --> H
    H --> I[onChange called with Selection]
    I --> J[findOption primary to get enrichments]
    J --> K[createDatasetSelection primary + filter + enrichments]
    K --> L[emit DatasetSelection]
    M[model.value] --> N[selectionValue computed]
    N -->|filter present| O[Selection with filter key]
    N -->|filter absent| P[Selection without filter key omit key for deepEqual match]
    O --> B
    P --> B
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/pl-dataset-selector-single-dropdown.md:2
Removing public props (`filterLabel`, `filterPlaceholder`) is a semver-breaking change. Any consumer currently passing either prop will receive a TypeScript error (or a Vue runtime warning for non-TS users) after upgrading. The bump should be `major` rather than `minor` so that downstream packages are not silently broken by a patch/minor upgrade.

```suggestion
"@platforma-sdk/ui-vue": major
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["PlDatasetSelector: single dropdown for d..."](https://github.com/milaboratory/platforma/commit/fb42251892c2254a30d44dcf0abf78af65f7cfde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31358379)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->