### PR TITLE
workflow-tengo: default workdir fill perms to 0o400 (read-only)

### DIFF
--- a/.changeset/fs-fillrule-readonly-default.md
+++ b/.changeset/fs-fillrule-readonly-default.md
@@ -1,0 +1,22 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+Workdir fill rules now default to read-only (0o400). The backend hardlinks
+the input from its content-addressable archive cache to the workdir
+instead of copying — the workdir entry shares the inode with the archive
+entry and is immutable.
+
+Workflows that legitimately need a writable copy of an input (rare; it
+usually means the tool mutates the input in place, which violates
+immutability) should pass `permissions: 0o600` explicitly. The backend
+will then copy the file to a fresh inode in the workdir, leaving the
+archive entry untouched.
+
+Pairs with the FS-storage honor-request change in pl: `addFileToWorkdir`
+takes the hardlink fast path iff the rule's permissions exactly match
+`mifs.ArchiveEntryPerms` (0o400). Anything else copies. Old workflows
+built against this SDK that did not pass an explicit mode (and therefore
+relied on the previous 0o600 default) will land in the copy branch on
+upgrade — observable behaviour matches the pre-PR-1810 era for those
+flows, with the archive entry safe.

--- a/.changeset/fs-fillrule-readonly-default.md
+++ b/.changeset/fs-fillrule-readonly-default.md
@@ -7,6 +7,12 @@ the input from its content-addressable archive cache to the workdir
 instead of copying — the workdir entry shares the inode with the archive
 entry and is immutable.
 
+Three fill-rule shapes change:
+
+- `_getFileFillRule.permissions`: 0o600 → 0o400
+- `_getArchiveFillRule.extractRules.filePerms`: 0o600 → 0o400
+- `_getValueFillRule.permissions`: 0o600 → 0o400
+
 Workflows that legitimately need a writable copy of an input (rare; it
 usually means the tool mutates the input in place, which violates
 immutability) should pass `permissions: 0o600` explicitly. The backend
@@ -15,8 +21,8 @@ archive entry untouched.
 
 Pairs with the FS-storage honor-request change in pl: `addFileToWorkdir`
 takes the hardlink fast path iff the rule's permissions exactly match
-`mifs.ArchiveEntryPerms` (0o400). Anything else copies. Old workflows
-built against this SDK that did not pass an explicit mode (and therefore
-relied on the previous 0o600 default) will land in the copy branch on
-upgrade — observable behaviour matches the pre-PR-1810 era for those
-flows, with the archive entry safe.
+the archive entry's canonical mode (0o400). Anything else copies. Old
+workflows built against this SDK that did not pass an explicit mode (and
+therefore relied on the previous 0o600 default) will land in the copy
+branch on upgrade — observable behaviour matches the pre-PR-1810 era for
+those flows, with the archive entry safe.

--- a/sdk/workflow-tengo/src/workdir/index.lib.tengo
+++ b/sdk/workflow-tengo/src/workdir/index.lib.tengo
@@ -40,11 +40,26 @@ createV2 := func(allocationRef) {
 	return wdCreate.getField(_WD_CREATE_FIELD_WORKDIR)
 }
 
+// Input fill rules default to read-only (0o400). The backend hardlinks the
+// file from its content-addressable archive cache to the workdir — fast,
+// inode-shared with the archive entry, immutable.
+//
+// If a workflow legitimately needs a writable copy of an input (rare — it
+// usually means the tool mutates the input in place, which violates
+// immutability), pass permissions: 0o600 explicitly. The backend will copy
+// the file to a fresh inode in the workdir, leaving the archive entry
+// untouched. The copy costs throughput per byte; default RO is the right
+// choice for input data.
+//
+// See the symmetric note in pl: drv_fs.HashAndArchive sets the archive
+// entry to mifs.ArchiveEntryPerms (0o400). The hardlink-or-copy decision in
+// task_wd_fill.addFileToWorkdir is an exact mode comparison against that
+// constant — anything other than 0o400 forces the copy branch.
 _getFileFillRule := func(filePath, extension) {
 	return {
 		type: "file",
 		path: filePath,
-		permissions: 0o600,
+		permissions: 0o400,
 		pathKey: filePath,
 		blobKey: filePath,
 		copyOptional: false,
@@ -58,7 +73,7 @@ _getArchiveFillRule := func(dstDir, whatToExtract, archiveBlobKey) {
 		extractRules = append(extractRules, {
 			srcPath: f,
 			dstPath: f,
-			filePerms: 0o600,
+			filePerms: 0o400,
 			dirPerms: 0o700
 		})
 	}
@@ -82,7 +97,7 @@ _getValueFillRule := func(filePath) {
 	return {
 		type: "value",
 		path: filePath,
-		permissions: 0o600,
+		permissions: 0o400,
 		pathKey: filePath,
 		valueKey: filePath
 	}


### PR DESCRIPTION
## Summary

Pairs with the FS-storage honor-request change in pl ([milaboratory/pl#1830](https://github.com/milaboratory/pl/pull/1830)). The backend hardlinks the input from its content-addressable archive cache to the workdir when the rule's permissions exactly match `mifs.ArchiveEntryPerms` (0o400) and copies to a fresh inode otherwise. Default-RO inputs become the fast path; workflows that legitimately need a writable copy pass `permissions: 0o600` explicitly and pay one full copy.

### Changes

- `_getFileFillRule.permissions`: 0o600 → 0o400
- `_getArchiveFillRule.extractRules.filePerms`: 0o600 → 0o400
- `_getValueFillRule.permissions`: 0o600 → 0o400
- Doc block above `_getFileFillRule` explains the hardlink-vs-copy semantics and the 0o600 opt-out for in-place mutation.

### Backward compatibility

Audit of 58 active first-party blocks (CHANGELOG within last 12 months):

- Zero blocks pass explicit `permissions:` / `filePerms:` in fill rules.
- Zero blocks construct `WorkdirFillRule` maps directly.
- Zero blocks mutate workdir inputs in place.
- The fill-rule constructors are private (`_`-prefixed) to `workdir/index.lib.tengo`; no block has a public API to inject perms today.

Net result: every active block gets the hardlink fast path on upgrade. The pl side is symmetric: old SDK builds (0o600 default) land in the copy branch on the new backend, with observable behaviour matching the pre-PR-1810 era. The Linus rule (old block on new runtime = backend bug, never block bug) is structurally satisfied without a flag.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the default permissions for workdir fill rules from `0o600` (owner read-write) to `0o400` (owner read-only), enabling the backend to hardlink workdir inputs directly from the content-addressable archive cache instead of copying them — a transparent performance improvement for read-only inputs.

- `_getFileFillRule`, `_getArchiveFillRule`, and `_getValueFillRule` all updated from `0o600` → `0o400`; a new doc block above `_getFileFillRule` explains the hardlink-vs-copy semantics and the `0o600` opt-out.
- The PR confirms zero active first-party blocks pass explicit permissions or mutate workdir inputs in-place, so existing workflows are unaffected; old SDK builds land in the copy branch on the new backend, preserving pre-PR-1810 behaviour.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the permission change is a straightforward default-tightening with verified zero blast radius across active first-party blocks.

The core change is narrow and well-reasoned: three fill-rule constructors each get one constant swapped, and the PR author audited 58 active blocks to confirm none rely on the old writable default. The one gap worth tracking is that the documented 'pass 0o600 to opt out' escape hatch has no corresponding public builder method today, so any future block that legitimately needs in-place mutation would have to rely on internal APIs — a forward-looking concern rather than a current breakage.

sdk/workflow-tengo/src/workdir/index.lib.tengo — specifically the public builder methods (addFile, writeFile, addFromZip) if the 0o600 opt-out ever needs to be exposed.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/workdir/index.lib.tengo | Changes default workdir fill-rule permissions from 0o600 to 0o400 across all three fill-rule constructors (_getFileFillRule, _getArchiveFillRule, _getValueFillRule), adding a doc block explaining the hardlink-vs-copy semantics and the 0o600 opt-out — however, that opt-out is not currently reachable through the public builder API. |
| .changeset/fs-fillrule-readonly-default.md | Changeset entry accurately describes the permission change and its backward-compatibility behaviour for old SDK builds. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Block as Workflow Block
    participant SDK as workdir.builder (SDK)
    participant Backend as pl Backend (addFileToWorkdir)
    participant Cache as Content-Addressable Archive

    Block->>SDK: addFile(name, ref)
    SDK->>SDK: "_getFileFillRule(name) → {permissions: 0o400}"
    SDK->>Backend: "fill rules JSON (permissions=0o400)"
    Backend->>Cache: "lookup archive entry (mifs.ArchiveEntryPerms=0o400)"
    alt "permissions == 0o400 (default, new fast path)"
        Backend->>Backend: hardlink workdir entry → archive entry (no copy)
    else "permissions != 0o400 (e.g. 0o600 explicit opt-out)"
        Backend->>Backend: copy to fresh inode in workdir
    end
    Backend-->>Block: workdir ready
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/workflow-tengo/src/workdir/index.lib.tengo`, line 96-104 ([link](https://github.com/milaboratory/platforma/blob/5b0b3e292c5836c969ab6490a7c8943a279c8e70/sdk/workflow-tengo/src/workdir/index.lib.tengo#L96-L104)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`_getValueFillRule` permission change is undocumented and uses different semantics**

   The new doc block above `_getFileFillRule` explains the hardlink-vs-copy rationale in terms of the content-addressable archive cache, but that reasoning doesn't apply to value-typed fill rules: `writeFile`/`writeFiles` content is materialised fresh from a value resource, not pulled from the archive. Setting `permissions: 0o400` on value rules makes the materialised file read-only (which is a fine default), but it silently omits: (a) any mention that this change also applies to dynamically-written content, and (b) that the same 0o600 opt-out described for file rules would be needed here too if a tool ever needs to modify a value-written config in-place. A short note in `_getValueFillRule`'s existing doc block, or in the shared comment block, would close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/workflow-tengo/src/workdir/index.lib.tengo
   Line: 96-104

   Comment:
   **`_getValueFillRule` permission change is undocumented and uses different semantics**

   The new doc block above `_getFileFillRule` explains the hardlink-vs-copy rationale in terms of the content-addressable archive cache, but that reasoning doesn't apply to value-typed fill rules: `writeFile`/`writeFiles` content is materialised fresh from a value resource, not pulled from the archive. Setting `permissions: 0o400` on value rules makes the materialised file read-only (which is a fine default), but it silently omits: (a) any mention that this change also applies to dynamically-written content, and (b) that the same 0o600 opt-out described for file rules would be needed here too if a tool ever needs to modify a value-written config in-place. A short note in `_getValueFillRule`'s existing doc block, or in the shared comment block, would close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
sdk/workflow-tengo/src/workdir/index.lib.tengo:47-51
**Documented opt-out isn't reachable through the public API**

The comment and changeset both tell callers to "pass `permissions: 0o600` explicitly," but no public builder method (`addFile`, `addFiles`, `writeFile`, `writeFiles`, `addFromZip`) exposes a permissions parameter. A block author who reads this comment and wants the writable-copy behaviour has no way to request it without touching private internals. If the opt-out path is intentionally a future feature, the comment should say so to avoid confusion; if it's intended to be usable today, the public builder API needs to grow a corresponding parameter on the affected methods.

### Issue 2 of 2
sdk/workflow-tengo/src/workdir/index.lib.tengo:96-104
**`_getValueFillRule` permission change is undocumented and uses different semantics**

The new doc block above `_getFileFillRule` explains the hardlink-vs-copy rationale in terms of the content-addressable archive cache, but that reasoning doesn't apply to value-typed fill rules: `writeFile`/`writeFiles` content is materialised fresh from a value resource, not pulled from the archive. Setting `permissions: 0o400` on value rules makes the materialised file read-only (which is a fine default), but it silently omits: (a) any mention that this change also applies to dynamically-written content, and (b) that the same 0o600 opt-out described for file rules would be needed here too if a tool ever needs to modify a value-written config in-place. A short note in `_getValueFillRule`'s existing doc block, or in the shared comment block, would close this gap.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["workflow-tengo: workdir fill default per..."](https://github.com/milaboratory/platforma/commit/5b0b3e292c5836c969ab6490a7c8943a279c8e70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31517438)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->