### PR TITLE
fix: drop redundant linker "via …" suffix in deriveDistinctLabels

### DIFF
--- a/.changeset/fix-redundant-linker-suffix.md
+++ b/.changeset/fix-redundant-linker-suffix.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Fix `deriveDistinctLabels` adding redundant "via …" linker suffix to records whose native label is already unique when other records collide on a shared linker.

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -706,6 +706,28 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
     expect(deriveDistinctLabels(entries)).toEqual(["Read counts", "Read counts via Sample mapper"]);
   });
 
+  test("linker suffix is NOT added to records whose native label is already unique, even when other records collide", () => {
+    // Repro for "Cluster Id via Clone to cluster link" bug:
+    // - "Representative Sequence" exists both as a direct column and via a linker → collision
+    //   forces algorithm to include LINKER_TYPE in the type set.
+    // - As a side effect, every linked entry gets the "via …" suffix appended — including
+    //   ones whose native label ("Cluster Id") is unique and needs no disambiguation.
+    const linker = linkerSpec("Clone to cluster link");
+    const entries: Entry[] = [
+      { spec: labeledSpec("Representative Sequence", "rep_direct") },
+      {
+        spec: labeledSpec("Representative Sequence", "rep_linked"),
+        linkerPath: [{ spec: linker }],
+      },
+      { spec: labeledSpec("Cluster Id", "cluster_id"), linkerPath: [{ spec: linker }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Representative Sequence",
+      "Representative Sequence via Clone to cluster link",
+      "Cluster Id",
+    ]);
+  });
+
   test("two linker paths → both get distinguishing via-suffix", () => {
     const s = labeledSpec("Counts");
     const entries: Entry[] = [

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -152,7 +152,16 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
         forcedSet,
         separator,
       );
-      return build(minimized, false) ?? throwError("Failed to derive unique labels");
+      const minimizedLabels =
+        build(minimized, false) ?? throwError("Failed to derive unique labels");
+      return dropRedundantLinkerSuffix(
+        records,
+        minimized,
+        forceTraceElements,
+        forcedSet,
+        separator,
+        minimizedLabels,
+      );
     }
 
     additionalType++;
@@ -171,7 +180,15 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
     forcedSet,
     separator,
   );
-  return build(minimized, true) ?? throwError("Failed to derive unique labels");
+  const minimizedLabels = build(minimized, true) ?? throwError("Failed to derive unique labels");
+  return dropRedundantLinkerSuffix(
+    records,
+    minimized,
+    forceTraceElements,
+    forcedSet,
+    separator,
+    minimizedLabels,
+  );
 }
 
 // --- Pure helpers ---
@@ -359,6 +376,44 @@ function classifyTypes(
   return { mainTypes, secondaryTypes };
 }
 
+function renderRecordLabel(
+  record: EnrichedRecord,
+  includedTypes: Set<string>,
+  forceTraceElements: Set<string> | undefined,
+  separator: string,
+): string | undefined {
+  const traceParts: string[] = [];
+  const anchorParts: string[] = [];
+  let linkerLabel: string | undefined;
+  let hitLabel: string | undefined;
+
+  for (const ft of record.fullTrace) {
+    if (!(includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type))) continue;
+    if (ft.type === LINKER_TYPE) linkerLabel = ft.label;
+    else if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
+    else if (isAnchorQualType(ft.type)) anchorParts.push(ft.label);
+    else traceParts.push(ft.label);
+  }
+
+  const isEmpty =
+    traceParts.length === 0 &&
+    anchorParts.length === 0 &&
+    linkerLabel === undefined &&
+    hitLabel === undefined;
+
+  if (isEmpty) return undefined;
+
+  let label = traceParts.join(separator);
+  const append = (part: string) => {
+    label = label.length === 0 ? part : `${label} ${part}`;
+  };
+  if (linkerLabel !== undefined) append(linkerLabel);
+  for (const a of anchorParts) append(a);
+  if (hitLabel !== undefined) append(hitLabel);
+
+  return label;
+}
+
 function buildLabels(
   records: EnrichedRecord[],
   includedTypes: Set<string>,
@@ -369,43 +424,58 @@ function buildLabels(
   const result: string[] = [];
 
   for (const r of records) {
-    const traceParts: string[] = [];
-    const anchorParts: string[] = [];
-    let linkerLabel: string | undefined;
-    let hitLabel: string | undefined;
-
-    for (const ft of r.fullTrace) {
-      if (!(includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type))) continue;
-      if (ft.type === LINKER_TYPE) linkerLabel = ft.label;
-      else if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
-      else if (isAnchorQualType(ft.type)) anchorParts.push(ft.label);
-      else traceParts.push(ft.label);
-    }
-
-    const isEmpty =
-      traceParts.length === 0 &&
-      anchorParts.length === 0 &&
-      linkerLabel === undefined &&
-      hitLabel === undefined;
-
-    if (isEmpty) {
+    const rendered = renderRecordLabel(r, includedTypes, forceTraceElements, separator);
+    if (rendered === undefined) {
       if (!force) return undefined;
       result.push("Unlabeled");
       continue;
     }
-
-    let label = traceParts.join(separator);
-    const append = (part: string) => {
-      label = label.length === 0 ? part : `${label} ${part}`;
-    };
-    if (linkerLabel !== undefined) append(linkerLabel);
-    for (const a of anchorParts) append(a);
-    if (hitLabel !== undefined) append(hitLabel);
-
-    result.push(label);
+    result.push(rendered);
   }
 
   return result;
+}
+
+/**
+ * Drop the "via …" linker suffix from records whose label is already unique without it.
+ *
+ * Global minimization may include `LINKER_TYPE_FULL` solely to resolve a collision between a
+ * subset of records — but `buildLabels` then renders the suffix on every record that carries a
+ * linker trace entry, including ones whose stem is already unique. We strip the suffix where it
+ * isn't load-bearing while keeping the symmetric rendering required by `linkerForced` /
+ * `forceTraceElements`.
+ *
+ * Rule: a record's linker suffix is redundant iff its stem (label rendered without LINKER) does
+ * not appear anywhere else in the set.
+ */
+function dropRedundantLinkerSuffix(
+  records: EnrichedRecord[],
+  globalTypeSet: Set<string>,
+  forceTraceElements: Set<string> | undefined,
+  forcedSet: Set<string>,
+  separator: string,
+  labels: string[],
+): string[] {
+  if (!globalTypeSet.has(LINKER_TYPE_FULL)) return labels;
+  if (forcedSet.has(LINKER_TYPE_FULL) || forceTraceElements?.has(LINKER_TYPE)) return labels;
+
+  const setWithoutLinker = new Set(globalTypeSet);
+  setWithoutLinker.delete(LINKER_TYPE_FULL);
+
+  const stems = records.map((r) =>
+    renderRecordLabel(r, setWithoutLinker, forceTraceElements, separator),
+  );
+
+  const stemOccurrences = new Map<string, number>();
+  for (const s of stems) {
+    if (s !== undefined) stemOccurrences.set(s, (stemOccurrences.get(s) ?? 0) + 1);
+  }
+
+  return labels.map((label, i) => {
+    const stem = stems[i];
+    if (stem === undefined) return label;
+    return stemOccurrences.get(stem) === 1 ? stem : label;
+  });
 }
 
 function countUniqueLabels(result: string[] | undefined): number {


### PR DESCRIPTION
When a shared linker forces LINKER_TYPE into the global type set to resolve a collision on one stem, records whose native label was already unique were still rendered with the suffix. Strip the suffix where it isn't load-bearing while preserving forced-trace symmetry.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in `deriveDistinctLabels` where records with already-unique native labels were still receiving the \"via …\" linker suffix when another collision in the same dataset forced `LINKER_TYPE` into the global type set.

- Extracts the inner label-building loop into a reusable `renderRecordLabel` helper, enabling a second pass over records without duplicating the rendering logic.
- Adds `dropRedundantLinkerSuffix`, called after both the main minimization path and the fallback path, which strips the linker suffix only from records whose stem (label without linker) is unique across all records — preserving `linkerForced` and `forceTraceElements` symmetry constraints via early-return guards.
- Introduces a regression test that reproduces the \"Cluster Id via Clone to cluster link\" bug.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped and all correctness constraints are preserved.

The refactored renderRecordLabel is a behaviour-identical extraction of the existing inline loop. dropRedundantLinkerSuffix correctly guards the two forced-linker cases (linkerForced via forcedSet and explicit forceTraceElements) before stripping, and uniqueness of the final label set cannot be broken: a stem is only substituted when it appears exactly once across all records, which prevents any collision between stripped and unstripped labels. The new regression test directly reproduces the reported bug and passes. No edge cases (undefined stems, fallback Unlabeled records, multiple linker trace entries) are left unhandled.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/labels/derive_distinct_labels.ts | Extracts renderRecordLabel helper and adds dropRedundantLinkerSuffix; logic is correct, guards for forced-linker and forceTraceElements cases are sound. |
| sdk/model/src/labels/derive_distinct_labels.test.ts | Adds a well-scoped regression test that directly reproduces the reported bug scenario. |
| .changeset/fix-redundant-linker-suffix.md | Correct patch-level changeset entry for the @platforma-sdk/model package. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deriveDistinctLabels] --> B{mainTypes found & unique labels?}
    B -- Yes --> C[minimizeTypeSet]
    B -- No, exhausted --> D[fallbackSet + minimizeTypeSet]
    C --> E[buildLabels force=false]
    D --> F[buildLabels force=true]
    E --> G[dropRedundantLinkerSuffix]
    F --> G
    G --> H{LINKER_TYPE_FULL in globalTypeSet?}
    H -- No --> I[return labels unchanged]
    H -- Yes --> J{linkerForced or forceTraceElements has LINKER_TYPE?}
    J -- Yes --> I
    J -- No --> K[build setWithoutLinker, compute stems for all records]
    K --> L[count stem occurrences]
    L --> M{for each record: stem unique?}
    M -- stem count == 1 --> N[replace label with stem, strip via suffix]
    M -- stem count > 1 or stem undefined --> O[keep original label]
    N --> P[return stripped labels]
    O --> P
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: drop redundant linker &quot;via …&quot; suffi..."](https://github.com/milaboratory/platforma/commit/a5a529b6de1156221a89c3c6b932f0bb906cd0f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31578355)</sub>

<!-- /greptile_comment -->