### PR TITLE
Support AbortSignal

### DIFF
--- a/.changeset/eager-lands-judge.md
+++ b/.changeset/eager-lands-judge.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-middle-layer": patch
+"@platforma-sdk/block-tools": patch
+---
+
+Support AbortSignal

--- a/lib/node/pl-middle-layer/src/block_registry/registry.ts
+++ b/lib/node/pl-middle-layer/src/block_registry/registry.ts
@@ -69,17 +69,20 @@ export class BlockPackRegistry {
     private readonly http?: Dispatcher,
   ) {}
 
-  private async getPackagesForRoot(regEntry: RegistryEntry): Promise<BlockPackOverview[]> {
+  private async getPackagesForRoot(
+    regEntry: RegistryEntry,
+    options?: { signal?: AbortSignal },
+  ): Promise<BlockPackOverview[]> {
     const result: BlockPackOverview[] = [];
     const regSpec = regEntry.spec;
     switch (regSpec.type) {
       case "remote-v1": {
         const httpOptions = this.http !== undefined ? { dispatcher: this.http } : {};
 
-        const overviewResponse = await request(
-          `${regSpec.url}/${RegistryV1.GlobalOverviewPath}`,
-          httpOptions,
-        );
+        const overviewResponse = await request(`${regSpec.url}/${RegistryV1.GlobalOverviewPath}`, {
+          ...httpOptions,
+          signal: options?.signal,
+        });
         const overview = (await overviewResponse.body.json()) as RegistryV1.GlobalOverview;
         for (const overviewEntry of overview) {
           const { organization, package: pkg, latestMeta, latestVersion } = overviewEntry;
@@ -118,7 +121,9 @@ export class BlockPackRegistry {
       }
 
       case "remote-v2":
-        return (await this.v2Provider.getRegistry(regSpec.url).listBlockPacks()).map((e) => ({
+        return (
+          await this.v2Provider.getRegistry(regSpec.url).listBlockPacks({ signal: options?.signal })
+        ).map((e) => ({
           ...e,
           registryId: regEntry.id,
         }));
@@ -233,12 +238,12 @@ export class BlockPackRegistry {
     }
   }
 
-  public async listBlockPacks(): Promise<BlockPackListing> {
+  public async listBlockPacks(options?: { signal?: AbortSignal }): Promise<BlockPackListing> {
     const blockPacks: BlockPackOverview[] = [];
     const registries: RegistryStatus[] = [];
     for (const regSpecs of this.registries) {
       registries.push({ ...regSpecs, status: "online" });
-      blockPacks.push(...(await this.getPackagesForRoot(regSpecs)));
+      blockPacks.push(...(await this.getPackagesForRoot(regSpecs, options)));
     }
     return { registries, blockPacks };
   }

--- a/tools/block-tools/src/io/folder_reader.ts
+++ b/tools/block-tools/src/io/folder_reader.ts
@@ -6,10 +6,12 @@ import pathPosix from "node:path/posix";
 import fsp from "node:fs/promises";
 import { defaultHttpDispatcher } from "@milaboratories/pl-http";
 
+export type ReadFileOptions = { signal?: AbortSignal };
+
 export interface FolderReader {
   readonly rootUrl: URL;
   relativeReader(relativePath: string): FolderReader;
-  readFile(file: string): Promise<Buffer>;
+  readFile(file: string, options?: ReadFileOptions): Promise<Buffer>;
   getContentReader(relativePath?: string): RelativeContentReader;
 }
 
@@ -19,10 +21,11 @@ class HttpFolderReader implements FolderReader {
     private readonly httpDispatcher: Dispatcher,
   ) {}
 
-  public async readFile(file: string): Promise<Buffer> {
+  public async readFile(file: string, options?: ReadFileOptions): Promise<Buffer> {
     const targetUrl = new URL(file, this.rootUrl);
     const response = await request(targetUrl, {
       dispatcher: this.httpDispatcher,
+      signal: options?.signal,
     });
     return Buffer.from(await response.body.arrayBuffer());
   }
@@ -45,9 +48,9 @@ class FSFolderReader implements FolderReader {
     private readonly root: string,
   ) {}
 
-  public async readFile(file: string): Promise<Buffer> {
+  public async readFile(file: string, options?: ReadFileOptions): Promise<Buffer> {
     const targetPath = path.join(this.root, ...file.split(pathPosix.sep));
-    return await fsp.readFile(targetPath);
+    return await fsp.readFile(targetPath, { signal: options?.signal });
   }
 
   public relativeReader(relativePath: string): FSFolderReader {

--- a/tools/block-tools/src/v2/registry/registry_reader.ts
+++ b/tools/block-tools/src/v2/registry/registry_reader.ts
@@ -112,7 +112,9 @@ export class RegistryV2Reader {
   private listCacheTimestamp: number = 0;
   private listCache: BlockPackOverviewNoRegistryId[] | undefined = undefined;
 
-  public async listBlockPacks(): Promise<BlockPackOverviewNoRegistryId[]> {
+  public async listBlockPacks(options?: {
+    signal?: AbortSignal;
+  }): Promise<BlockPackOverviewNoRegistryId[]> {
     if (
       this.listCache !== undefined &&
       Date.now() - this.listCacheTimestamp <= this.ops.cacheBlockListFor
@@ -123,7 +125,11 @@ export class RegistryV2Reader {
         // const rootContentReader = this.v2RootFolderReader.getContentReader();
         const globalOverview = GlobalOverviewReg.parse(
           JSON.parse(
-            Buffer.from(await this.v2RootFolderReader.readFile(GlobalOverviewFileName)).toString(),
+            Buffer.from(
+              await this.v2RootFolderReader.readFile(GlobalOverviewFileName, {
+                signal: options?.signal,
+              }),
+            ).toString(),
           ),
         );
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds optional `AbortSignal` support to the block-pack registry listing path, threading the signal from `BlockPackRegistry.listBlockPacks` down through `RegistryV2Reader.listBlockPacks` and into both the HTTP (`undici` request) and filesystem (`fsp.readFile`) readers.

- `ReadFileOptions` type introduced on `FolderReader.readFile`; signal forwarded in `HttpFolderReader` and `FSFolderReader`.
- `RegistryV2Reader.listBlockPacks` and `BlockPackRegistry.listBlockPacks`/`getPackagesForRoot` accept and propagate the signal for `remote-v1` and `remote-v2` registry types.
- The `local-dev` registry branch and the `getContentReader` closure path (used by metadata embedding) are not updated, leaving those I/O operations unaffected by cancellation.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

AbortSignal reaches the I/O layer for remote registries, but an aborted request inside the retry loop causes repeated failed attempts before the error surfaces, making cancellation slower than expected.

The retry wrapper in `RegistryV2Reader.listBlockPacks` will catch and re-attempt `AbortError`s from `readFile` rather than letting them propagate immediately. A caller that aborts the operation will wait out the retry back-off delays before the signal is actually honoured. Additionally, the `local-dev` registry branch and `getContentReader` closures are left without signal forwarding, so cancellation coverage is incomplete across the whole listing flow.

`tools/block-tools/src/v2/registry/registry_reader.ts` — the retry + AbortSignal interaction needs attention before this can be considered fully correct.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/block-tools/src/v2/registry/registry_reader.ts | Adds optional AbortSignal to `listBlockPacks`; the signal is passed to `readFile` but the surrounding `retry` wrapper will re-attempt aborted calls instead of propagating the AbortError immediately, delaying cancellation by the retry back-off period. |
| lib/node/pl-middle-layer/src/block_registry/registry.ts | Signal correctly threaded through `listBlockPacks` → `getPackagesForRoot` for remote-v1 and remote-v2 registry types; local-dev branch leaves all its file I/O un-cancelled. |
| tools/block-tools/src/io/folder_reader.ts | Introduces `ReadFileOptions` and threads the signal into both `HttpFolderReader` and `FSFolderReader`; `getContentReader` closures still call `readFile` without options, leaving that call-path uncancellable. |
| .changeset/eager-lands-judge.md | Changeset entry marking both affected packages as patch releases for AbortSignal support — no issues. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant BlockPackRegistry
    participant RegistryV2Reader
    participant FolderReader
    participant HTTP/FS

    Caller->>BlockPackRegistry: "listBlockPacks({ signal })"
    BlockPackRegistry->>BlockPackRegistry: "getPackagesForRoot(regEntry, { signal })"

    alt remote-v1
        BlockPackRegistry->>HTTP/FS: "request(url, { signal })"
        HTTP/FS-->>BlockPackRegistry: GlobalOverview
    else remote-v2
        BlockPackRegistry->>RegistryV2Reader: "listBlockPacks({ signal })"
        RegistryV2Reader->>RegistryV2Reader: check listCache
        RegistryV2Reader->>FolderReader: "readFile(GlobalOverviewFileName, { signal })"
        Note over RegistryV2Reader,FolderReader: wrapped in retry() — AbortError is retried, not propagated immediately
        FolderReader->>HTTP/FS: request / fsp.readFile (with signal)
        HTTP/FS-->>FolderReader: Buffer
        FolderReader-->>RegistryV2Reader: Buffer
        RegistryV2Reader-->>BlockPackRegistry: BlockPackOverview[]
    else local-dev
        BlockPackRegistry->>HTTP/FS: readdir / readFile (no signal)
        Note over BlockPackRegistry,HTTP/FS: signal is NOT forwarded here
        HTTP/FS-->>BlockPackRegistry: entries
    end

    BlockPackRegistry-->>Caller: BlockPackListing
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `tools/block-tools/src/v2/registry/registry_reader.ts`, line 124-173 ([link](https://github.com/milaboratory/platforma/blob/664cd830a41db054a095318b5ae98a446f4c1344/tools/block-tools/src/v2/registry/registry_reader.ts#L124-L173)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **AbortError retried instead of propagated immediately**

   The `readFile` call (line 129) is wrapped in `retry(..., Retry2TimesWithDelay)`. When the `AbortSignal` fires, `readFile` throws an `AbortError` immediately, but `retry` catches it and waits for the inter-retry delay before attempting again — repeating until retries are exhausted. Instead of immediate cancellation, the caller experiences a delay equal to the retry back-off multiplied by the retry count. The `retry` call should re-throw (or skip retrying) when the error is an `AbortError`, e.g. by checking `err.name === 'AbortError'` or `signal?.aborted` before scheduling the next attempt.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tools/block-tools/src/v2/registry/registry_reader.ts
   Line: 124-173

   Comment:
   **AbortError retried instead of propagated immediately**

   The `readFile` call (line 129) is wrapped in `retry(..., Retry2TimesWithDelay)`. When the `AbortSignal` fires, `readFile` throws an `AbortError` immediately, but `retry` catches it and waits for the inter-retry delay before attempting again — repeating until retries are exhausted. Instead of immediate cancellation, the caller experiences a delay equal to the retry back-off multiplied by the retry count. The `retry` call should re-throw (or skip retrying) when the error is an `AbortError`, e.g. by checking `err.name === 'AbortError'` or `signal?.aborted` before scheduling the next attempt.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `lib/node/pl-middle-layer/src/block_registry/registry.ts`, line 150-235 ([link](https://github.com/milaboratory/platforma/blob/664cd830a41db054a095318b5ae98a446f4c1344/lib/node/pl-middle-layer/src/block_registry/registry.ts#L150-L235)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`local-dev` branch silently ignores the AbortSignal**

   The `remote-v1` and `remote-v2` branches now honour `options?.signal`, but the `local-dev` branch's I/O calls — `fs.promises.readdir` (line 151), `getFileContent`, `getFileStat`, and the two `getDevXPacketMtime` helpers — do not receive the signal. Aborting while the registry is scanning a local dev folder will have no effect until every file stat/read completes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-middle-layer/src/block_registry/registry.ts
   Line: 150-235

   Comment:
   **`local-dev` branch silently ignores the AbortSignal**

   The `remote-v1` and `remote-v2` branches now honour `options?.signal`, but the `local-dev` branch's I/O calls — `fs.promises.readdir` (line 151), `getFileContent`, `getFileStat`, and the two `getDevXPacketMtime` helpers — do not receive the signal. Aborting while the registry is scanning a local dev folder will have no effect until every file stat/read completes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `tools/block-tools/src/io/folder_reader.ts`, line 38-42 ([link](https://github.com/milaboratory/platforma/blob/664cd830a41db054a095318b5ae98a446f4c1344/tools/block-tools/src/io/folder_reader.ts#L38-L42)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`getContentReader` closures don't forward the signal**

   Both `HttpFolderReader.getContentReader` and `FSFolderReader.getContentReader` return a `RelativeContentReader` that calls `readFile(path)` without an options argument. All callers that go through `getContentReader` — most notably the `embeddedGlobalMetaCache.fetchMethod` in `registry_reader.ts` — cannot be cancelled even after this PR. Consider whether `RelativeContentReader`'s signature should also accept optional `ReadFileOptions` so the signal can be forwarded end-to-end.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tools/block-tools/src/io/folder_reader.ts
   Line: 38-42

   Comment:
   **`getContentReader` closures don't forward the signal**

   Both `HttpFolderReader.getContentReader` and `FSFolderReader.getContentReader` return a `RelativeContentReader` that calls `readFile(path)` without an options argument. All callers that go through `getContentReader` — most notably the `embeddedGlobalMetaCache.fetchMethod` in `registry_reader.ts` — cannot be cancelled even after this PR. Consider whether `RelativeContentReader`'s signature should also accept optional `ReadFileOptions` so the signal can be forwarded end-to-end.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
tools/block-tools/src/v2/registry/registry_reader.ts:124-173
**AbortError retried instead of propagated immediately**

The `readFile` call (line 129) is wrapped in `retry(..., Retry2TimesWithDelay)`. When the `AbortSignal` fires, `readFile` throws an `AbortError` immediately, but `retry` catches it and waits for the inter-retry delay before attempting again — repeating until retries are exhausted. Instead of immediate cancellation, the caller experiences a delay equal to the retry back-off multiplied by the retry count. The `retry` call should re-throw (or skip retrying) when the error is an `AbortError`, e.g. by checking `err.name === 'AbortError'` or `signal?.aborted` before scheduling the next attempt.

### Issue 2 of 3
lib/node/pl-middle-layer/src/block_registry/registry.ts:150-235
**`local-dev` branch silently ignores the AbortSignal**

The `remote-v1` and `remote-v2` branches now honour `options?.signal`, but the `local-dev` branch's I/O calls — `fs.promises.readdir` (line 151), `getFileContent`, `getFileStat`, and the two `getDevXPacketMtime` helpers — do not receive the signal. Aborting while the registry is scanning a local dev folder will have no effect until every file stat/read completes.

### Issue 3 of 3
tools/block-tools/src/io/folder_reader.ts:38-42
**`getContentReader` closures don't forward the signal**

Both `HttpFolderReader.getContentReader` and `FSFolderReader.getContentReader` return a `RelativeContentReader` that calls `readFile(path)` without an options argument. All callers that go through `getContentReader` — most notably the `embeddedGlobalMetaCache.fetchMethod` in `registry_reader.ts` — cannot be cancelled even after this PR. Consider whether `RelativeContentReader`'s signature should also accept optional `ReadFileOptions` so the signal can be forwarded end-to-end.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Support AbortSignal"](https://github.com/milaboratory/platforma/commit/664cd830a41db054a095318b5ae98a446f4c1344) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31595299)</sub>

<!-- /greptile_comment -->