### PR TITLE
pl-client: deflake ll_transaction.test.ts active-TX tests

### DIFF
--- a/.changeset/fix-ll-transaction-active-tx-fragility.md
+++ b/.changeset/fix-ll-transaction-active-tx-fragility.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: stop flaky `ll_transaction.test.ts` active-TX tests caused by empty root-signature fallback and bare-catch error masking.

--- a/lib/node/pl-client/src/core/ll_transaction.test.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.test.ts
@@ -1,6 +1,6 @@
-import { getTestLLClient } from "../test/test_config";
+import { getTestClient, getTestLLClient } from "../test/test_config";
 import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
-import { createLocalResourceId } from "./types";
+import { createLocalResourceId, parseSignedResourceId } from "./types";
 import { test, expect } from "vitest";
 
 import { isTimeoutOrCancelError } from "./errors";
@@ -11,15 +11,14 @@ let cachedRootSig: Uint8Array | undefined;
 
 async function getRootSignature(): Promise<Uint8Array> {
   if (cachedRootSig !== undefined) return cachedRootSig;
-  const client = await getTestLLClient();
-  const responses = await client.listUserResources({ limit: 1 });
-  for (const msg of responses) {
-    if (msg.entry.oneofKind === "userRoot" && msg.entry.userRoot.resourceSignature) {
-      cachedRootSig = msg.entry.userRoot.resourceSignature;
-      return cachedRootSig;
-    }
+  // Use PlClient (not LLPlClient) so UserResources auto-creates the root if missing.
+  const client = await getTestClient();
+  try {
+    const rootId = await client.getUserRoot({ createIfNotExists: true });
+    cachedRootSig = parseSignedResourceId(rootId).signature;
+  } finally {
+    await client.close();
   }
-  cachedRootSig = new Uint8Array(0);
   return cachedRootSig;
 }
 
@@ -100,7 +99,7 @@ test("check timeout error type (active)", async () => {
   const rootSig = await getRootSignature();
   const tx = client.createTx(true, { timeout: 500 });
 
-  try {
+  await expect(async () => {
     const openResponse = await tx.send(
       {
         oneofKind: "txOpen",
@@ -163,9 +162,7 @@ test("check timeout error type (active)", async () => {
 
       expect(Buffer.compare(vr.resourceGet.resource!.data, rData)).toBe(0);
     }
-  } catch (err: unknown) {
-    expect(isTimeoutOrCancelError(err)).toBe(true);
-  }
+  }).rejects.toSatisfy(isTimeoutOrCancelError);
 });
 
 test("check is abort error (active)", async () => {
@@ -173,7 +170,7 @@ test("check is abort error (active)", async () => {
   const rootSig = await getRootSignature();
   const tx = client.createTx(true, { abortSignal: AbortSignal.timeout(100) });
 
-  try {
+  await expect(async () => {
     const openResponse = await tx.send(
       {
         oneofKind: "txOpen",
@@ -236,7 +233,5 @@ test("check is abort error (active)", async () => {
 
       expect(Buffer.compare(vr.resourceGet.resource!.data, rData)).toBe(0);
     }
-  } catch (err: unknown) {
-    expect(isTimeoutOrCancelError(err)).toBe(true);
-  }
+  }).rejects.toSatisfy(isTimeoutOrCancelError);
 });


### PR DESCRIPTION
## Summary

Two tests in `lib/node/pl-client/src/core/ll_transaction.test.ts` — `check timeout error type (active)` and `check is abort error (active)` — flake on the `monorepo tests (s3)` job whenever their vitest worker runs before any other test file initializes a `PlClient` against the shared backend.

**Root cause**

- The `getRootSignature` helper called `LLPlClient.listUserResources`. If no `userRoot` was on the backend yet, it cached `new Uint8Array(0)` and returned it.
- The empty `colorProof` was rejected by the backend (`tx_handlers_signature.go`) with `InvalidArgument "color_proof is required"`.
- A bare `catch (err) { expect(isTimeoutOrCancelError(err)).toBe(true); }` swallowed the real status code and reported only `expected false to be true`, masquerading as a missing-timeout regression.

Whether a `userRoot` was already present depended on whether some other test file in the same CI run had already constructed a `PlClient` (which auto-creates it via `UserResources.getUserRoot({ createIfNotExists: true })` inside `PlClient.init`). Pure worker-scheduling flake — the backend code path is unchanged.

## Fix

1. Route `getRootSignature` through `getTestClient()` (PlClient) and call `client.getUserRoot({ createIfNotExists: true })`. `UserResources` already handles all three backend tiers (modern `getUserRoot` RPC, mid-tier `listUserResources`, legacy writable-tx create), so the helper is now backend-version agnostic. Drop the silent `Uint8Array(0)` fallback entirely.

2. Replace the bare `try { ... } catch (err) { expect(isTimeoutOrCancelError(err)).toBe(true); }` in the two failing tests with `await expect(async () => { ... }).rejects.toSatisfy(isTimeoutOrCancelError)`. Same semantics for the green path; a non-timeout rejection now surfaces with its real error object instead of a meaningless boolean assertion.

No backend or production-code changes. Test-only.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two flaky integration tests (`check timeout error type (active)` and `check is abort error (active)`) in `ll_transaction.test.ts` that failed intermittently when their vitest worker ran before any other test file initialized a `PlClient` against the shared backend.

- **Root-signature bootstrap**: `getRootSignature` now uses `PlClient.getUserRoot({ createIfNotExists: true })` instead of `LLPlClient.listUserResources`, eliminating the silent `new Uint8Array(0)` fallback that caused the backend to reject the `setDefaultColor` call with `InvalidArgument \"color_proof is required\"`.
- **Error assertion hardening**: Both active tests replace bare `try/catch` with `await expect(async () => { ... }).rejects.toSatisfy(isTimeoutOrCancelError)`, so unexpected non-timeout errors surface with their actual error object rather than a misleading boolean assertion failure.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Test-only change with no production code touched; safe to merge.

The root cause (silent empty-signature fallback + bare-catch masking) is correctly diagnosed and the active tests are properly hardened. The sibling passive test retains the old bare-catch pattern that can obscure real errors, and the try/finally structure in getRootSignature has a subtle edge case where a close() failure propagates even when the signature was already cached — both minor concerns confined to the test file.

lib/node/pl-client/src/core/ll_transaction.test.ts — the passive timeout test and the getRootSignature return placement are worth a quick look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/ll_transaction.test.ts | Fixes flaky active-TX tests: replaces LLPlClient.listUserResources (with silent empty-signature fallback) with PlClient.getUserRoot({ createIfNotExists: true }) for robust root setup, and replaces bare try/catch assertions with rejects.toSatisfy for accurate error reporting. The sibling passive test retains the old bare-catch pattern. |
| .changeset/fix-ll-transaction-active-tx-fragility.md | Changeset entry for the test-only fix; no version bumps required, description accurately reflects the change. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Test (active)
    participant RSig as getRootSignature()
    participant PC as PlClient
    participant BE as Backend

    Note over Test,BE: Before fix - flaky path
    Test->>RSig: getRootSignature()
    RSig->>BE: listUserResources (empty - no userRoot yet)
    BE-->>RSig: []
    RSig-->>Test: Uint8Array(0) silent fallback
    Test->>BE: "setDefaultColor(colorProof=empty)"
    BE-->>Test: InvalidArgument color_proof is required
    Test->>Test: catch masks error as boolean assertion

    Note over Test,BE: After fix - stable path
    Test->>RSig: getRootSignature()
    RSig->>PC: getUserRoot createIfNotExists true
    PC->>BE: create userRoot if missing
    BE-->>PC: signed rootId
    PC-->>RSig: rootId with real signature
    RSig->>PC: close()
    RSig-->>Test: real Uint8Array signature
    Test->>BE: "setDefaultColor(colorProof=signature)"
    BE-->>Test: timeout or abort error
    Test->>Test: rejects.toSatisfy(isTimeoutOrCancelError)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pl-client/src/core/ll_transaction.test.ts`, line 78-94 ([link](https://github.com/milaboratory/platforma/blob/ddc97d208ebec2de2b63fd24adf355bff6f58ea5/lib/node/pl-client/src/core/ll_transaction.test.ts#L78-L94)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The sibling `check timeout error type (passive)` test (lines 78–94) still uses the bare `try/catch` pattern that was just fixed in the active tests. If the passive transaction throws a non-timeout gRPC error the catch block hides it with a confusing `expected false to be true`, making the same class of failure hard to diagnose.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-client/src/core/ll_transaction.test.ts
   Line: 78-94

   Comment:
   The sibling `check timeout error type (passive)` test (lines 78–94) still uses the bare `try/catch` pattern that was just fixed in the active tests. If the passive transaction throws a non-timeout gRPC error the catch block hides it with a confusing `expected false to be true`, making the same class of failure hard to diagnose.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pl-client/src/core/ll_transaction.test.ts:78-94
The sibling `check timeout error type (passive)` test (lines 78–94) still uses the bare `try/catch` pattern that was just fixed in the active tests. If the passive transaction throws a non-timeout gRPC error the catch block hides it with a confusing `expected false to be true`, making the same class of failure hard to diagnose.

```suggestion
  await expect(async () => {
    const response = await tx.send(
      {
        oneofKind: "txOpen",
        txOpen: {
          name: "test",
          writable: TxAPI_Open_Request_WritableTx.WRITABLE,
          enableFormattedErrors: false,
        },
      },
      false,
    );
    expect(response.txOpen.tx?.isValid).toBeTruthy();
    await tx.await();
  }).rejects.toSatisfy(isTimeoutOrCancelError);
```

### Issue 2 of 2
lib/node/pl-client/src/core/ll_transaction.test.ts:20-22
**`close()` failure silently loses the cached signature**

If `parseSignedResourceId` succeeds and populates `cachedRootSig`, but the subsequent `await client.close()` in `finally` throws, the exception propagates out of `getRootSignature()` — failing the current test call — even though `cachedRootSig` was already assigned. Subsequent test calls will hit the `cachedRootSig !== undefined` early-return path and succeed, so the failure is a one-shot phantom. Moving `return cachedRootSig` inside the `try` block (before `finally`) makes the intent explicit and avoids the confusing "signature is cached but current call throws" state.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pl-client: deflake ll\_transaction.test.t..."](https://github.com/milaboratory/platforma/commit/ddc97d208ebec2de2b63fd24adf355bff6f58ea5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31658582)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->