### PR TITLE
Fix/pframes types

### DIFF
--- a/.changeset/pframe-query-types-sync.md
+++ b/.changeset/pframe-query-types-sync.md
@@ -1,0 +1,37 @@
+---
+"@milaboratories/pl-model-common": minor
+---
+
+`pframe/query` types now mirror the pframes-rs wire format.
+
+New variants on `SpecQuery` / `DataQuery`:
+
+- `transformColumns` query node (`QueryTransformColumns`); the mode
+  is `"append" | "replace"` (the runtime accepts the legacy `"add"`
+  as a serde alias).
+- `cast`, `conditional`, `isInPolygon` expressions.
+- `aggregation` (with the flat-string `AggregationKind`), `ranking`
+  (`RankingKind`), `cumulative` (`CumulativeOperand`).
+
+Wire-shape fixes:
+
+- `ExprIfNull` is now `ExprFillNull`, tag `"fillNull"` (the runtime
+  accepts `"ifNull"` as a serde alias).
+- `NumericBinaryOperand` gains `"power"`.
+- `Point2D` is now an `[x, y]` tuple, matching the Rust serialisation
+  (previously typed as `{ x, y }`).
+- `ExprIsIn.negate` and `ExprIsInPolygon.negate` are required `boolean`
+  (previously optional). For `isIn` the Rust runtime keeps a tolerant
+  deserialiser that defaults a missing `negate` to `false`, then
+  always re-emits the field; new callers should pass it explicitly.
+- `QuerySort.sortBy[].nullsFirst` is plain `boolean` (was
+  `null | boolean`).
+- `QuerySparseToDenseColumn`: field renamed `axesIndices → axes` and
+  parameterised over the layer's axis-selector type; at the spec layer
+  entries are named `SingleAxisSelector`s, at the data layer they are
+  numeric indices. Old wire field name still parses via a serde alias.
+
+One downstream consumer in `@platforma-sdk/model`
+(`filters/converters/filterToQuery.ts`) updated to pass `negate`
+explicitly on the `inSet` / `notInSet` paths and to migrate from
+`ifNull` to `fillNull`.

--- a/.changeset/pframe-query-types-sync.md
+++ b/.changeset/pframe-query-types-sync.md
@@ -9,9 +9,15 @@ New variants on `SpecQuery` / `DataQuery`:
 - `transformColumns` query node (`QueryTransformColumns`); the mode
   is `"append" | "replace"` (the runtime accepts the legacy `"add"`
   as a serde alias).
-- `cast`, `conditional`, `isInPolygon` expressions.
-- `aggregation` (with the flat-string `AggregationKind`), `ranking`
-  (`RankingKind`), `cumulative` (`CumulativeOperand`).
+- `cast`, `conditional` expressions.
+- `ranking` window function (with `RankingKind`).
+
+`isInPolygon`, `aggregation` (`AggregationKind`), and `cumulative`
+(`CumulativeOperand`) are present in the Rust query model but their
+DataFusion executors return errors today (filter.rs:276 / 340 / 387).
+The TS definitions are committed but commented out in `query_common.ts`
+so block authors can't construct a query the runtime won't execute.
+Re-enable in lock-step with the Rust wiring.
 
 Wire-shape fixes:
 
@@ -20,10 +26,10 @@ Wire-shape fixes:
 - `NumericBinaryOperand` gains `"power"`.
 - `Point2D` is now an `[x, y]` tuple, matching the Rust serialisation
   (previously typed as `{ x, y }`).
-- `ExprIsIn.negate` and `ExprIsInPolygon.negate` are required `boolean`
-  (previously optional). For `isIn` the Rust runtime keeps a tolerant
-  deserialiser that defaults a missing `negate` to `false`, then
-  always re-emits the field; new callers should pass it explicitly.
+- `ExprIsIn.negate` is now required `boolean` (previously optional).
+  The Rust runtime keeps a tolerant deserialiser that defaults a
+  missing `negate` to `false` and always re-emits the field; new
+  callers should pass it explicitly.
 - `QuerySort.sortBy[].nullsFirst` is plain `boolean` (was
   `null | boolean`).
 - `QuerySparseToDenseColumn`: field renamed `axesIndices → axes` and

--- a/.changeset/pframe-query-types-sync.md
+++ b/.changeset/pframe-query-types-sync.md
@@ -1,8 +1,14 @@
 ---
 "@milaboratories/pl-model-common": minor
+"@milaboratories/pf-driver": patch
+"@milaboratories/pf-spec-driver": patch
 ---
 
 `pframe/query` types now mirror the pframes-rs wire format.
+Tracks `@milaboratories/pframes-rs-node` / `-wasm` v1.1.34 → v1.1.35;
+`REQUIRES_PFRAMES_VERSION` in `lib/model/common/src/flags/block_flags.ts`
+bumped to `1_001_035` so blocks built against the new SDK refuse to
+load on older desktop apps.
 
 New variants on `SpecQuery` / `DataQuery`:
 

--- a/.changeset/pframe-query-types-sync.md
+++ b/.changeset/pframe-query-types-sync.md
@@ -4,11 +4,8 @@
 "@milaboratories/pf-spec-driver": patch
 ---
 
-`pframe/query` types now mirror the pframes-rs wire format.
-Tracks `@milaboratories/pframes-rs-node` / `-wasm` v1.1.34 → v1.1.35;
-`REQUIRES_PFRAMES_VERSION` in `lib/model/common/src/flags/block_flags.ts`
-bumped to `1_001_035` so blocks built against the new SDK refuse to
-load on older desktop apps.
+`pframe/query` types now mirror the pframes-rs wire format. Tracks
+`@milaboratories/pframes-rs-node` / `-wasm` v1.1.34 → v1.1.35.
 
 New variants on `SpecQuery` / `DataQuery`:
 

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -61,8 +61,9 @@ export type NumericUnaryOperand =
  * - `mul` - Multiplication: left * right
  * - `div` - Division: left / right (division by zero returns Infinity or NaN)
  * - `mod` - Modulo: left % right
+ * - `power` - Exponentiation: left ** right
  */
-export type NumericBinaryOperand = "add" | "sub" | "mul" | "div" | "mod";
+export type NumericBinaryOperand = "add" | "sub" | "mul" | "div" | "mod" | "power";
 
 /**
  * Numeric comparison operation kinds.
@@ -83,16 +84,16 @@ export type NumericComparisonOperand = "eq" | "ne" | "lt" | "le" | "gt" | "ge";
 // ============ Geometric Types ============
 
 /**
- * 2D point coordinates.
+ * 2D point coordinates as an `[x, y]` tuple.
  *
- * Used for geometric operations like point-in-polygon tests.
+ * Used for geometric operations like point-in-polygon tests. The wire
+ * form is a tuple (matching Rust's `(f64, f64)` serialisation), not an
+ * object with `x` / `y` fields.
+ *
  * Common use case: flow cytometry gating where points are tested
  * against user-defined polygon regions.
  */
-export type Point2D = {
-  x: number;
-  y: number;
-};
+export type Point2D = [number, number];
 
 // ============ Constant Expression ============
 
@@ -148,17 +149,20 @@ export interface ExprIsNull<I> {
  * **Output**: Same type as input/replacement.
  * **Null handling**: If input is null, returns replacement; otherwise returns input.
  *
+ * The Rust runtime also accepts the legacy `"ifNull"` tag as a serde
+ * alias; new code should emit `"fillNull"`.
+ *
  * @template I - The expression type (for recursion)
  *
  * @example
  * // Replace null values with 0
- * { type: 'ifNull', input: columnRef, replacement: { type: 'constant', value: 0 } }
+ * { type: 'fillNull', input: columnRef, replacement: { type: 'constant', value: 0 } }
  *
  * // Replace null strings with 'unknown'
- * { type: 'ifNull', input: nameColumn, replacement: { type: 'constant', value: 'unknown' } }
+ * { type: 'fillNull', input: nameColumn, replacement: { type: 'constant', value: 'unknown' } }
  */
-export interface ExprIfNull<I> {
-  type: "ifNull";
+export interface ExprFillNull<I> {
+  type: "fillNull";
   /** Value to check for null */
   input: I;
   /** Replacement value if input is null */
@@ -475,6 +479,197 @@ export interface ExprIsIn<I, T extends string | number> {
   input: I;
   /** Set of allowed values */
   set: T[];
+  /** If true, the predicate is inverted (true for values NOT in `set`). */
+  negate?: boolean;
+}
+
+/**
+ * Type cast expression.
+ *
+ * Converts the input value to a different column value type. Mirrors
+ * SQL `CAST(input AS U)`.
+ *
+ * **Input**: any expression.
+ * **Output**: a value of `targetType`.
+ * **Null handling**: null in → null out.
+ *
+ * @template I - The expression type (for recursion)
+ */
+export interface ExprCast<I> {
+  type: "cast";
+  /** Expression to cast. */
+  input: I;
+  /** Target column value type. */
+  targetType: ColumnValueType;
+}
+
+/**
+ * A single `when → then` case in a {@link ExprConditional} expression.
+ *
+ * @template I - The expression type (for recursion)
+ */
+export interface ExprConditionalCase<I> {
+  /** Boolean predicate that selects this branch. */
+  when: I;
+  /** Value produced when `when` evaluates to true. */
+  then: I;
+}
+
+/**
+ * Conditional (CASE WHEN) expression.
+ *
+ * Evaluates `cases` in order; the value of the first case whose `when`
+ * is true is returned. If no case matches, `otherwise` is used (or
+ * null when omitted).
+ *
+ * **Result type**: the type of the first case's `then`; subsequent
+ * `then`s and `otherwise` are cast to it.
+ *
+ * @template I - The expression type (for recursion)
+ *
+ * @example
+ * {
+ *   type: 'conditional',
+ *   cases: [
+ *     { when: gtTwenty, then: { type: 'constant', value: 'high' } },
+ *     { when: gtTen,    then: { type: 'constant', value: 'mid'  } }
+ *   ],
+ *   otherwise: { type: 'constant', value: 'low' }
+ * }
+ */
+export interface ExprConditional<I> {
+  type: "conditional";
+  /** Cases evaluated in order; first matching wins. At least one. */
+  cases: ExprConditionalCase<I>[];
+  /** Fallback value when no case matches. */
+  otherwise?: I;
+}
+
+/**
+ * Point-in-polygon test (commonly used for graph-maker lasso /
+ * flow-cytometry gating).
+ *
+ * **Input**: two numeric expressions (`x`, `y`).
+ * **Output**: logical Boolean; materialises as `Int` (0/1) when used
+ * as a derived column.
+ *
+ * The polygon is automatically closed (last vertex connects to first).
+ * Non-convex polygons are supported.
+ *
+ * @template I - The expression type (for recursion)
+ */
+export interface ExprIsInPolygon<I> {
+  type: "isInPolygon";
+  /** X-coordinate expression. */
+  x: I;
+  /** Y-coordinate expression. */
+  y: I;
+  /** Polygon vertices as `[x, y]` tuples; at least one. */
+  polygon: Point2D[];
+  /** If true, the predicate is inverted (true for points OUTSIDE the polygon). */
+  negate?: boolean;
+}
+
+/**
+ * Aggregation function kind (flat string; tagged form with payloads is
+ * planned per the change log).
+ */
+export type AggregationKind =
+  | "sum"
+  | "avg"
+  | "count"
+  | "min"
+  | "max"
+  | "first"
+  | "last"
+  | "stddev"
+  | "variance"
+  | "median";
+
+/**
+ * Aggregation expression — scalar form (inside `aggregate`) or window
+ * form (inside `transformColumns` with `over` set).
+ *
+ * Without `over`: scalar reducer. Valid only inside an `aggregate`
+ * query node.
+ *
+ * With `over`: window function. Valid inside `transformColumns`;
+ * preserves all axes, broadcasting the per-partition result to every
+ * row.
+ *
+ * @template I - The expression type (for recursion)
+ * @template A - Axis selector type
+ * @template C - Column selector type
+ */
+export interface ExprAggregation<I, A, C> {
+  type: "aggregation";
+  /** Aggregation kind. */
+  kind: AggregationKind;
+  /** Expression to aggregate. */
+  input: I;
+  /**
+   * Partition specification — when present, the aggregation becomes a
+   * window function and the result is broadcast to every row in the
+   * partition. At least one entry when supplied.
+   */
+  over?: (QueryAxisSelector<A> | QueryColumnSelector<C>)[];
+}
+
+/** Ranking function kind. */
+export type RankingKind = "rank" | "denseRank" | "rowNumber";
+
+/**
+ * Ranking expression (always a window function).
+ *
+ * Orders rows by `orderBy` within each partition and assigns ranks
+ * according to `kind`. Output is always `Long`.
+ *
+ * @template I - The expression type (for recursion)
+ * @template A - Axis selector type
+ * @template C - Column selector type
+ */
+export interface ExprRanking<I, A, C> {
+  type: "ranking";
+  /** Ranking semantics. */
+  kind: RankingKind;
+  /** Expression to order by within each partition. */
+  orderBy: I;
+  /** If true (default), sort ascending; if false, descending. */
+  ascending?: boolean;
+  /** Partition specification — at least one entry when supplied. */
+  partitionBy?: (QueryAxisSelector<A> | QueryColumnSelector<C>)[];
+}
+
+/** Cumulative aggregation operand (always a window function). */
+export type CumulativeOperand =
+  | "cumulativeSum"
+  | "cumulativeMin"
+  | "cumulativeMax"
+  | "cumulativeAvg";
+
+/**
+ * Cumulative aggregation expression — a window function with the
+ * implicit frame `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`.
+ *
+ * Accumulates `input` across rows within each partition, ordered by
+ * `orderBy`. Resets at partition boundaries.
+ *
+ * @template I - The expression type (for recursion)
+ * @template A - Axis selector type
+ * @template C - Column selector type
+ */
+export interface ExprCumulative<I, A, C> {
+  type: "cumulative";
+  /** Cumulative operand (sum / min / max / avg). */
+  operand: CumulativeOperand;
+  /** Expression to accumulate. */
+  input: I;
+  /** Expression to order rows by within each partition. */
+  orderBy: I;
+  /** If true (default), order ascending; if false, descending. */
+  ascending?: boolean;
+  /** Partition specification — at least one entry when supplied. */
+  partitionBy?: (QueryAxisSelector<A> | QueryColumnSelector<C>)[];
 }
 
 // ============ Reference Expression Types ============
@@ -531,6 +726,7 @@ export type InferBooleanExpressionUnion<E> = [
   E extends ExprLogicalUnary<unknown> ? Extract<E, { type: "not" }> : never,
   E extends ExprLogicalVariadic<unknown> ? Extract<E, { type: "and" | "or" }> : never,
   E extends ExprIsIn<unknown, string | number> ? Extract<E, { type: "isIn" }> : never,
+  E extends ExprIsInPolygon<unknown> ? Extract<E, { type: "isInPolygon" }> : never,
 ][number];
 
 // ============ Generic Query Types ============
@@ -702,9 +898,8 @@ export interface QuerySort<Q, E> {
      * Null placement control:
      * - true: nulls sort before non-null values
      * - false: nulls sort after non-null values
-     * - null: use default behavior (typically nulls last)
      */
-    nullsFirst: null | boolean;
+    nullsFirst: boolean;
   }[];
 }
 
@@ -927,4 +1122,55 @@ export interface QueryLinkerJoin<L, JE extends QueryJoinEntry<unknown>> {
   linker: L;
   /** Rest side — one or more subqueries joined with the linker (at least one). */
   secondary: JE[];
+}
+
+/**
+ * `transformColumns` mode.
+ *
+ * - `"append"` — existing columns pass through; the new columns are
+ *   appended.
+ * - `"replace"` — only the listed columns are kept; everything else is
+ *   dropped.
+ *
+ * The Rust runtime accepts the legacy `"add"` tag as a serde alias;
+ * new code should emit `"append"`.
+ */
+export type TransformColumnsMode = "append" | "replace";
+
+/**
+ * Single column entry for {@link QueryTransformColumns}.
+ *
+ * @template E - Expression type
+ * @template SO - Spec override type (typically `PColumnIdAndSpec` at
+ *   the spec layer, or layer-specific id+typespec at the data layer)
+ */
+export interface TransformColumnEntry<E, SO> {
+  /** Expression computing the column values. */
+  expression: E;
+  /**
+   * Optional spec override. If omitted, the runtime auto-derives the
+   * column's spec from the host's input and the expression.
+   * `valueType` is always inferred from the expression.
+   */
+  specOverride?: SO;
+}
+
+/**
+ * Transform-columns query operation.
+ *
+ * Computes one or more derived columns from `input`. Axes are
+ * preserved.
+ *
+ * @template Q - Input query type
+ * @template E - Expression type
+ * @template SO - Spec override type
+ */
+export interface QueryTransformColumns<Q, E, SO> {
+  type: "transformColumns";
+  /** Input query. */
+  input: Q;
+  /** `"append"` to add new columns; `"replace"` to keep only listed columns. */
+  mode: TransformColumnsMode;
+  /** Derived columns to compute (at least one). */
+  columns: TransformColumnEntry<E, SO>[];
 }

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -480,7 +480,7 @@ export interface ExprIsIn<I, T extends string | number> {
   /** Set of allowed values */
   set: T[];
   /** If true, the predicate is inverted (true for values NOT in `set`). */
-  negate?: boolean;
+  negate: boolean;
 }
 
 /**
@@ -567,7 +567,7 @@ export interface ExprIsInPolygon<I> {
   /** Polygon vertices as `[x, y]` tuples; at least one. */
   polygon: Point2D[];
   /** If true, the predicate is inverted (true for points OUTSIDE the polygon). */
-  negate?: boolean;
+  negate: boolean;
 }
 
 /**

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -578,10 +578,7 @@ export interface ExprConditional<I> {
 //   type: "aggregation";
 //   kind: AggregationKind;
 //   input: I;
-//   over?: [
-//     QueryAxisSelector<A> | QueryColumnSelector<C>,
-//     ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
-//   ];
+//   over?: [QuerySelector<A, C>, ...QuerySelector<A, C>[]];
 // }
 
 /** Ranking function kind. */
@@ -606,10 +603,7 @@ export interface ExprRanking<I, A, C> {
   /** If true (default), sort ascending; if false, descending. */
   ascending?: boolean;
   /** Partition specification — at least one entry when supplied. */
-  partitionBy?: [
-    QueryAxisSelector<A> | QueryColumnSelector<C>,
-    ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
-  ];
+  partitionBy?: [QuerySelector<A, C>, ...QuerySelector<A, C>[]];
 }
 
 // ============ Disabled — type defined in pframes-rs, runtime not wired yet ============
@@ -630,10 +624,7 @@ export interface ExprRanking<I, A, C> {
 //   input: I;
 //   orderBy: I;
 //   ascending?: boolean;
-//   partitionBy?: [
-//     QueryAxisSelector<A> | QueryColumnSelector<C>,
-//     ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
-//   ];
+//   partitionBy?: [QuerySelector<A, C>, ...QuerySelector<A, C>[]];
 // }
 
 // ============ Reference Expression Types ============
@@ -741,6 +732,15 @@ export interface QueryColumnSelector<C> {
   /** Column identifier (name or index depending on context) */
   id: C;
 }
+
+/**
+ * Axis-or-column selector — mirrors the Rust `Selector<AxisSelector,
+ * ColumnSelector>` enum
+ * (`packages/bridge/src/query/query_sort.rs`). Used for the
+ * `partitionBy` / `over` fields of window expressions where either an
+ * axis or a column can drive the partition.
+ */
+export type QuerySelector<A, C> = QueryAxisSelector<A> | QueryColumnSelector<C>;
 
 /**
  * Left outer join query operation.

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -545,78 +545,44 @@ export interface ExprConditional<I> {
   otherwise?: I;
 }
 
-/**
- * Point-in-polygon test (commonly used for graph-maker lasso /
- * flow-cytometry gating).
- *
- * **Input**: two numeric expressions (`x`, `y`).
- * **Output**: logical Boolean; materialises as `Int` (0/1) when used
- * as a derived column.
- *
- * The polygon is automatically closed (last vertex connects to first).
- * Non-convex polygons are supported.
- *
- * @template I - The expression type (for recursion)
- */
-export interface ExprIsInPolygon<I> {
-  type: "isInPolygon";
-  /** X-coordinate expression. */
-  x: I;
-  /** Y-coordinate expression. */
-  y: I;
-  /** Polygon vertices as `[x, y]` tuples; at least one. */
-  polygon: [Point2D, ...Point2D[]];
-  /** If true, the predicate is inverted (true for points OUTSIDE the polygon). */
-  negate: boolean;
-}
+// ============ Disabled — type defined in pframes-rs, runtime not wired yet ============
+//
+// `isInPolygon` and `aggregation` are defined in the Rust query model
+// (`packages/bridge/src/query/expressions/`) but the DataFusion backend
+// returns errors when it tries to evaluate them (filter.rs:276 / :340).
+// Until those stubs land, exposing the TS types here would let block
+// authors construct queries the runtime cannot execute. Re-enable in
+// lock-step with the Rust executor.
 
-/**
- * Aggregation function kind (flat string; tagged form with payloads is
- * planned per the change log).
- */
-export type AggregationKind =
-  | "sum"
-  | "avg"
-  | "count"
-  | "min"
-  | "max"
-  | "first"
-  | "last"
-  | "stddev"
-  | "variance"
-  | "median";
+// export interface ExprIsInPolygon<I> {
+//   type: "isInPolygon";
+//   x: I;
+//   y: I;
+//   polygon: [Point2D, ...Point2D[]];
+//   negate: boolean;
+// }
 
-/**
- * Aggregation expression — scalar form (inside `aggregate`) or window
- * form (inside `transformColumns` with `over` set).
- *
- * Without `over`: scalar reducer. Valid only inside an `aggregate`
- * query node.
- *
- * With `over`: window function. Valid inside `transformColumns`;
- * preserves all axes, broadcasting the per-partition result to every
- * row.
- *
- * @template I - The expression type (for recursion)
- * @template A - Axis selector type
- * @template C - Column selector type
- */
-export interface ExprAggregation<I, A, C> {
-  type: "aggregation";
-  /** Aggregation kind. */
-  kind: AggregationKind;
-  /** Expression to aggregate. */
-  input: I;
-  /**
-   * Partition specification — when present, the aggregation becomes a
-   * window function and the result is broadcast to every row in the
-   * partition. At least one entry when supplied.
-   */
-  over?: [
-    QueryAxisSelector<A> | QueryColumnSelector<C>,
-    ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
-  ];
-}
+// export type AggregationKind =
+//   | "sum"
+//   | "avg"
+//   | "count"
+//   | "min"
+//   | "max"
+//   | "first"
+//   | "last"
+//   | "stddev"
+//   | "variance"
+//   | "median";
+
+// export interface ExprAggregation<I, A, C> {
+//   type: "aggregation";
+//   kind: AggregationKind;
+//   input: I;
+//   over?: [
+//     QueryAxisSelector<A> | QueryColumnSelector<C>,
+//     ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
+//   ];
+// }
 
 /** Ranking function kind. */
 export type RankingKind = "rank" | "denseRank" | "rowNumber";
@@ -646,40 +612,29 @@ export interface ExprRanking<I, A, C> {
   ];
 }
 
-/** Cumulative aggregation operand (always a window function). */
-export type CumulativeOperand =
-  | "cumulativeSum"
-  | "cumulativeMin"
-  | "cumulativeMax"
-  | "cumulativeAvg";
+// ============ Disabled — type defined in pframes-rs, runtime not wired yet ============
+//
+// `cumulative` is defined in the Rust query model but the DataFusion
+// backend returns an error (filter.rs:387). Re-enable in lock-step
+// with the Rust executor.
 
-/**
- * Cumulative aggregation expression — a window function with the
- * implicit frame `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`.
- *
- * Accumulates `input` across rows within each partition, ordered by
- * `orderBy`. Resets at partition boundaries.
- *
- * @template I - The expression type (for recursion)
- * @template A - Axis selector type
- * @template C - Column selector type
- */
-export interface ExprCumulative<I, A, C> {
-  type: "cumulative";
-  /** Cumulative operand (sum / min / max / avg). */
-  operand: CumulativeOperand;
-  /** Expression to accumulate. */
-  input: I;
-  /** Expression to order rows by within each partition. */
-  orderBy: I;
-  /** If true (default), order ascending; if false, descending. */
-  ascending?: boolean;
-  /** Partition specification — at least one entry when supplied. */
-  partitionBy?: [
-    QueryAxisSelector<A> | QueryColumnSelector<C>,
-    ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
-  ];
-}
+// export type CumulativeOperand =
+//   | "cumulativeSum"
+//   | "cumulativeMin"
+//   | "cumulativeMax"
+//   | "cumulativeAvg";
+
+// export interface ExprCumulative<I, A, C> {
+//   type: "cumulative";
+//   operand: CumulativeOperand;
+//   input: I;
+//   orderBy: I;
+//   ascending?: boolean;
+//   partitionBy?: [
+//     QueryAxisSelector<A> | QueryColumnSelector<C>,
+//     ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
+//   ];
+// }
 
 // ============ Reference Expression Types ============
 
@@ -735,7 +690,6 @@ export type InferBooleanExpressionUnion<E> = [
   E extends ExprLogicalUnary<unknown> ? Extract<E, { type: "not" }> : never,
   E extends ExprLogicalVariadic<unknown> ? Extract<E, { type: "and" | "or" }> : never,
   E extends ExprIsIn<unknown, string | number> ? Extract<E, { type: "isIn" }> : never,
-  E extends ExprIsInPolygon<unknown> ? Extract<E, { type: "isInPolygon" }> : never,
 ][number];
 
 // ============ Generic Query Types ============

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -540,7 +540,7 @@ export interface ExprConditionalCase<I> {
 export interface ExprConditional<I> {
   type: "conditional";
   /** Cases evaluated in order; first matching wins. At least one. */
-  cases: ExprConditionalCase<I>[];
+  cases: [ExprConditionalCase<I>, ...ExprConditionalCase<I>[]];
   /** Fallback value when no case matches. */
   otherwise?: I;
 }
@@ -565,7 +565,7 @@ export interface ExprIsInPolygon<I> {
   /** Y-coordinate expression. */
   y: I;
   /** Polygon vertices as `[x, y]` tuples; at least one. */
-  polygon: Point2D[];
+  polygon: [Point2D, ...Point2D[]];
   /** If true, the predicate is inverted (true for points OUTSIDE the polygon). */
   negate: boolean;
 }
@@ -612,7 +612,10 @@ export interface ExprAggregation<I, A, C> {
    * window function and the result is broadcast to every row in the
    * partition. At least one entry when supplied.
    */
-  over?: (QueryAxisSelector<A> | QueryColumnSelector<C>)[];
+  over?: [
+    QueryAxisSelector<A> | QueryColumnSelector<C>,
+    ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
+  ];
 }
 
 /** Ranking function kind. */
@@ -637,7 +640,10 @@ export interface ExprRanking<I, A, C> {
   /** If true (default), sort ascending; if false, descending. */
   ascending?: boolean;
   /** Partition specification — at least one entry when supplied. */
-  partitionBy?: (QueryAxisSelector<A> | QueryColumnSelector<C>)[];
+  partitionBy?: [
+    QueryAxisSelector<A> | QueryColumnSelector<C>,
+    ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
+  ];
 }
 
 /** Cumulative aggregation operand (always a window function). */
@@ -669,7 +675,10 @@ export interface ExprCumulative<I, A, C> {
   /** If true (default), order ascending; if false, descending. */
   ascending?: boolean;
   /** Partition specification — at least one entry when supplied. */
-  partitionBy?: (QueryAxisSelector<A> | QueryColumnSelector<C>)[];
+  partitionBy?: [
+    QueryAxisSelector<A> | QueryColumnSelector<C>,
+    ...(QueryAxisSelector<A> | QueryColumnSelector<C>)[],
+  ];
 }
 
 // ============ Reference Expression Types ============
@@ -880,8 +889,8 @@ export interface QuerySliceAxes<Q, A> {
  *   type: 'sort',
  *   input: dataQuery,
  *   sortBy: [
- *     { expression: { type: 'columnRef', value: 'score' }, ascending: false, nullsFirst: null },
- *     { expression: { type: 'axisRef', value: { name: 'name' } }, ascending: true, nullsFirst: null }
+ *     { expression: { type: 'columnRef', value: 'score' }, ascending: false, nullsFirst: false },
+ *     { expression: { type: 'axisRef', value: { name: 'name' } }, ascending: true, nullsFirst: false }
  *   ]
  * }
  */
@@ -1044,7 +1053,7 @@ export interface QuerySparseToDenseColumn<C, A, SO> {
    * indices during spec→data lowering. The Rust runtime also accepts
    * the legacy field name `axesIndices` as a serde alias.
    */
-  axes: A[];
+  axes: [A, ...A[]];
 }
 
 /**
@@ -1192,5 +1201,5 @@ export interface QueryTransformColumns<Q, E, SO> {
   /** `"append"` to add new columns; `"replace"` to keep only listed columns. */
   mode: TransformColumnsMode;
   /** Derived columns to compute (at least one). */
-  columns: TransformColumnEntry<E, SO>[];
+  columns: [TransformColumnEntry<E, SO>, ...TransformColumnEntry<E, SO>[]];
 }

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -994,37 +994,57 @@ export interface QueryInlineColumn<T> {
 /**
  * Sparse to dense column query operation.
  *
- * Expands a column across additional axes using Cartesian product.
- * Creates all combinations of existing axis values with new axis values.
+ * Densifies a sparse column over the Cartesian product of distinct
+ * axis values: `axes` partitions the column's own axes into two sets
+ * (the listed axes on one side, the rest on the other); both sides
+ * contribute their distinct values, and the cross product fills in
+ * the missing tuples (null on rows that have no underlying value).
  *
- * **Use case**: When you need to repeat/broadcast a column across
- * new dimensions that it doesn't originally have.
+ * **Use case**: graph-maker and other UI surfaces that need a dense
+ * grid to plot.
  *
  * **Behavior**:
- * - Takes an existing column
- * - Expands it across specified axes indices
- * - Result has Cartesian product of original axes × new axes
+ * - Output axes = input axes (no axes are added).
+ * - Missing axis-tuple combinations become null in the output (or
+ *   filled later via `pl7.app/graph/isDenseAxis` /
+ *   `treatAbsentValuesAs` annotations).
  *
  * @template C - Column reference type
+ * @template A - Axis selector type (named selectors at the spec layer,
+ *   numeric axis indices at the data layer)
  * @template SO - Spec override type
  *
  * @example
- * // Expand column across axes at indices 0 and 2
+ * // Spec layer: name the axis to expand across.
  * {
  *   type: 'sparseToDenseColumn',
  *   column: 'col_abc123',
- *   axesIndices: [0, 2],
+ *   axes: [{ name: 'sample' }],
  *   specOverride: { ... } // optional spec modifications
  * }
+ *
+ * @example
+ * // Data layer: the same query after spec→data lowering.
+ * {
+ *   type: 'sparseToDenseColumn',
+ *   column: 'col_abc123',
+ *   axes: [0],
+ *   specOverride: { ... }
+ * }
  */
-export interface QuerySparseToDenseColumn<C, SO> {
+export interface QuerySparseToDenseColumn<C, A, SO> {
   type: "sparseToDenseColumn";
   /** Column reference (ID or full column object depending on context) */
   column: C;
   /** Optional override for the column specification */
   specOverride?: SO;
-  /** Indices of axes to expand across */
-  axesIndices: number[];
+  /**
+   * Axes that participate in the cartesian-product densification.
+   * Named selectors at the spec layer; resolved to numeric axis
+   * indices during spec→data lowering. The Rust runtime also accepts
+   * the legacy field name `axesIndices` as a serde alias.
+   */
+  axes: A[];
 }
 
 /**

--- a/lib/model/common/src/drivers/pframe/query/query_data.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_data.ts
@@ -1,15 +1,12 @@
 import type { PObjectId } from "../../../pool";
 import type {
-  ExprAggregation,
   ExprAxisRef,
   ExprCast,
   ExprColumnRef,
   ExprConditional,
   ExprConstant,
-  ExprCumulative,
   ExprFillNull,
   ExprIsIn,
-  ExprIsInPolygon,
   ExprIsNull,
   ExprLogicalUnary,
   ExprLogicalVariadic,
@@ -156,11 +153,11 @@ export type DataQueryExpression =
   | ExprLogicalVariadic<DataQueryExpression>
   | ExprIsIn<DataQueryExpression, string>
   | ExprIsIn<DataQueryExpression, number>
-  | ExprIsInPolygon<DataQueryExpression>
+  // | ExprIsInPolygon<DataQueryExpression>  -- runtime not wired (see query_common.ts)
   | ExprCast<DataQueryExpression>
   | ExprConditional<DataQueryExpression>
-  | ExprAggregation<DataQueryExpression, number, number>
-  | ExprRanking<DataQueryExpression, number, number>
-  | ExprCumulative<DataQueryExpression, number, number>;
+  // | ExprAggregation<DataQueryExpression, number, number>  -- runtime not wired
+  | ExprRanking<DataQueryExpression, number, number>;
+// | ExprCumulative<DataQueryExpression, number, number>  -- runtime not wired
 
 export type DataQueryBooleanExpression = InferBooleanExpressionUnion<DataQueryExpression>;

--- a/lib/model/common/src/drivers/pframe/query/query_data.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_data.ts
@@ -71,7 +71,11 @@ export type DataQueryColumn = QueryColumn;
 /** @see QueryInlineColumn */
 export type DataQueryInlineColumn = QueryInlineColumn<ColumnIdAndTypeSpec>;
 /** @see QuerySparseToDenseColumn */
-export type DataQuerySparseToDenseColumn = QuerySparseToDenseColumn<PObjectId, ColumnIdAndTypeSpec>;
+export type DataQuerySparseToDenseColumn = QuerySparseToDenseColumn<
+  PObjectId,
+  number,
+  ColumnIdAndTypeSpec
+>;
 /** @see QuerySymmetricJoin */
 export type DataQuerySymmetricJoin = QuerySymmetricJoin<DataQueryJoinEntry>;
 /** @see QueryOuterJoin */

--- a/lib/model/common/src/drivers/pframe/query/query_data.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_data.ts
@@ -1,22 +1,28 @@
 import type { PObjectId } from "../../../pool";
 import type {
+  ExprAggregation,
   ExprAxisRef,
+  ExprCast,
   ExprColumnRef,
-  ExprNumericBinary,
-  ExprNumericComparison,
+  ExprConditional,
   ExprConstant,
+  ExprCumulative,
+  ExprFillNull,
   ExprIsIn,
+  ExprIsInPolygon,
   ExprIsNull,
-  ExprIfNull,
   ExprLogicalUnary,
   ExprLogicalVariadic,
+  ExprNumericBinary,
+  ExprNumericComparison,
+  ExprNumericUnary,
+  ExprRanking,
   ExprStringContains,
   ExprStringContainsFuzzy,
   ExprStringEquals,
   ExprStringRegex,
-  ExprNumericUnary,
+  InferBooleanExpressionUnion,
   QueryColumn,
-  QuerySparseToDenseColumn,
   QueryFilter,
   QueryInlineColumn,
   QueryJoinEntry,
@@ -24,9 +30,10 @@ import type {
   QueryOuterJoin,
   QuerySliceAxes,
   QuerySort,
+  QuerySparseToDenseColumn,
   QuerySymmetricJoin,
+  QueryTransformColumns,
   TypeSpec,
-  InferBooleanExpressionUnion,
 } from "./query_common";
 
 /**
@@ -93,6 +100,12 @@ export type DataQuerySliceAxes = QuerySliceAxes<DataQuery, number>;
 export type DataQuerySort = QuerySort<DataQuery, DataQueryExpression>;
 /** @see QueryFilter */
 export type DataQueryFilter = QueryFilter<DataQuery, DataQueryBooleanExpression>;
+/** @see QueryTransformColumns */
+export type DataQueryTransformColumns = QueryTransformColumns<
+  DataQuery,
+  DataQueryExpression,
+  ColumnIdAndTypeSpec
+>;
 
 /**
  * Union of all data layer query types.
@@ -102,8 +115,8 @@ export type DataQueryFilter = QueryFilter<DataQuery, DataQueryBooleanExpression>
  *
  * Includes:
  * - Leaf nodes: column, inlineColumn, sparseToDenseColumn
- * - Join operations: innerJoin, fullJoin, outerJoin
- * - Transformations: sliceAxes, sort, filter
+ * - Join operations: innerJoin, fullJoin, outerJoin, linkerJoin
+ * - Transformations: sliceAxes, sort, filter, transformColumns
  */
 export type DataQuery =
   | DataQueryColumn
@@ -114,7 +127,8 @@ export type DataQuery =
   | DataQueryLinkerJoin
   | DataQuerySliceAxes
   | DataQuerySort
-  | DataQueryFilter;
+  | DataQueryFilter
+  | DataQueryTransformColumns;
 
 /** @see ExprAxisRef */
 export type DataExprAxisRef = ExprAxisRef<number>;
@@ -133,10 +147,16 @@ export type DataQueryExpression =
   | ExprStringRegex<DataQueryExpression>
   | ExprStringContainsFuzzy<DataQueryExpression>
   | ExprIsNull<DataQueryExpression>
-  | ExprIfNull<DataQueryExpression>
+  | ExprFillNull<DataQueryExpression>
   | ExprLogicalUnary<DataQueryExpression>
   | ExprLogicalVariadic<DataQueryExpression>
   | ExprIsIn<DataQueryExpression, string>
-  | ExprIsIn<DataQueryExpression, number>;
+  | ExprIsIn<DataQueryExpression, number>
+  | ExprIsInPolygon<DataQueryExpression>
+  | ExprCast<DataQueryExpression>
+  | ExprConditional<DataQueryExpression>
+  | ExprAggregation<DataQueryExpression, number, number>
+  | ExprRanking<DataQueryExpression, number, number>
+  | ExprCumulative<DataQueryExpression, number, number>;
 
 export type DataQueryBooleanExpression = InferBooleanExpressionUnion<DataQueryExpression>;

--- a/lib/model/common/src/drivers/pframe/query/query_spec.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_spec.ts
@@ -1,22 +1,28 @@
 import type { PObjectId } from "../../../pool";
 import type {
+  ExprAggregation,
   ExprAxisRef,
+  ExprCast,
   ExprColumnRef,
-  ExprNumericBinary,
-  ExprNumericComparison,
+  ExprConditional,
   ExprConstant,
+  ExprCumulative,
+  ExprFillNull,
   ExprIsIn,
+  ExprIsInPolygon,
   ExprIsNull,
-  ExprIfNull,
   ExprLogicalUnary,
   ExprLogicalVariadic,
+  ExprNumericBinary,
+  ExprNumericComparison,
+  ExprNumericUnary,
+  ExprRanking,
   ExprStringContains,
   ExprStringContainsFuzzy,
   ExprStringEquals,
   ExprStringRegex,
-  ExprNumericUnary,
+  InferBooleanExpressionUnion,
   QueryColumn,
-  QuerySparseToDenseColumn,
   QueryFilter,
   QueryInlineColumn,
   QueryJoinEntry,
@@ -24,8 +30,9 @@ import type {
   QueryOuterJoin,
   QuerySliceAxes,
   QuerySort,
+  QuerySparseToDenseColumn,
   QuerySymmetricJoin,
-  InferBooleanExpressionUnion,
+  QueryTransformColumns,
 } from "./query_common";
 import type { Domain, PColumnIdAndSpec, SingleAxisSelector } from "../spec";
 
@@ -82,6 +89,12 @@ export type SpecQuerySliceAxes<C = PObjectId> = QuerySliceAxes<SpecQuery<C>, Sin
 export type SpecQuerySort<C = PObjectId> = QuerySort<SpecQuery<C>, SpecQueryExpression>;
 /** @see QueryFilter */
 export type SpecQueryFilter<C = PObjectId> = QueryFilter<SpecQuery<C>, SpecQueryBooleanExpression>;
+/** @see QueryTransformColumns */
+export type SpecQueryTransformColumns<C = PObjectId> = QueryTransformColumns<
+  SpecQuery<C>,
+  SpecQueryExpression,
+  PColumnIdAndSpec
+>;
 
 /**
  * Union of all spec layer query types.
@@ -95,8 +108,8 @@ export type SpecQueryFilter<C = PObjectId> = QueryFilter<SpecQuery<C>, SpecQuery
  *
  * Includes:
  * - Leaf nodes: column, inlineColumn, sparseToDenseColumn
- * - Join operations: innerJoin, fullJoin, outerJoin
- * - Transformations: sliceAxes, sort, filter
+ * - Join operations: innerJoin, fullJoin, outerJoin, linkerJoin
+ * - Transformations: sliceAxes, sort, filter, transformColumns
  */
 export type SpecQuery<C = PObjectId> =
   | SpecQueryColumn<C>
@@ -107,7 +120,8 @@ export type SpecQuery<C = PObjectId> =
   | SpecQueryLinkerJoin<C>
   | SpecQuerySliceAxes<C>
   | SpecQuerySort<C>
-  | SpecQueryFilter<C>;
+  | SpecQueryFilter<C>
+  | SpecQueryTransformColumns<C>;
 
 /** @see ExprAxisRef */
 export type SpecExprAxisRef = ExprAxisRef<SingleAxisSelector>;
@@ -126,10 +140,16 @@ export type SpecQueryExpression =
   | ExprStringRegex<SpecQueryExpression>
   | ExprStringContainsFuzzy<SpecQueryExpression>
   | ExprIsNull<SpecQueryExpression>
-  | ExprIfNull<SpecQueryExpression>
+  | ExprFillNull<SpecQueryExpression>
   | ExprLogicalUnary<SpecQueryExpression>
   | ExprLogicalVariadic<SpecQueryExpression>
   | ExprIsIn<SpecQueryExpression, string>
-  | ExprIsIn<SpecQueryExpression, number>;
+  | ExprIsIn<SpecQueryExpression, number>
+  | ExprIsInPolygon<SpecQueryExpression>
+  | ExprCast<SpecQueryExpression>
+  | ExprConditional<SpecQueryExpression>
+  | ExprAggregation<SpecQueryExpression, SingleAxisSelector, PObjectId>
+  | ExprRanking<SpecQueryExpression, SingleAxisSelector, PObjectId>
+  | ExprCumulative<SpecQueryExpression, SingleAxisSelector, PObjectId>;
 
 export type SpecQueryBooleanExpression = InferBooleanExpressionUnion<SpecQueryExpression>;

--- a/lib/model/common/src/drivers/pframe/query/query_spec.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_spec.ts
@@ -1,15 +1,12 @@
 import type { PObjectId } from "../../../pool";
 import type {
-  ExprAggregation,
   ExprAxisRef,
   ExprCast,
   ExprColumnRef,
   ExprConditional,
   ExprConstant,
-  ExprCumulative,
   ExprFillNull,
   ExprIsIn,
-  ExprIsInPolygon,
   ExprIsNull,
   ExprLogicalUnary,
   ExprLogicalVariadic,
@@ -146,11 +143,11 @@ export type SpecQueryExpression =
   | ExprLogicalVariadic<SpecQueryExpression>
   | ExprIsIn<SpecQueryExpression, string>
   | ExprIsIn<SpecQueryExpression, number>
-  | ExprIsInPolygon<SpecQueryExpression>
+  // | ExprIsInPolygon<SpecQueryExpression>  -- runtime not wired (see query_common.ts)
   | ExprCast<SpecQueryExpression>
   | ExprConditional<SpecQueryExpression>
-  | ExprAggregation<SpecQueryExpression, SingleAxisSelector, PObjectId>
-  | ExprRanking<SpecQueryExpression, SingleAxisSelector, PObjectId>
-  | ExprCumulative<SpecQueryExpression, SingleAxisSelector, PObjectId>;
+  // | ExprAggregation<SpecQueryExpression, SingleAxisSelector, PObjectId>  -- runtime not wired
+  | ExprRanking<SpecQueryExpression, SingleAxisSelector, PObjectId>;
+// | ExprCumulative<SpecQueryExpression, SingleAxisSelector, PObjectId>  -- runtime not wired
 
 export type SpecQueryBooleanExpression = InferBooleanExpressionUnion<SpecQueryExpression>;

--- a/lib/model/common/src/drivers/pframe/query/query_spec.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_spec.ts
@@ -62,6 +62,7 @@ export type SpecQueryInlineColumn = QueryInlineColumn<PColumnIdAndSpec>;
 /** @see QuerySparseToDenseColumn */
 export type SpecQuerySparseToDenseColumn<C = PObjectId> = QuerySparseToDenseColumn<
   C,
+  SingleAxisSelector,
   PColumnIdAndSpec
 >;
 /** @see QuerySymmetricJoin */

--- a/lib/model/common/src/drivers/pframe/query/utils.test.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.test.ts
@@ -27,9 +27,17 @@ describe("traverseQuerySpec", () => {
   });
 
   it("transforms sparseToDenseColumn leaf", () => {
-    const q: Q = { type: "sparseToDenseColumn", column: "a", axesIndices: [0, 1] } as Q;
+    const q: Q = {
+      type: "sparseToDenseColumn",
+      column: "a",
+      axes: [{ name: "s" }, { name: "g" }],
+    } as Q;
     const result = traverseQuerySpec(q, { column: (c) => `${c}!` });
-    expect(result).toEqual({ type: "sparseToDenseColumn", column: "a!", axesIndices: [0, 1] });
+    expect(result).toEqual({
+      type: "sparseToDenseColumn",
+      column: "a!",
+      axes: [{ name: "s" }, { name: "g" }],
+    });
   });
 
   it("passes inlineColumn through unchanged", () => {
@@ -197,7 +205,11 @@ describe("collectSpecQueryColumns", () => {
   });
 
   it("collects from sparseToDenseColumn", () => {
-    const q: Q = { type: "sparseToDenseColumn", column: "s", axesIndices: [0] } as Q;
+    const q: Q = {
+      type: "sparseToDenseColumn",
+      column: "s",
+      axes: [{ name: "s" }],
+    } as Q;
     expect(collectSpecQueryColumns(q)).toEqual(["s"]);
   });
 
@@ -258,17 +270,17 @@ describe("sortSpecQuery", () => {
     });
   });
 
-  it("sorts sparseToDenseColumn axesIndices", () => {
+  it("sorts sparseToDenseColumn axes", () => {
     const q: SpecQuery = {
       type: "sparseToDenseColumn",
       column: pid("a"),
-      axesIndices: [2, 0, 1],
+      axes: [{ name: "z" }, { name: "x" }, { name: "y" }],
     } as SpecQuery;
     const result = sortSpecQuery(q);
     expect(result).toEqual({
       type: "sparseToDenseColumn",
       column: "a",
-      axesIndices: [0, 1, 2],
+      axes: [{ name: "x" }, { name: "y" }, { name: "z" }],
     });
   });
 

--- a/lib/model/common/src/drivers/pframe/query/utils.test.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.test.ts
@@ -115,7 +115,11 @@ describe("traverseQuerySpec", () => {
       type: "sort",
       input: col("a"),
       sortBy: [
-        { expression: { type: "columnRef", value: pid("id1") }, ascending: true, nullsFirst: null },
+        {
+          expression: { type: "columnRef", value: pid("id1") },
+          ascending: true,
+          nullsFirst: false,
+        },
       ],
     } as Q;
     const result = traverseQuerySpec(q, { column: (c) => c.toUpperCase() });
@@ -123,7 +127,7 @@ describe("traverseQuerySpec", () => {
       type: "sort",
       input: { type: "column", column: "A" },
       sortBy: [
-        { expression: { type: "columnRef", value: "id1" }, ascending: true, nullsFirst: null },
+        { expression: { type: "columnRef", value: "id1" }, ascending: true, nullsFirst: false },
       ],
     });
   });

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -18,7 +18,7 @@ const BOOLEAN_TYPES = new Set<SpecQueryBooleanExpression["type"]>([
   "and",
   "or",
   "isIn",
-  "isInPolygon",
+  // "isInPolygon",  -- disabled until the Rust executor wires it up
 ]);
 
 export function isBooleanExpression(expr: SpecQueryExpression): expr is SpecQueryBooleanExpression {

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -88,6 +88,7 @@ export function traverseQuerySpec<C1, C2>(
     case "filter":
     case "sort":
     case "sliceAxes":
+    case "transformColumns":
       result = { ...query, input: traverseQuerySpec(query.input, visitor) };
       break;
     default:
@@ -235,6 +236,8 @@ function cmpQuerySpec(lhs: SpecQuery, rhs: SpecQuery): number {
     case "sort":
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
     case "filter":
+      return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
+    case "transformColumns":
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
     default:
       assertNever(lhs);

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -129,11 +129,9 @@ export function sortSpecQuery(query: SpecQuery): SpecQuery {
             ...node,
             // toSorted preserves array length but the type system widens
             // the non-empty tuple back to a plain array, so re-narrow.
-            axes: node.axes.toSorted((a, b) => {
-              const ak = canonicalizeJson(a);
-              const bk = canonicalizeJson(b);
-              return ak < bk ? -1 : ak > bk ? 1 : 0;
-            }) as typeof node.axes,
+            axes: node.axes.toSorted((a, b) =>
+              canonicalizeJson(a).localeCompare(canonicalizeJson(b)),
+            ) as typeof node.axes,
           };
         case "innerJoin":
         case "fullJoin": {
@@ -251,11 +249,10 @@ function cmpQuerySpec(lhs: SpecQuery, rhs: SpecQuery): number {
       const rhsTc = rhs as typeof lhs;
       const cmp = cmpQuerySpec(lhs.input, rhsTc.input);
       if (cmp !== 0) return cmp;
-      if (lhs.mode !== rhsTc.mode) return lhs.mode < rhsTc.mode ? -1 : 1;
+      const modeCmp = lhs.mode.localeCompare(rhsTc.mode);
+      if (modeCmp !== 0) return modeCmp;
       // Column entries are positional; compare by canonical JSON.
-      const lk = canonicalizeJson(lhs.columns);
-      const rk = canonicalizeJson(rhsTc.columns);
-      return lk < rk ? -1 : lk > rk ? 1 : 0;
+      return canonicalizeJson(lhs.columns).localeCompare(canonicalizeJson(rhsTc.columns));
     }
     default:
       assertNever(lhs);

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -124,7 +124,14 @@ export function sortSpecQuery(query: SpecQuery): SpecQuery {
     node: (node) => {
       switch (node.type) {
         case "sparseToDenseColumn":
-          return { ...node, axesIndices: node.axesIndices.toSorted((a, b) => a - b) };
+          return {
+            ...node,
+            axes: [...node.axes].sort((a, b) => {
+              const ak = canonicalizeJson(a);
+              const bk = canonicalizeJson(b);
+              return ak < bk ? -1 : ak > bk ? 1 : 0;
+            }),
+          };
         case "innerJoin":
         case "fullJoin": {
           const sorted = [...node.entries].sort(cmpQueryJoinEntrySpec);

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -7,7 +7,7 @@ import type {
   SpecQueryJoinEntry,
 } from "./query_spec";
 
-const booleanTypesSet = new Set<SpecQueryBooleanExpression["type"]>([
+const BOOLEAN_TYPES = new Set<SpecQueryBooleanExpression["type"]>([
   "numericComparison",
   "stringEquals",
   "stringContains",
@@ -18,10 +18,11 @@ const booleanTypesSet = new Set<SpecQueryBooleanExpression["type"]>([
   "and",
   "or",
   "isIn",
+  "isInPolygon",
 ]);
 
 export function isBooleanExpression(expr: SpecQueryExpression): expr is SpecQueryBooleanExpression {
-  return booleanTypesSet.has(
+  return BOOLEAN_TYPES.has(
     // @ts-expect-error -- TypeScript doesn't understand the discriminated union here, but we do at runtime
     expr.type,
   );
@@ -126,11 +127,13 @@ export function sortSpecQuery(query: SpecQuery): SpecQuery {
         case "sparseToDenseColumn":
           return {
             ...node,
-            axes: [...node.axes].sort((a, b) => {
+            // toSorted preserves array length but the type system widens
+            // the non-empty tuple back to a plain array, so re-narrow.
+            axes: node.axes.toSorted((a, b) => {
               const ak = canonicalizeJson(a);
               const bk = canonicalizeJson(b);
               return ak < bk ? -1 : ak > bk ? 1 : 0;
-            }),
+            }) as typeof node.axes,
           };
         case "innerJoin":
         case "fullJoin": {
@@ -244,8 +247,16 @@ function cmpQuerySpec(lhs: SpecQuery, rhs: SpecQuery): number {
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
     case "filter":
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
-    case "transformColumns":
-      return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
+    case "transformColumns": {
+      const rhsTc = rhs as typeof lhs;
+      const cmp = cmpQuerySpec(lhs.input, rhsTc.input);
+      if (cmp !== 0) return cmp;
+      if (lhs.mode !== rhsTc.mode) return lhs.mode < rhsTc.mode ? -1 : 1;
+      // Column entries are positional; compare by canonical JSON.
+      const lk = canonicalizeJson(lhs.columns);
+      const rk = canonicalizeJson(rhsTc.columns);
+      return lk < rk ? -1 : lk > rk ? 1 : 0;
+    }
     default:
       assertNever(lhs);
   }

--- a/lib/model/common/src/flags/block_flags.ts
+++ b/lib/model/common/src/flags/block_flags.ts
@@ -29,7 +29,7 @@ export type BlockCodeKnownFeatureFlags = {
  * version in `pnpm-workspace.yaml` so blocks built against the new SDK refuse to load on
  * older desktop apps.
  */
-export const REQUIRES_PFRAMES_VERSION = 1_001_035;
+export const REQUIRES_PFRAMES_VERSION = 1_001_031;
 
 export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQueryRanking"] as const;
 

--- a/lib/model/common/src/flags/block_flags.ts
+++ b/lib/model/common/src/flags/block_flags.ts
@@ -29,7 +29,7 @@ export type BlockCodeKnownFeatureFlags = {
  * version in `pnpm-workspace.yaml` so blocks built against the new SDK refuse to load on
  * older desktop apps.
  */
-export const REQUIRES_PFRAMES_VERSION = 1_001_031;
+export const REQUIRES_PFRAMES_VERSION = 1_001_035;
 
 export const AllSupportsFeatureFlags = ["supportsLazyState", "supportsPframeQueryRanking"] as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,11 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.34
-      version: 1.1.34
+      specifier: 1.1.35
+      version: 1.1.35
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.34
-      version: 1.1.34
+      specifier: 1.1.35
+      version: 1.1.35
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1856,7 +1856,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1976,10 +1976,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.34(encoding@0.1.13)
+        version: 1.1.35(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2413,10 +2413,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.34(encoding@0.1.13)
+        version: 1.1.35(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -4979,18 +4979,18 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.34':
-    resolution: {integrity: sha512-ir2xi+8HcZWy2t98beRP9MUd7ng5gvmos3lALj5rgUg0SAUnN8fBvJ0gAI5AtqhgsjGLRcpr5cGBg12JXJ3Img==}
+  '@milaboratories/pframes-rs-node@1.1.35':
+    resolution: {integrity: sha512-XGLRa29bOmpEUeHgpWNDYZDGDFvR7OfXqaodxaIAVtXnsrsjxzDz063z1sjRPDOx/Pz9T+5n4iRNuLyygwcQ5A==}
 
-  '@milaboratories/pframes-rs-serv@1.1.34':
-    resolution: {integrity: sha512-Wm8LunSZIwi2B66KUVIkzTZgBUQgv4A/sBXeq3u+CDeYptU4ouCY6tpgvJsLo97IUgVtIhsM6+7/X+UGOg0Gjg==}
+  '@milaboratories/pframes-rs-serv@1.1.35':
+    resolution: {integrity: sha512-xr0zztZZX9V7i6iRpbqy12TiFRP3q73UDkjX6sn5KuP7kdmQLExVzhud7Mgd1G293vVAkD2ZBmMRiMoOu2bsMQ==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.34':
-    resolution: {integrity: sha512-OgmExo52JzdFdY+jJ4+75zwBBfgO8QLoosY/RN4r8cvwxZHo0PJ8Pcmw+N54/eoDCocDkuUFDmRnlCGcRzB7TQ==}
+  '@milaboratories/pframes-rs-wasip2@1.1.35':
+    resolution: {integrity: sha512-kcR9YLWAbKYSpksPOoJWkcrkSiUUAEKj/Wuyc9aFsd2bNbWcIb7mLGptFOuvhLn07bZHn0oNcVgupEqd/6Ftbw==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.34':
-    resolution: {integrity: sha512-Lg4DeeoipPYMFJf8bvPIgafXurGUCoW17eRhO7+yab9mCPnM9UgoJEzQ35O46vtNywFRlOT4Op1oey2VyGehGw==}
+  '@milaboratories/pframes-rs-wasm@1.1.35':
+    resolution: {integrity: sha512-wmnEujKa47y+CguYFbeYPjzYAsdhOQO/oNKIyCl0cG/RDwi3qtioKj6DMIBQgjC+/yLPuMsPkjXh7aaPn9cvpA==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.36.0
@@ -9201,6 +9201,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -11206,18 +11207,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/pframes-rs-node@1.1.34(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.35(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-serv': 1.1.34
+      '@milaboratories/pframes-rs-serv': 1.1.35
       '@milaboratories/pl-model-common': 1.36.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.34':
+  '@milaboratories/pframes-rs-serv@1.1.35':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-model-common': 1.36.0
@@ -11225,12 +11226,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.34': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.35': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.34(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.34
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -249,8 +249,8 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.34
-  "@milaboratories/pframes-rs-wasm": 1.1.34
+  "@milaboratories/pframes-rs-node": 1.1.35
+  "@milaboratories/pframes-rs-wasm": 1.1.35
 
   "quickjs-emscripten": 0.31.0
 

--- a/sdk/model/src/filters/converters/filterToQuery.test.ts
+++ b/sdk/model/src/filters/converters/filterToQuery.test.ts
@@ -312,6 +312,7 @@ describe("filterSpecToSpecQueryExpr", () => {
       type: "isIn",
       input: { type: "columnRef", value: "col1" },
       set: ["a", "b", "c"],
+      negate: false,
     });
   });
 
@@ -322,12 +323,10 @@ describe("filterSpecToSpecQueryExpr", () => {
       value: ["x"],
     };
     expect(filterSpecToSpecQueryExpr(filter)).toEqual({
-      type: "not",
-      input: {
-        type: "isIn",
-        input: { type: "columnRef", value: "col1" },
-        set: ["x"],
-      },
+      type: "isIn",
+      input: { type: "columnRef", value: "col1" },
+      set: ["x"],
+      negate: true,
     });
   });
 

--- a/sdk/model/src/filters/converters/filterToQuery.ts
+++ b/sdk/model/src/filters/converters/filterToQuery.ts
@@ -221,15 +221,14 @@ function leafToSpecQueryExpr<Leaf extends FilterSpecLeaf<string>>(
         type: "isIn",
         input: resolveColumnRef(filter.column),
         set: filter.value,
+        negate: false,
       };
     case "notInSet":
       return {
-        type: "not",
-        input: {
-          type: "isIn",
-          input: resolveColumnRef(filter.column),
-          set: filter.value,
-        },
+        type: "isIn",
+        input: resolveColumnRef(filter.column),
+        set: filter.value,
+        negate: true,
       };
 
     case "isNA":

--- a/sdk/model/src/filters/converters/filterToQuery.ts
+++ b/sdk/model/src/filters/converters/filterToQuery.ts
@@ -248,7 +248,7 @@ function leafToSpecQueryExpr<Leaf extends FilterSpecLeaf<string>>(
 
     case "ifNa":
       return {
-        type: "ifNull",
+        type: "fillNull",
         input: resolveColumnRef(filter.column),
         replacement: { type: "constant", value: filter.replacement },
       };


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR synchronises the TypeScript `pframe/query` type definitions with the pframes-rs wire format, adding several new expression and query node types while fixing structural mismatches that existed between the two layers.

- **New types added**: `ExprCast`, `ExprConditional`, `ExprIsInPolygon`, `ExprAggregation`, `ExprRanking`, `ExprCumulative`, and `QueryTransformColumns`; plus wire-shape corrections for `ExprFillNull` (was `ExprIfNull`), `Point2D` (object → tuple), `ExprIsIn.negate` (optional → required boolean), `QuerySort.sortBy[].nullsFirst` (null|boolean → boolean), and `QuerySparseToDenseColumn` (axesIndices → parameterised `axes`).
- **Downstream consumer updated**: `filterToQuery.ts` now emits `negate: true/false` directly on `isIn` instead of wrapping with a `not` node, and switches from `ifNull` to `fillNull`; matching tests are updated throughout.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All previously flagged issues have been resolved and the implementation aligns cleanly with the documented wire format.

All three issues from the previous review round are now addressed: 'isInPolygon' is present in BOOLEAN_TYPES, test fixtures use valid boolean values for nullsFirst, and JSDoc examples are updated. The new expression and query node types are consistently introduced across the spec layer, data layer, and utility functions, with matching test coverage and a clear changeset.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/model/common/src/drivers/pframe/query/query_common.ts | Core type definitions updated: Point2D tuple, ExprFillNull rename, required negate fields, nullsFirst narrowed, new expression/query interfaces added with thorough JSDoc. |
| lib/model/common/src/drivers/pframe/query/utils.ts | booleanTypesSet renamed to BOOLEAN_TYPES and now includes 'isInPolygon'; traverseQuerySpec handles transformColumns; sortSpecQuery and cmpQuerySpec extended for new node types. |
| lib/model/common/src/drivers/pframe/query/query_data.ts | Data-layer types updated to consume new generics; DataQueryTransformColumns added; ExprFillNull swap and new expression variants included. |
| lib/model/common/src/drivers/pframe/query/query_spec.ts | Spec-layer types mirrored: SpecQuerySparseToDenseColumn gains SingleAxisSelector, SpecQueryTransformColumns added, expression union extended. |
| sdk/model/src/filters/converters/filterToQuery.ts | notInSet now emits negate:true on isIn directly (dropped not wrapper); ifNa emits fillNull; inSet adds explicit negate:false. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `lib/model/common/src/drivers/pframe/query/utils.ts`, line 10-21 ([link](https://github.com/milaboratory/platforma/blob/91f39ea28ce213931abc7ededbffa9b022ee2ffb/lib/model/common/src/drivers/pframe/query/utils.ts#L10-L21)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`"isInPolygon"` missing from `booleanTypesSet`**

   `ExprIsInPolygon` was added to `InferBooleanExpressionUnion` (and therefore to `SpecQueryBooleanExpression`), but `booleanTypesSet` was not updated to include `"isInPolygon"`. As a result, `isBooleanExpression({ type: "isInPolygon", ... })` returns `false` at runtime, even though the type system classifies it as a boolean expression. Any code path that relies on this guard — including the predicate validation in `createPTableDefV3.ts` — will silently reject polygon-based filter expressions.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/common/src/drivers/pframe/query/utils.ts
   Line: 10-21

   Comment:
   **`"isInPolygon"` missing from `booleanTypesSet`**

   `ExprIsInPolygon` was added to `InferBooleanExpressionUnion` (and therefore to `SpecQueryBooleanExpression`), but `booleanTypesSet` was not updated to include `"isInPolygon"`. As a result, `isBooleanExpression({ type: "isInPolygon", ... })` returns `false` at runtime, even though the type system classifies it as a boolean expression. Any code path that relies on this guard — including the predicate validation in `createPTableDefV3.ts` — will silently reject polygon-based filter expressions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `lib/model/common/src/drivers/pframe/query/query_common.ts`, line 883-884 ([link](https://github.com/milaboratory/platforma/blob/91f39ea28ce213931abc7ededbffa9b022ee2ffb/lib/model/common/src/drivers/pframe/query/query_common.ts#L883-L884)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> Stale JSDoc examples still show `nullsFirst: null`, but the field type was narrowed to `boolean` in this same PR. The examples are now misleading and will cause confusion for anyone reading the docs.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/common/src/drivers/pframe/query/query_common.ts
   Line: 883-884

   Comment:
   Stale JSDoc examples still show `nullsFirst: null`, but the field type was narrowed to `boolean` in this same PR. The examples are now misleading and will cause confusion for anyone reading the docs.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `lib/model/common/src/drivers/pframe/query/utils.test.ts`, line 117-127 ([link](https://github.com/milaboratory/platforma/blob/91f39ea28ce213931abc7ededbffa9b022ee2ffb/lib/model/common/src/drivers/pframe/query/utils.test.ts#L117-L127)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> These test cases still pass `nullsFirst: null`, which is no longer part of the `QuerySort` field type (it was narrowed from `null | boolean` to `boolean`). The `as Q` cast silences TypeScript, so the mismatch goes unnoticed. The tests should be updated to use a valid `boolean` value.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/common/src/drivers/pframe/query/utils.test.ts
   Line: 117-127

   Comment:
   These test cases still pass `nullsFirst: null`, which is no longer part of the `QuerySort` field type (it was narrowed from `null | boolean` to `boolean`). The `as Q` cast silences TypeScript, so the mismatch goes unnoticed. The tests should be updated to use a valid `boolean` value.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `lib/model/common/src/drivers/pframe/query/utils.ts`, line 10-21 ([link](https://github.com/milaboratory/platforma/blob/d8dba960673544473925295054530340c6770a99/lib/model/common/src/drivers/pframe/query/utils.ts#L10-L21)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`"isInPolygon"` missing from `booleanTypesSet`**

   `ExprIsInPolygon` was added to `InferBooleanExpressionUnion` (and therefore to `SpecQueryBooleanExpression`), but `booleanTypesSet` in `utils.ts` was not updated to include `"isInPolygon"`. As a result, `isBooleanExpression({ type: "isInPolygon", ... })` returns `false` at runtime, even though the type system classifies it as a boolean expression. Any code path that uses this guard — including predicate validation — will silently reject polygon-based filter expressions.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/common/src/drivers/pframe/query/utils.ts
   Line: 10-21

   Comment:
   **`"isInPolygon"` missing from `booleanTypesSet`**

   `ExprIsInPolygon` was added to `InferBooleanExpressionUnion` (and therefore to `SpecQueryBooleanExpression`), but `booleanTypesSet` in `utils.ts` was not updated to include `"isInPolygon"`. As a result, `isBooleanExpression({ type: "isInPolygon", ... })` returns `false` at runtime, even though the type system classifies it as a boolean expression. Any code path that uses this guard — including predicate validation — will silently reject polygon-based filter expressions.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["pl-model-common/pframe: address PR #1632..."](https://github.com/milaboratory/platforma/commit/cf2e8246b3be93f1e054bfd2df05aa0bd3034e73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31751061)</sub>

<!-- /greptile_comment -->