### PR TITLE
Milab 5622 load tree speed up

### DIFF
--- a/.changeset/fix-ll-transaction-active-tx-fragility.md
+++ b/.changeset/fix-ll-transaction-active-tx-fragility.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: stop flaky `ll_transaction.test.ts` active-TX tests caused by empty root-signature fallback and bare-catch error masking.

--- a/.changeset/violet-frogs-enter.md
+++ b/.changeset/violet-frogs-enter.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-middle-layer": minor
+"@milaboratories/pl-client": minor
+"@milaboratories/pl-tree": minor
+---
+
+optimize resource tree updates

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -876,11 +876,12 @@ message ResourceAPI {
       // MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
       // field.
       //
-      // If fields match the predicate, the traversal does not descend into
-      // that field's value.
+      // If a field matches the predicate, the traversal does not descend
+      // into that field's value.
       //
-      // Filters combine via AND.
-      repeated Filter field_filters = 5;
+      // Only one filter is accepted. Compose multiple rules into a single
+      // predicate via AND/OR/NOT groups.
+      optional Filter field_filter = 5;
 
       // If true, the response carries per-resource key-values alongside
       // each visited resource. Defaults to false. Old servers ignore this

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package MiLaboratories.PL.API;
 
-import "github.com/googleapis/googleapis/google/rpc/status.proto";
 import "github.com/googleapis/googleapis/google/api/annotations.proto";
+import "github.com/googleapis/googleapis/google/rpc/status.proto";
 import "github.com/milaboratory/pl/plapi/plapiproto/api_types.proto";
 import "github.com/milaboratory/pl/plapi/plapiproto/base_types.proto";
 import "github.com/milaboratory/pl/plapi/plapiproto/resource_types.proto";
@@ -179,9 +179,7 @@ service Platform {
   // Authentication
   //
   rpc AuthMethods(AuthAPI.ListMethods.Request) returns (AuthAPI.ListMethods.Response) {
-    option (google.api.http) = {
-      get: "/v1/auth/methods"
-    };
+    option (google.api.http) = {get: "/v1/auth/methods"};
   }
   rpc GetJWTToken(AuthAPI.GetJWTToken.Request) returns (AuthAPI.GetJWTToken.Response) {
     option (google.api.http) = {
@@ -233,23 +231,17 @@ service Platform {
   // Other stuff
   //
   rpc ListResourceTypes(MiscAPI.ListResourceTypes.Request) returns (MiscAPI.ListResourceTypes.Response) {
-    option (google.api.http) = {
-      get: "/v1/resource-types"
-    };
+    option (google.api.http) = {get: "/v1/resource-types"};
   }
 
   //
   // Various service requests
   //
   rpc Ping(MaintenanceAPI.Ping.Request) returns (MaintenanceAPI.Ping.Response) {
-    option (google.api.http) = {
-      get: "/v1/ping"
-    };
+    option (google.api.http) = {get: "/v1/ping"};
   }
   rpc License(MaintenanceAPI.License.Request) returns (MaintenanceAPI.License.Response) {
-    option (google.api.http) = {
-      get: "/v1/license"
-    };
+    option (google.api.http) = {get: "/v1/license"};
   }
 }
 
@@ -877,11 +869,118 @@ message ResourceAPI {
       // A 0 value makes the API return only a single resource <resource_id> and is actually
       // equal to Get.Request
       optional uint32 max_depth = 2;
+
+      // Optional per-(resource, field) filter. Unset / nil means
+      // "keep all fields" (current Tree behavior). Servers advertise
+      // support via "treeFilter:v1" in
+      // MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
+      // field.
+      //
+      // If fields match the predicate, the traversal does not descend into
+      // that field's value.
+      //
+      // Filters combine via AND.
+      repeated Filter field_filters = 5;
+
+      // If true, the response carries per-resource key-values alongside
+      // each visited resource. Defaults to false. Old servers ignore this
+      // field and never populate Response.kv.
+      bool include_kv = 6;
+
+      // Optional predicate evaluated at the resource (not field) level.
+      // When set, the traversal does not descend into child resources that do not
+      // satisfy the predicate but resource still returns in the response.
+      //
+      // Each Tree.Response carries traverse_was_stopped=true if this
+      // resource satisfies the predicate.
+      //
+      // Available properties: resource_type (string), is_final (bool),
+      // resource_ready (bool), has_errors (bool), inputs_locked (bool),
+      // outputs_locked (bool). Old servers ignore this field and never
+      // set traverse_was_stopped.
+      optional Filter traverse_stop_rules = 7;
+
+      // Optional alternative entry points for multi-root traversal.
+      // When non-empty, the traversal starts from each listed seed instead
+      // of resource_id. Servers advertise support via "treeSeeds:v1" in
+      // MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
+      // field. resource_id is used as the sole root when seeds is empty.
+      repeated SeedResource seeds = 8;
+    }
+
+    // A single entry point for multi-root tree traversal.
+    message SeedResource {
+      uint64 resource_id        = 1;
+      bytes  resource_signature = 2;
+    }
+
+    // Filter applied to each visited resource's fields during the walk.
+    // The filter is evaluated per (resource, field) pair. If the property
+    // specified by `key` matches the `value` according to the `operator`,
+    // the field is kept; otherwise, it is dropped. A dropped field is not
+    // descended into. Resources are always emitted; when all of a resource's
+    // fields are dropped, descent stops naturally.
+    // Filter evaluated per (resource, field) pair.
+    //
+    // Leaf filter (EQUAL/NOT_EQUAL/MATCH/NOT_MATCH): key is required and
+    // selects which property to test; value carries the expected scalar.
+    //
+    // Composite filter (OR/AND/NOT): key is absent, filters_value carries
+    // sub-filters combined with the chosen operator. OR/AND/NOT may be nested
+    // arbitrarily. Top-level filters (in Tree.Request.filters) are AND-combined.
+    // NOT requires exactly one sub-filter. Dropped fields are not descended into.
+    message Filter {
+      enum OperatorType {
+        UNSPECIFIED = 0;
+        EQUAL = 1;
+        MATCH = 2;
+        OR = 3;
+        AND = 4;
+        NOT = 5;
+      }
+
+      enum Property {
+        FIELD_NAME = 0;
+        RESOURCE_TYPE = 1;
+        IS_FINAL = 2;
+        // Evaluated per resource node (traverse_stop_rules only). True when every non-error
+        // output field has a final value. Matches the TypeScript readyAndHasAllOutputsFilled check.
+        ALL_OUTPUTS_FINAL = 3;
+      }
+
+      // Required for leaf operators (EQUAL/MATCH).
+      // Absent when operator == OR, AND, or NOT.
+      optional Property key = 1;
+      OperatorType operator = 2;
+
+      oneof value {
+        bool bool_value = 3;
+        string string_value = 4;
+        // Used when operator == OR, AND, or NOT.
+        FilterGroup filters_value = 5;
+      }
+
+      // Wrapper for repeated Filter (oneof cannot contain repeated fields directly).
+      message FilterGroup {
+        repeated Filter filters = 1;
+      }
+    }
+
+    message KV {
+      string key = 1;
+      bytes value = 2;
     }
 
     // Multi-message
     message Response {
       Resource resource = 1;
+
+      // Populated only when include_kv=true in the request.
+      repeated KV kv = 2;
+
+      // True when the request specified a traverse_stop_rules and this resource
+      // satisfied it. Always false when traverse_stop_rules was absent.
+      bool traverse_was_stopped = 3;
     }
   }
 
@@ -1406,7 +1505,6 @@ message CacheAPI {
     }
     message Response {}
   }
-
 }
 
 message LocksAPI {
@@ -1496,7 +1594,7 @@ message AuthAPI {
 
   enum Role {
     ROLE_UNSPECIFIED = 0; // issue JWT with caller's natural role. Never appears in server responses.
-    
+
     // Controller roles
     ROLE_CONTROLLER = 2;
     ROLE_WORKFLOW = 3;
@@ -1514,7 +1612,7 @@ message AuthAPI {
 
     message Response {
       string token = 1;
-      
+
       // Session info fields
       bytes session_id = 2;
       Role role = 3;
@@ -1522,8 +1620,7 @@ message AuthAPI {
   }
 
   message GetSessionInfo {
-    message Request {
-    }
+    message Request {}
 
     message Response {
       bytes session_id = 1;
@@ -1688,7 +1785,19 @@ message MaintenanceAPI {
       string os = 7; // linux / windows / macosx
       string arch = 8; // x64 / aarch64
 
-      // next free: 9
+      // Opt-in capabilities advertised by this server instance, used by
+      // clients to pick between fast and fallback code paths without waiting
+      // for a failed RPC.
+      //
+      // Each entry is an opaque token "<feature>:<version>" (e.g.
+      // "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
+      // The field is unset on servers predating this mechanism, which the
+      // client treats as "no optional capabilities advertised".
+      //
+      // All list see pl/platform/api/plapiserver/server_capabilities.go
+      repeated string capabilities = 9;
+
+      // next free: 10
     }
   }
 

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -910,8 +910,8 @@ message ResourceAPI {
 
     // A single entry point for multi-root tree traversal.
     message SeedResource {
-      uint64 resource_id        = 1;
-      bytes  resource_signature = 2;
+      uint64 resource_id = 1;
+      bytes resource_signature = 2;
     }
 
     // Filter applied to each visited resource's fields during the walk.
@@ -973,14 +973,29 @@ message ResourceAPI {
 
     // Multi-message
     message Response {
-      Resource resource = 1;
+      // Full resource payload. Absent on stop-marker frames (when the server
+      // advertises `treeStopMarker:v1` and traverse_was_stopped is true).
+      // Always populated on normal frames.
+      optional Resource resource = 1;
 
       // Populated only when include_kv=true in the request.
       repeated KV kv = 2;
 
       // True when the request specified a traverse_stop_rules and this resource
       // satisfied it. Always false when traverse_stop_rules was absent.
+      //
+      // When the server advertises `treeStopMarker:v1`, a stop-marker frame has
+      // traverse_was_stopped=true with resource unset; resource_id and
+      // resource_signature carry the identity of the stopped node instead.
+      // On normal frames (traverse_was_stopped=false or server without the
+      // capability) resource is always populated and resource_id/resource_signature
+      // are zero/empty.
       bool traverse_was_stopped = 3;
+
+      // Populated only on stop-marker frames (resource is unset).
+      // Zero / empty on normal frames; use resource.resource_id instead.
+      uint64 resource_id        = 4;
+      bytes  resource_signature = 5;
     }
   }
 

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -943,10 +943,29 @@ message ResourceAPI {
       enum Property {
         FIELD_NAME = 0;
         RESOURCE_TYPE = 1;
+        // Status().IsFinal(): true when status is Original, Duplicate, or Error.
+        // Does NOT require AllInputsFinal — a resource with unresolved input fields
+        // can still report IS_FINAL=true if its own status is terminal. Use
+        // RESOURCE_READY_FOR_CALCULATION + IS_DUPLICATE + HAS_ERRORS to mirror the
+        // client-side readyOrDuplicateOrError predicate precisely.
         IS_FINAL = 2;
         // Evaluated per resource node (traverse_stop_rules only). True when every non-error
         // output field has a final value. Matches the TypeScript readyAndHasAllOutputsFilled check.
         ALL_OUTPUTS_FINAL = 3;
+        // IsReadyForCalculation(): Status==Original AND AllInputsFinal AND no input errors AND IO feature.
+        // Mirrors the client-side r.resourceReady property used in readyOrDuplicateOrError.
+        RESOURCE_READY_FOR_CALCULATION = 4;
+        // True when status is Duplicate (original_resource_id != 0). Mirrors the
+        // isNotNullSignedResourceId(r.originalResourceId) branch of readyOrDuplicateOrError.
+        IS_DUPLICATE = 5;
+        // True when the resource has at least one field carrying an error
+        // (aggregated has-error flag). Mirrors the isNotNullSignedResourceId(r.error)
+        // branch of readyOrDuplicateOrError. Note: this can be true even when the
+        // resource's own status is not Error (e.g., an Original resource with a
+        // failed input field).
+        HAS_ERRORS = 6;
+        // True when no further output fields can be added to the resource.
+        OUTPUTS_LOCKED = 7;
       }
 
       // Required for leaf operators (EQUAL/MATCH).

--- a/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
@@ -41,6 +41,8 @@ message Resource {
   bool outputs_locked = 9;
   bool resource_ready = 14;
   bool is_final = 15;
+  // Status() == Error; distinct from has_errors (which means any field has an error value)
+  bool is_error = 20;
 
   uint64 original_resource_id = 10;
   bytes original_resource_signature = 19;
@@ -48,8 +50,6 @@ message Resource {
 
   google.protobuf.Timestamp created_time = 12;
   google.protobuf.Timestamp deleted_time = 13;
-
-  // next free: 20
 }
 
 message Field {

--- a/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
@@ -159,15 +159,15 @@ message ResourceSchema {
   message AccessFlags {
     // Deny-list approach: default = allowed (true)
     // Controllers set these to false to restrict non-controller roles (role='u', role='w')
-    optional bool create_resource = 1;  // default: true (creation allowed)
+    optional bool create_resource = 1; // default: true (creation allowed)
 
     // IMPORTANT: read_fields=false with write_fields=true is a forbidden combination
-    optional bool read_fields = 2;    // default: true (reads allowed)
-    optional bool write_fields = 3;   // default: true (writes allowed)
+    optional bool read_fields = 2; // default: true (reads allowed)
+    optional bool write_fields = 3; // default: true (writes allowed)
 
     // IMPORTANT: read_kv=false with write_kv=true is a forbidden combination
-    optional bool read_kv = 4;   // if unset, falls back to read_fields
-    optional bool write_kv = 5;  // if unset, falls back to write_fields
+    optional bool read_kv = 4; // if unset, falls back to read_fields
+    optional bool write_kv = 5; // if unset, falls back to write_fields
 
     // Per-field-type overrides (map: field_type → bool)
     // When defined for a field type, overrides resource-level flags
@@ -178,8 +178,8 @@ message ResourceSchema {
   // Access restriction flags for non-controller roles
   optional AccessFlags access_flags = 3;
 
-  bool free_inputs = 4;   // if true, skip automatic input locking on creation
-  bool free_outputs = 5;  // if true, skip automatic output locking on creation
+  bool free_inputs = 4; // if true, skip automatic input locking on creation
+  bool free_outputs = 5; // if true, skip automatic output locking on creation
 }
 
 message FieldSchema {

--- a/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
@@ -41,8 +41,6 @@ message Resource {
   bool outputs_locked = 9;
   bool resource_ready = 14;
   bool is_final = 15;
-  // Status() == Error; distinct from has_errors (which means any field has an error value)
-  bool is_error = 20;
 
   uint64 original_resource_id = 10;
   bytes original_resource_signature = 19;

--- a/lib/node/pl-client/src/core/final.ts
+++ b/lib/node/pl-client/src/core/final.ts
@@ -47,7 +47,7 @@ export const DefaultFinalResourceDataPredicate: FinalResourceDataPredicate = (r)
       if (isNotNullSignedResourceId(r.error)) return true;
       const downloadable = getField(r as ResourceData, "downloadable");
       const stream = getField(r as ResourceData, "stream");
-      return stream.value === downloadable.value;
+      return stream.value === downloadable.value; // it's equal to the resource is marked as final on backend side
     }
     case ResourceTypeName.StdMap:
     case ResourceTypeName.StdMapSlash:

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -496,7 +496,11 @@ export class LLPlClient implements WireClientProviderFactory {
     if (cl instanceof GrpcPlApiClient) {
       return (await cl.ping({})).response;
     } else {
-      return notEmpty((await cl.GET("/v1/ping")).data, "REST: empty response for ping request");
+      // The REST ping response predates the `capabilities` field (proto field 9).
+      // Old servers omit it; treat absence as empty capability list.
+      const pingData = notEmpty((await cl.GET("/v1/ping")).data, "REST: empty response for ping request");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return { ...(pingData as unknown as grpcTypes.MaintenanceAPI_Ping_Response), capabilities: (pingData as any).capabilities ?? [] };
     }
   }
 

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -498,9 +498,15 @@ export class LLPlClient implements WireClientProviderFactory {
     } else {
       // The REST ping response predates the `capabilities` field (proto field 9).
       // Old servers omit it; treat absence as empty capability list.
-      const pingData = notEmpty((await cl.GET("/v1/ping")).data, "REST: empty response for ping request");
+      const pingData = notEmpty(
+        (await cl.GET("/v1/ping")).data,
+        "REST: empty response for ping request",
+      );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return { ...(pingData as unknown as grpcTypes.MaintenanceAPI_Ping_Response), capabilities: (pingData as any).capabilities ?? [] };
+      return {
+        ...(pingData as unknown as grpcTypes.MaintenanceAPI_Ping_Response),
+        capabilities: (pingData as any).capabilities ?? [],
+      };
     }
   }
 

--- a/lib/node/pl-client/src/core/ll_transaction.test.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.test.ts
@@ -1,6 +1,6 @@
-import { getTestLLClient } from "../test/test_config";
+import { getTestClient, getTestLLClient } from "../test/test_config";
 import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
-import { createLocalResourceId } from "./types";
+import { createLocalResourceId, parseSignedResourceId } from "./types";
 import { test, expect } from "vitest";
 
 import { isTimeoutOrCancelError } from "./errors";
@@ -11,15 +11,14 @@ let cachedRootSig: Uint8Array | undefined;
 
 async function getRootSignature(): Promise<Uint8Array> {
   if (cachedRootSig !== undefined) return cachedRootSig;
-  const client = await getTestLLClient();
-  const responses = await client.listUserResources({ limit: 1 });
-  for (const msg of responses) {
-    if (msg.entry.oneofKind === "userRoot" && msg.entry.userRoot.resourceSignature) {
-      cachedRootSig = msg.entry.userRoot.resourceSignature;
-      return cachedRootSig;
-    }
+  // Use PlClient (not LLPlClient) so UserResources auto-creates the root if missing.
+  const client = await getTestClient();
+  try {
+    const rootId = await client.getUserRoot({ createIfNotExists: true });
+    cachedRootSig = parseSignedResourceId(rootId).signature;
+  } finally {
+    await client.close();
   }
-  cachedRootSig = new Uint8Array(0);
   return cachedRootSig;
 }
 
@@ -100,7 +99,7 @@ test("check timeout error type (active)", async () => {
   const rootSig = await getRootSignature();
   const tx = client.createTx(true, { timeout: 500 });
 
-  try {
+  await expect(async () => {
     const openResponse = await tx.send(
       {
         oneofKind: "txOpen",
@@ -163,9 +162,7 @@ test("check timeout error type (active)", async () => {
 
       expect(Buffer.compare(vr.resourceGet.resource!.data, rData)).toBe(0);
     }
-  } catch (err: unknown) {
-    expect(isTimeoutOrCancelError(err)).toBe(true);
-  }
+  }).rejects.toSatisfy(isTimeoutOrCancelError);
 });
 
 test("check is abort error (active)", async () => {
@@ -173,7 +170,7 @@ test("check is abort error (active)", async () => {
   const rootSig = await getRootSignature();
   const tx = client.createTx(true, { abortSignal: AbortSignal.timeout(100) });
 
-  try {
+  await expect(async () => {
     const openResponse = await tx.send(
       {
         oneofKind: "txOpen",
@@ -236,7 +233,5 @@ test("check is abort error (active)", async () => {
 
       expect(Buffer.compare(vr.resourceGet.resource!.data, rData)).toBe(0);
     }
-  } catch (err: unknown) {
-    expect(isTimeoutOrCancelError(err)).toBe(true);
-  }
+  }).rejects.toSatisfy(isTimeoutOrCancelError);
 });

--- a/lib/node/pl-client/src/core/ll_transaction.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.ts
@@ -24,37 +24,114 @@ export type OneOfKind<T extends { oneofKind: unknown }, Kind extends T["oneofKin
   { oneofKind: Kind }
 >;
 
-interface SingleResponseHandler<Kind extends ServerMessageResponse["oneofKind"]> {
-  kind: Kind;
-  expectMultiResponse: false;
-  resolve: (v: OneOfKind<ServerMessageResponse, Kind>) => void;
+interface SingleResponseHandler {
+  mode: "single";
+  kind: ServerMessageResponse["oneofKind"];
+  resolve: (v: ServerMessageResponse) => void;
   reject: (e: Error) => void;
 }
 
-interface MultiResponseHandler<Kind extends ServerMessageResponse["oneofKind"]> {
-  kind: Kind;
-  expectMultiResponse: true;
-  resolve: (v: OneOfKind<ServerMessageResponse, Kind>[]) => void;
+interface MultiResponseHandler {
+  mode: "multiBuffered";
+  kind: ServerMessageResponse["oneofKind"];
+  resolve: (v: ServerMessageResponse[]) => void;
   reject: (e: Error) => void;
 }
 
-type AnySingleResponseHandler = SingleResponseHandler<ServerMessageResponse["oneofKind"]>;
+interface MultiStreamResponseHandler {
+  mode: "multiStream";
+  kind: ServerMessageResponse["oneofKind"];
+  stream: AsyncMessageStream<ServerMessageResponse>;
+}
 
-type AnyMultiResponseHandler = MultiResponseHandler<ServerMessageResponse["oneofKind"]>;
+type AnySingleResponseHandler = SingleResponseHandler;
+type AnyMultiStreamResponseHandler = MultiStreamResponseHandler;
 
 type AnyResponseHandler =
-  | SingleResponseHandler<ServerMessageResponse["oneofKind"]>
-  | MultiResponseHandler<ServerMessageResponse["oneofKind"]>;
+  | AnySingleResponseHandler
+  | MultiResponseHandler
+  | AnyMultiStreamResponseHandler;
 
-function createResponseHandler<Kind extends ServerMessageResponse["oneofKind"]>(
-  kind: Kind,
-  expectMultiResponse: boolean,
-  resolve:
-    | ((v: OneOfKind<ServerMessageResponse, Kind>) => void)
-    | ((v: OneOfKind<ServerMessageResponse, Kind>[]) => void),
-  reject: (e: Error) => void,
-): AnyResponseHandler {
-  return { kind, expectMultiResponse, resolve, reject } as AnyResponseHandler;
+class AsyncMessageStream<T> implements AsyncIterable<T> {
+  private readonly queue = new Denque<T>();
+  private done = false;
+  private cancelled = false;
+  private failure?: Error;
+  private waitingResolve?: (value: IteratorResult<T>) => void;
+  private waitingReject?: (reason?: unknown) => void;
+
+  public push(value: T): void {
+    if (this.done || this.cancelled) return;
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = undefined;
+      this.waitingReject = undefined;
+      resolve({ value, done: false });
+      return;
+    }
+    this.queue.push(value);
+  }
+
+  public end(): void {
+    if (this.done) return;
+    this.done = true;
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = undefined;
+      this.waitingReject = undefined;
+      resolve({ value: undefined, done: true });
+    }
+  }
+
+  public fail(error: Error): void {
+    if (this.done) return;
+    this.failure = error;
+    this.done = true;
+    if (this.waitingReject) {
+      const reject = this.waitingReject;
+      this.waitingResolve = undefined;
+      this.waitingReject = undefined;
+      reject(error);
+    }
+  }
+
+  public cancel(): void {
+    this.cancelled = true;
+    this.done = true;
+    this.queue.clear();
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = undefined;
+      this.waitingReject = undefined;
+      resolve({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async (): Promise<IteratorResult<T>> => {
+        if (this.failure) throw this.failure;
+
+        const value = this.queue.shift();
+        if (value !== undefined) return { value, done: false };
+
+        if (this.done) return { value: undefined, done: true };
+
+        return await new Promise<IteratorResult<T>>((resolve, reject) => {
+          this.waitingResolve = resolve;
+          this.waitingReject = reject;
+        });
+      },
+      return: async (): Promise<IteratorResult<T>> => {
+        this.cancel();
+        return { value: undefined, done: true };
+      },
+      throw: async (error?: unknown): Promise<IteratorResult<T>> => {
+        this.cancel();
+        throw error;
+      },
+    };
+  }
 }
 
 function isRecoverable(status: Status): boolean {
@@ -81,6 +158,7 @@ export class LLPlTransaction {
 
   /** Queue from which incoming message processor takes handlers to which pass incoming messages */
   private readonly responseHandlerQueue = new Denque<AnyResponseHandler>();
+
 
   /** Each new resource, created by the transaction, is assigned with virtual (local) resource id, to make it possible
    * to populate its fields without awaiting actual resource id. This counter tracks those ids on client side, the
@@ -127,6 +205,7 @@ export class LLPlTransaction {
     // to the specific request on which it happened
     let currentHandler: AnyResponseHandler | undefined = undefined;
     let responseAggregator: ServerMessageResponse[] | undefined = undefined;
+    let currentMultiIdx = 0;
     try {
       for await (const message of this.stream.responses) {
         if (currentHandler === undefined) {
@@ -139,9 +218,8 @@ export class LLPlTransaction {
             break;
           }
 
-          // allocating response aggregator array
-          if (currentHandler.expectMultiResponse) responseAggregator = [];
-
+          if (currentHandler.mode === "multiBuffered") responseAggregator = [];
+          currentMultiIdx = 0;
           expectedId++;
         }
 
@@ -157,11 +235,14 @@ export class LLPlTransaction {
           const status = message.error;
 
           if (isRecoverable(status)) {
-            currentHandler.reject(
-              new RethrowError(() => {
-                throw new RecoverablePlError(status);
-              }),
-            );
+            const recoverableError = new RethrowError(() => {
+              throw new RecoverablePlError(status);
+            });
+            if (currentHandler.mode === "single" || currentHandler.mode === "multiBuffered") {
+              currentHandler.reject(recoverableError);
+            } else {
+              currentHandler.stream.fail(recoverableError);
+            }
             currentHandler = undefined;
 
             if (message.multiMessage !== undefined && !message.multiMessage.isLast) {
@@ -176,7 +257,12 @@ export class LLPlTransaction {
           } else {
             this.assignErrorFactoryIfNotSet(() => {
               throw new UnrecoverablePlError(status);
-            }, currentHandler.reject);
+            }, currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
+              ? currentHandler.reject
+              : undefined);
+            if (currentHandler.mode === "multiStream") {
+              currentHandler.stream.fail(new UnrecoverablePlError(status));
+            }
             currentHandler = undefined;
 
             // In case of unrecoverable errors we close the transaction
@@ -192,18 +278,30 @@ export class LLPlTransaction {
 
           this.assignErrorFactoryIfNotSet(() => {
             throw new Error(errorMessage);
-          }, currentHandler.reject);
+          }, currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
+            ? currentHandler.reject
+            : undefined);
+          if (currentHandler.mode === "multiStream") {
+            currentHandler.stream.fail(new Error(errorMessage));
+          }
           currentHandler = undefined;
 
           break;
         }
 
-        if (currentHandler.expectMultiResponse !== (message.multiMessage !== undefined)) {
-          const errorMessage = `inconsistent multi state: ${currentHandler.expectMultiResponse} !== ${message.multiMessage !== undefined}`;
+        const expectMultiResponse =
+          currentHandler.mode === "multiBuffered" || currentHandler.mode === "multiStream";
+        if (expectMultiResponse !== (message.multiMessage !== undefined)) {
+          const errorMessage = `inconsistent multi state: ${expectMultiResponse} !== ${message.multiMessage !== undefined}`;
 
           this.assignErrorFactoryIfNotSet(() => {
             throw new Error(errorMessage);
-          }, currentHandler.reject);
+          }, currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
+            ? currentHandler.reject
+            : undefined);
+          if (currentHandler.mode === "multiStream") {
+            currentHandler.stream.fail(new Error(errorMessage));
+          }
           currentHandler = undefined;
 
           break;
@@ -213,23 +311,35 @@ export class LLPlTransaction {
 
         if (message.multiMessage !== undefined) {
           if (!message.multiMessage.isEmpty) {
-            if (message.multiMessage.id !== responseAggregator!.length + 1) {
-              const errorMessage = `inconsistent multi id: ${message.multiMessage.id} !== ${responseAggregator!.length + 1}`;
+            if (message.multiMessage.id !== currentMultiIdx + 1) {
+              const errorMessage = `inconsistent multi id: ${message.multiMessage.id} !== ${currentMultiIdx + 1}`;
 
               this.assignErrorFactoryIfNotSet(() => {
                 throw new Error(errorMessage);
-              }, currentHandler.reject);
+              }, currentHandler.mode === "multiBuffered" ? currentHandler.reject : undefined);
+              if (currentHandler.mode === "multiStream") {
+                currentHandler.stream.fail(new Error(errorMessage));
+              }
               currentHandler = undefined;
 
               break;
             }
 
-            responseAggregator!.push(message.response);
+            currentMultiIdx++;
+            if (currentHandler.mode === "multiBuffered") {
+              responseAggregator!.push(message.response);
+            } else if (currentHandler.mode === "multiStream") {
+              currentHandler.stream.push(message.response);
+            }
           }
 
           if (message.multiMessage.isLast) {
-            (currentHandler as AnyMultiResponseHandler).resolve(responseAggregator!);
-            responseAggregator = undefined;
+            if (currentHandler.mode === "multiBuffered") {
+              currentHandler.resolve(responseAggregator!);
+              responseAggregator = undefined;
+            } else if (currentHandler.mode === "multiStream") {
+              currentHandler.stream.end();
+            }
             currentHandler = undefined;
           }
         } else {
@@ -245,9 +355,14 @@ export class LLPlTransaction {
         }
       }
     } catch (e: any) {
-      return this.assignErrorFactoryIfNotSet(() => {
-        rethrowMeaningfulError(e, true);
-      }, currentHandler?.reject);
+      return this.assignErrorFactoryIfNotSet(
+        () => {
+          rethrowMeaningfulError(e, true);
+        },
+        currentHandler && (currentHandler.mode === "single" || currentHandler.mode === "multiBuffered")
+          ? currentHandler.reject
+          : undefined,
+      );
     } finally {
       await this.close();
     }
@@ -265,8 +380,14 @@ export class LLPlTransaction {
     while (true) {
       const handler = this.responseHandlerQueue.shift();
       if (!handler) break;
-      if (this.errorFactory) handler.reject(new RethrowError(this.errorFactory));
-      else handler.reject(new Error("no reply"));
+      const noReplyError = this.errorFactory
+        ? new RethrowError(this.errorFactory)
+        : new Error("no reply");
+      if (handler.mode === "single" || handler.mode === "multiBuffered") {
+        handler.reject(noReplyError);
+      } else {
+        handler.stream.fail(noReplyError);
+      }
     }
 
     // closing outgoing stream
@@ -311,10 +432,24 @@ export class LLPlTransaction {
 
     // Note: Promise synchronously executes a callback passed to a constructor
     const result = StatefulPromise.fromDeferredReject(
-      new Promise<OneOfKind<ServerMessageResponse, Kind>>((resolve, reject) => {
-        this.responseHandlerQueue.push(
-          createResponseHandler(r.oneofKind, expectMultiResponse, resolve, reject),
-        );
+      new Promise<
+        OneOfKind<ServerMessageResponse, Kind> | OneOfKind<ServerMessageResponse, Kind>[]
+      >((resolve, reject) => {
+        if (expectMultiResponse) {
+          this.responseHandlerQueue.push({
+            mode: "multiBuffered",
+            kind: r.oneofKind,
+            resolve: resolve as (v: ServerMessageResponse[]) => void,
+            reject,
+          });
+        } else {
+          this.responseHandlerQueue.push({
+            mode: "single",
+            kind: r.oneofKind,
+            resolve: resolve as (v: ServerMessageResponse) => void,
+            reject,
+          });
+        }
       }),
     );
 
@@ -331,6 +466,25 @@ export class LLPlTransaction {
       if (e instanceof RethrowError) e.rethrowLambda();
       throw new Error("Error while waiting for response", { cause: e });
     }
+  }
+
+  public sendStream<Kind extends ClientMessageRequest["oneofKind"]>(
+    r: OneOfKind<ClientMessageRequest, Kind>,
+  ): AsyncIterable<OneOfKind<ServerMessageResponse, Kind>> {
+    if (this.errorFactory) throw new RethrowError(this.errorFactory);
+    if (this.closed) throw new Error("Transaction already closed");
+
+    const stream = new AsyncMessageStream<ServerMessageResponse>();
+    this.responseHandlerQueue.push({ mode: "multiStream", kind: r.oneofKind, stream });
+
+    void this.stream.requests
+      .send({ requestId: this.requestIdxCounter++, request: r })
+      .catch((e: unknown) => {
+        if (e instanceof Error) stream.fail(e);
+        else stream.fail(new Error("Error while sending request", { cause: e }));
+      });
+
+    return stream as AsyncIterable<OneOfKind<ServerMessageResponse, Kind>>;
   }
 
   private _completed = false;

--- a/lib/node/pl-client/src/core/ll_transaction.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.ts
@@ -159,7 +159,6 @@ export class LLPlTransaction {
   /** Queue from which incoming message processor takes handlers to which pass incoming messages */
   private readonly responseHandlerQueue = new Denque<AnyResponseHandler>();
 
-
   /** Each new resource, created by the transaction, is assigned with virtual (local) resource id, to make it possible
    * to populate its fields without awaiting actual resource id. This counter tracks those ids on client side, the
    * same way it is tracked on the server, so client can synchronously return such ids to the user. */
@@ -255,11 +254,14 @@ export class LLPlTransaction {
             // We can continue to work after recoverable errors
             continue;
           } else {
-            this.assignErrorFactoryIfNotSet(() => {
-              throw new UnrecoverablePlError(status);
-            }, currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
-              ? currentHandler.reject
-              : undefined);
+            this.assignErrorFactoryIfNotSet(
+              () => {
+                throw new UnrecoverablePlError(status);
+              },
+              currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
+                ? currentHandler.reject
+                : undefined,
+            );
             if (currentHandler.mode === "multiStream") {
               currentHandler.stream.fail(new UnrecoverablePlError(status));
             }
@@ -276,11 +278,14 @@ export class LLPlTransaction {
         ) {
           const errorMessage = `inconsistent request response types: ${currentHandler.kind} !== ${message.response.oneofKind}`;
 
-          this.assignErrorFactoryIfNotSet(() => {
-            throw new Error(errorMessage);
-          }, currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
-            ? currentHandler.reject
-            : undefined);
+          this.assignErrorFactoryIfNotSet(
+            () => {
+              throw new Error(errorMessage);
+            },
+            currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
+              ? currentHandler.reject
+              : undefined,
+          );
           if (currentHandler.mode === "multiStream") {
             currentHandler.stream.fail(new Error(errorMessage));
           }
@@ -294,11 +299,14 @@ export class LLPlTransaction {
         if (expectMultiResponse !== (message.multiMessage !== undefined)) {
           const errorMessage = `inconsistent multi state: ${expectMultiResponse} !== ${message.multiMessage !== undefined}`;
 
-          this.assignErrorFactoryIfNotSet(() => {
-            throw new Error(errorMessage);
-          }, currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
-            ? currentHandler.reject
-            : undefined);
+          this.assignErrorFactoryIfNotSet(
+            () => {
+              throw new Error(errorMessage);
+            },
+            currentHandler.mode === "single" || currentHandler.mode === "multiBuffered"
+              ? currentHandler.reject
+              : undefined,
+          );
           if (currentHandler.mode === "multiStream") {
             currentHandler.stream.fail(new Error(errorMessage));
           }
@@ -314,9 +322,12 @@ export class LLPlTransaction {
             if (message.multiMessage.id !== currentMultiIdx + 1) {
               const errorMessage = `inconsistent multi id: ${message.multiMessage.id} !== ${currentMultiIdx + 1}`;
 
-              this.assignErrorFactoryIfNotSet(() => {
-                throw new Error(errorMessage);
-              }, currentHandler.mode === "multiBuffered" ? currentHandler.reject : undefined);
+              this.assignErrorFactoryIfNotSet(
+                () => {
+                  throw new Error(errorMessage);
+                },
+                currentHandler.mode === "multiBuffered" ? currentHandler.reject : undefined,
+              );
               if (currentHandler.mode === "multiStream") {
                 currentHandler.stream.fail(new Error(errorMessage));
               }
@@ -359,7 +370,8 @@ export class LLPlTransaction {
         () => {
           rethrowMeaningfulError(e, true);
         },
-        currentHandler && (currentHandler.mode === "single" || currentHandler.mode === "multiBuffered")
+        currentHandler &&
+          (currentHandler.mode === "single" || currentHandler.mode === "multiBuffered")
           ? currentHandler.reject
           : undefined,
       );

--- a/lib/node/pl-client/src/core/ll_transaction.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.ts
@@ -52,7 +52,11 @@ type AnyResponseHandler =
   | MultiResponseHandler
   | AnyMultiStreamResponseHandler;
 
-class AsyncMessageStream<T> implements AsyncIterable<T> {
+// Implements both AsyncIterable and AsyncIterator: `[Symbol.asyncIterator]()` returns
+// `this`, so multiple `for await` loops over the same stream share state instead of
+// creating independent iterators that would race on `waitingResolve`/`waitingReject`.
+// Only one active consumer is supported; concurrent `next()` calls are not safe.
+class AsyncMessageStream<T> implements AsyncIterable<T>, AsyncIterator<T> {
   private readonly queue = new Denque<T>();
   private done = false;
   private cancelled = false;
@@ -83,6 +87,11 @@ class AsyncMessageStream<T> implements AsyncIterable<T> {
     }
   }
 
+  // Fail-fast: any frames still buffered in `this.queue` are intentionally dropped.
+  // `next()` checks `this.failure` before draining the queue, so consumers see the
+  // error immediately. This differs from `end()`, which drains buffered frames first.
+  // Rationale: when the upstream stream errors, the in-flight response is treated as
+  // corrupt and partial frames must not be surfaced.
   public fail(error: Error): void {
     if (this.done) return;
     this.failure = error;
@@ -107,30 +116,32 @@ class AsyncMessageStream<T> implements AsyncIterable<T> {
     }
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return {
-      next: async (): Promise<IteratorResult<T>> => {
-        if (this.failure) throw this.failure;
+  public async next(): Promise<IteratorResult<T>> {
+    if (this.failure) throw this.failure;
 
-        const value = this.queue.shift();
-        if (value !== undefined) return { value, done: false };
+    const value = this.queue.shift();
+    if (value !== undefined) return { value, done: false };
 
-        if (this.done) return { value: undefined, done: true };
+    if (this.done) return { value: undefined, done: true };
 
-        return await new Promise<IteratorResult<T>>((resolve, reject) => {
-          this.waitingResolve = resolve;
-          this.waitingReject = reject;
-        });
-      },
-      return: async (): Promise<IteratorResult<T>> => {
-        this.cancel();
-        return { value: undefined, done: true };
-      },
-      throw: async (error?: unknown): Promise<IteratorResult<T>> => {
-        this.cancel();
-        throw error;
-      },
-    };
+    return await new Promise<IteratorResult<T>>((resolve, reject) => {
+      this.waitingResolve = resolve;
+      this.waitingReject = reject;
+    });
+  }
+
+  public async return(): Promise<IteratorResult<T>> {
+    this.cancel();
+    return { value: undefined, done: true };
+  }
+
+  public async throw(error?: unknown): Promise<IteratorResult<T>> {
+    this.cancel();
+    throw error;
+  }
+
+  [Symbol.asyncIterator](): this {
+    return this;
   }
 }
 

--- a/lib/node/pl-client/src/core/transaction.test.ts
+++ b/lib/node/pl-client/src/core/transaction.test.ts
@@ -177,3 +177,41 @@ test("handle KV storage 2", async () => {
     });
   });
 });
+
+test("resourceTree accepts mixed seed types and returns kv entries", async () => {
+  await withTempRoot(async (pl) => {
+    const [rootId, childId] = await pl.withWriteTx("resourceTreeSetup", async (tx) => {
+      const root = tx.createStruct(StructTestResource);
+      const child = tx.createStruct(StructTestResource);
+
+      tx.createField(field(root, "child"), "Dynamic", child);
+      tx.createField(field(tx.clientRoot, "treeRoot"), "Dynamic", root);
+      tx.setKValue(root, "root-k", "root-v");
+
+      await tx.commit();
+      return [await root.globalId, await child.globalId];
+    });
+
+    await pl.withReadTx("resourceTreeRead", async (tx) => {
+      const rootData = await tx.getResourceData(rootId, true);
+      const visitedIds = new Set<string>();
+      const iter = tx.resourceTree([rootData, childId], { includeKv: true });
+
+      for await (const item of iter) {
+        visitedIds.add(item.id);
+        expect(typeof item.traverseWasStopped).toBe("boolean");
+      }
+
+      expect(visitedIds.has(rootId)).toBe(true);
+      expect(visitedIds.has(childId)).toBe(true);
+    });
+  });
+});
+
+test("resourceTree empty seeds fails", async () => {
+  await withTempRoot(async (pl) => {
+    await pl.withReadTx("resourceTreeEmptySeeds", async (tx) => {
+      expect(() => tx.resourceTree([])).toThrow("resourceTree: at least one seed must be provided");
+    });
+  });
+});

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -88,8 +88,8 @@ export type ResourceTreeItem = ResourceData & { kv: KeyValue[]; traverseWasStopp
  * Note: `frameKind` is distinct from `ResourceData.kind` (which is the resource kind).
  */
 export type ResourceTreeFrame =
-  | (ResourceTreeItem & { frameKind: 'resource' })
-  | { frameKind: 'stopMarker'; id: SignedResourceId; traverseWasStopped: true };
+  | (ResourceTreeItem & { frameKind: "resource" })
+  | { frameKind: "stopMarker"; id: SignedResourceId; traverseWasStopped: true };
 
 interface _FieldId<RId> {
   /** Parent resource id */
@@ -1150,13 +1150,13 @@ export class PlTransaction {
                 toResourceSignature(frame.resourceSignature),
               );
               return {
-                value: { frameKind: 'stopMarker', id, traverseWasStopped: true },
+                value: { frameKind: "stopMarker", id, traverseWasStopped: true },
                 done: false,
               };
             }
             return {
               value: {
-                frameKind: 'resource',
+                frameKind: "resource",
                 ...protoToResource(frame.resource),
                 kv: frame.kv,
                 traverseWasStopped: frame.traverseWasStopped,

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -37,7 +37,12 @@ import type {
 import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import type { NonUndefined } from "utility-types";
 import { toBytes } from "../util/util";
-import { fieldTypeToProto, protoToField, protoToResource } from "./type_conversion";
+import {
+  fieldTypeToProto,
+  protoToField,
+  protoToResource,
+  resourceIsDeleted,
+} from "./type_conversion";
 import {
   canonicalJsonBytes,
   canonicalJsonGzBytes,
@@ -1140,29 +1145,39 @@ export class PlTransaction {
 
         return {
           async next(): Promise<IteratorResult<ResourceTreeFrame>> {
-            const item = await iterator.next();
-            if (item.done) return { value: undefined, done: true };
-            const frame = item.value.resourceTree;
-            if (!frame.resource) {
-              // Stop-marker frame: no resource body; server advertised treeStopMarker:v1.
-              const id = createSignedResourceId(
-                frame.resourceId,
-                toResourceSignature(frame.resourceSignature),
-              );
+            while (true) {
+              const item = await iterator.next();
+              if (item.done) return { value: undefined, done: true };
+
+              const frame = item.value.resourceTree;
+              if (frame === undefined) continue;
+
+              if (frame.resource && resourceIsDeleted(frame.resource)) {
+                continue;
+              }
+
+              if (!frame.resource) {
+                // Stop-marker frame: no resource body; server advertised treeStopMarker:v1.
+                const id = createSignedResourceId(
+                  frame.resourceId,
+                  toResourceSignature(frame.resourceSignature),
+                );
+                return {
+                  value: { frameKind: "stopMarker", id, traverseWasStopped: true },
+                  done: false,
+                };
+              }
+
               return {
-                value: { frameKind: "stopMarker", id, traverseWasStopped: true },
+                value: {
+                  frameKind: "resource",
+                  ...protoToResource(frame.resource),
+                  kv: frame.kv,
+                  traverseWasStopped: frame.traverseWasStopped,
+                },
                 done: false,
               };
             }
-            return {
-              value: {
-                frameKind: "resource",
-                ...protoToResource(frame.resource),
-                kv: frame.kv,
-                traverseWasStopped: frame.traverseWasStopped,
-              },
-              done: false,
-            };
           },
           async return(): Promise<IteratorResult<ResourceTreeFrame>> {
             if (iterator.return) await iterator.return();

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -30,7 +30,10 @@ import type {
   OneOfKind,
   ServerMessageResponse,
 } from "./ll_transaction";
-import type { ResourceAPI_Tree_Filter, ResourceAPI_Tree_SeedResource } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
+import type {
+  ResourceAPI_Tree_Filter,
+  ResourceAPI_Tree_SeedResource,
+} from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import type { NonUndefined } from "utility-types";
 import { toBytes } from "../util/util";
@@ -1086,7 +1089,9 @@ export class PlTransaction {
    *
    * @param seeds - Roots for the traversal. May include both {@link ResourceData}
    *   and {@link SignedResourceId} values in the same array.
-   * @param opts.fieldFilters      - Per-field predicates; matching field edges are not descended.
+   * @param opts.fieldFilter       - Per-field predicate; matching field edges are not descended.
+   *   This wire field accepts only one filter. Compose multiple rules via
+   *   `treeFilter.and(...)` / `treeFilter.or(...)`.
    * @param opts.traverseStopRules - Per-resource predicate; matching resources are returned
    *   with `traverseWasStopped = true` and their children are not visited.
    *   This wire field accepts only one filter. Compose multiple rules via
@@ -1097,7 +1102,7 @@ export class PlTransaction {
   public resourceTree(
     seeds: (ResourceData | SignedResourceId)[],
     opts?: {
-      fieldFilters?: ResourceAPI_Tree_Filter[];
+      fieldFilter?: ResourceAPI_Tree_Filter;
       traverseStopRules?: ResourceAPI_Tree_Filter;
       includeKv?: boolean;
       maxDepth?: number;
@@ -1122,7 +1127,7 @@ export class PlTransaction {
         resourceId: firstSeed?.resourceId ?? 0n,
         resourceSignature: firstSeed?.resourceSignature ?? new Uint8Array(0),
         seeds: seedProtos,
-        fieldFilters: opts?.fieldFilters ?? [],
+        fieldFilter: opts?.fieldFilter,
         traverseStopRules: opts?.traverseStopRules,
         includeKv: opts?.includeKv ?? false,
         maxDepth: opts?.maxDepth,

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -77,6 +77,17 @@ export interface KeyValueString {
 
 export type ResourceTreeItem = ResourceData & { kv: KeyValue[]; traverseWasStopped: boolean };
 
+/** A single frame from the resourceTree() stream.
+ *
+ * When the server advertises `treeStopMarker:v1`, a stop-matched node is emitted
+ * as a lightweight marker instead of a full resource payload. Callers must
+ * narrow on `frameKind` before accessing type-specific fields.
+ * Note: `frameKind` is distinct from `ResourceData.kind` (which is the resource kind).
+ */
+export type ResourceTreeFrame =
+  | (ResourceTreeItem & { frameKind: 'resource' })
+  | { frameKind: 'stopMarker'; id: SignedResourceId; traverseWasStopped: true };
+
 interface _FieldId<RId> {
   /** Parent resource id */
   resourceId: RId;
@@ -1091,7 +1102,7 @@ export class PlTransaction {
       includeKv?: boolean;
       maxDepth?: number;
     },
-  ): AsyncIterable<ResourceTreeItem> {
+  ): AsyncIterable<ResourceTreeFrame> {
     if (seeds.length === 0) {
       throw new Error("resourceTree: at least one seed must be provided");
     }
@@ -1119,27 +1130,40 @@ export class PlTransaction {
     });
 
     return {
-      [Symbol.asyncIterator](): AsyncIterator<ResourceTreeItem> {
+      [Symbol.asyncIterator](): AsyncIterator<ResourceTreeFrame> {
         const iterator = responseStream[Symbol.asyncIterator]();
 
         return {
-          async next(): Promise<IteratorResult<ResourceTreeItem>> {
+          async next(): Promise<IteratorResult<ResourceTreeFrame>> {
             const item = await iterator.next();
             if (item.done) return { value: undefined, done: true };
+            const frame = item.value.resourceTree;
+            if (!frame.resource) {
+              // Stop-marker frame: no resource body; server advertised treeStopMarker:v1.
+              const id = createSignedResourceId(
+                frame.resourceId,
+                toResourceSignature(frame.resourceSignature),
+              );
+              return {
+                value: { frameKind: 'stopMarker', id, traverseWasStopped: true },
+                done: false,
+              };
+            }
             return {
               value: {
-                ...protoToResource(notEmpty(item.value.resourceTree.resource)),
-                kv: item.value.resourceTree.kv,
-                traverseWasStopped: item.value.resourceTree.traverseWasStopped,
+                frameKind: 'resource',
+                ...protoToResource(frame.resource),
+                kv: frame.kv,
+                traverseWasStopped: frame.traverseWasStopped,
               },
               done: false,
             };
           },
-          async return(): Promise<IteratorResult<ResourceTreeItem>> {
+          async return(): Promise<IteratorResult<ResourceTreeFrame>> {
             if (iterator.return) await iterator.return();
             return { value: undefined, done: true };
           },
-          async throw(error?: unknown): Promise<IteratorResult<ResourceTreeItem>> {
+          async throw(error?: unknown): Promise<IteratorResult<ResourceTreeFrame>> {
             if (iterator.throw) await iterator.throw(error);
             throw error;
           },

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -30,6 +30,7 @@ import type {
   OneOfKind,
   ServerMessageResponse,
 } from "./ll_transaction";
+import type { ResourceAPI_Tree_Filter, ResourceAPI_Tree_SeedResource } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import type { NonUndefined } from "utility-types";
 import { toBytes } from "../util/util";
@@ -73,6 +74,8 @@ export interface KeyValueString {
   key: string;
   value: string;
 }
+
+export type ResourceTreeItem = ResourceData & { kv: KeyValue[]; traverseWasStopped: boolean };
 
 interface _FieldId<RId> {
   /** Parent resource id */
@@ -1055,6 +1058,94 @@ export class PlTransaction {
    * any leftover errors if it was unsuccessful */
   public async await() {
     await this.ll.await();
+  }
+
+  //
+  // Tree streaming
+  //
+
+  /**
+   * Perform a single `ResourceTree` walk and yield each visited resource.
+   *
+   * Items are yielded incrementally as stream frames arrive from server.
+   *
+   * The low-level transaction stream is still ordered, so each active request
+   * must be consumed to completion (or closed via iterator `return()`/`throw()`)
+   * before later responses can be dispatched.
+   *
+   * @param seeds - Roots for the traversal. May include both {@link ResourceData}
+   *   and {@link SignedResourceId} values in the same array.
+   * @param opts.fieldFilters      - Per-field predicates; matching field edges are not descended.
+   * @param opts.traverseStopRules - Per-resource predicate; matching resources are returned
+   *   with `traverseWasStopped = true` and their children are not visited.
+   *   This wire field accepts only one filter. Compose multiple rules via
+   *   `treeFilter.and(...)` / `treeFilter.or(...)`.
+   * @param opts.includeKv         - When true, each yielded item includes KV entries.
+   * @param opts.maxDepth          - Optional depth cap.
+   */
+  public resourceTree(
+    seeds: (ResourceData | SignedResourceId)[],
+    opts?: {
+      fieldFilters?: ResourceAPI_Tree_Filter[];
+      traverseStopRules?: ResourceAPI_Tree_Filter;
+      includeKv?: boolean;
+      maxDepth?: number;
+    },
+  ): AsyncIterable<ResourceTreeItem> {
+    if (seeds.length === 0) {
+      throw new Error("resourceTree: at least one seed must be provided");
+    }
+
+    const seedProtos = seeds.map((seed): ResourceAPI_Tree_SeedResource => {
+      const signedId = typeof seed === "string" ? seed : seed.id;
+      const { globalId, signature } = parseSignedResourceId(signedId);
+      return { resourceId: globalId, resourceSignature: signature };
+    });
+
+    const firstSeed = seedProtos[0];
+
+    const responseStream = this.ll.sendStream({
+      oneofKind: "resourceTree",
+      resourceTree: {
+        // Keep compatibility with request shape that requires non-optional fields.
+        resourceId: firstSeed?.resourceId ?? 0n,
+        resourceSignature: firstSeed?.resourceSignature ?? new Uint8Array(0),
+        seeds: seedProtos,
+        fieldFilters: opts?.fieldFilters ?? [],
+        traverseStopRules: opts?.traverseStopRules,
+        includeKv: opts?.includeKv ?? false,
+        maxDepth: opts?.maxDepth,
+      },
+    });
+
+    return {
+      [Symbol.asyncIterator](): AsyncIterator<ResourceTreeItem> {
+        const iterator = responseStream[Symbol.asyncIterator]();
+
+        return {
+          async next(): Promise<IteratorResult<ResourceTreeItem>> {
+            const item = await iterator.next();
+            if (item.done) return { value: undefined, done: true };
+            return {
+              value: {
+                ...protoToResource(notEmpty(item.value.resourceTree.resource)),
+                kv: item.value.resourceTree.kv,
+                traverseWasStopped: item.value.resourceTree.traverseWasStopped,
+              },
+              done: false,
+            };
+          },
+          async return(): Promise<IteratorResult<ResourceTreeItem>> {
+            if (iterator.return) await iterator.return();
+            return { value: undefined, done: true };
+          },
+          async throw(error?: unknown): Promise<IteratorResult<ResourceTreeItem>> {
+            if (iterator.throw) await iterator.throw(error);
+            throw error;
+          },
+        };
+      },
+    };
   }
 
   //

--- a/lib/node/pl-client/src/core/tree_filter.test.ts
+++ b/lib/node/pl-client/src/core/tree_filter.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "vitest";
+import { treeFilter, FilterOperatorType, FilterProperty } from "./tree_filter";
+import type { Filter } from "./tree_filter";
+
+describe("treeFilter builders — wire shape", () => {
+  // ── Leaf helpers ───────────────────────────────────────────────────────────
+
+  test("resourceTypeEq produces EQUAL / RESOURCE_TYPE / stringValue", () => {
+    const f = treeFilter.resourceTypeEq("Blob");
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.RESOURCE_TYPE,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "stringValue", stringValue: "Blob" },
+    });
+  });
+
+  test("resourceTypeMatch produces MATCH / RESOURCE_TYPE / stringValue", () => {
+    const f = treeFilter.resourceTypeMatch("^Blob/");
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.RESOURCE_TYPE,
+      operator: FilterOperatorType.MATCH,
+      value: { oneofKind: "stringValue", stringValue: "^Blob/" },
+    });
+  });
+
+  test("fieldNameEq produces EQUAL / FIELD_NAME / stringValue", () => {
+    const f = treeFilter.fieldNameEq("output");
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.FIELD_NAME,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "stringValue", stringValue: "output" },
+    });
+  });
+
+  test("fieldNameMatch produces MATCH / FIELD_NAME / stringValue", () => {
+    const f = treeFilter.fieldNameMatch("^__service");
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.FIELD_NAME,
+      operator: FilterOperatorType.MATCH,
+      value: { oneofKind: "stringValue", stringValue: "^__service" },
+    });
+  });
+
+  test("isFinal(true) produces EQUAL / IS_FINAL / boolValue:true", () => {
+    const f = treeFilter.isFinal(true);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.IS_FINAL,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
+  test("isFinal(false) produces EQUAL / IS_FINAL / boolValue:false", () => {
+    const f = treeFilter.isFinal(false);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.IS_FINAL,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: false },
+    });
+  });
+
+  test("allOutputsFinal(true) produces EQUAL / ALL_OUTPUTS_FINAL / boolValue:true", () => {
+    const f = treeFilter.allOutputsFinal(true);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.ALL_OUTPUTS_FINAL,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
+  test("generic eq() and match() use supplied property", () => {
+    expect(treeFilter.eq(FilterProperty.RESOURCE_TYPE, "Foo")).toEqual<Filter>({
+      key: FilterProperty.RESOURCE_TYPE,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "stringValue", stringValue: "Foo" },
+    });
+    expect(treeFilter.match(FilterProperty.FIELD_NAME, "^out")).toEqual<Filter>({
+      key: FilterProperty.FIELD_NAME,
+      operator: FilterOperatorType.MATCH,
+      value: { oneofKind: "stringValue", stringValue: "^out" },
+    });
+  });
+
+  // ── Group operators ────────────────────────────────────────────────────────
+
+  test("and() wraps children in AND / filtersValue", () => {
+    const a = treeFilter.resourceTypeEq("A");
+    const b = treeFilter.resourceTypeEq("B");
+    const f = treeFilter.and(a, b);
+    expect(f).toEqual<Filter>({
+      operator: FilterOperatorType.AND,
+      value: { oneofKind: "filtersValue", filtersValue: { filters: [a, b] } },
+    });
+    // key must be absent for group operators
+    expect(f.key).toBeUndefined();
+  });
+
+  test("or() wraps children in OR / filtersValue", () => {
+    const a = treeFilter.isFinal(true);
+    const b = treeFilter.allOutputsFinal(true);
+    const f = treeFilter.or(a, b);
+    expect(f).toEqual<Filter>({
+      operator: FilterOperatorType.OR,
+      value: { oneofKind: "filtersValue", filtersValue: { filters: [a, b] } },
+    });
+  });
+
+  test("not() wraps single child in NOT / filtersValue", () => {
+    const inner = treeFilter.resourceTypeEq("Blob");
+    const f = treeFilter.not(inner);
+    expect(f).toEqual<Filter>({
+      operator: FilterOperatorType.NOT,
+      value: { oneofKind: "filtersValue", filtersValue: { filters: [inner] } },
+    });
+  });
+
+  // ── Nested composition ────────────────────────────────────────────────────
+
+  test("nested AND(RESOURCE_TYPE, IS_FINAL) round-trips correctly", () => {
+    // Mirrors the Go-side mustCompileTraverseStopRules usage:
+    // AND(RESOURCE_TYPE == "StdMap", IS_FINAL == true)
+    const f = treeFilter.and(treeFilter.resourceTypeEq("StdMap"), treeFilter.isFinal(true));
+
+    expect(f.operator).toBe(FilterOperatorType.AND);
+    expect(f.key).toBeUndefined();
+    if (f.value.oneofKind !== "filtersValue") throw new Error("expected filtersValue");
+
+    const { filters } = f.value.filtersValue;
+    expect(filters).toHaveLength(2);
+
+    expect(filters[0]).toEqual<Filter>({
+      key: FilterProperty.RESOURCE_TYPE,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "stringValue", stringValue: "StdMap" },
+    });
+    expect(filters[1]).toEqual<Filter>({
+      key: FilterProperty.IS_FINAL,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
+  test("NOT(AND(RESOURCE_TYPE, FIELD_NAME)) used in field_filters", () => {
+    // NOT( AND(RESOURCE_TYPE == "BlockPackCustom", FIELD_NAME == "template") )
+    const f = treeFilter.not(
+      treeFilter.and(
+        treeFilter.resourceTypeEq("BlockPackCustom"),
+        treeFilter.fieldNameEq("template"),
+      ),
+    );
+    expect(f.operator).toBe(FilterOperatorType.NOT);
+    if (f.value.oneofKind !== "filtersValue") throw new Error("expected filtersValue");
+    const [andNode] = f.value.filtersValue.filters;
+    expect(andNode.operator).toBe(FilterOperatorType.AND);
+    if (andNode.value.oneofKind !== "filtersValue") throw new Error("expected filtersValue");
+    expect(andNode.value.filtersValue.filters).toHaveLength(2);
+  });
+});

--- a/lib/node/pl-client/src/core/tree_filter.test.ts
+++ b/lib/node/pl-client/src/core/tree_filter.test.ts
@@ -68,6 +68,65 @@ describe("treeFilter builders — wire shape", () => {
     });
   });
 
+  test("resourceReadyForCalculation(true) produces EQUAL / RESOURCE_READY_FOR_CALCULATION / boolValue:true", () => {
+    const f = treeFilter.resourceReadyForCalculation(true);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.RESOURCE_READY_FOR_CALCULATION,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
+  test("isDuplicate(false) produces EQUAL / IS_DUPLICATE / boolValue:false", () => {
+    const f = treeFilter.isDuplicate(false);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.IS_DUPLICATE,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: false },
+    });
+  });
+
+  test("hasErrors(true) produces EQUAL / HAS_ERRORS / boolValue:true", () => {
+    const f = treeFilter.hasErrors(true);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.HAS_ERRORS,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
+  test("outputsLocked(true) produces EQUAL / OUTPUTS_LOCKED / boolValue:true", () => {
+    const f = treeFilter.outputsLocked(true);
+    expect(f).toEqual<Filter>({
+      key: FilterProperty.OUTPUTS_LOCKED,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
+  test("readyOrDuplicateOrError() produces OR of the three conditions", () => {
+    const f = treeFilter.readyOrDuplicateOrError();
+    expect(f.operator).toBe(FilterOperatorType.OR);
+    if (f.value.oneofKind !== "filtersValue") throw new Error("expected filtersValue");
+    const { filters } = f.value.filtersValue;
+    expect(filters).toHaveLength(3);
+    expect(filters[0]).toEqual<Filter>({
+      key: FilterProperty.RESOURCE_READY_FOR_CALCULATION,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+    expect(filters[1]).toEqual<Filter>({
+      key: FilterProperty.IS_DUPLICATE,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+    expect(filters[2]).toEqual<Filter>({
+      key: FilterProperty.HAS_ERRORS,
+      operator: FilterOperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: true },
+    });
+  });
+
   test("generic eq() and match() use supplied property", () => {
     expect(treeFilter.eq(FilterProperty.RESOURCE_TYPE, "Foo")).toEqual<Filter>({
       key: FilterProperty.RESOURCE_TYPE,

--- a/lib/node/pl-client/src/core/tree_filter.ts
+++ b/lib/node/pl-client/src/core/tree_filter.ts
@@ -120,4 +120,63 @@ export const treeFilter = {
   allOutputsFinal(value: boolean): Filter {
     return treeFilter.boolEq(ResourceAPI_Tree_Filter_Property.ALL_OUTPUTS_FINAL, value);
   },
+
+  /**
+   * Match resources where `resource_ready_for_calculation == value`.
+   * True when the resource is Original, inputs are locked, and all inputs are final.
+   * Valid only inside `traverseStopRules`.
+   */
+  resourceReadyForCalculation(value: boolean): Filter {
+    return treeFilter.boolEq(
+      ResourceAPI_Tree_Filter_Property.RESOURCE_READY_FOR_CALCULATION,
+      value,
+    );
+  },
+
+  /**
+   * Match resources where `is_duplicate == value`.
+   * True when the resource has a non-zero original_resource_id.
+   * Valid only inside `traverseStopRules`.
+   */
+  isDuplicate(value: boolean): Filter {
+    return treeFilter.boolEq(ResourceAPI_Tree_Filter_Property.IS_DUPLICATE, value);
+  },
+
+  /**
+   * Match resources where `has_errors == value`.
+   * True when the resource has at least one field carrying an error (aggregated
+   * has-error flag). Can be true even when the resource's own status is not
+   * Error (e.g., an Original resource with a failed input field).
+   * Valid only inside `traverseStopRules`.
+   */
+  hasErrors(value: boolean): Filter {
+    return treeFilter.boolEq(ResourceAPI_Tree_Filter_Property.HAS_ERRORS, value);
+  },
+
+  /**
+   * Match resources where `outputs_locked == value`.
+   * Valid only inside `traverseStopRules`.
+   */
+  outputsLocked(value: boolean): Filter {
+    return treeFilter.boolEq(ResourceAPI_Tree_Filter_Property.OUTPUTS_LOCKED, value);
+  },
+
+  /**
+   * Match resources that are ready-or-duplicate-or-error: mirrors the BFS
+   * `readyOrDuplicateOrError` predicate used by pl-tree to decide whether a
+   * resource subtree needs further polling.
+   *
+   * Use this as `traverseStopRules` to stop the server-side tree walk at
+   * exactly the same nodes where the client BFS would stop, eliminating
+   * unnecessary follow-up calls.
+   *
+   * Valid only inside `traverseStopRules`.
+   */
+  readyOrDuplicateOrError(): Filter {
+    return treeFilter.or(
+      treeFilter.resourceReadyForCalculation(true),
+      treeFilter.isDuplicate(true),
+      treeFilter.hasErrors(true),
+    );
+  },
 } as const;

--- a/lib/node/pl-client/src/core/tree_filter.ts
+++ b/lib/node/pl-client/src/core/tree_filter.ts
@@ -1,0 +1,123 @@
+import type { ResourceAPI_Tree_Filter } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
+import {
+  ResourceAPI_Tree_Filter_OperatorType,
+  ResourceAPI_Tree_Filter_Property,
+} from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
+
+export type { ResourceAPI_Tree_Filter };
+
+/** Shorthand alias for the filter predicate type. */
+export type Filter = ResourceAPI_Tree_Filter;
+
+/** Shorthand alias for the Property enum. */
+export type Property = ResourceAPI_Tree_Filter_Property;
+
+// Re-export enum namespaces under shorter aliases so callers need not import api.ts directly.
+export { ResourceAPI_Tree_Filter_OperatorType as FilterOperatorType };
+export { ResourceAPI_Tree_Filter_Property as FilterProperty };
+
+/**
+ * Builder helpers for {@link ResourceAPI_Tree_Filter} predicates used in
+ * `ResourceAPI_Tree_Request.fieldFilters` and `traverseStopRules`.
+ *
+ * Property restrictions (not enforced here; the backend rejects invalid combinations):
+ *   - `FIELD_NAME` is only valid inside `fieldFilters`.
+ *   - `IS_FINAL` and `ALL_OUTPUTS_FINAL` are only valid inside `traverseStopRules`.
+ */
+export const treeFilter = {
+  // ── Group operators ──────────────────────────────────────────────────────
+
+  and(...children: Filter[]): Filter {
+    return {
+      operator: ResourceAPI_Tree_Filter_OperatorType.AND,
+      value: { oneofKind: "filtersValue", filtersValue: { filters: children } },
+    };
+  },
+
+  or(...children: Filter[]): Filter {
+    return {
+      operator: ResourceAPI_Tree_Filter_OperatorType.OR,
+      value: { oneofKind: "filtersValue", filtersValue: { filters: children } },
+    };
+  },
+
+  not(child: Filter): Filter {
+    return {
+      operator: ResourceAPI_Tree_Filter_OperatorType.NOT,
+      value: { oneofKind: "filtersValue", filtersValue: { filters: [child] } },
+    };
+  },
+
+  // ── Generic leaf operators ───────────────────────────────────────────────
+
+  /** Exact-match predicate on a string property. */
+  eq(prop: Property, value: string): Filter {
+    return {
+      key: prop,
+      operator: ResourceAPI_Tree_Filter_OperatorType.EQUAL,
+      value: { oneofKind: "stringValue", stringValue: value },
+    };
+  },
+
+  /** Regex-match predicate on a string property. */
+  match(prop: Property, pattern: string): Filter {
+    return {
+      key: prop,
+      operator: ResourceAPI_Tree_Filter_OperatorType.MATCH,
+      value: { oneofKind: "stringValue", stringValue: pattern },
+    };
+  },
+
+  /** Boolean-equality predicate. */
+  boolEq(prop: Property, value: boolean): Filter {
+    return {
+      key: prop,
+      operator: ResourceAPI_Tree_Filter_OperatorType.EQUAL,
+      value: { oneofKind: "boolValue", boolValue: value },
+    };
+  },
+
+  // ── Typed convenience wrappers ───────────────────────────────────────────
+
+  /** Match resources whose type string equals `name` exactly. */
+  resourceTypeEq(name: string): Filter {
+    return treeFilter.eq(ResourceAPI_Tree_Filter_Property.RESOURCE_TYPE, name);
+  },
+
+  /** Match resources whose type string satisfies the regex `pattern`. */
+  resourceTypeMatch(pattern: string): Filter {
+    return treeFilter.match(ResourceAPI_Tree_Filter_Property.RESOURCE_TYPE, pattern);
+  },
+
+  /**
+   * Match field edges whose name equals `name` exactly.
+   * Valid only inside `fieldFilters`.
+   */
+  fieldNameEq(name: string): Filter {
+    return treeFilter.eq(ResourceAPI_Tree_Filter_Property.FIELD_NAME, name);
+  },
+
+  /**
+   * Match field edges whose name satisfies the regex `pattern`.
+   * Valid only inside `fieldFilters`.
+   */
+  fieldNameMatch(pattern: string): Filter {
+    return treeFilter.match(ResourceAPI_Tree_Filter_Property.FIELD_NAME, pattern);
+  },
+
+  /**
+   * Match resources where `is_final == value`.
+   * Valid only inside `traverseStopRules`.
+   */
+  isFinal(value: boolean): Filter {
+    return treeFilter.boolEq(ResourceAPI_Tree_Filter_Property.IS_FINAL, value);
+  },
+
+  /**
+   * Match resources where `all_outputs_final == value`.
+   * Valid only inside `traverseStopRules`.
+   */
+  allOutputsFinal(value: boolean): Filter {
+    return treeFilter.boolEq(ResourceAPI_Tree_Filter_Property.ALL_OUTPUTS_FINAL, value);
+  },
+} as const;

--- a/lib/node/pl-client/src/core/tree_filter.ts
+++ b/lib/node/pl-client/src/core/tree_filter.ts
@@ -18,11 +18,11 @@ export { ResourceAPI_Tree_Filter_Property as FilterProperty };
 
 /**
  * Builder helpers for {@link ResourceAPI_Tree_Filter} predicates used in
- * `ResourceAPI_Tree_Request.fieldFilters` and `traverseStopRules`.
+ * `ResourceAPI_Tree_Request.fieldFilter` and `traverseStopRules`.
  *
  * Property restrictions (not enforced here; the backend rejects invalid combinations):
- *   - `FIELD_NAME` is only valid inside `fieldFilters`.
- *   - `IS_FINAL` and `ALL_OUTPUTS_FINAL` are only valid inside `traverseStopRules`.
+ *   - `FIELD_NAME` is only valid inside `fieldFilter`.
+ *   - `IS_FINAL`, `ALL_OUTPUTS_FINAL`, and resource-level boolean predicates are only valid inside `traverseStopRules`.
  */
 export const treeFilter = {
   // ── Group operators ──────────────────────────────────────────────────────
@@ -91,7 +91,7 @@ export const treeFilter = {
 
   /**
    * Match field edges whose name equals `name` exactly.
-   * Valid only inside `fieldFilters`.
+   * Valid only inside `fieldFilter`.
    */
   fieldNameEq(name: string): Filter {
     return treeFilter.eq(ResourceAPI_Tree_Filter_Property.FIELD_NAME, name);
@@ -99,7 +99,7 @@ export const treeFilter = {
 
   /**
    * Match field edges whose name satisfies the regex `pattern`.
-   * Valid only inside `fieldFilters`.
+   * Valid only inside `fieldFilter`.
    */
   fieldNameMatch(pattern: string): Filter {
     return treeFilter.match(ResourceAPI_Tree_Filter_Property.FIELD_NAME, pattern);

--- a/lib/node/pl-client/src/core/type_conversion.ts
+++ b/lib/node/pl-client/src/core/type_conversion.ts
@@ -26,7 +26,7 @@ import { throwPlNotFoundError } from "./errors";
 
 const ResourceErrorField = "resourceError";
 
-function resourceIsDeleted(proto: Resource): boolean {
+export function resourceIsDeleted(proto: Resource): boolean {
   return proto.deletedTime !== undefined && proto.deletedTime.seconds !== 0n;
 }
 

--- a/lib/node/pl-client/src/index.ts
+++ b/lib/node/pl-client/src/index.ts
@@ -9,6 +9,7 @@ export * from "./core/default_client";
 export * from "./core/unauth_client";
 export * from "./core/auth";
 export * from "./core/final";
+export * from "./core/tree_filter";
 export * from "./core/user_resources";
 export * from "./core/wire";
 export * from "./helpers/tx_helpers";

--- a/lib/node/pl-client/src/proto-grpc/github.com/googleapis/googleapis/google/rpc/status.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/googleapis/googleapis/google/rpc/status.ts
@@ -2,7 +2,7 @@
 // @generated from protobuf file "github.com/googleapis/googleapis/google/rpc/status.proto" (package "google.rpc", syntax proto3)
 // tslint:disable
 //
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1949,9 +1949,11 @@ export interface ResourceAPI_Tree_KV {
  */
 export interface ResourceAPI_Tree_Response {
     /**
-     * Full resource payload. Absent on stop-marker frames.
+     * Full resource payload. Absent on stop-marker frames (when the server
+     * advertises `treeStopMarker:v1` and traverse_was_stopped is true).
+     * Always populated on normal frames.
      *
-     * @generated from protobuf field: MiLaboratories.PL.API.Resource resource = 1
+     * @generated from protobuf field: optional MiLaboratories.PL.API.Resource resource = 1
      */
     resource?: Resource;
     /**
@@ -1963,23 +1965,25 @@ export interface ResourceAPI_Tree_Response {
     /**
      * True when the request specified a traverse_stop_rules and this resource
      * satisfied it. Always false when traverse_stop_rules was absent.
-     * On stop-marker frames (treeStopMarker:v1), resource is absent and
-     * resourceId/resourceSignature carry the stopped node's identity.
+     *
+     * When the server advertises `treeStopMarker:v1`, a stop-marker frame has
+     * traverse_was_stopped=true with resource unset; resource_id and
+     * resource_signature carry the identity of the stopped node instead.
+     * On normal frames (traverse_was_stopped=false or server without the
+     * capability) resource is always populated and resource_id/resource_signature
+     * are zero/empty.
      *
      * @generated from protobuf field: bool traverse_was_stopped = 3
      */
     traverseWasStopped: boolean;
     /**
-     * Populated only on stop-marker frames (resource is absent).
-     * Zero on normal frames; use resource.resourceId instead.
+     * Populated only on stop-marker frames (resource is unset).
+     * Zero / empty on normal frames; use resource.resource_id instead.
      *
      * @generated from protobuf field: uint64 resource_id = 4
      */
     resourceId: bigint;
     /**
-     * Populated only on stop-marker frames (resource is absent).
-     * Empty on normal frames; use resource.resourceSignature instead.
-     *
      * @generated from protobuf field: bytes resource_signature = 5
      */
     resourceSignature: Uint8Array;
@@ -9470,7 +9474,7 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
             { no: 1, name: "resource", kind: "message", T: () => Resource },
             { no: 2, name: "kv", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_KV },
             { no: 3, name: "traverse_was_stopped", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 4, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/ },
+            { no: 4, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 5, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
@@ -9489,7 +9493,7 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* MiLaboratories.PL.API.Resource resource */ 1:
+                case /* optional MiLaboratories.PL.API.Resource resource */ 1:
                     message.resource = Resource.internalBinaryRead(reader, reader.uint32(), options, message.resource);
                     break;
                 case /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.KV kv */ 2:
@@ -9516,7 +9520,7 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         return message;
     }
     internalBinaryWrite(message: ResourceAPI_Tree_Response, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* MiLaboratories.PL.API.Resource resource = 1; */
+        /* optional MiLaboratories.PL.API.Resource resource = 1; */
         if (message.resource)
             Resource.internalBinaryWrite(message.resource, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.KV kv = 2; */

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1919,6 +1919,12 @@ export enum ResourceAPI_Tree_Filter_Property {
      */
     RESOURCE_TYPE = 1,
     /**
+     * Status().IsFinal(): true when status is Original, Duplicate, or Error.
+     * Does NOT require AllInputsFinal — a resource with unresolved input fields
+     * can still report IS_FINAL=true if its own status is terminal. Use
+     * RESOURCE_READY_FOR_CALCULATION + IS_DUPLICATE + HAS_ERRORS to mirror the
+     * client-side readyOrDuplicateOrError predicate precisely.
+     *
      * @generated from protobuf enum value: IS_FINAL = 2;
      */
     IS_FINAL = 2,
@@ -1928,7 +1934,37 @@ export enum ResourceAPI_Tree_Filter_Property {
      *
      * @generated from protobuf enum value: ALL_OUTPUTS_FINAL = 3;
      */
-    ALL_OUTPUTS_FINAL = 3
+    ALL_OUTPUTS_FINAL = 3,
+    /**
+     * IsReadyForCalculation(): Status==Original AND AllInputsFinal AND no input errors AND IO feature.
+     * Mirrors the client-side r.resourceReady property used in readyOrDuplicateOrError.
+     *
+     * @generated from protobuf enum value: RESOURCE_READY_FOR_CALCULATION = 4;
+     */
+    RESOURCE_READY_FOR_CALCULATION = 4,
+    /**
+     * True when status is Duplicate (original_resource_id != 0). Mirrors the
+     * isNotNullSignedResourceId(r.originalResourceId) branch of readyOrDuplicateOrError.
+     *
+     * @generated from protobuf enum value: IS_DUPLICATE = 5;
+     */
+    IS_DUPLICATE = 5,
+    /**
+     * True when the resource has at least one field carrying an error
+     * (aggregated has-error flag). Mirrors the isNotNullSignedResourceId(r.error)
+     * branch of readyOrDuplicateOrError. Note: this can be true even when the
+     * resource's own status is not Error (e.g., an Original resource with a
+     * failed input field).
+     *
+     * @generated from protobuf enum value: HAS_ERRORS = 6;
+     */
+    HAS_ERRORS = 6,
+    /**
+     * True when no further output fields can be added to the resource.
+     *
+     * @generated from protobuf enum value: OUTPUTS_LOCKED = 7;
+     */
+    OUTPUTS_LOCKED = 7
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.KV

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1749,14 +1749,15 @@ export interface ResourceAPI_Tree_Request {
      * MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
      * field.
      *
-     * If fields match the predicate, the traversal does not descend into
-     * that field's value.
+     * If a field matches the predicate, the traversal does not descend
+     * into that field's value.
      *
-     * Filters combine via AND.
+     * Only one filter is accepted. Compose multiple rules into a single
+     * predicate via AND/OR/NOT groups.
      *
-     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filters = 5
+     * @generated from protobuf field: optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filter = 5
      */
-    fieldFilters: ResourceAPI_Tree_Filter[];
+    fieldFilter?: ResourceAPI_Tree_Filter;
     /**
      * If true, the response carries per-resource key-values alongside
      * each visited resource. Defaults to false. Old servers ignore this
@@ -9139,7 +9140,7 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
             { no: 1, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 3, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "max_depth", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
-            { no: 5, name: "field_filters", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_Filter },
+            { no: 5, name: "field_filter", kind: "message", T: () => ResourceAPI_Tree_Filter },
             { no: 6, name: "include_kv", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 7, name: "traverse_stop_rules", kind: "message", T: () => ResourceAPI_Tree_Filter },
             { no: 8, name: "seeds", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_SeedResource }
@@ -9149,7 +9150,6 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
         const message = globalThis.Object.create((this.messagePrototype!));
         message.resourceId = 0n;
         message.resourceSignature = new Uint8Array(0);
-        message.fieldFilters = [];
         message.includeKv = false;
         message.seeds = [];
         if (value !== undefined)
@@ -9170,8 +9170,8 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
                 case /* optional uint32 max_depth */ 2:
                     message.maxDepth = reader.uint32();
                     break;
-                case /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filters */ 5:
-                    message.fieldFilters.push(ResourceAPI_Tree_Filter.internalBinaryRead(reader, reader.uint32(), options));
+                case /* optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filter */ 5:
+                    message.fieldFilter = ResourceAPI_Tree_Filter.internalBinaryRead(reader, reader.uint32(), options, message.fieldFilter);
                     break;
                 case /* bool include_kv */ 6:
                     message.includeKv = reader.bool();
@@ -9203,9 +9203,9 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
         /* bytes resource_signature = 3; */
         if (message.resourceSignature.length)
             writer.tag(3, WireType.LengthDelimited).bytes(message.resourceSignature);
-        /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filters = 5; */
-        for (let i = 0; i < message.fieldFilters.length; i++)
-            ResourceAPI_Tree_Filter.internalBinaryWrite(message.fieldFilters[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        /* optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filter = 5; */
+        if (message.fieldFilter)
+            ResourceAPI_Tree_Filter.internalBinaryWrite(message.fieldFilter, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         /* bool include_kv = 6; */
         if (message.includeKv !== false)
             writer.tag(6, WireType.Varint).bool(message.includeKv);

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1949,6 +1949,8 @@ export interface ResourceAPI_Tree_KV {
  */
 export interface ResourceAPI_Tree_Response {
     /**
+     * Full resource payload. Absent on stop-marker frames.
+     *
      * @generated from protobuf field: MiLaboratories.PL.API.Resource resource = 1
      */
     resource?: Resource;
@@ -1961,10 +1963,26 @@ export interface ResourceAPI_Tree_Response {
     /**
      * True when the request specified a traverse_stop_rules and this resource
      * satisfied it. Always false when traverse_stop_rules was absent.
+     * On stop-marker frames (treeStopMarker:v1), resource is absent and
+     * resourceId/resourceSignature carry the stopped node's identity.
      *
      * @generated from protobuf field: bool traverse_was_stopped = 3
      */
     traverseWasStopped: boolean;
+    /**
+     * Populated only on stop-marker frames (resource is absent).
+     * Zero on normal frames; use resource.resourceId instead.
+     *
+     * @generated from protobuf field: uint64 resource_id = 4
+     */
+    resourceId: bigint;
+    /**
+     * Populated only on stop-marker frames (resource is absent).
+     * Empty on normal frames; use resource.resourceSignature instead.
+     *
+     * @generated from protobuf field: bytes resource_signature = 5
+     */
+    resourceSignature: Uint8Array;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.TreeSize
@@ -9451,13 +9469,17 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         super("MiLaboratories.PL.API.ResourceAPI.Tree.Response", [
             { no: 1, name: "resource", kind: "message", T: () => Resource },
             { no: 2, name: "kv", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_KV },
-            { no: 3, name: "traverse_was_stopped", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 3, name: "traverse_was_stopped", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/ },
+            { no: 5, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<ResourceAPI_Tree_Response>): ResourceAPI_Tree_Response {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.kv = [];
         message.traverseWasStopped = false;
+        message.resourceId = 0n;
+        message.resourceSignature = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_Tree_Response>(this, message, value);
         return message;
@@ -9475,6 +9497,12 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
                     break;
                 case /* bool traverse_was_stopped */ 3:
                     message.traverseWasStopped = reader.bool();
+                    break;
+                case /* uint64 resource_id */ 4:
+                    message.resourceId = reader.uint64().toBigInt();
+                    break;
+                case /* bytes resource_signature */ 5:
+                    message.resourceSignature = reader.bytes();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -9497,6 +9525,12 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         /* bool traverse_was_stopped = 3; */
         if (message.traverseWasStopped !== false)
             writer.tag(3, WireType.Varint).bool(message.traverseWasStopped);
+        /* uint64 resource_id = 4; */
+        if (message.resourceId !== 0n)
+            writer.tag(4, WireType.Varint).uint64(message.resourceId);
+        /* bytes resource_signature = 5; */
+        if (message.resourceSignature.length)
+            writer.tag(5, WireType.LengthDelimited).bytes(message.resourceSignature);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1742,6 +1742,205 @@ export interface ResourceAPI_Tree_Request {
      * @generated from protobuf field: optional uint32 max_depth = 2
      */
     maxDepth?: number;
+    /**
+     * Optional per-(resource, field) filter. Unset / nil means
+     * "keep all fields" (current Tree behavior). Servers advertise
+     * support via "treeFilter:v1" in
+     * MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
+     * field.
+     *
+     * If fields match the predicate, the traversal does not descend into
+     * that field's value.
+     *
+     * Filters combine via AND.
+     *
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filters = 5
+     */
+    fieldFilters: ResourceAPI_Tree_Filter[];
+    /**
+     * If true, the response carries per-resource key-values alongside
+     * each visited resource. Defaults to false. Old servers ignore this
+     * field and never populate Response.kv.
+     *
+     * @generated from protobuf field: bool include_kv = 6
+     */
+    includeKv: boolean;
+    /**
+     * Optional predicate evaluated at the resource (not field) level.
+     * When set, the traversal does not descend into child resources that do not
+     * satisfy the predicate but resource still returns in the response.
+     *
+     * Each Tree.Response carries traverse_was_stopped=true if this
+     * resource satisfies the predicate.
+     *
+     * Available properties: resource_type (string), is_final (bool),
+     * resource_ready (bool), has_errors (bool), inputs_locked (bool),
+     * outputs_locked (bool). Old servers ignore this field and never
+     * set traverse_was_stopped.
+     *
+     * @generated from protobuf field: optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter traverse_stop_rules = 7
+     */
+    traverseStopRules?: ResourceAPI_Tree_Filter;
+    /**
+     * Optional alternative entry points for multi-root traversal.
+     * When non-empty, the traversal starts from each listed seed instead
+     * of resource_id. Servers advertise support via "treeSeeds:v1" in
+     * MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
+     * field. resource_id is used as the sole root when seeds is empty.
+     *
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.Tree.SeedResource seeds = 8
+     */
+    seeds: ResourceAPI_Tree_SeedResource[];
+}
+/**
+ * A single entry point for multi-root tree traversal.
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.SeedResource
+ */
+export interface ResourceAPI_Tree_SeedResource {
+    /**
+     * @generated from protobuf field: uint64 resource_id = 1
+     */
+    resourceId: bigint;
+    /**
+     * @generated from protobuf field: bytes resource_signature = 2
+     */
+    resourceSignature: Uint8Array;
+}
+/**
+ * Filter applied to each visited resource's fields during the walk.
+ * The filter is evaluated per (resource, field) pair. If the property
+ * specified by `key` matches the `value` according to the `operator`,
+ * the field is kept; otherwise, it is dropped. A dropped field is not
+ * descended into. Resources are always emitted; when all of a resource's
+ * fields are dropped, descent stops naturally.
+ * Filter evaluated per (resource, field) pair.
+ *
+ * Leaf filter (EQUAL/NOT_EQUAL/MATCH/NOT_MATCH): key is required and
+ * selects which property to test; value carries the expected scalar.
+ *
+ * Composite filter (OR/AND/NOT): key is absent, filters_value carries
+ * sub-filters combined with the chosen operator. OR/AND/NOT may be nested
+ * arbitrarily. Top-level filters (in Tree.Request.filters) are AND-combined.
+ * NOT requires exactly one sub-filter. Dropped fields are not descended into.
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.Filter
+ */
+export interface ResourceAPI_Tree_Filter {
+    /**
+     * Required for leaf operators (EQUAL/MATCH).
+     * Absent when operator == OR, AND, or NOT.
+     *
+     * @generated from protobuf field: optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter.Property key = 1
+     */
+    key?: ResourceAPI_Tree_Filter_Property;
+    /**
+     * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.Tree.Filter.OperatorType operator = 2
+     */
+    operator: ResourceAPI_Tree_Filter_OperatorType;
+    /**
+     * @generated from protobuf oneof: value
+     */
+    value: {
+        oneofKind: "boolValue";
+        /**
+         * @generated from protobuf field: bool bool_value = 3
+         */
+        boolValue: boolean;
+    } | {
+        oneofKind: "stringValue";
+        /**
+         * @generated from protobuf field: string string_value = 4
+         */
+        stringValue: string;
+    } | {
+        oneofKind: "filtersValue";
+        /**
+         * Used when operator == OR, AND, or NOT.
+         *
+         * @generated from protobuf field: MiLaboratories.PL.API.ResourceAPI.Tree.Filter.FilterGroup filters_value = 5
+         */
+        filtersValue: ResourceAPI_Tree_Filter_FilterGroup;
+    } | {
+        oneofKind: undefined;
+    };
+}
+/**
+ * Wrapper for repeated Filter (oneof cannot contain repeated fields directly).
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.Filter.FilterGroup
+ */
+export interface ResourceAPI_Tree_Filter_FilterGroup {
+    /**
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter filters = 1
+     */
+    filters: ResourceAPI_Tree_Filter[];
+}
+/**
+ * @generated from protobuf enum MiLaboratories.PL.API.ResourceAPI.Tree.Filter.OperatorType
+ */
+export enum ResourceAPI_Tree_Filter_OperatorType {
+    /**
+     * @generated from protobuf enum value: UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * @generated from protobuf enum value: EQUAL = 1;
+     */
+    EQUAL = 1,
+    /**
+     * @generated from protobuf enum value: MATCH = 2;
+     */
+    MATCH = 2,
+    /**
+     * @generated from protobuf enum value: OR = 3;
+     */
+    OR = 3,
+    /**
+     * @generated from protobuf enum value: AND = 4;
+     */
+    AND = 4,
+    /**
+     * @generated from protobuf enum value: NOT = 5;
+     */
+    NOT = 5
+}
+/**
+ * @generated from protobuf enum MiLaboratories.PL.API.ResourceAPI.Tree.Filter.Property
+ */
+export enum ResourceAPI_Tree_Filter_Property {
+    /**
+     * @generated from protobuf enum value: FIELD_NAME = 0;
+     */
+    FIELD_NAME = 0,
+    /**
+     * @generated from protobuf enum value: RESOURCE_TYPE = 1;
+     */
+    RESOURCE_TYPE = 1,
+    /**
+     * @generated from protobuf enum value: IS_FINAL = 2;
+     */
+    IS_FINAL = 2,
+    /**
+     * Evaluated per resource node (traverse_stop_rules only). True when every non-error
+     * output field has a final value. Matches the TypeScript readyAndHasAllOutputsFilled check.
+     *
+     * @generated from protobuf enum value: ALL_OUTPUTS_FINAL = 3;
+     */
+    ALL_OUTPUTS_FINAL = 3
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.KV
+ */
+export interface ResourceAPI_Tree_KV {
+    /**
+     * @generated from protobuf field: string key = 1
+     */
+    key: string;
+    /**
+     * @generated from protobuf field: bytes value = 2
+     */
+    value: Uint8Array;
 }
 /**
  * Multi-message
@@ -1753,6 +1952,19 @@ export interface ResourceAPI_Tree_Response {
      * @generated from protobuf field: MiLaboratories.PL.API.Resource resource = 1
      */
     resource?: Resource;
+    /**
+     * Populated only when include_kv=true in the request.
+     *
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.ResourceAPI.Tree.KV kv = 2
+     */
+    kv: ResourceAPI_Tree_KV[];
+    /**
+     * True when the request specified a traverse_stop_rules and this resource
+     * satisfied it. Always false when traverse_stop_rules was absent.
+     *
+     * @generated from protobuf field: bool traverse_was_stopped = 3
+     */
+    traverseWasStopped: boolean;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.TreeSize
@@ -3728,6 +3940,21 @@ export interface MaintenanceAPI_Ping_Response {
      * @generated from protobuf field: string arch = 8
      */
     arch: string; // x64 / aarch64
+    /**
+     * Opt-in capabilities advertised by this server instance, used by
+     * clients to pick between fast and fallback code paths without waiting
+     * for a failed RPC.
+     *
+     * Each entry is an opaque token "<feature>:<version>" (e.g.
+     * "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
+     * The field is unset on servers predating this mechanism, which the
+     * client treats as "no optional capabilities advertised".
+     *
+     * All list see pl/platform/api/plapiserver/server_capabilities.go
+     *
+     * @generated from protobuf field: repeated string capabilities = 9
+     */
+    capabilities: string[];
 }
 /**
  * @generated from protobuf enum MiLaboratories.PL.API.MaintenanceAPI.Ping.Response.Compression
@@ -8889,13 +9116,20 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
         super("MiLaboratories.PL.API.ResourceAPI.Tree.Request", [
             { no: 1, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 3, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "max_depth", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ }
+            { no: 2, name: "max_depth", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
+            { no: 5, name: "field_filters", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_Filter },
+            { no: 6, name: "include_kv", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 7, name: "traverse_stop_rules", kind: "message", T: () => ResourceAPI_Tree_Filter },
+            { no: 8, name: "seeds", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_SeedResource }
         ]);
     }
     create(value?: PartialMessage<ResourceAPI_Tree_Request>): ResourceAPI_Tree_Request {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.resourceId = 0n;
         message.resourceSignature = new Uint8Array(0);
+        message.fieldFilters = [];
+        message.includeKv = false;
+        message.seeds = [];
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_Tree_Request>(this, message, value);
         return message;
@@ -8913,6 +9147,18 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
                     break;
                 case /* optional uint32 max_depth */ 2:
                     message.maxDepth = reader.uint32();
+                    break;
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filters */ 5:
+                    message.fieldFilters.push(ResourceAPI_Tree_Filter.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* bool include_kv */ 6:
+                    message.includeKv = reader.bool();
+                    break;
+                case /* optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter traverse_stop_rules */ 7:
+                    message.traverseStopRules = ResourceAPI_Tree_Filter.internalBinaryRead(reader, reader.uint32(), options, message.traverseStopRules);
+                    break;
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.SeedResource seeds */ 8:
+                    message.seeds.push(ResourceAPI_Tree_SeedResource.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -8935,6 +9181,18 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
         /* bytes resource_signature = 3; */
         if (message.resourceSignature.length)
             writer.tag(3, WireType.LengthDelimited).bytes(message.resourceSignature);
+        /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter field_filters = 5; */
+        for (let i = 0; i < message.fieldFilters.length; i++)
+            ResourceAPI_Tree_Filter.internalBinaryWrite(message.fieldFilters[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        /* bool include_kv = 6; */
+        if (message.includeKv !== false)
+            writer.tag(6, WireType.Varint).bool(message.includeKv);
+        /* optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter traverse_stop_rules = 7; */
+        if (message.traverseStopRules)
+            ResourceAPI_Tree_Filter.internalBinaryWrite(message.traverseStopRules, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.SeedResource seeds = 8; */
+        for (let i = 0; i < message.seeds.length; i++)
+            ResourceAPI_Tree_SeedResource.internalBinaryWrite(message.seeds[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -8946,14 +9204,260 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
  */
 export const ResourceAPI_Tree_Request = new ResourceAPI_Tree_Request$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_Tree_SeedResource$Type extends MessageType<ResourceAPI_Tree_SeedResource> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.Tree.SeedResource", [
+            { no: 1, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_Tree_SeedResource>): ResourceAPI_Tree_SeedResource {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.resourceId = 0n;
+        message.resourceSignature = new Uint8Array(0);
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_Tree_SeedResource>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_Tree_SeedResource): ResourceAPI_Tree_SeedResource {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 resource_id */ 1:
+                    message.resourceId = reader.uint64().toBigInt();
+                    break;
+                case /* bytes resource_signature */ 2:
+                    message.resourceSignature = reader.bytes();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_Tree_SeedResource, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 resource_id = 1; */
+        if (message.resourceId !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.resourceId);
+        /* bytes resource_signature = 2; */
+        if (message.resourceSignature.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.resourceSignature);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.SeedResource
+ */
+export const ResourceAPI_Tree_SeedResource = new ResourceAPI_Tree_SeedResource$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_Tree_Filter$Type extends MessageType<ResourceAPI_Tree_Filter> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.Tree.Filter", [
+            { no: 1, name: "key", kind: "enum", opt: true, T: () => ["MiLaboratories.PL.API.ResourceAPI.Tree.Filter.Property", ResourceAPI_Tree_Filter_Property] },
+            { no: 2, name: "operator", kind: "enum", T: () => ["MiLaboratories.PL.API.ResourceAPI.Tree.Filter.OperatorType", ResourceAPI_Tree_Filter_OperatorType] },
+            { no: 3, name: "bool_value", kind: "scalar", oneof: "value", T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "string_value", kind: "scalar", oneof: "value", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "filters_value", kind: "message", oneof: "value", T: () => ResourceAPI_Tree_Filter_FilterGroup }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_Tree_Filter>): ResourceAPI_Tree_Filter {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.operator = 0;
+        message.value = { oneofKind: undefined };
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_Tree_Filter>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_Tree_Filter): ResourceAPI_Tree_Filter {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter.Property key */ 1:
+                    message.key = reader.int32();
+                    break;
+                case /* MiLaboratories.PL.API.ResourceAPI.Tree.Filter.OperatorType operator */ 2:
+                    message.operator = reader.int32();
+                    break;
+                case /* bool bool_value */ 3:
+                    message.value = {
+                        oneofKind: "boolValue",
+                        boolValue: reader.bool()
+                    };
+                    break;
+                case /* string string_value */ 4:
+                    message.value = {
+                        oneofKind: "stringValue",
+                        stringValue: reader.string()
+                    };
+                    break;
+                case /* MiLaboratories.PL.API.ResourceAPI.Tree.Filter.FilterGroup filters_value */ 5:
+                    message.value = {
+                        oneofKind: "filtersValue",
+                        filtersValue: ResourceAPI_Tree_Filter_FilterGroup.internalBinaryRead(reader, reader.uint32(), options, (message.value as any).filtersValue)
+                    };
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_Tree_Filter, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional MiLaboratories.PL.API.ResourceAPI.Tree.Filter.Property key = 1; */
+        if (message.key !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.key);
+        /* MiLaboratories.PL.API.ResourceAPI.Tree.Filter.OperatorType operator = 2; */
+        if (message.operator !== 0)
+            writer.tag(2, WireType.Varint).int32(message.operator);
+        /* bool bool_value = 3; */
+        if (message.value.oneofKind === "boolValue")
+            writer.tag(3, WireType.Varint).bool(message.value.boolValue);
+        /* string string_value = 4; */
+        if (message.value.oneofKind === "stringValue")
+            writer.tag(4, WireType.LengthDelimited).string(message.value.stringValue);
+        /* MiLaboratories.PL.API.ResourceAPI.Tree.Filter.FilterGroup filters_value = 5; */
+        if (message.value.oneofKind === "filtersValue")
+            ResourceAPI_Tree_Filter_FilterGroup.internalBinaryWrite(message.value.filtersValue, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.Filter
+ */
+export const ResourceAPI_Tree_Filter = new ResourceAPI_Tree_Filter$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_Tree_Filter_FilterGroup$Type extends MessageType<ResourceAPI_Tree_Filter_FilterGroup> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.Tree.Filter.FilterGroup", [
+            { no: 1, name: "filters", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_Filter }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_Tree_Filter_FilterGroup>): ResourceAPI_Tree_Filter_FilterGroup {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.filters = [];
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_Tree_Filter_FilterGroup>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_Tree_Filter_FilterGroup): ResourceAPI_Tree_Filter_FilterGroup {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter filters */ 1:
+                    message.filters.push(ResourceAPI_Tree_Filter.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_Tree_Filter_FilterGroup, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.Filter filters = 1; */
+        for (let i = 0; i < message.filters.length; i++)
+            ResourceAPI_Tree_Filter.internalBinaryWrite(message.filters[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.Filter.FilterGroup
+ */
+export const ResourceAPI_Tree_Filter_FilterGroup = new ResourceAPI_Tree_Filter_FilterGroup$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ResourceAPI_Tree_KV$Type extends MessageType<ResourceAPI_Tree_KV> {
+    constructor() {
+        super("MiLaboratories.PL.API.ResourceAPI.Tree.KV", [
+            { no: 1, name: "key", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "value", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ResourceAPI_Tree_KV>): ResourceAPI_Tree_KV {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.key = "";
+        message.value = new Uint8Array(0);
+        if (value !== undefined)
+            reflectionMergePartial<ResourceAPI_Tree_KV>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ResourceAPI_Tree_KV): ResourceAPI_Tree_KV {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string key */ 1:
+                    message.key = reader.string();
+                    break;
+                case /* bytes value */ 2:
+                    message.value = reader.bytes();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ResourceAPI_Tree_KV, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string key = 1; */
+        if (message.key !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.key);
+        /* bytes value = 2; */
+        if (message.value.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.value);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.ResourceAPI.Tree.KV
+ */
+export const ResourceAPI_Tree_KV = new ResourceAPI_Tree_KV$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Response> {
     constructor() {
         super("MiLaboratories.PL.API.ResourceAPI.Tree.Response", [
-            { no: 1, name: "resource", kind: "message", T: () => Resource }
+            { no: 1, name: "resource", kind: "message", T: () => Resource },
+            { no: 2, name: "kv", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_KV },
+            { no: 3, name: "traverse_was_stopped", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ResourceAPI_Tree_Response>): ResourceAPI_Tree_Response {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.kv = [];
+        message.traverseWasStopped = false;
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_Tree_Response>(this, message, value);
         return message;
@@ -8965,6 +9469,12 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
             switch (fieldNo) {
                 case /* MiLaboratories.PL.API.Resource resource */ 1:
                     message.resource = Resource.internalBinaryRead(reader, reader.uint32(), options, message.resource);
+                    break;
+                case /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.KV kv */ 2:
+                    message.kv.push(ResourceAPI_Tree_KV.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* bool traverse_was_stopped */ 3:
+                    message.traverseWasStopped = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -8981,6 +9491,12 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         /* MiLaboratories.PL.API.Resource resource = 1; */
         if (message.resource)
             Resource.internalBinaryWrite(message.resource, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* repeated MiLaboratories.PL.API.ResourceAPI.Tree.KV kv = 2; */
+        for (let i = 0; i < message.kv.length; i++)
+            ResourceAPI_Tree_KV.internalBinaryWrite(message.kv[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* bool traverse_was_stopped = 3; */
+        if (message.traverseWasStopped !== false)
+            writer.tag(3, WireType.Varint).bool(message.traverseWasStopped);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -18254,7 +18770,8 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
             { no: 5, name: "instance_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "platform", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "os", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 8, name: "arch", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 8, name: "arch", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "capabilities", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<MaintenanceAPI_Ping_Response>): MaintenanceAPI_Ping_Response {
@@ -18266,6 +18783,7 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
         message.platform = "";
         message.os = "";
         message.arch = "";
+        message.capabilities = [];
         if (value !== undefined)
             reflectionMergePartial<MaintenanceAPI_Ping_Response>(this, message, value);
         return message;
@@ -18295,6 +18813,9 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
                     break;
                 case /* string arch */ 8:
                     message.arch = reader.string();
+                    break;
+                case /* repeated string capabilities */ 9:
+                    message.capabilities.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -18329,6 +18850,9 @@ class MaintenanceAPI_Ping_Response$Type extends MessageType<MaintenanceAPI_Ping_
         /* string arch = 8; */
         if (message.arch !== "")
             writer.tag(8, WireType.LengthDelimited).string(message.arch);
+        /* repeated string capabilities = 9; */
+        for (let i = 0; i < message.capabilities.length; i++)
+            writer.tag(9, WireType.LengthDelimited).string(message.capabilities[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
@@ -87,12 +87,6 @@ export interface Resource {
      */
     isFinal: boolean;
     /**
-     * Status() == Error; distinct from has_errors (which means any field has an error value)
-     *
-     * @generated from protobuf field: bool is_error = 20
-     */
-    isError: boolean;
-    /**
      * @generated from protobuf field: uint64 original_resource_id = 10
      */
     originalResourceId: bigint;
@@ -571,7 +565,6 @@ class Resource$Type extends MessageType<Resource> {
             { no: 9, name: "outputs_locked", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 14, name: "resource_ready", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 15, name: "is_final", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 20, name: "is_error", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 10, name: "original_resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 19, name: "original_resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 11, name: "parent_resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
@@ -592,7 +585,6 @@ class Resource$Type extends MessageType<Resource> {
         message.outputsLocked = false;
         message.resourceReady = false;
         message.isFinal = false;
-        message.isError = false;
         message.originalResourceId = 0n;
         message.originalResourceSignature = new Uint8Array(0);
         message.parentResourceId = 0n;
@@ -643,9 +635,6 @@ class Resource$Type extends MessageType<Resource> {
                     break;
                 case /* bool is_final */ 15:
                     message.isFinal = reader.bool();
-                    break;
-                case /* bool is_error */ 20:
-                    message.isError = reader.bool();
                     break;
                 case /* uint64 original_resource_id */ 10:
                     message.originalResourceId = reader.uint64().toBigInt();
@@ -728,9 +717,6 @@ class Resource$Type extends MessageType<Resource> {
         /* bytes original_resource_signature = 19; */
         if (message.originalResourceSignature.length)
             writer.tag(19, WireType.LengthDelimited).bytes(message.originalResourceSignature);
-        /* bool is_error = 20; */
-        if (message.isError !== false)
-            writer.tag(20, WireType.Varint).bool(message.isError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
@@ -87,6 +87,12 @@ export interface Resource {
      */
     isFinal: boolean;
     /**
+     * Status() == Error; distinct from has_errors (which means any field has an error value)
+     *
+     * @generated from protobuf field: bool is_error = 20
+     */
+    isError: boolean;
+    /**
      * @generated from protobuf field: uint64 original_resource_id = 10
      */
     originalResourceId: bigint;
@@ -565,6 +571,7 @@ class Resource$Type extends MessageType<Resource> {
             { no: 9, name: "outputs_locked", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 14, name: "resource_ready", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 15, name: "is_final", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 20, name: "is_error", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 10, name: "original_resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 19, name: "original_resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 11, name: "parent_resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
@@ -585,6 +592,7 @@ class Resource$Type extends MessageType<Resource> {
         message.outputsLocked = false;
         message.resourceReady = false;
         message.isFinal = false;
+        message.isError = false;
         message.originalResourceId = 0n;
         message.originalResourceSignature = new Uint8Array(0);
         message.parentResourceId = 0n;
@@ -635,6 +643,9 @@ class Resource$Type extends MessageType<Resource> {
                     break;
                 case /* bool is_final */ 15:
                     message.isFinal = reader.bool();
+                    break;
+                case /* bool is_error */ 20:
+                    message.isError = reader.bool();
                     break;
                 case /* uint64 original_resource_id */ 10:
                     message.originalResourceId = reader.uint64().toBigInt();
@@ -717,6 +728,9 @@ class Resource$Type extends MessageType<Resource> {
         /* bytes original_resource_signature = 19; */
         if (message.originalResourceSignature.length)
             writer.tag(19, WireType.LengthDelimited).bytes(message.originalResourceSignature);
+        /* bool is_error = 20; */
+        if (message.isError !== false)
+            writer.tag(20, WireType.Varint).bool(message.isError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-grpc/google/api/http.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/api/http.ts
@@ -2,7 +2,7 @@
 // @generated from protobuf file "google/api/http.proto" (package "google.api", syntax proto3)
 // tslint:disable
 //
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/node/pl-client/src/proto-grpc/google/protobuf/descriptor.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/protobuf/descriptor.ts
@@ -96,6 +96,13 @@ export interface FileDescriptorProto {
      */
     weakDependency: number[];
     /**
+     * Names of files imported by this file purely for the purpose of providing
+     * option extensions. These are excluded from the dependency list above.
+     *
+     * @generated from protobuf field: repeated string option_dependency = 15
+     */
+    optionDependency: string[];
+    /**
      * All top-level definitions in this file.
      *
      * @generated from protobuf field: repeated google.protobuf.DescriptorProto message_type = 4
@@ -131,12 +138,18 @@ export interface FileDescriptorProto {
      * The supported values are "proto2", "proto3", and "editions".
      *
      * If `edition` is present, this value must be "editions".
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional string syntax = 12
      */
     syntax?: string;
     /**
      * The edition of the proto file.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.Edition edition = 14
      */
@@ -191,6 +204,12 @@ export interface DescriptorProto {
      * @generated from protobuf field: repeated string reserved_name = 10
      */
     reservedName: string[];
+    /**
+     * Support for `export` and `local` keywords on enums.
+     *
+     * @generated from protobuf field: optional google.protobuf.SymbolVisibility visibility = 11
+     */
+    visibility?: SymbolVisibility;
 }
 /**
  * @generated from protobuf message google.protobuf.DescriptorProto.ExtensionRange
@@ -594,6 +613,12 @@ export interface EnumDescriptorProto {
      * @generated from protobuf field: repeated string reserved_name = 5
      */
     reservedName: string[];
+    /**
+     * Support for `export` and `local` keywords on enums.
+     *
+     * @generated from protobuf field: optional google.protobuf.SymbolVisibility visibility = 6
+     */
+    visibility?: SymbolVisibility;
 }
 /**
  * Range of reserved numeric values. Reserved values may not be used by
@@ -887,6 +912,9 @@ export interface FileOptions {
     rubyPackage?: string;
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 50
      */
@@ -1018,6 +1046,9 @@ export interface MessageOptions {
     deprecatedLegacyJsonFieldConflicts?: boolean;
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 12
      */
@@ -1118,9 +1149,11 @@ export interface FieldOptions {
      */
     deprecated?: boolean;
     /**
+     * DEPRECATED. DO NOT USE!
      * For Google-internal migration only. Do not use.
      *
-     * @generated from protobuf field: optional bool weak = 10 [default = false]
+     * @deprecated
+     * @generated from protobuf field: optional bool weak = 10 [default = false, deprecated = true]
      */
     weak?: boolean;
     /**
@@ -1144,6 +1177,9 @@ export interface FieldOptions {
     editionDefaults: FieldOptions_EditionDefault[];
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 21
      */
@@ -1208,6 +1244,13 @@ export interface FieldOptions_FeatureSupport {
      * @generated from protobuf field: optional google.protobuf.Edition edition_removed = 4
      */
     editionRemoved?: Edition;
+    /**
+     * The removal error text if this feature is used after the edition it was
+     * removed in.
+     *
+     * @generated from protobuf field: optional string removal_error = 5
+     */
+    removalError?: string;
 }
 /**
  * @generated from protobuf enum google.protobuf.FieldOptions.CType
@@ -1260,8 +1303,6 @@ export enum FieldOptions_JSType {
 }
 /**
  * If set to RETENTION_SOURCE, the option will be omitted from the binary.
- * Note: as of January 2023, support for this is in progress and does not yet
- * have an effect (b/264593489).
  *
  * @generated from protobuf enum google.protobuf.FieldOptions.OptionRetention
  */
@@ -1282,8 +1323,7 @@ export enum FieldOptions_OptionRetention {
 /**
  * This indicates the types of entities that the field may apply to when used
  * as an option. If it is unset, then the field may be freely used as an
- * option on any kind of entity. Note: as of January 2023, support for this is
- * in progress and does not yet have an effect (b/264593489).
+ * option on any kind of entity.
  *
  * @generated from protobuf enum google.protobuf.FieldOptions.OptionTargetType
  */
@@ -1335,6 +1375,9 @@ export enum FieldOptions_OptionTargetType {
 export interface OneofOptions {
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 1
      */
@@ -1380,6 +1423,9 @@ export interface EnumOptions {
     deprecatedLegacyJsonFieldConflicts?: boolean;
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 7
      */
@@ -1406,6 +1452,9 @@ export interface EnumValueOptions {
     deprecated?: boolean;
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 2
      */
@@ -1437,6 +1486,9 @@ export interface EnumValueOptions {
 export interface ServiceOptions {
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 34
      */
@@ -1486,6 +1538,9 @@ export interface MethodOptions {
     idempotencyLevel?: MethodOptions_IdempotencyLevel;
     /**
      * Any features defined in the specific edition.
+     * WARNING: This field should only be used by protobuf plugins or special
+     * cases like the proto compiler. Other uses are discouraged and
+     * developers should rely on the protoreflect APIs for their client language.
      *
      * @generated from protobuf field: optional google.protobuf.FeatureSet features = 35
      */
@@ -1622,6 +1677,54 @@ export interface FeatureSet {
      * @generated from protobuf field: optional google.protobuf.FeatureSet.JsonFormat json_format = 6
      */
     jsonFormat?: FeatureSet_JsonFormat;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style = 7
+     */
+    enforceNamingStyle?: FeatureSet_EnforceNamingStyle;
+    /**
+     * @generated from protobuf field: optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8
+     */
+    defaultSymbolVisibility?: FeatureSet_VisibilityFeature_DefaultSymbolVisibility;
+}
+/**
+ * @generated from protobuf message google.protobuf.FeatureSet.VisibilityFeature
+ */
+export interface FeatureSet_VisibilityFeature {
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility
+ */
+export enum FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+    /**
+     * @generated from protobuf enum value: DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0;
+     */
+    DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0,
+    /**
+     * Default pre-EDITION_2024, all UNSET visibility are export.
+     *
+     * @generated from protobuf enum value: EXPORT_ALL = 1;
+     */
+    EXPORT_ALL = 1,
+    /**
+     * All top-level symbols default to export, nested default to local.
+     *
+     * @generated from protobuf enum value: EXPORT_TOP_LEVEL = 2;
+     */
+    EXPORT_TOP_LEVEL = 2,
+    /**
+     * All symbols default to local.
+     *
+     * @generated from protobuf enum value: LOCAL_ALL = 3;
+     */
+    LOCAL_ALL = 3,
+    /**
+     * All symbols local by default. Nested types cannot be exported.
+     * With special case caveat for message { enum {} reserved 1 to max; }
+     * This is the recommended setting for new protos.
+     *
+     * @generated from protobuf enum value: STRICT = 4;
+     */
+    STRICT = 4
 }
 /**
  * @generated from protobuf enum google.protobuf.FeatureSet.FieldPresence
@@ -1728,6 +1831,23 @@ export enum FeatureSet_JsonFormat {
      * @generated from protobuf enum value: LEGACY_BEST_EFFORT = 2;
      */
     LEGACY_BEST_EFFORT = 2
+}
+/**
+ * @generated from protobuf enum google.protobuf.FeatureSet.EnforceNamingStyle
+ */
+export enum FeatureSet_EnforceNamingStyle {
+    /**
+     * @generated from protobuf enum value: ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+     */
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0,
+    /**
+     * @generated from protobuf enum value: STYLE2024 = 1;
+     */
+    STYLE2024 = 1,
+    /**
+     * @generated from protobuf enum value: STYLE_LEGACY = 2;
+     */
+    STYLE_LEGACY = 2
 }
 /**
  * A compiled specification for the defaults of a set of features.  These
@@ -2069,8 +2189,14 @@ export enum Edition {
      */
     EDITION_2024 = 1001,
     /**
+     * A placeholder edition for developing and testing unscheduled features.
+     *
+     * @generated from protobuf enum value: EDITION_UNSTABLE = 9999;
+     */
+    EDITION_UNSTABLE = 9999,
+    /**
      * Placeholder editions for testing feature resolution.  These should not be
-     * used or relyed on outside of tests.
+     * used or relied on outside of tests.
      *
      * @generated from protobuf enum value: EDITION_1_TEST_ONLY = 1;
      */
@@ -2099,6 +2225,29 @@ export enum Edition {
      * @generated from protobuf enum value: EDITION_MAX = 2147483647;
      */
     EDITION_MAX = 2147483647
+}
+/**
+ * Describes the 'visibility' of a symbol with respect to the proto import
+ * system. Symbols can only be imported when the visibility rules do not prevent
+ * it (ex: local symbols cannot be imported).  Visibility modifiers can only set
+ * on `message` and `enum` as they are the only types available to be referenced
+ * from other files.
+ *
+ * @generated from protobuf enum google.protobuf.SymbolVisibility
+ */
+export enum SymbolVisibility {
+    /**
+     * @generated from protobuf enum value: VISIBILITY_UNSET = 0;
+     */
+    VISIBILITY_UNSET = 0,
+    /**
+     * @generated from protobuf enum value: VISIBILITY_LOCAL = 1;
+     */
+    VISIBILITY_LOCAL = 1,
+    /**
+     * @generated from protobuf enum value: VISIBILITY_EXPORT = 2;
+     */
+    VISIBILITY_EXPORT = 2
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class FileDescriptorSet$Type extends MessageType<FileDescriptorSet> {
@@ -2156,6 +2305,7 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
             { no: 3, name: "dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 10, name: "public_dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 5 /*ScalarType.INT32*/ },
             { no: 11, name: "weak_dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 5 /*ScalarType.INT32*/ },
+            { no: 15, name: "option_dependency", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "message_type", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => DescriptorProto },
             { no: 5, name: "enum_type", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumDescriptorProto },
             { no: 6, name: "service", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ServiceDescriptorProto },
@@ -2171,6 +2321,7 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         message.dependency = [];
         message.publicDependency = [];
         message.weakDependency = [];
+        message.optionDependency = [];
         message.messageType = [];
         message.enumType = [];
         message.service = [];
@@ -2206,6 +2357,9 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
                             message.weakDependency.push(reader.int32());
                     else
                         message.weakDependency.push(reader.int32());
+                    break;
+                case /* repeated string option_dependency */ 15:
+                    message.optionDependency.push(reader.string());
                     break;
                 case /* repeated google.protobuf.DescriptorProto message_type */ 4:
                     message.messageType.push(DescriptorProto.internalBinaryRead(reader, reader.uint32(), options));
@@ -2282,6 +2436,9 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.Edition edition = 14; */
         if (message.edition !== undefined)
             writer.tag(14, WireType.Varint).int32(message.edition);
+        /* repeated string option_dependency = 15; */
+        for (let i = 0; i < message.optionDependency.length; i++)
+            writer.tag(15, WireType.LengthDelimited).string(message.optionDependency[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2305,7 +2462,8 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
             { no: 8, name: "oneof_decl", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => OneofDescriptorProto },
             { no: 7, name: "options", kind: "message", T: () => MessageOptions },
             { no: 9, name: "reserved_range", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => DescriptorProto_ReservedRange },
-            { no: 10, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+            { no: 10, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 11, name: "visibility", kind: "enum", opt: true, T: () => ["google.protobuf.SymbolVisibility", SymbolVisibility] }
         ]);
     }
     create(value?: PartialMessage<DescriptorProto>): DescriptorProto {
@@ -2357,6 +2515,9 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
                 case /* repeated string reserved_name */ 10:
                     message.reservedName.push(reader.string());
                     break;
+                case /* optional google.protobuf.SymbolVisibility visibility */ 11:
+                    message.visibility = reader.int32();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -2399,6 +2560,9 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated string reserved_name = 10; */
         for (let i = 0; i < message.reservedName.length; i++)
             writer.tag(10, WireType.LengthDelimited).string(message.reservedName[i]);
+        /* optional google.protobuf.SymbolVisibility visibility = 11; */
+        if (message.visibility !== undefined)
+            writer.tag(11, WireType.Varint).int32(message.visibility);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2842,7 +3006,8 @@ class EnumDescriptorProto$Type extends MessageType<EnumDescriptorProto> {
             { no: 2, name: "value", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumValueDescriptorProto },
             { no: 3, name: "options", kind: "message", T: () => EnumOptions },
             { no: 4, name: "reserved_range", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumDescriptorProto_EnumReservedRange },
-            { no: 5, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+            { no: 5, name: "reserved_name", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 6, name: "visibility", kind: "enum", opt: true, T: () => ["google.protobuf.SymbolVisibility", SymbolVisibility] }
         ]);
     }
     create(value?: PartialMessage<EnumDescriptorProto>): EnumDescriptorProto {
@@ -2874,6 +3039,9 @@ class EnumDescriptorProto$Type extends MessageType<EnumDescriptorProto> {
                 case /* repeated string reserved_name */ 5:
                     message.reservedName.push(reader.string());
                     break;
+                case /* optional google.protobuf.SymbolVisibility visibility */ 6:
+                    message.visibility = reader.int32();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -2901,6 +3069,9 @@ class EnumDescriptorProto$Type extends MessageType<EnumDescriptorProto> {
         /* repeated string reserved_name = 5; */
         for (let i = 0; i < message.reservedName.length; i++)
             writer.tag(5, WireType.LengthDelimited).string(message.reservedName[i]);
+        /* optional google.protobuf.SymbolVisibility visibility = 6; */
+        if (message.visibility !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.visibility);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3494,7 +3665,7 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
                 case /* optional bool deprecated = 3 [default = false] */ 3:
                     message.deprecated = reader.bool();
                     break;
-                case /* optional bool weak = 10 [default = false] */ 10:
+                case /* optional bool weak = 10 [default = false, deprecated = true] */ 10:
                     message.weak = reader.bool();
                     break;
                 case /* optional bool debug_redact = 16 [default = false] */ 16:
@@ -3549,7 +3720,7 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional google.protobuf.FieldOptions.JSType jstype = 6 [default = JS_NORMAL]; */
         if (message.jstype !== undefined)
             writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool weak = 10 [default = false]; */
+        /* optional bool weak = 10 [default = false, deprecated = true]; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
         /* optional bool unverified_lazy = 15 [default = false]; */
@@ -3646,7 +3817,8 @@ class FieldOptions_FeatureSupport$Type extends MessageType<FieldOptions_FeatureS
             { no: 1, name: "edition_introduced", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
             { no: 2, name: "edition_deprecated", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
             { no: 3, name: "deprecation_warning", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
-            { no: 4, name: "edition_removed", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] }
+            { no: 4, name: "edition_removed", kind: "enum", opt: true, T: () => ["google.protobuf.Edition", Edition] },
+            { no: 5, name: "removal_error", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<FieldOptions_FeatureSupport>): FieldOptions_FeatureSupport {
@@ -3672,6 +3844,9 @@ class FieldOptions_FeatureSupport$Type extends MessageType<FieldOptions_FeatureS
                 case /* optional google.protobuf.Edition edition_removed */ 4:
                     message.editionRemoved = reader.int32();
                     break;
+                case /* optional string removal_error */ 5:
+                    message.removalError = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -3696,6 +3871,9 @@ class FieldOptions_FeatureSupport$Type extends MessageType<FieldOptions_FeatureS
         /* optional google.protobuf.Edition edition_removed = 4; */
         if (message.editionRemoved !== undefined)
             writer.tag(4, WireType.Varint).int32(message.editionRemoved);
+        /* optional string removal_error = 5; */
+        if (message.removalError !== undefined)
+            writer.tag(5, WireType.LengthDelimited).string(message.removalError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -4192,7 +4370,9 @@ class FeatureSet$Type extends MessageType<FeatureSet> {
             { no: 3, name: "repeated_field_encoding", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.RepeatedFieldEncoding", FeatureSet_RepeatedFieldEncoding] },
             { no: 4, name: "utf8_validation", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.Utf8Validation", FeatureSet_Utf8Validation] },
             { no: 5, name: "message_encoding", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.MessageEncoding", FeatureSet_MessageEncoding] },
-            { no: 6, name: "json_format", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.JsonFormat", FeatureSet_JsonFormat] }
+            { no: 6, name: "json_format", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.JsonFormat", FeatureSet_JsonFormat] },
+            { no: 7, name: "enforce_naming_style", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.EnforceNamingStyle", FeatureSet_EnforceNamingStyle] },
+            { no: 8, name: "default_symbol_visibility", kind: "enum", opt: true, T: () => ["google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility", FeatureSet_VisibilityFeature_DefaultSymbolVisibility] }
         ]);
     }
     create(value?: PartialMessage<FeatureSet>): FeatureSet {
@@ -4224,6 +4404,12 @@ class FeatureSet$Type extends MessageType<FeatureSet> {
                 case /* optional google.protobuf.FeatureSet.JsonFormat json_format */ 6:
                     message.jsonFormat = reader.int32();
                     break;
+                case /* optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style */ 7:
+                    message.enforceNamingStyle = reader.int32();
+                    break;
+                case /* optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility */ 8:
+                    message.defaultSymbolVisibility = reader.int32();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -4254,6 +4440,12 @@ class FeatureSet$Type extends MessageType<FeatureSet> {
         /* optional google.protobuf.FeatureSet.JsonFormat json_format = 6; */
         if (message.jsonFormat !== undefined)
             writer.tag(6, WireType.Varint).int32(message.jsonFormat);
+        /* optional google.protobuf.FeatureSet.EnforceNamingStyle enforce_naming_style = 7; */
+        if (message.enforceNamingStyle !== undefined)
+            writer.tag(7, WireType.Varint).int32(message.enforceNamingStyle);
+        /* optional google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8; */
+        if (message.defaultSymbolVisibility !== undefined)
+            writer.tag(8, WireType.Varint).int32(message.defaultSymbolVisibility);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -4264,6 +4456,44 @@ class FeatureSet$Type extends MessageType<FeatureSet> {
  * @generated MessageType for protobuf message google.protobuf.FeatureSet
  */
 export const FeatureSet = new FeatureSet$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class FeatureSet_VisibilityFeature$Type extends MessageType<FeatureSet_VisibilityFeature> {
+    constructor() {
+        super("google.protobuf.FeatureSet.VisibilityFeature", []);
+    }
+    create(value?: PartialMessage<FeatureSet_VisibilityFeature>): FeatureSet_VisibilityFeature {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<FeatureSet_VisibilityFeature>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FeatureSet_VisibilityFeature): FeatureSet_VisibilityFeature {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FeatureSet_VisibilityFeature, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message google.protobuf.FeatureSet.VisibilityFeature
+ */
+export const FeatureSet_VisibilityFeature = new FeatureSet_VisibilityFeature$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class FeatureSetDefaults$Type extends MessageType<FeatureSetDefaults> {
     constructor() {

--- a/lib/node/pl-client/src/proto-grpc/google/protobuf/timestamp.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/protobuf/timestamp.ts
@@ -119,8 +119,8 @@ import { MessageType } from "@protobuf-ts/runtime";
  * {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
  * seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
  * are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
- * is required. A proto3 JSON serializer should always use UTC (as indicated by
- * "Z") when printing the Timestamp type and a proto3 JSON parser should be
+ * is required. A ProtoJSON serializer should always use UTC (as indicated by
+ * "Z") when printing the Timestamp type and a ProtoJSON parser should be
  * able to accept both UTC and other timezones (as indicated by an offset).
  *
  * For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
@@ -142,17 +142,18 @@ import { MessageType } from "@protobuf-ts/runtime";
  */
 export interface Timestamp {
     /**
-     * Represents seconds of UTC time since Unix epoch
-     * 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-     * 9999-12-31T23:59:59Z inclusive.
+     * Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+     * be between -62135596800 and 253402300799 inclusive (which corresponds to
+     * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
      *
      * @generated from protobuf field: int64 seconds = 1
      */
     seconds: bigint;
     /**
-     * Non-negative fractions of a second at nanosecond resolution. Negative
-     * second values with fractions must still have non-negative nanos values
-     * that count forward in time. Must be from 0 to 999,999,999
+     * Non-negative fractions of a second at nanosecond resolution. This field is
+     * the nanosecond portion of the duration, not an alternative to seconds.
+     * Negative second values with fractions must still have non-negative nanos
+     * values that count forward in time. Must be between 0 and 999,999,999
      * inclusive.
      *
      * @generated from protobuf field: int32 nanos = 2

--- a/lib/node/pl-client/src/proto-grpc/google/protobuf/wrappers.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/protobuf/wrappers.ts
@@ -32,10 +32,17 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Wrappers for primitive (non-message) types. These types are useful
-// for embedding primitives in the `google.protobuf.Any` type and for places
-// where we need to distinguish between the absence of a primitive
-// typed field and its default value.
+// Wrappers for primitive (non-message) types. These types were needed
+// for legacy reasons and are not recommended for use in new APIs.
+//
+// Historically these wrappers were useful to have presence on proto3 primitive
+// fields, but proto3 syntax has been updated to support the `optional` keyword.
+// Using that keyword is now the strongly preferred way to add presence to
+// proto3 primitive fields.
+//
+// A secondary usecase was to embed primitives in the `google.protobuf.Any`
+// type: it is now recommended that you embed your value in your own wrapper
+// message which can be specifically documented.
 //
 // These wrappers have no meaningful use within repeated fields as they lack
 // the ability to detect presence on individual elements.
@@ -61,6 +68,9 @@ import { MessageType } from "@protobuf-ts/runtime";
  *
  * The JSON representation for `DoubleValue` is JSON number.
  *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
+ *
  * @generated from protobuf message google.protobuf.DoubleValue
  */
 export interface DoubleValue {
@@ -75,6 +85,9 @@ export interface DoubleValue {
  * Wrapper message for `float`.
  *
  * The JSON representation for `FloatValue` is JSON number.
+ *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
  *
  * @generated from protobuf message google.protobuf.FloatValue
  */
@@ -91,6 +104,9 @@ export interface FloatValue {
  *
  * The JSON representation for `Int64Value` is JSON string.
  *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
+ *
  * @generated from protobuf message google.protobuf.Int64Value
  */
 export interface Int64Value {
@@ -105,6 +121,9 @@ export interface Int64Value {
  * Wrapper message for `uint64`.
  *
  * The JSON representation for `UInt64Value` is JSON string.
+ *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
  *
  * @generated from protobuf message google.protobuf.UInt64Value
  */
@@ -121,6 +140,9 @@ export interface UInt64Value {
  *
  * The JSON representation for `Int32Value` is JSON number.
  *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
+ *
  * @generated from protobuf message google.protobuf.Int32Value
  */
 export interface Int32Value {
@@ -135,6 +157,9 @@ export interface Int32Value {
  * Wrapper message for `uint32`.
  *
  * The JSON representation for `UInt32Value` is JSON number.
+ *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
  *
  * @generated from protobuf message google.protobuf.UInt32Value
  */
@@ -151,6 +176,9 @@ export interface UInt32Value {
  *
  * The JSON representation for `BoolValue` is JSON `true` and `false`.
  *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
+ *
  * @generated from protobuf message google.protobuf.BoolValue
  */
 export interface BoolValue {
@@ -166,6 +194,9 @@ export interface BoolValue {
  *
  * The JSON representation for `StringValue` is JSON string.
  *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
+ *
  * @generated from protobuf message google.protobuf.StringValue
  */
 export interface StringValue {
@@ -180,6 +211,9 @@ export interface StringValue {
  * Wrapper message for `bytes`.
  *
  * The JSON representation for `BytesValue` is JSON string.
+ *
+ * Not recommended for use in new APIs, but still useful for legacy APIs and
+ * has no plan to be removed.
  *
  * @generated from protobuf message google.protobuf.BytesValue
  */

--- a/lib/node/pl-client/src/proto-grpc/google/rpc/code.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/rpc/code.ts
@@ -2,7 +2,7 @@
 // @generated from protobuf file "google/rpc/code.proto" (package "google.rpc", syntax proto3)
 // tslint:disable
 //
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/node/pl-client/src/proto-grpc/google/rpc/error_details.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/rpc/error_details.ts
@@ -2,7 +2,7 @@
 // @generated from protobuf file "google/rpc/error_details.proto" (package "google.rpc", syntax proto3)
 // tslint:disable
 //
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -368,17 +368,17 @@ export interface BadRequest_FieldViolation {
      * In this example, in proto `field` could take one of the following values:
      *
      * * `full_name` for a violation in the `full_name` value
-     * * `email_addresses[1].email` for a violation in the `email` field of the
+     * * `email_addresses[0].email` for a violation in the `email` field of the
      *   first `email_addresses` message
-     * * `email_addresses[3].type[2]` for a violation in the second `type`
+     * * `email_addresses[2].type[1]` for a violation in the second `type`
      *   value in the third `email_addresses` message.
      *
      * In JSON, the same values are represented as:
      *
      * * `fullName` for a violation in the `fullName` value
-     * * `emailAddresses[1].email` for a violation in the `email` field of the
+     * * `emailAddresses[0].email` for a violation in the `email` field of the
      *   first `emailAddresses` message
-     * * `emailAddresses[3].type[2]` for a violation in the second `type`
+     * * `emailAddresses[2].type[1]` for a violation in the second `type`
      *   value in the third `emailAddresses` message.
      *
      * @generated from protobuf field: string field = 1

--- a/lib/node/pl-client/src/proto-grpc/google/rpc/http.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/rpc/http.ts
@@ -2,7 +2,7 @@
 // @generated from protobuf file "google/rpc/http.proto" (package "google.rpc", syntax proto3)
 // tslint:disable
 //
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/node/pl-client/src/proto-grpc/google/rpc/status.ts
+++ b/lib/node/pl-client/src/proto-grpc/google/rpc/status.ts
@@ -2,7 +2,7 @@
 // @generated from protobuf file "google/rpc/status.proto" (package "google.rpc", syntax proto3)
 // tslint:disable
 //
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/node/pl-deployments/package.json
+++ b/lib/node/pl-deployments/package.json
@@ -67,5 +67,5 @@
   "engines": {
     "node": ">=22.19.0"
   },
-  "pl-version": "3.2.1"
+  "pl-version": "3.5.0"
 }

--- a/lib/node/pl-middle-layer/src/debug/index.ts
+++ b/lib/node/pl-middle-layer/src/debug/index.ts
@@ -7,7 +7,31 @@ export type MlDebugFlags = {
   logOutputRecalculations?: boolean;
   logProjectOverviewStat: boolean;
   logJsExecStat: boolean;
+  /** Resolved value of MI_TREE_TRAVERSAL env var, or undefined if not set. */
+  treeTraversalMode?: "auto" | "client-bfs" | "backend-streaming";
 };
+
+const VALID_TRAVERSAL_MODES = ["auto", "client-bfs", "backend-streaming"] as const;
+
+/**
+ * Parse the raw MI_TREE_TRAVERSAL env value into a typed TraversalMode.
+ * Returns undefined when raw is undefined (env var absent).
+ * Logs a warning and returns "auto" on unrecognised values (AC-TM5).
+ * Exported for unit testing.
+ */
+export function parseTraversalMode(
+  raw: string | undefined,
+  warn: (msg: string) => void = console.warn,
+): "auto" | "client-bfs" | "backend-streaming" | undefined {
+  if (raw === undefined) return undefined;
+  if ((VALID_TRAVERSAL_MODES as readonly string[]).includes(raw))
+    return raw as "auto" | "client-bfs" | "backend-streaming";
+  warn(
+    `MI_TREE_TRAVERSAL="${raw}" is not a valid traversal mode ` +
+      `(valid: ${VALID_TRAVERSAL_MODES.join(", ")}); falling back to "auto"`,
+  );
+  return "auto";
+}
 
 let flags: MlDebugFlags | undefined = undefined;
 export function getDebugFlags() {
@@ -26,5 +50,7 @@ export function getDebugFlags() {
   if (process.env.MI_LOG_TREE_STAT)
     flags.logTreeStats =
       process.env.MI_LOG_TREE_STAT === "cumulative" ? "cumulative" : "per-request";
+  const treeTraversalMode = parseTraversalMode(process.env.MI_TREE_TRAVERSAL);
+  if (treeTraversalMode !== undefined) flags.treeTraversalMode = treeTraversalMode;
   return flags;
 }

--- a/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/middle_layer.ts
@@ -344,6 +344,12 @@ export class MiddleLayer {
     // overriding debug options from environment variables
     ops.defaultTreeOptions.logStat = getDebugFlags().logTreeStats;
     ops.debugOps.dumpInitialTreeState = getDebugFlags().dumpInitialTreeState;
+    // apply MI_TREE_TRAVERSAL only when the embedder hasn't set an explicit mode
+    if (
+      ops.defaultTreeOptions.traversalMode === undefined &&
+      getDebugFlags().treeTraversalMode !== undefined
+    )
+      ops.defaultTreeOptions.traversalMode = getDebugFlags().treeTraversalMode;
 
     const projects = await pl.withWriteTx("MLInitialization", async (tx) => {
       const projectsField = field(tx.clientRoot, ProjectsField);

--- a/lib/node/pl-middle-layer/src/middle_layer/ops.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/ops.ts
@@ -238,7 +238,7 @@ export const DefaultMiddleLayerOpsSettings: Pick<
 > = {
   ...DefaultDriverKitOpsSettings,
   defaultTreeOptions: {
-    pollingInterval: 350,
+    pollingInterval: 200,
     stopPollingDelay: 2500,
     initialTreeLoadingTimeout: 100 * 60 * 60 * 1000, // disable timeout for loading project tree (100 hours)
   },

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -801,7 +801,7 @@ export function projectTreeFieldFilter(): Filter {
  *
  *   BFS predicate: readyOrDuplicateOrError(r)
  *     → readyOrDuplicateOrError(): stops when resource_ready_for_calculation,
- *       is_duplicate, or is_error is true — exactly mirroring the BFS predicate.
+ *       is_duplicate, or has_errors is true — exactly mirroring the BFS predicate.
  *
  *   BFS predicate: readyAndHasAllOutputsFilled(r)
  *     → isFinal(true) + allOutputsFinal(true).

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -1,5 +1,5 @@
 import type { MiddleLayerEnvironment } from "./middle_layer";
-import type { FieldData, OptionalAnyResourceId, SignedResourceId } from "@milaboratories/pl-client";
+import type { FieldData, Filter, OptionalAnyResourceId, SignedResourceId } from "@milaboratories/pl-client";
 import {
   DefaultRetryOptions,
   ensureSignedResourceIdNotNull,
@@ -8,6 +8,9 @@ import {
   isTimeoutOrCancelError,
   Pl,
   resourceIdToString,
+  ResourceTypeName,
+  ResourceTypePrefix,
+  treeFilter,
 } from "@milaboratories/pl-client";
 import type { ComputableStableDefined, ComputableValueOrErrors } from "@milaboratories/computable";
 import { Computable } from "@milaboratories/computable";
@@ -723,6 +726,8 @@ export class Project {
       {
         ...env.ops.defaultTreeOptions,
         pruning: projectTreePruning(env.logger),
+        fieldFilters: projectTreeFieldFilters(),
+        traverseStopRules: projectTreeTraverseStopRules(),
       },
       env.logger,
     );
@@ -739,7 +744,7 @@ export class Project {
   }
 }
 
-function projectTreePruning(logger: MiLogger): PruningFunction {
+export function projectTreePruning(logger: MiLogger): PruningFunction {
   return (r: ExtendedResourceData): FieldData[] => {
     if (r.fields.length > 1000)
       logger.warn(
@@ -761,6 +766,177 @@ function projectTreePruning(logger: MiLogger): PruningFunction {
         return r.fields;
     }
   };
+}
+
+/** ResourceTree analogue of projectTreePruning() used by modern backend path. */
+export function projectTreeFieldFilters(): Filter[] {
+  return [
+    treeFilter.not(
+      treeFilter.or(
+        // StreamWorkdir/* — pruned entirely
+        treeFilter.resourceTypeMatch("^StreamWorkdir/"),
+        // BlockPackCustom: drop `template`
+        treeFilter.and(
+          treeFilter.resourceTypeEq("BlockPackCustom"),
+          treeFilter.fieldNameEq("template"),
+        ),
+        // UserProject: drop `__serviceTemplate*`
+        treeFilter.and(
+          treeFilter.resourceTypeEq("UserProject"),
+          treeFilter.fieldNameMatch("^__serviceTemplate"),
+        ),
+        // Blob — pruned entirely
+        treeFilter.resourceTypeEq("Blob"),
+      ),
+    ),
+  ];
+}
+
+/**
+ * Stop-rules for the ResourceTree backend path.
+ *
+ * Mirrors every case of DefaultFinalResourceDataPredicate in the same order.
+ * The mapping from BFS predicate logic to backend filter conditions:
+ *
+ *   BFS predicate always true
+ *     → no isFinal guard; backend stops traversal unconditionally.
+ *
+ *   BFS predicate: readyOrDuplicateOrError(r)
+ *     → isFinal(true): backend sets item.final when the predicate fires,
+ *       so isFinal on the wire equals readyOrDuplicateOrError evaluated server-side.
+ *
+ *   BFS predicate: readyAndHasAllOutputsFilled(r)
+ *     → isFinal(true) + allOutputsFinal(true).
+ *
+ *   BFS predicate always false (UserProject, Projects, ClientRoot)
+ *     → no entry here; traversal always continues into them.
+ *       Even if the backend sets item.final=true for these types,
+ *       isFinalPredicate in PlTreeState.updateFromResourceData returns false,
+ *       so their finalState stays false and they always appear in seedResources
+ *       on the next poll.
+ */
+export function projectTreeTraverseStopRules(): Filter {
+  return treeFilter.or(
+    // BFS: readyOrDuplicateOrError(r) AND (fields===undefined OR error OR stream.value===downloadable.value).
+    // datactl sets stream field to point at the same resource as downloadable once processing
+    // is complete, so stream.value===downloadable.value is the "done" signal.
+    // isFinal(true) captures all three exit paths of the predicate on the backend side.
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.StreamManager),
+      treeFilter.isFinal(true),
+    ),
+    // BFS: readyOrDuplicateOrError(r) → isFinal(true)
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.StdMap),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.StdMapSlash),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.EphStdMap),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.PFrame),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.ParquetChunk),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BContext),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BlockPackCustom),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BinaryMap),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BinaryValue),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BlobMap),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BResolveSingle),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BResolveSingleNoResult),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.BQueryResult),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.TengoTemplate),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.TengoLib),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.SoftwareInfo),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeEq(ResourceTypeName.Dummy),
+      treeFilter.isFinal(true),
+    ),
+    // BFS: r.type.version === "1" → isFinal(true) (backend sets final when predicate fires)
+    treeFilter.and(treeFilter.resourceTypeEq(ResourceTypeName.JsonResourceError), treeFilter.isFinal(true)),
+    // BFS: return true (unconditionally) → no isFinal guard needed
+    treeFilter.resourceTypeEq(ResourceTypeName.JsonObject),
+    treeFilter.resourceTypeEq(ResourceTypeName.JsonGzObject),
+    treeFilter.resourceTypeEq(ResourceTypeName.JsonString),
+    treeFilter.resourceTypeEq(ResourceTypeName.JsonArray),
+    treeFilter.resourceTypeEq(ResourceTypeName.JsonNumber),
+    treeFilter.resourceTypeEq(ResourceTypeName.BContextEnd),
+    treeFilter.resourceTypeEq(ResourceTypeName.FrontendFromUrl),
+    treeFilter.resourceTypeEq(ResourceTypeName.FrontendFromFolder),
+    treeFilter.resourceTypeEq(ResourceTypeName.BObjectSpec),
+    treeFilter.resourceTypeEq(ResourceTypeName.Blob),
+    treeFilter.resourceTypeEq(ResourceTypeName.Null),
+    treeFilter.resourceTypeEq(ResourceTypeName.Binary),
+    treeFilter.resourceTypeEq(ResourceTypeName.LSProvider),
+    treeFilter.resourceTypeEq(ResourceTypeName.WorkingDirectory),
+    // BFS default branch: startsWith prefix → return true → no isFinal guard needed
+    treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.Blob),
+    treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.LS),
+    treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.WorkingDirectory),
+    treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.StorageSpaceAllocation),
+    // BFS default branch: readyAndHasAllOutputsFilled → isFinal(true) + allOutputsFinal(true)
+    treeFilter.and(
+      treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.BlobUpload),
+      treeFilter.isFinal(true),
+      treeFilter.allOutputsFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.BlobIndex),
+      treeFilter.isFinal(true),
+      treeFilter.allOutputsFinal(true),
+    ),
+    // BFS default branch: readyOrDuplicateOrError → isFinal(true)
+    treeFilter.and(
+      treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.PColumnData),
+      treeFilter.isFinal(true),
+    ),
+    treeFilter.and(
+      treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.StreamWorkdir),
+      treeFilter.isFinal(true),
+    ),
+  );
 }
 
 /** Returns true if sdk version of the block is old and we need to convert

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -746,6 +746,10 @@ export class Project {
 
 export function projectTreePruning(logger: MiLogger): PruningFunction {
   return (r: ExtendedResourceData): FieldData[] => {
+    // Backend stopped traversal here — children were not streamed.
+    // Strip fields to keep pl-tree's refCount invariant (mirrors BFS behaviour
+    // where the stop equivalent is "pruner returns []").
+    if (r.traverseWasStopped) return [];
     if (r.fields.length > 1000)
       logger.warn(
         `resource with excessive field count: type=${r.type.name} id=${r.id} fields=${r.fields.length}` +

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -726,7 +726,7 @@ export class Project {
       {
         ...env.ops.defaultTreeOptions,
         pruning: projectTreePruning(env.logger),
-        fieldFilters: projectTreeFieldFilters(),
+        fieldFilter: projectTreeFieldFilter(),
         traverseStopRules: projectTreeTraverseStopRules(),
       },
       env.logger,
@@ -769,27 +769,25 @@ export function projectTreePruning(logger: MiLogger): PruningFunction {
 }
 
 /** ResourceTree analogue of projectTreePruning() used by modern backend path. */
-export function projectTreeFieldFilters(): Filter[] {
-  return [
-    treeFilter.not(
-      treeFilter.or(
-        // StreamWorkdir/* — pruned entirely
-        treeFilter.resourceTypeMatch("^StreamWorkdir/"),
-        // BlockPackCustom: drop `template`
-        treeFilter.and(
-          treeFilter.resourceTypeEq("BlockPackCustom"),
-          treeFilter.fieldNameEq("template"),
-        ),
-        // UserProject: drop `__serviceTemplate*`
-        treeFilter.and(
-          treeFilter.resourceTypeEq("UserProject"),
-          treeFilter.fieldNameMatch("^__serviceTemplate"),
-        ),
-        // Blob — pruned entirely
-        treeFilter.resourceTypeEq("Blob"),
+export function projectTreeFieldFilter(): Filter {
+  return treeFilter.not(
+    treeFilter.or(
+      // StreamWorkdir/* — pruned entirely
+      treeFilter.resourceTypeMatch("^StreamWorkdir/"),
+      // BlockPackCustom: drop `template`
+      treeFilter.and(
+        treeFilter.resourceTypeEq("BlockPackCustom"),
+        treeFilter.fieldNameEq("template"),
       ),
+      // UserProject: drop `__serviceTemplate*`
+      treeFilter.and(
+        treeFilter.resourceTypeEq("UserProject"),
+        treeFilter.fieldNameMatch("^__serviceTemplate"),
+      ),
+      // Blob — pruned entirely
+      treeFilter.resourceTypeEq("Blob"),
     ),
-  ];
+  );
 }
 
 /**

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -1,5 +1,10 @@
 import type { MiddleLayerEnvironment } from "./middle_layer";
-import type { FieldData, Filter, OptionalAnyResourceId, SignedResourceId } from "@milaboratories/pl-client";
+import type {
+  FieldData,
+  Filter,
+  OptionalAnyResourceId,
+  SignedResourceId,
+} from "@milaboratories/pl-client";
 import {
   DefaultRetryOptions,
   ensureSignedResourceIdNotNull,

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -746,10 +746,6 @@ export class Project {
 
 export function projectTreePruning(logger: MiLogger): PruningFunction {
   return (r: ExtendedResourceData): FieldData[] => {
-    // Backend stopped traversal here — children were not streamed.
-    // Strip fields to keep pl-tree's refCount invariant (mirrors BFS behaviour
-    // where the stop equivalent is "pruner returns []").
-    if (r.traverseWasStopped) return [];
     if (r.fields.length > 1000)
       logger.warn(
         `resource with excessive field count: type=${r.type.name} id=${r.id} fields=${r.fields.length}` +

--- a/lib/node/pl-middle-layer/src/middle_layer/project.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project.ts
@@ -797,104 +797,99 @@ export function projectTreeFieldFilter(): Filter {
  * The mapping from BFS predicate logic to backend filter conditions:
  *
  *   BFS predicate always true
- *     → no isFinal guard; backend stops traversal unconditionally.
+ *     → no readyOrDuplicateOrError guard; backend stops traversal unconditionally.
  *
  *   BFS predicate: readyOrDuplicateOrError(r)
- *     → isFinal(true): backend sets item.final when the predicate fires,
- *       so isFinal on the wire equals readyOrDuplicateOrError evaluated server-side.
+ *     → readyOrDuplicateOrError(): stops when resource_ready_for_calculation,
+ *       is_duplicate, or is_error is true — exactly mirroring the BFS predicate.
  *
  *   BFS predicate: readyAndHasAllOutputsFilled(r)
  *     → isFinal(true) + allOutputsFinal(true).
  *
  *   BFS predicate always false (UserProject, Projects, ClientRoot)
  *     → no entry here; traversal always continues into them.
- *       Even if the backend sets item.final=true for these types,
- *       isFinalPredicate in PlTreeState.updateFromResourceData returns false,
- *       so their finalState stays false and they always appear in seedResources
- *       on the next poll.
  */
 export function projectTreeTraverseStopRules(): Filter {
   return treeFilter.or(
     // BFS: readyOrDuplicateOrError(r) AND (fields===undefined OR error OR stream.value===downloadable.value).
     // datactl sets stream field to point at the same resource as downloadable once processing
     // is complete, so stream.value===downloadable.value is the "done" signal.
-    // isFinal(true) captures all three exit paths of the predicate on the backend side.
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.StreamManager),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
-    // BFS: readyOrDuplicateOrError(r) → isFinal(true)
+    // BFS: readyOrDuplicateOrError(r)
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.StdMap),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.StdMapSlash),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.EphStdMap),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.PFrame),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.ParquetChunk),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BContext),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BlockPackCustom),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BinaryMap),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BinaryValue),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BlobMap),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BResolveSingle),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BResolveSingleNoResult),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.BQueryResult),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.TengoTemplate),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.TengoLib),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.SoftwareInfo),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeEq(ResourceTypeName.Dummy),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
-    // BFS: r.type.version === "1" → isFinal(true) (backend sets final when predicate fires)
-    treeFilter.and(treeFilter.resourceTypeEq(ResourceTypeName.JsonResourceError), treeFilter.isFinal(true)),
-    // BFS: return true (unconditionally) → no isFinal guard needed
+    // BFS: r.type.version === "1" → always true → no state guard needed
+    treeFilter.resourceTypeEq(ResourceTypeName.JsonResourceError),
+    // BFS: return true (unconditionally) → no readyOrDuplicateOrError guard needed
     treeFilter.resourceTypeEq(ResourceTypeName.JsonObject),
     treeFilter.resourceTypeEq(ResourceTypeName.JsonGzObject),
     treeFilter.resourceTypeEq(ResourceTypeName.JsonString),
@@ -909,30 +904,32 @@ export function projectTreeTraverseStopRules(): Filter {
     treeFilter.resourceTypeEq(ResourceTypeName.Binary),
     treeFilter.resourceTypeEq(ResourceTypeName.LSProvider),
     treeFilter.resourceTypeEq(ResourceTypeName.WorkingDirectory),
-    // BFS default branch: startsWith prefix → return true → no isFinal guard needed
+    // BFS default branch: startsWith prefix → return true → no guard needed
     treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.Blob),
     treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.LS),
     treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.WorkingDirectory),
     treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.StorageSpaceAllocation),
-    // BFS default branch: readyAndHasAllOutputsFilled → isFinal(true) + allOutputsFinal(true)
+    // BFS default branch: readyAndHasAllOutputsFilled → readyOrDuplicateOrError() + outputsLocked(true) + allOutputsFinal(true)
     treeFilter.and(
       treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.BlobUpload),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
+      treeFilter.outputsLocked(true),
       treeFilter.allOutputsFinal(true),
     ),
     treeFilter.and(
       treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.BlobIndex),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
+      treeFilter.outputsLocked(true),
       treeFilter.allOutputsFinal(true),
     ),
-    // BFS default branch: readyOrDuplicateOrError → isFinal(true)
+    // BFS default branch: readyOrDuplicateOrError
     treeFilter.and(
       treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.PColumnData),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
     treeFilter.and(
       treeFilter.resourceTypeMatch("^" + ResourceTypePrefix.StreamWorkdir),
-      treeFilter.isFinal(true),
+      treeFilter.readyOrDuplicateOrError(),
     ),
   );
 }

--- a/lib/node/pl-middle-layer/src/middle_layer/project_list.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_list.ts
@@ -23,7 +23,7 @@ export const ProjectsListTreePruningFunction: PruningFunction = (resource) => {
   return resource.fields;
 };
 
-export const projectsListFieldFilters: Filter[] = [treeFilter.resourceTypeEq("Projects")];
+export const projectsListFieldFilter: Filter = treeFilter.resourceTypeEq("Projects");
 
 export async function createProjectList(
   pl: PlClient,
@@ -37,7 +37,7 @@ export async function createProjectList(
     {
       ...env.ops.defaultTreeOptions,
       pruning: ProjectsListTreePruningFunction,
-      fieldFilters: projectsListFieldFilters,
+      fieldFilter: projectsListFieldFilter,
     },
     env.logger,
   );

--- a/lib/node/pl-middle-layer/src/middle_layer/project_list.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_list.ts
@@ -1,7 +1,7 @@
 import type { PruningFunction } from "@milaboratories/pl-tree";
 import { SynchronizedTreeState } from "@milaboratories/pl-tree";
-import type { PlClient, SignedResourceId, ResourceType } from "@milaboratories/pl-client";
-import { resourceIdToString, resourceTypesEqual } from "@milaboratories/pl-client";
+import type { Filter, PlClient, ResourceType, SignedResourceId } from "@milaboratories/pl-client";
+import { resourceIdToString, resourceTypesEqual, treeFilter } from "@milaboratories/pl-client";
 import type { TreeAndComputableU } from "./types";
 import type { WatchableValue } from "@milaboratories/computable";
 import { Computable } from "@milaboratories/computable";
@@ -23,6 +23,8 @@ export const ProjectsListTreePruningFunction: PruningFunction = (resource) => {
   return resource.fields;
 };
 
+export const projectsListFieldFilters: Filter[] = [treeFilter.resourceTypeEq("Projects")];
+
 export async function createProjectList(
   pl: PlClient,
   rid: SignedResourceId,
@@ -35,6 +37,7 @@ export async function createProjectList(
     {
       ...env.ops.defaultTreeOptions,
       pruning: ProjectsListTreePruningFunction,
+      fieldFilters: projectsListFieldFilters,
     },
     env.logger,
   );

--- a/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
@@ -138,6 +138,17 @@ function evalFilter(
         return isFinal === want;
       case FilterProperty.ALL_OUTPUTS_FINAL:
         return allOutputsFinal === want;
+      // readyOrDuplicateOrError() expands to OR(resourceReady, isDuplicate, hasErrors);
+      // model the "ready" branch as isFinal and the other two as always-false so
+      // the OR collapses to the test's isFinal flag.
+      case FilterProperty.RESOURCE_READY_FOR_CALCULATION:
+        return isFinal === want;
+      case FilterProperty.IS_DUPLICATE:
+        return want === false;
+      case FilterProperty.HAS_ERRORS:
+        return want === false;
+      case FilterProperty.OUTPUTS_LOCKED:
+        return allOutputsFinal === want;
       default:
         return false;
     }
@@ -334,15 +345,17 @@ describe("§4.2 projectTreeTraverseStopRules", () => {
     expect(evaluateStopRule(rule, { resourceType: "BlockPackCustom", isFinal: false })).toBe(false);
   });
 
-  // isFinal=true conditional stops — json/resourceError
+  // json/resourceError — unconditional stop (BFS treats v1 as always-final; impl
+  // matches the type regardless of version since the proto filter has no version
+  // property).
   it("json/resourceError + isFinal=true → stops", () => {
     expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(
       true,
     );
   });
-  it("json/resourceError + isFinal=false → continues", () => {
+  it("json/resourceError + isFinal=false → stops (unconditional)", () => {
     expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(
-      false,
+      true,
     );
   });
 
@@ -586,14 +599,17 @@ describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ pr
     );
   });
 
-  it("json/resourceError v2: predicate=false (version check), stop does NOT fire with isFinal=false", () => {
+  // Intentional divergence: the predicate is version-aware (false for v2), but
+  // the ResourceTree filter proto has no version property — the stop rule fires
+  // for any json/resourceError regardless of version. Documented gap.
+  it("json/resourceError v2: predicate=false (version check), stop still fires (no version filter)", () => {
     const r = {
       ...makeResource("json/resourceError", []),
       type: { name: "json/resourceError", version: "2" },
     };
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
     expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(
-      false,
+      true,
     );
   });
 

--- a/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Parity tests verifying that the new ResourceTree field-filter + traversal-stop-rule
+ * predicates produce the same outcome as the legacy BFS pruning functions.
+ *
+ * §4.1 — pruning parity: projectTreePruning ⇄ projectTreeFieldFilters
+ *         and ProjectsListTreePruningFunction ⇄ projectsListFieldFilters
+ * §4.2 — stop-rule isolation coverage for projectTreeTraverseStopRules
+ * §4.3 — final-predicate parity: DefaultFinalResourceDataPredicate ⇄ projectTreeTraverseStopRules
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  projectTreeFieldFilters,
+  projectTreePruning,
+  projectTreeTraverseStopRules,
+} from "./project";
+import { projectsListFieldFilters, ProjectsListTreePruningFunction } from "./project_list";
+import type { Filter } from "@milaboratories/pl-client";
+import {
+  DefaultFinalResourceDataPredicate,
+  FilterOperatorType,
+  FilterProperty,
+  NullSignedResourceId,
+} from "@milaboratories/pl-client";
+import type { ExtendedResourceData } from "@milaboratories/pl-tree";
+import type { MiLogger } from "@milaboratories/ts-helpers";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Minimal no-op logger satisfying MiLogger interface. */
+const noopLogger: MiLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/** Build a minimal ExtendedResourceData for tests. */
+function makeResource(
+  typeName: string,
+  fieldNames: string[],
+): ExtendedResourceData {
+  return {
+    id: "NG:0x1" as any,
+    type: { name: typeName, version: "1" },
+    kind: "Structural",
+    data: undefined,
+    resourceReady: false,
+    error: NullSignedResourceId,
+    originalResourceId: NullSignedResourceId,
+    final: false,
+    inputsLocked: false,
+    outputsLocked: false,
+    fields: fieldNames.map((name) => ({
+      name,
+      type: "Dynamic",
+      value: NullSignedResourceId,
+      error: NullSignedResourceId,
+      status: "Resolved",
+      valueIsFinal: false,
+    })),
+    kv: [],
+  } as unknown as ExtendedResourceData;
+}
+
+/** Build a resource where resourceReady=true (satisfies readyOrDuplicateOrError). */
+function makeReadyResource(typeName: string, version = "1"): ExtendedResourceData {
+  return { ...makeResource(typeName, []), type: { name: typeName, version }, resourceReady: true };
+}
+
+/**
+ * Build a resource that satisfies readyAndHasAllOutputsFilled:
+ *   resourceReady=true, outputsLocked=true, one field with valueIsFinal=true.
+ */
+function makeAllOutputsFinalResource(typeName: string): ExtendedResourceData {
+  const base = makeResource(typeName, ["output"]);
+  return {
+    ...base,
+    resourceReady: true,
+    outputsLocked: true,
+    fields: [
+      {
+        name: "output",
+        type: "Dynamic",
+        value: "NG:0x99" as any,
+        error: NullSignedResourceId,
+        status: "Resolved",
+        valueIsFinal: true,
+      } as any,
+    ],
+  } as unknown as ExtendedResourceData;
+}
+
+/** Evaluate a single Filter against a resource + optional field-name context. */
+function evalFilter(
+  filter: Filter,
+  ctx: { resourceType: string; fieldName?: string; isFinal?: boolean; allOutputsFinal?: boolean },
+): boolean {
+  const { resourceType, fieldName = "", isFinal = false, allOutputsFinal = false } = ctx;
+
+  if (filter.value.oneofKind === "filtersValue") {
+    const children = filter.value.filtersValue.filters;
+    switch (filter.operator) {
+      case FilterOperatorType.AND:
+        return children.every((c) => evalFilter(c, ctx));
+      case FilterOperatorType.OR:
+        return children.some((c) => evalFilter(c, ctx));
+      case FilterOperatorType.NOT:
+        return !evalFilter(children[0]!, ctx);
+      default:
+        return false;
+    }
+  }
+
+  if (filter.value.oneofKind === "stringValue") {
+    const pattern = filter.value.stringValue;
+    let subject: string;
+    switch (filter.key) {
+      case FilterProperty.RESOURCE_TYPE:
+        subject = resourceType;
+        break;
+      case FilterProperty.FIELD_NAME:
+        subject = fieldName;
+        break;
+      default:
+        return false;
+    }
+    switch (filter.operator) {
+      case FilterOperatorType.EQUAL:
+        return subject === pattern;
+      case FilterOperatorType.MATCH:
+        return new RegExp(pattern).test(subject);
+      default:
+        return false;
+    }
+  }
+
+  if (filter.value.oneofKind === "boolValue") {
+    const want = filter.value.boolValue;
+    switch (filter.key) {
+      case FilterProperty.IS_FINAL:
+        return isFinal === want;
+      case FilterProperty.ALL_OUTPUTS_FINAL:
+        return allOutputsFinal === want;
+      default:
+        return false;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Apply fieldFilters to a resource's fields.
+ * A field is kept when every filter in the array evaluates true for that (resource, field) pair.
+ * This mirrors the backend's AND-across-array semantics.
+ */
+function evaluateFieldFilters(
+  filters: Filter[],
+  resource: { type: { name: string }; fields: { name: string }[] },
+): string[] {
+  return resource.fields
+    .filter((f) =>
+      filters.every((filter) =>
+        evalFilter(filter, { resourceType: resource.type.name, fieldName: f.name }),
+      ),
+    )
+    .map((f) => f.name);
+}
+
+/** Evaluate traverseStopRules (a single filter) against a resource. */
+function evaluateStopRule(
+  rule: Filter,
+  ctx: { resourceType: string; isFinal?: boolean; allOutputsFinal?: boolean },
+): boolean {
+  return evalFilter(rule, ctx);
+}
+
+// ── §4.1 — Pruning parity: projectTreePruning ⇄ projectTreeFieldFilters ────
+
+const projectPruningCases: Array<{
+  name: string;
+  typeName: string;
+  fields: string[];
+  expected: string[];
+}> = [
+  {
+    name: "StreamWorkdir/* — all fields dropped",
+    typeName: "StreamWorkdir/run-42",
+    fields: ["cmd", "output"],
+    expected: [],
+  },
+  {
+    name: "BlockPackCustom — template dropped, other kept",
+    typeName: "BlockPackCustom",
+    fields: ["template", "output"],
+    expected: ["output"],
+  },
+  {
+    name: "UserProject — __serviceTemplate* dropped, others kept",
+    typeName: "UserProject",
+    fields: ["__serviceTemplateA", "__serviceTemplateB", "x"],
+    expected: ["x"],
+  },
+  {
+    name: "Blob — all fields dropped",
+    typeName: "Blob",
+    fields: ["data"],
+    expected: [],
+  },
+  {
+    name: "arbitrary other type — all fields kept",
+    typeName: "SomeStructure",
+    fields: ["a", "b", "c"],
+    expected: ["a", "b", "c"],
+  },
+];
+
+describe("§4.1 project tree pruning parity", () => {
+  const pruner = projectTreePruning(noopLogger);
+  const filters = projectTreeFieldFilters();
+
+  for (const c of projectPruningCases) {
+    it(`${c.name} — BFS keeps [${c.expected.join(",")}]`, () => {
+      const resource = makeResource(c.typeName, c.fields);
+      const kept = pruner(resource).map((f) => f.name);
+      expect(kept).toEqual(c.expected);
+    });
+
+    it(`${c.name} — fieldFilters keep [${c.expected.join(",")}]`, () => {
+      const resource = makeResource(c.typeName, c.fields);
+      const kept = evaluateFieldFilters(filters, resource);
+      expect(kept).toEqual(c.expected);
+    });
+  }
+});
+
+// ── §4.1 — Pruning parity: ProjectsListTreePruningFunction ⇄ projectsListFieldFilters
+
+const projectsListPruningCases: Array<{
+  name: string;
+  typeName: string;
+  fields: string[];
+  expected: string[];
+}> = [
+  {
+    name: "Projects root — all fields kept",
+    typeName: "Projects",
+    fields: ["project-1", "project-2"],
+    expected: ["project-1", "project-2"],
+  },
+  {
+    name: "non-Projects (UserProject) — no fields traversed",
+    typeName: "UserProject",
+    fields: ["x", "y"],
+    expected: [],
+  },
+  {
+    name: "non-Projects (Blob) — no fields traversed",
+    typeName: "Blob",
+    fields: ["data"],
+    expected: [],
+  },
+];
+
+describe("§4.1 projects-list pruning parity", () => {
+  const filters = projectsListFieldFilters;
+
+  for (const c of projectsListPruningCases) {
+    it(`${c.name} — BFS keeps [${c.expected.join(",")}]`, () => {
+      const resource = makeResource(c.typeName, c.fields);
+      const kept = ProjectsListTreePruningFunction(resource).map((f) => f.name);
+      expect(kept).toEqual(c.expected);
+    });
+
+    it(`${c.name} — fieldFilters keep [${c.expected.join(",")}]`, () => {
+      const resource = makeResource(c.typeName, c.fields);
+      const kept = evaluateFieldFilters(filters, resource);
+      expect(kept).toEqual(c.expected);
+    });
+  }
+});
+
+// ── §4.2 — traverseStopRules coverage ────────────────────────────────────────
+
+describe("§4.2 projectTreeTraverseStopRules", () => {
+  const rule = projectTreeTraverseStopRules();
+
+  // Always-terminal exact types
+  const alwaysTerminalTypes = [
+    "json/object",
+    "json-gz/object",
+    "json/string",
+    "json/array",
+    "json/number",
+    "binary",
+    "Frontend/FromUrl",
+    "Frontend/FromFolder",
+    "BObjectSpec",
+    "BContextEnd",
+    "Null",
+    "LSProvider",
+    "Blob",
+  ];
+  for (const t of alwaysTerminalTypes) {
+    it(`always-terminal: ${t}`, () => {
+      expect(evaluateStopRule(rule, { resourceType: t })).toBe(true);
+    });
+  }
+
+  // Always-terminal prefix types
+  const prefixTerminalCases: Array<{ desc: string; type: string }> = [
+    { desc: "Blob/ prefix", type: "Blob/v2" },
+    { desc: "LS/ prefix", type: "LS/remote" },
+    { desc: "WorkingDirectory/ prefix", type: "WorkingDirectory/1" },
+    { desc: "StorageSpaceAllocation/ prefix", type: "StorageSpaceAllocation/disk" },
+  ];
+  for (const { desc, type } of prefixTerminalCases) {
+    it(`always-terminal: ${desc} (${type})`, () => {
+      expect(evaluateStopRule(rule, { resourceType: type })).toBe(true);
+    });
+  }
+
+  // isFinal=true conditional stops — StreamManager (and other container types)
+  it("StreamManager + isFinal=true → stops", () => {
+    expect(evaluateStopRule(rule, { resourceType: "StreamManager", isFinal: true })).toBe(true);
+  });
+  it("StreamManager + isFinal=false → continues", () => {
+    expect(evaluateStopRule(rule, { resourceType: "StreamManager", isFinal: false })).toBe(false);
+  });
+
+  // isFinal=true conditional stops — container types (representative sample)
+  it("StdMap + isFinal=true → stops", () => {
+    expect(evaluateStopRule(rule, { resourceType: "StdMap", isFinal: true })).toBe(true);
+  });
+  it("StdMap + isFinal=false → continues", () => {
+    expect(evaluateStopRule(rule, { resourceType: "StdMap", isFinal: false })).toBe(false);
+  });
+  it("BlockPackCustom + isFinal=true → stops", () => {
+    expect(evaluateStopRule(rule, { resourceType: "BlockPackCustom", isFinal: true })).toBe(true);
+  });
+  it("BlockPackCustom + isFinal=false → continues", () => {
+    expect(evaluateStopRule(rule, { resourceType: "BlockPackCustom", isFinal: false })).toBe(false);
+  });
+
+  // isFinal=true conditional stops — json/resourceError
+  it("json/resourceError + isFinal=true → stops", () => {
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(true);
+  });
+  it("json/resourceError + isFinal=false → continues", () => {
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(false);
+  });
+
+  it("PColumnData/Int32 + isFinal=true → stops", () => {
+    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: true })).toBe(true);
+  });
+  it("PColumnData/Int32 + isFinal=false → continues", () => {
+    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: false })).toBe(false);
+  });
+
+  it("StreamWorkdir/run-42 + isFinal=true → stops", () => {
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: true })).toBe(true);
+  });
+  it("StreamWorkdir/run-42 + isFinal=false → continues", () => {
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: false })).toBe(false);
+  });
+
+  // isFinal + allOutputsFinal stops
+  it("BlobUpload/v1 + isFinal=true + allOutputsFinal=true → stops", () => {
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: true, allOutputsFinal: true }),
+    ).toBe(true);
+  });
+  it("BlobUpload/v1 + isFinal=false → continues", () => {
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: false, allOutputsFinal: true }),
+    ).toBe(false);
+  });
+  it("BlobUpload/v1 + isFinal=true but allOutputsFinal=false → continues", () => {
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: true, allOutputsFinal: false }),
+    ).toBe(false);
+  });
+
+  it("BlobIndex/v2 + isFinal=true + allOutputsFinal=true → stops", () => {
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobIndex/v2", isFinal: true, allOutputsFinal: true }),
+    ).toBe(true);
+  });
+
+  // Non-matching type — traversal continues
+  it("arbitrary type SomeStructure → does not stop", () => {
+    expect(evaluateStopRule(rule, { resourceType: "SomeStructure" })).toBe(false);
+  });
+  it("UserProject → does not stop", () => {
+    expect(evaluateStopRule(rule, { resourceType: "UserProject" })).toBe(false);
+  });
+  it("Projects → does not stop", () => {
+    expect(evaluateStopRule(rule, { resourceType: "Projects" })).toBe(false);
+  });
+});
+
+// ── §4.3 — Final-predicate parity ────────────────────────────────────────────
+//
+// For each case we assert:
+//   1. DefaultFinalResourceDataPredicate(resource) === expectedPredicate
+//   2. evaluateStopRule(rule, flags) === expectedStop
+//
+// `flags` encodes what the backend would emit for the same resource state:
+//   - isFinal   = resource is "ready/error/duplicate" (or always-final type)
+//   - allOutputsFinal = outputsLocked && every field value is final
+//
+// The parity contract: when the predicate says "final" AND the type is one the
+// stop rule covers, the stop rule must also fire.  Types that are final only due
+// to runtime state (StdMap, BlockPackCustom, …) are NOT in the stop rules —
+// those are left to the backend's own isFinal flag (`item.final`) and are
+// documented as intentional gaps below.
+
+describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ projectTreeTraverseStopRules", () => {
+  const rule = projectTreeTraverseStopRules();
+
+  // ── Group A: Always-terminal (predicate=true always; stop fires regardless of isFinal) ──
+
+  const alwaysTerminal: Array<{ typeName: string; version?: string }> = [
+    { typeName: "json/object" },
+    { typeName: "json-gz/object" },
+    { typeName: "json/string" },
+    { typeName: "json/array" },
+    { typeName: "json/number" },
+    { typeName: "binary" },
+    { typeName: "Frontend/FromUrl" },
+    { typeName: "Frontend/FromFolder" },
+    { typeName: "BObjectSpec" },
+    { typeName: "BContextEnd" },
+    { typeName: "Null" },
+    { typeName: "LSProvider" },
+    { typeName: "Blob" },
+    { typeName: "Blob/v2" },
+    { typeName: "LS/remote" },
+    { typeName: "WorkingDirectory/1" },
+    { typeName: "StorageSpaceAllocation/disk" },
+  ];
+
+  for (const { typeName, version } of alwaysTerminal) {
+    it(`${typeName}: predicate=true, stop fires (even isFinal=false)`, () => {
+      const r = version
+        ? { ...makeResource(typeName, []), type: { name: typeName, version } }
+        : makeResource(typeName, []);
+      expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+      // stop rule fires unconditionally for these types
+      expect(evaluateStopRule(rule, { resourceType: typeName, isFinal: false })).toBe(true);
+    });
+  }
+
+  // ── Group B: isFinal-conditional — readyOrDuplicateOrError maps to isFinal ──
+
+  it("StreamManager — ready resource (fields=undefined): predicate=true, stop fires with isFinal=true", () => {
+    // fields=undefined triggers the early-return path in the predicate (no getField call needed)
+    const r = { ...makeReadyResource("StreamManager"), fields: undefined };
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "StreamManager", isFinal: true })).toBe(true);
+  });
+
+  it("StreamManager — not-ready resource: predicate=false, stop does NOT fire with isFinal=false", () => {
+    const r = makeResource("StreamManager", []);
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "StreamManager", isFinal: false })).toBe(false);
+  });
+
+  it("StdMap — ready resource: predicate=true, stop fires with isFinal=true", () => {
+    const r = makeReadyResource("StdMap");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "StdMap", isFinal: true })).toBe(true);
+  });
+
+  it("StdMap — not-ready resource: predicate=false, stop does NOT fire with isFinal=false", () => {
+    const r = makeResource("StdMap", []);
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "StdMap", isFinal: false })).toBe(false);
+  });
+
+  it("BlockPackCustom — ready resource: predicate=true, stop fires with isFinal=true", () => {
+    const r = makeReadyResource("BlockPackCustom");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "BlockPackCustom", isFinal: true })).toBe(true);
+  });
+
+  it("BlockPackCustom — not-ready resource: predicate=false, stop does NOT fire with isFinal=false", () => {
+    const r = makeResource("BlockPackCustom", []);
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "BlockPackCustom", isFinal: false })).toBe(false);
+  });
+
+  it("PColumnData/Int32 — ready resource: predicate=true, stop fires with isFinal=true", () => {
+    const r = makeReadyResource("PColumnData/Int32");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: true })).toBe(true);
+  });
+
+  it("PColumnData/Int32 — not-ready resource: predicate=false, stop does NOT fire with isFinal=false", () => {
+    const r = makeResource("PColumnData/Int32", []);
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: false })).toBe(false);
+  });
+
+  it("StreamWorkdir/run-42 — ready resource: predicate=true, stop fires with isFinal=true", () => {
+    const r = makeReadyResource("StreamWorkdir/run-42");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: true })).toBe(true);
+  });
+
+  it("StreamWorkdir/run-42 — not-ready: predicate=false, stop does NOT fire with isFinal=false", () => {
+    const r = makeResource("StreamWorkdir/run-42", []);
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: false })).toBe(false);
+  });
+
+  // ── Group C: isFinal+allOutputsFinal-conditional — readyAndHasAllOutputsFilled ──
+
+  it("BlobUpload/v1 — all outputs final: predicate=true, stop fires with isFinal+allOutputsFinal=true", () => {
+    const r = makeAllOutputsFinalResource("BlobUpload/v1");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: true, allOutputsFinal: true }),
+    ).toBe(true);
+  });
+
+  it("BlobUpload/v1 — not ready: predicate=false, stop does NOT fire with isFinal=false", () => {
+    const r = makeResource("BlobUpload/v1", []);
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: false, allOutputsFinal: false }),
+    ).toBe(false);
+  });
+
+  it("BlobIndex/v2 — all outputs final: predicate=true, stop fires with isFinal+allOutputsFinal=true", () => {
+    const r = makeAllOutputsFinalResource("BlobIndex/v2");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(
+      evaluateStopRule(rule, { resourceType: "BlobIndex/v2", isFinal: true, allOutputsFinal: true }),
+    ).toBe(true);
+  });
+
+  // ── Group D: json/resourceError — final for version "1" only ──
+
+  it("json/resourceError v1: predicate=true (version check), stop fires with isFinal=true", () => {
+    const r = makeReadyResource("json/resourceError", "1");
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(true);
+  });
+
+  it("json/resourceError v2: predicate=false (version check), stop does NOT fire with isFinal=false", () => {
+    const r = { ...makeResource("json/resourceError", []), type: { name: "json/resourceError", version: "2" } };
+    expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(false);
+  });
+
+  // ── Group E: never-final types — predicate=false, stop rule does not fire ──
+  //
+  // Covers the explicit `return false` cases in DefaultFinalResourceDataPredicate
+  // (UserProject, Projects, ClientRoot) and the `default` else-branch for unknown
+  // types.  Both paths agree: not final, traversal continues.
+
+  const neverFinalCases: Array<{ typeName: string; label: string }> = [
+    { typeName: "UserProject", label: "explicit false in predicate" },
+    { typeName: "Projects", label: "explicit false in predicate" },
+    { typeName: "ClientRoot", label: "explicit false in predicate" },
+    { typeName: "SomeUnknownType", label: "default branch else → false" },
+  ];
+
+  for (const { typeName, label } of neverFinalCases) {
+    it(`${typeName} (${label}): predicate=false, stop does NOT fire`, () => {
+      const r = makeResource(typeName, []);
+      expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
+      expect(evaluateStopRule(rule, { resourceType: typeName, isFinal: false })).toBe(false);
+    });
+  }
+});

--- a/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
@@ -35,10 +35,7 @@ const noopLogger: MiLogger = {
 };
 
 /** Build a minimal ExtendedResourceData for tests. */
-function makeResource(
-  typeName: string,
-  fieldNames: string[],
-): ExtendedResourceData {
+function makeResource(typeName: string, fieldNames: string[]): ExtendedResourceData {
   return {
     id: "NG:0x1" as any,
     type: { name: typeName, version: "1" },
@@ -158,9 +155,7 @@ function evaluateFieldFilter(
   resource: { type: { name: string }; fields: { name: string }[] },
 ): string[] {
   return resource.fields
-    .filter((f) =>
-      evalFilter(filter, { resourceType: resource.type.name, fieldName: f.name }),
-    )
+    .filter((f) => evalFilter(filter, { resourceType: resource.type.name, fieldName: f.name }))
     .map((f) => f.name);
 }
 
@@ -341,46 +336,72 @@ describe("§4.2 projectTreeTraverseStopRules", () => {
 
   // isFinal=true conditional stops — json/resourceError
   it("json/resourceError + isFinal=true → stops", () => {
-    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(
+      true,
+    );
   });
   it("json/resourceError + isFinal=false → continues", () => {
-    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(
+      false,
+    );
   });
 
   it("PColumnData/Int32 + isFinal=true → stops", () => {
     expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: true })).toBe(true);
   });
   it("PColumnData/Int32 + isFinal=false → continues", () => {
-    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: false })).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: false })).toBe(
+      false,
+    );
   });
 
   it("StreamWorkdir/run-42 + isFinal=true → stops", () => {
-    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: true })).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: true })).toBe(
+      true,
+    );
   });
   it("StreamWorkdir/run-42 + isFinal=false → continues", () => {
-    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: false })).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: false })).toBe(
+      false,
+    );
   });
 
   // isFinal + allOutputsFinal stops
   it("BlobUpload/v1 + isFinal=true + allOutputsFinal=true → stops", () => {
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: true, allOutputsFinal: true }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobUpload/v1",
+        isFinal: true,
+        allOutputsFinal: true,
+      }),
     ).toBe(true);
   });
   it("BlobUpload/v1 + isFinal=false → continues", () => {
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: false, allOutputsFinal: true }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobUpload/v1",
+        isFinal: false,
+        allOutputsFinal: true,
+      }),
     ).toBe(false);
   });
   it("BlobUpload/v1 + isFinal=true but allOutputsFinal=false → continues", () => {
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: true, allOutputsFinal: false }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobUpload/v1",
+        isFinal: true,
+        allOutputsFinal: false,
+      }),
     ).toBe(false);
   });
 
   it("BlobIndex/v2 + isFinal=true + allOutputsFinal=true → stops", () => {
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobIndex/v2", isFinal: true, allOutputsFinal: true }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobIndex/v2",
+        isFinal: true,
+        allOutputsFinal: true,
+      }),
     ).toBe(true);
   });
 
@@ -496,19 +517,25 @@ describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ pr
   it("PColumnData/Int32 — not-ready resource: predicate=false, stop does NOT fire with isFinal=false", () => {
     const r = makeResource("PColumnData/Int32", []);
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
-    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: false })).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "PColumnData/Int32", isFinal: false })).toBe(
+      false,
+    );
   });
 
   it("StreamWorkdir/run-42 — ready resource: predicate=true, stop fires with isFinal=true", () => {
     const r = makeReadyResource("StreamWorkdir/run-42");
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
-    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: true })).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: true })).toBe(
+      true,
+    );
   });
 
   it("StreamWorkdir/run-42 — not-ready: predicate=false, stop does NOT fire with isFinal=false", () => {
     const r = makeResource("StreamWorkdir/run-42", []);
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
-    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: false })).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "StreamWorkdir/run-42", isFinal: false })).toBe(
+      false,
+    );
   });
 
   // ── Group C: isFinal+allOutputsFinal-conditional — readyAndHasAllOutputsFilled ──
@@ -517,7 +544,11 @@ describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ pr
     const r = makeAllOutputsFinalResource("BlobUpload/v1");
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: true, allOutputsFinal: true }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobUpload/v1",
+        isFinal: true,
+        allOutputsFinal: true,
+      }),
     ).toBe(true);
   });
 
@@ -525,7 +556,11 @@ describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ pr
     const r = makeResource("BlobUpload/v1", []);
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobUpload/v1", isFinal: false, allOutputsFinal: false }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobUpload/v1",
+        isFinal: false,
+        allOutputsFinal: false,
+      }),
     ).toBe(false);
   });
 
@@ -533,7 +568,11 @@ describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ pr
     const r = makeAllOutputsFinalResource("BlobIndex/v2");
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
     expect(
-      evaluateStopRule(rule, { resourceType: "BlobIndex/v2", isFinal: true, allOutputsFinal: true }),
+      evaluateStopRule(rule, {
+        resourceType: "BlobIndex/v2",
+        isFinal: true,
+        allOutputsFinal: true,
+      }),
     ).toBe(true);
   });
 
@@ -542,13 +581,20 @@ describe("§4.3 final-predicate parity: DefaultFinalResourceDataPredicate ⇄ pr
   it("json/resourceError v1: predicate=true (version check), stop fires with isFinal=true", () => {
     const r = makeReadyResource("json/resourceError", "1");
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(true);
-    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(true);
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: true })).toBe(
+      true,
+    );
   });
 
   it("json/resourceError v2: predicate=false (version check), stop does NOT fire with isFinal=false", () => {
-    const r = { ...makeResource("json/resourceError", []), type: { name: "json/resourceError", version: "2" } };
+    const r = {
+      ...makeResource("json/resourceError", []),
+      type: { name: "json/resourceError", version: "2" },
+    };
     expect(DefaultFinalResourceDataPredicate(r as any)).toBe(false);
-    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(false);
+    expect(evaluateStopRule(rule, { resourceType: "json/resourceError", isFinal: false })).toBe(
+      false,
+    );
   });
 
   // ── Group E: never-final types — predicate=false, stop rule does not fire ──

--- a/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/project_pruning.test.ts
@@ -2,19 +2,19 @@
  * Parity tests verifying that the new ResourceTree field-filter + traversal-stop-rule
  * predicates produce the same outcome as the legacy BFS pruning functions.
  *
- * §4.1 — pruning parity: projectTreePruning ⇄ projectTreeFieldFilters
- *         and ProjectsListTreePruningFunction ⇄ projectsListFieldFilters
+ * §4.1 — pruning parity: projectTreePruning ⇄ projectTreeFieldFilter
+ *         and ProjectsListTreePruningFunction ⇄ projectsListFieldFilter
  * §4.2 — stop-rule isolation coverage for projectTreeTraverseStopRules
  * §4.3 — final-predicate parity: DefaultFinalResourceDataPredicate ⇄ projectTreeTraverseStopRules
  */
 
 import { describe, expect, it } from "vitest";
 import {
-  projectTreeFieldFilters,
+  projectTreeFieldFilter,
   projectTreePruning,
   projectTreeTraverseStopRules,
 } from "./project";
-import { projectsListFieldFilters, ProjectsListTreePruningFunction } from "./project_list";
+import { projectsListFieldFilter, ProjectsListTreePruningFunction } from "./project_list";
 import type { Filter } from "@milaboratories/pl-client";
 import {
   DefaultFinalResourceDataPredicate,
@@ -150,19 +150,16 @@ function evalFilter(
 }
 
 /**
- * Apply fieldFilters to a resource's fields.
- * A field is kept when every filter in the array evaluates true for that (resource, field) pair.
- * This mirrors the backend's AND-across-array semantics.
+ * Apply fieldFilter to a resource's fields.
+ * A field is kept when the filter evaluates true for that (resource, field) pair.
  */
-function evaluateFieldFilters(
-  filters: Filter[],
+function evaluateFieldFilter(
+  filter: Filter,
   resource: { type: { name: string }; fields: { name: string }[] },
 ): string[] {
   return resource.fields
     .filter((f) =>
-      filters.every((filter) =>
-        evalFilter(filter, { resourceType: resource.type.name, fieldName: f.name }),
-      ),
+      evalFilter(filter, { resourceType: resource.type.name, fieldName: f.name }),
     )
     .map((f) => f.name);
 }
@@ -175,7 +172,7 @@ function evaluateStopRule(
   return evalFilter(rule, ctx);
 }
 
-// ── §4.1 — Pruning parity: projectTreePruning ⇄ projectTreeFieldFilters ────
+// ── §4.1 — Pruning parity: projectTreePruning ⇄ projectTreeFieldFilter ────
 
 const projectPruningCases: Array<{
   name: string;
@@ -217,7 +214,7 @@ const projectPruningCases: Array<{
 
 describe("§4.1 project tree pruning parity", () => {
   const pruner = projectTreePruning(noopLogger);
-  const filters = projectTreeFieldFilters();
+  const filter = projectTreeFieldFilter();
 
   for (const c of projectPruningCases) {
     it(`${c.name} — BFS keeps [${c.expected.join(",")}]`, () => {
@@ -226,15 +223,15 @@ describe("§4.1 project tree pruning parity", () => {
       expect(kept).toEqual(c.expected);
     });
 
-    it(`${c.name} — fieldFilters keep [${c.expected.join(",")}]`, () => {
+    it(`${c.name} — fieldFilter keeps [${c.expected.join(",")}]`, () => {
       const resource = makeResource(c.typeName, c.fields);
-      const kept = evaluateFieldFilters(filters, resource);
+      const kept = evaluateFieldFilter(filter, resource);
       expect(kept).toEqual(c.expected);
     });
   }
 });
 
-// ── §4.1 — Pruning parity: ProjectsListTreePruningFunction ⇄ projectsListFieldFilters
+// ── §4.1 — Pruning parity: ProjectsListTreePruningFunction ⇄ projectsListFieldFilter
 
 const projectsListPruningCases: Array<{
   name: string;
@@ -263,7 +260,7 @@ const projectsListPruningCases: Array<{
 ];
 
 describe("§4.1 projects-list pruning parity", () => {
-  const filters = projectsListFieldFilters;
+  const filter = projectsListFieldFilter;
 
   for (const c of projectsListPruningCases) {
     it(`${c.name} — BFS keeps [${c.expected.join(",")}]`, () => {
@@ -272,9 +269,9 @@ describe("§4.1 projects-list pruning parity", () => {
       expect(kept).toEqual(c.expected);
     });
 
-    it(`${c.name} — fieldFilters keep [${c.expected.join(",")}]`, () => {
+    it(`${c.name} — fieldFilter keeps [${c.expected.join(",")}]`, () => {
       const resource = makeResource(c.typeName, c.fields);
-      const kept = evaluateFieldFilters(filters, resource);
+      const kept = evaluateFieldFilter(filter, resource);
       expect(kept).toEqual(c.expected);
     });
   }

--- a/lib/node/pl-middle-layer/src/middle_layer/types.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/types.ts
@@ -3,7 +3,7 @@ import type { Computable } from "@milaboratories/computable";
 
 export type TemporalSynchronizedTreeOps = Pick<
   SynchronizedTreeOps,
-  "pollingInterval" | "stopPollingDelay" | "logStat" | "initialTreeLoadingTimeout"
+  "pollingInterval" | "stopPollingDelay" | "logStat" | "initialTreeLoadingTimeout" | "traversalMode"
 >;
 
 export interface TreeAndComputable<T, ST extends T = T> {

--- a/lib/node/pl-tree/src/state.ts
+++ b/lib/node/pl-tree/src/state.ts
@@ -28,6 +28,10 @@ import type { FinalResourceDataPredicate } from "@milaboratories/pl-client";
 
 export type ExtendedResourceData = ResourceData & {
   kv: KeyValue[];
+  /** Set by the ResourceTree backend path when traversal stop rules matched
+   * this node — its children were not streamed. Pruners must treat such a
+   * node as a leaf (drop fields) to keep the refCount invariant. */
+  traverseWasStopped?: boolean;
 };
 
 export class TreeStateUpdateError extends Error {

--- a/lib/node/pl-tree/src/state.ts
+++ b/lib/node/pl-tree/src/state.ts
@@ -28,10 +28,6 @@ import type { FinalResourceDataPredicate } from "@milaboratories/pl-client";
 
 export type ExtendedResourceData = ResourceData & {
   kv: KeyValue[];
-  /** Set by the ResourceTree backend path when traversal stop rules matched
-   * this node — its children were not streamed. Pruners must treat such a
-   * node as a leaf (drop fields) to keep the refCount invariant. */
-  traverseWasStopped?: boolean;
 };
 
 export class TreeStateUpdateError extends Error {

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -1,10 +1,169 @@
 import { test, expect } from "vitest";
-import { DefaultFinalResourceDataPredicate, field, TestHelpers } from "@milaboratories/pl-client";
+import {
+  DefaultFinalResourceDataPredicate,
+  field,
+  NullSignedResourceId,
+  TestHelpers,
+} from "@milaboratories/pl-client";
 import { PlTreeState } from "./state";
 import { constructTreeLoadingRequest, loadTreeState } from "./sync";
 import { Computable } from "@milaboratories/computable";
 import { TestStructuralResourceType1 } from "./test_utils";
 import * as tp from "node:timers/promises";
+
+test("loadTreeState uses ResourceTree path with full options", async () => {
+  const received: { seeds?: string[]; includeKv?: boolean; hasFilters?: boolean; hasStopRules?: boolean } = {};
+
+  const tx = {
+    resourceTree: (seeds: string[], opts?: { includeKv?: boolean; fieldFilters?: unknown[]; traverseStopRules?: unknown }) => {
+      received.seeds = seeds;
+      received.includeKv = opts?.includeKv;
+      received.hasFilters = (opts?.fieldFilters?.length ?? 0) > 0;
+      received.hasStopRules = opts?.traverseStopRules !== undefined;
+
+      const itemA = {
+        id: "NG:0x1",
+        type: { name: "Projects", version: "1" },
+        kind: "Structural",
+        data: undefined,
+        resourceReady: false,
+        error: NullSignedResourceId,
+        originalResourceId: NullSignedResourceId,
+        final: false,
+        inputsLocked: false,
+        outputsLocked: false,
+        fields: [{ name: "keep", type: "Dynamic", value: NullSignedResourceId, error: NullSignedResourceId, status: "Resolved", valueIsFinal: false }],
+        kv: [],
+        traverseWasStopped: false,
+      };
+      const itemSkipped = { ...itemA, id: "NG:0x2" };
+
+      return (async function* () {
+        yield itemA;
+        yield itemSkipped;
+      })();
+    },
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x1", "NG:0x2"],
+    finalResources: new Set<string>(["NG:0x2"]),
+    pruningFunction: (r: any) => r.fields.filter((f: any) => f.name === "keep"),
+    fieldFilters: [{}],
+    traverseStopRules: {},
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const result = await loadTreeState(tx, request, undefined, ["treeFilter:v1"]);
+
+  expect(received).toEqual({
+    seeds: ["NG:0x1", "NG:0x2"],
+    includeKv: true,
+    hasFilters: true,
+    hasStopRules: true,
+  });
+  expect(result).toHaveLength(1);
+  expect(result[0]?.id).toBe("NG:0x1");
+});
+
+test("loadTreeState propagates ResourceTree stream failure", async () => {
+  const tx = {
+    resourceTree: () =>
+      (async function* () {
+        throw new Error("stream failed");
+      })(),
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x1"],
+    finalResources: new Set<string>(),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"]))
+    .rejects.toThrow("stream failed");
+});
+
+test("loadTreeState cancels ResourceTree iterator on pruning failure", async () => {
+  let returnCalled = false;
+
+  const iterable = {
+    [Symbol.asyncIterator]() {
+      let done = false;
+      return {
+        next: async () => {
+          if (done) return { done: true as const, value: undefined };
+          done = true;
+          return {
+            done: false as const,
+            value: {
+              id: "NG:0x1",
+              type: { name: "Projects", version: "1" },
+              kind: "Structural",
+              data: undefined,
+              resourceReady: false,
+              error: NullSignedResourceId,
+              originalResourceId: NullSignedResourceId,
+              final: false,
+              inputsLocked: false,
+              outputsLocked: false,
+              fields: [],
+              kv: [],
+              traverseWasStopped: false,
+            },
+          };
+        },
+        return: async () => {
+          returnCalled = true;
+          return { done: true as const, value: undefined };
+        },
+      };
+    },
+  };
+
+  const tx = {
+    resourceTree: () => iterable,
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x1"],
+    finalResources: new Set<string>(),
+    pruningFunction: () => {
+      throw new Error("pruning failed");
+    },
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"]))
+    .rejects.toThrow("pruning failed");
+  expect(returnCalled).toBe(true);
+});
+
+test("loadTreeState falls back to BFS when capabilities are absent", async () => {
+  const tx = {
+    getResourceDataIfExists: async (rid: string) => ({
+      id: rid,
+      type: { name: "Projects", version: "1" },
+      kind: "Structural",
+      data: undefined,
+      resourceReady: false,
+      error: NullSignedResourceId,
+      originalResourceId: NullSignedResourceId,
+      final: false,
+      inputsLocked: false,
+      outputsLocked: false,
+      fields: [],
+    }),
+    listKeyValuesIfResourceExists: async () => [],
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x2"],
+    finalResources: new Set<string>(),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const result = await loadTreeState(tx, request, undefined, []);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]?.id).toBe("NG:0x2");
+});
 
 test("load resources", async () => {
   await TestHelpers.withTempRoot(async (cl) => {

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -6,7 +6,7 @@ import {
   TestHelpers,
 } from "@milaboratories/pl-client";
 import { PlTreeState } from "./state";
-import { constructTreeLoadingRequest, loadTreeState } from "./sync";
+import { constructTreeLoadingRequest, initialTreeLoadingStat, loadTreeState } from "./sync";
 import type { TraversalMode } from "./sync";
 import { Computable } from "@milaboratories/computable";
 import { TestStructuralResourceType1 } from "./test_utils";
@@ -369,4 +369,158 @@ test("traversalMode=auto default regression: streaming on capable, BFS on incapa
   await loadTreeState(txNoCap, baseRequest, undefined, []);
   expect(callsNoCap.bfs).toBeGreaterThan(0);
   expect(callsNoCap.streaming).toBe(0);
+});
+
+// ─── Stop-marker handling tests ───────────────────────────────────────────────
+
+/** Capabilities for backends that support streaming traversal. */
+const stopMarkerCaps = ["treeFilter:v1"] as const;
+
+/** Minimal full-resource frame suitable for stop-marker tests. */
+function makeFullResource(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    type: { name: "Test", version: "1" },
+    kind: "Structural",
+    data: undefined,
+    resourceReady: false,
+    error: NullSignedResourceId,
+    originalResourceId: NullSignedResourceId,
+    final: false,
+    inputsLocked: false,
+    outputsLocked: false,
+    fields: [],
+    kv: [],
+    traverseWasStopped: false,
+    ...overrides,
+  };
+}
+
+/** Minimal stop-marker frame. */
+function makeStopMarker(id: string): Record<string, unknown> {
+  return { frameKind: "stopMarker", id, traverseWasStopped: true };
+}
+
+test("stop-marker-final-locally-skipped: marker for final id is not followed up", async () => {
+  let callCount = 0;
+  const tx = {
+    resourceTree: () => {
+      callCount++;
+      return (async function* () {
+        yield makeStopMarker("NG:0x1");
+      })();
+    },
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x99"],
+    finalResources: new Set<string>(["NG:0x1"]),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const stats = initialTreeLoadingStat();
+  const result = await loadTreeState(tx, request, stats, stopMarkerCaps);
+
+  expect(result).toHaveLength(0);
+  expect(stats.stopMarkersSkipped).toBe(1);
+  expect(callCount).toBe(1); // no follow-up call issued
+});
+
+test("stop-marker-unknown-triggers-followup: unknown marker fetched in follow-up", async () => {
+  let callCount = 0;
+  const tx = {
+    resourceTree: () => {
+      callCount++;
+      if (callCount === 1) {
+        // Round 0: emit a stop marker for an unknown id
+        return (async function* () {
+          yield makeStopMarker("NG:0x1");
+        })();
+      } else {
+        // Follow-up: return full resource for that id
+        return (async function* () {
+          yield makeFullResource("NG:0x1");
+        })();
+      }
+    },
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x99"],
+    finalResources: new Set<string>(),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const stats = initialTreeLoadingStat();
+  const result = await loadTreeState(tx, request, stats, stopMarkerCaps);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]?.id).toBe("NG:0x1");
+  expect(stats.stopMarkerFollowUpRoundTrips).toBe(1);
+  expect(callCount).toBe(2);
+});
+
+
+test("legacy-backend-compat: no stop markers in stream → no follow-up call", async () => {
+  // Old backends emit only full-resource frames; pendingFollowUp stays empty
+  // and the follow-up loop body never executes.
+  let callCount = 0;
+  const tx = {
+    resourceTree: () => {
+      callCount++;
+      return (async function* () {
+        yield makeFullResource("NG:0x1");
+      })();
+    },
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x1"],
+    finalResources: new Set<string>(),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const stats = initialTreeLoadingStat();
+  const result = await loadTreeState(tx, request, stats, ["treeFilter:v1"]);
+
+  expect(result).toHaveLength(1);
+  expect(callCount).toBe(1);
+  expect(stats.stopMarkerFollowUpRoundTrips).toBe(0);
+});
+
+test("orphan-invariant-preserved: error referent streamed alongside stop marker", async () => {
+  // Server streams the error referent (errY) as a normal frame and the
+  // stopped node (X) as a stop marker.  Follow-up returns X as a full
+  // resource with error pointing to errY.  Both should appear in the result.
+  const errY = makeFullResource("NG:0xE", { final: true, inputsLocked: true, outputsLocked: true });
+  const stoppedX = makeFullResource("NG:0x1", {
+    error: "NG:0xE", // X's error field points to errY
+    traverseWasStopped: true,
+  });
+
+  let callCount = 0;
+  const tx = {
+    resourceTree: () => {
+      callCount++;
+      if (callCount === 1) {
+        return (async function* () {
+          yield errY;                       // error referent — normal frame
+          yield makeStopMarker("NG:0x1");   // stopped node — marker frame
+        })();
+      } else {
+        return (async function* () {
+          yield stoppedX;                   // follow-up returns full resource
+        })();
+      }
+    },
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x1"],
+    finalResources: new Set<string>(),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const result = await loadTreeState(tx, request, undefined, stopMarkerCaps);
+
+  // Both the error referent and the stopped resource must be present
+  const ids = result.map((r) => r.id).sort();
+  expect(ids).toEqual(["NG:0x1", "NG:0xE"]);
+  // No throw means the invariant held throughout loadTreeState
 });

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -16,10 +16,10 @@ test("loadTreeState uses ResourceTree path with full options", async () => {
   const received: { seeds?: string[]; includeKv?: boolean; hasFilters?: boolean; hasStopRules?: boolean } = {};
 
   const tx = {
-    resourceTree: (seeds: string[], opts?: { includeKv?: boolean; fieldFilters?: unknown[]; traverseStopRules?: unknown }) => {
+    resourceTree: (seeds: string[], opts?: { includeKv?: boolean; fieldFilter?: unknown; traverseStopRules?: unknown }) => {
       received.seeds = seeds;
       received.includeKv = opts?.includeKv;
-      received.hasFilters = (opts?.fieldFilters?.length ?? 0) > 0;
+      received.hasFilters = opts?.fieldFilter !== undefined;
       received.hasStopRules = opts?.traverseStopRules !== undefined;
 
       const itemA = {
@@ -50,7 +50,7 @@ test("loadTreeState uses ResourceTree path with full options", async () => {
     seedResources: ["NG:0x1", "NG:0x2"],
     finalResources: new Set<string>(["NG:0x2"]),
     pruningFunction: (r: any) => r.fields.filter((f: any) => f.name === "keep"),
-    fieldFilters: [{}],
+    fieldFilter: {},
     traverseStopRules: {},
   } as unknown as Parameters<typeof loadTreeState>[1];
 

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -13,10 +13,18 @@ import { TestStructuralResourceType1 } from "./test_utils";
 import * as tp from "node:timers/promises";
 
 test("loadTreeState uses ResourceTree path with full options", async () => {
-  const received: { seeds?: string[]; includeKv?: boolean; hasFilters?: boolean; hasStopRules?: boolean } = {};
+  const received: {
+    seeds?: string[];
+    includeKv?: boolean;
+    hasFilters?: boolean;
+    hasStopRules?: boolean;
+  } = {};
 
   const tx = {
-    resourceTree: (seeds: string[], opts?: { includeKv?: boolean; fieldFilter?: unknown; traverseStopRules?: unknown }) => {
+    resourceTree: (
+      seeds: string[],
+      opts?: { includeKv?: boolean; fieldFilter?: unknown; traverseStopRules?: unknown },
+    ) => {
       received.seeds = seeds;
       received.includeKv = opts?.includeKv;
       received.hasFilters = opts?.fieldFilter !== undefined;
@@ -33,7 +41,16 @@ test("loadTreeState uses ResourceTree path with full options", async () => {
         final: false,
         inputsLocked: false,
         outputsLocked: false,
-        fields: [{ name: "keep", type: "Dynamic", value: NullSignedResourceId, error: NullSignedResourceId, status: "Resolved", valueIsFinal: false }],
+        fields: [
+          {
+            name: "keep",
+            type: "Dynamic",
+            value: NullSignedResourceId,
+            error: NullSignedResourceId,
+            status: "Resolved",
+            valueIsFinal: false,
+          },
+        ],
         kv: [],
         traverseWasStopped: false,
       };
@@ -70,7 +87,7 @@ test("loadTreeState propagates ResourceTree stream failure", async () => {
   const tx = {
     resourceTree: () =>
       (async function* () {
-        throw new Error("stream failed");
+        yield await Promise.reject(new Error("stream failed"));
       })(),
   } as unknown as Parameters<typeof loadTreeState>[0];
 
@@ -79,8 +96,9 @@ test("loadTreeState propagates ResourceTree stream failure", async () => {
     finalResources: new Set<string>(),
   } as unknown as Parameters<typeof loadTreeState>[1];
 
-  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"]))
-    .rejects.toThrow("stream failed");
+  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"])).rejects.toThrow(
+    "stream failed",
+  );
 });
 
 test("loadTreeState cancels ResourceTree iterator on pruning failure", async () => {
@@ -132,8 +150,9 @@ test("loadTreeState cancels ResourceTree iterator on pruning failure", async () 
     },
   } as unknown as Parameters<typeof loadTreeState>[1];
 
-  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"]))
-    .rejects.toThrow("pruning failed");
+  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"])).rejects.toThrow(
+    "pruning failed",
+  );
   expect(returnCalled).toBe(true);
 });
 
@@ -377,7 +396,10 @@ test("traversalMode=auto default regression: streaming on capable, BFS on incapa
 const stopMarkerCaps = ["treeFilter:v1"] as const;
 
 /** Minimal full-resource frame suitable for stop-marker tests. */
-function makeFullResource(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function makeFullResource(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     id,
     type: { name: "Test", version: "1" },
@@ -458,7 +480,6 @@ test("stop-marker-unknown-triggers-followup: unknown marker fetched in follow-up
   expect(callCount).toBe(2);
 });
 
-
 test("legacy-backend-compat: no stop markers in stream → no follow-up call", async () => {
   // Old backends emit only full-resource frames; pendingFollowUp stays empty
   // and the follow-up loop body never executes.
@@ -501,12 +522,12 @@ test("orphan-invariant-preserved: error referent streamed alongside stop marker"
       callCount++;
       if (callCount === 1) {
         return (async function* () {
-          yield errY;                       // error referent — normal frame
-          yield makeStopMarker("NG:0x1");   // stopped node — marker frame
+          yield errY; // error referent — normal frame
+          yield makeStopMarker("NG:0x1"); // stopped node — marker frame
         })();
       } else {
         return (async function* () {
-          yield stoppedX;                   // follow-up returns full resource
+          yield stoppedX; // follow-up returns full resource
         })();
       }
     },

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@milaboratories/pl-client";
 import { PlTreeState } from "./state";
 import { constructTreeLoadingRequest, loadTreeState } from "./sync";
+import type { TraversalMode } from "./sync";
 import { Computable } from "@milaboratories/computable";
 import { TestStructuralResourceType1 } from "./test_utils";
 import * as tp from "node:timers/promises";
@@ -262,4 +263,110 @@ test("load resources", async () => {
       value: "hi!",
     });
   });
+});
+
+// ─── TraversalMode tests ──────────────────────────────────────────────────────
+
+/** Build a minimal mock tx that records whether resourceTree / getResourceDataIfExists
+ * was called.  Both surfaces are instrumented so we can assert which path ran. */
+function buildMockTx(opts: { capable: boolean }): {
+  tx: Parameters<typeof loadTreeState>[0];
+  calls: { bfs: number; streaming: number };
+} {
+  const calls = { bfs: 0, streaming: 0 };
+
+  const bfsResource = {
+    id: "NG:0x1",
+    type: { name: "Test", version: "1" },
+    kind: "Structural" as const,
+    data: undefined,
+    resourceReady: false,
+    error: NullSignedResourceId,
+    originalResourceId: NullSignedResourceId,
+    final: false,
+    inputsLocked: false,
+    outputsLocked: false,
+    fields: [],
+  };
+
+  const streamingResource = {
+    ...bfsResource,
+    kv: [],
+    traverseWasStopped: false,
+  };
+
+  const tx = {
+    getResourceDataIfExists: async () => {
+      calls.bfs++;
+      return bfsResource;
+    },
+    listKeyValuesIfResourceExists: async () => [],
+    resourceTree: opts.capable
+      ? () => {
+          calls.streaming++;
+          return (async function* () {
+            yield streamingResource;
+          })();
+        }
+      : undefined,
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  return { tx, calls };
+}
+
+const baseRequest = {
+  seedResources: ["NG:0x1"],
+  finalResources: new Set<string>(),
+} as unknown as Parameters<typeof loadTreeState>[1];
+
+test("traversalMode=client-bfs forces BFS on capable backend", async () => {
+  const { tx, calls } = buildMockTx({ capable: true });
+  const mode: TraversalMode = "client-bfs";
+
+  const result = await loadTreeState(tx, baseRequest, undefined, ["treeFilter:v1"], mode);
+
+  expect(result).toHaveLength(1);
+  expect(calls.bfs).toBeGreaterThan(0);
+  expect(calls.streaming).toBe(0);
+});
+
+test("traversalMode=backend-streaming falls back to BFS when capability is absent, warns once", async () => {
+  const { tx, calls } = buildMockTx({ capable: false });
+  const mode: TraversalMode = "backend-streaming";
+
+  const warnings: string[] = [];
+  const logger = { warn: (msg: string) => warnings.push(msg) };
+
+  const result = await loadTreeState(tx, baseRequest, undefined, [], mode, logger);
+
+  expect(result).toHaveLength(1);
+  expect(calls.bfs).toBeGreaterThan(0);
+  expect(calls.streaming).toBe(0);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toMatch(/treeFilter:v1/);
+});
+
+test("traversalMode=backend-streaming uses streaming on capable backend", async () => {
+  const { tx, calls } = buildMockTx({ capable: true });
+  const mode: TraversalMode = "backend-streaming";
+
+  const result = await loadTreeState(tx, baseRequest, undefined, ["treeFilter:v1"], mode);
+
+  expect(result).toHaveLength(1);
+  expect(calls.streaming).toBeGreaterThan(0);
+  expect(calls.bfs).toBe(0);
+});
+
+test("traversalMode=auto default regression: streaming on capable, BFS on incapable", async () => {
+  // capable backend → streaming
+  const { tx: txCap, calls: callsCap } = buildMockTx({ capable: true });
+  await loadTreeState(txCap, baseRequest, undefined, ["treeFilter:v1"]);
+  expect(callsCap.streaming).toBeGreaterThan(0);
+  expect(callsCap.bfs).toBe(0);
+
+  // incapable backend → BFS
+  const { tx: txNoCap, calls: callsNoCap } = buildMockTx({ capable: false });
+  await loadTreeState(txNoCap, baseRequest, undefined, []);
+  expect(callsNoCap.bfs).toBeGreaterThan(0);
+  expect(callsNoCap.streaming).toBe(0);
 });

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -230,7 +230,6 @@ async function loadTreeStateViaBfs(
   return result;
 }
 
-
 type ResourceTreeFrame = ExtendedResourceData & { frameKind: string; traverseWasStopped: boolean };
 
 async function processResourceTreeStream(
@@ -249,7 +248,7 @@ async function processResourceTreeStream(
   // Usually stop rules indicates the resources with final state. In that case middle layer
   // should make a decision: has it already loaded the resource or should it be requested for get the latest state?
   for await (const frame of treeItems) {
-    if (frame.frameKind === 'stopMarker') {
+    if (frame.frameKind === "stopMarker") {
       if (finalResources.has(frame.id)) {
         if (stats) stats.stopMarkersSkipped++;
         continue;
@@ -284,7 +283,10 @@ async function processResourceTreeStream(
     // Apply field rules: traverseWasStopped drops all fields to keep the refCount
     // invariant; pruning function further filters the remaining fields.
     const rawFields = frame.traverseWasStopped ? [] : nextResource.fields;
-    const resolvedFields = pruningFunction !== undefined ? pruningFunction({ ...nextResource, fields: rawFields }) : rawFields;
+    const resolvedFields =
+      pruningFunction !== undefined
+        ? pruningFunction({ ...nextResource, fields: rawFields })
+        : rawFields;
     if (stats) stats.prunedFields += nextResource.fields.length - resolvedFields.length;
     nextResource = { ...nextResource, fields: resolvedFields };
 
@@ -313,7 +315,12 @@ async function loadTreeStateViaResourceTree(
     traverseStopRules,
   });
 
-  const { result, followUpSeeds } = await processResourceTreeStream(treeItems, finalResources, pruningFunction, stats);
+  const { result, followUpSeeds } = await processResourceTreeStream(
+    treeItems,
+    finalResources,
+    pruningFunction,
+    stats,
+  );
   if (stats) stats.roundTrips++;
 
   // Client must request full resource tree in case when stop-marker seeds are returned,
@@ -323,10 +330,17 @@ async function loadTreeStateViaResourceTree(
       includeKv: true,
       fieldFilter,
     });
-    const { result: followUpResult } = await processResourceTreeStream(followUpItems, finalResources, pruningFunction, stats);
+    const { result: followUpResult } = await processResourceTreeStream(
+      followUpItems,
+      finalResources,
+      pruningFunction,
+      stats,
+    );
     result.push(...followUpResult);
     if (stats) {
-      logger?.info?.(`loadTreeStateViaResourceTree: follow-up request for ${followUpSeeds.length} stop-marker seeds: ${JSON.stringify(followUpSeeds)}`)
+      logger?.info?.(
+        `loadTreeStateViaResourceTree: follow-up request for ${followUpSeeds.length} stop-marker seeds: ${JSON.stringify(followUpSeeds)}`,
+      );
       stats.roundTrips++;
       stats.stopMarkerFollowUpRoundTrips++;
     }

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -231,6 +231,7 @@ async function loadTreeStateViaResourceTree(
       outputsLocked: item.outputsLocked,
       fields: item.fields,
       kv: item.kv,
+      traverseWasStopped: item.traverseWasStopped,
     };
 
     if (pruningFunction !== undefined) {

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -27,8 +27,8 @@ export interface TreeLoadingRequest {
   /** Applied to each resource field list in fallback BFS mode and to streamed results. */
   readonly pruningFunction?: PruningFunction;
 
-  /** ResourceTree field filters passed to the backend when supported. */
-  readonly fieldFilters?: Filter[];
+  /** ResourceTree field filter passed to the backend when supported. */
+  readonly fieldFilter?: Filter;
 
   /** ResourceTree traversal stop rules passed to the backend when supported. */
   readonly traverseStopRules?: Filter;
@@ -49,7 +49,7 @@ export type TraversalMode = "auto" | "client-bfs" | "backend-streaming";
  * {@link loadTreeState} to load updated state. */
 export function constructTreeLoadingRequest(
   tree: PlTreeState,
-  options: Pick<TreeLoadingRequest, "pruningFunction" | "fieldFilters" | "traverseStopRules"> = {},
+  options: Pick<TreeLoadingRequest, "pruningFunction" | "fieldFilter" | "traverseStopRules"> = {},
 ): TreeLoadingRequest {
   const seedResources: SignedResourceId[] = [];
   const finalResources = new Set<SignedResourceId>();
@@ -65,7 +65,7 @@ export function constructTreeLoadingRequest(
     seedResources,
     finalResources,
     pruningFunction: options.pruningFunction,
-    fieldFilters: options.fieldFilters,
+    fieldFilter: options.fieldFilter,
     traverseStopRules: options.traverseStopRules,
   };
 }
@@ -273,8 +273,9 @@ async function loadTreeStateViaResourceTree(
   tx: PlTransaction,
   loadingRequest: TreeLoadingRequest,
   stats?: TreeLoadingStat,
+  logger?: { warn: (msg: string) => void; info?: (msg: unknown) => void },
 ): Promise<ExtendedResourceData[]> {
-  const { seedResources, finalResources, pruningFunction, fieldFilters, traverseStopRules } =
+  const { seedResources, finalResources, pruningFunction, fieldFilter, traverseStopRules } =
     loadingRequest;
 
   const treeAny = tx as any;
@@ -282,26 +283,24 @@ async function loadTreeStateViaResourceTree(
   // Round 0: initial tree traversal.
   const treeItems = treeAny.resourceTree(seedResources, {
     includeKv: true,
-    fieldFilters,
+    fieldFilter,
     traverseStopRules,
   });
 
   const { result, followUpSeeds } = await processResourceTreeStream(treeItems, finalResources, pruningFunction, stats);
   if (stats) stats.roundTrips++;
 
-  // Single follow-up for unknown stop markers.
-  // traverseStopRules is omitted so the server performs a full traversal and
-  // cannot emit further stop markers — one round is sufficient.
-  // Old backends emit no stop-marker frames, so followUpSeeds stays empty
-  // and this block is skipped — backward compatible.
+  // Client must request full resource tree in case when stop-marker seeds are returned,
+  // to ensure all resources are loaded and stop-marker frames are processed.
   if (followUpSeeds.length > 0) {
     const followUpItems = treeAny.resourceTree(followUpSeeds, {
       includeKv: true,
-      fieldFilters,
+      fieldFilter,
     });
     const { result: followUpResult } = await processResourceTreeStream(followUpItems, finalResources, pruningFunction, stats);
     result.push(...followUpResult);
     if (stats) {
+      logger?.info?.(`loadTreeStateViaResourceTree: follow-up request for ${followUpSeeds.length} stop-marker seeds: ${JSON.stringify(followUpSeeds)}`)
       stats.roundTrips++;
       stats.stopMarkerFollowUpRoundTrips++;
     }
@@ -319,7 +318,7 @@ export async function loadTreeState(
   stats?: TreeLoadingStat,
   capabilities: readonly string[] = [],
   mode: TraversalMode = "auto",
-  logger?: { warn: (msg: string) => void },
+  logger?: { warn: (msg: string) => void; info?: (msg: unknown) => void },
 ): Promise<ExtendedResourceData[]> {
   const startTimestamp = Date.now();
   if (stats) stats.requests++;
@@ -338,7 +337,7 @@ export async function loadTreeState(
     }
 
     return wantsStreaming
-      ? await loadTreeStateViaResourceTree(tx, loadingRequest, stats)
+      ? await loadTreeStateViaResourceTree(tx, loadingRequest, stats, logger)
       : await loadTreeStateViaBfs(tx, loadingRequest, stats);
   } finally {
     if (stats) stats.millisSpent += Date.now() - startTimestamp;

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -36,6 +36,15 @@ export interface TreeLoadingRequest {
 
 const CapabilityTreeFilter = "treeFilter:v1";
 
+/** Controls which tree-loading path is used.
+ * - `"auto"` (default): use backend streaming when the backend advertises `treeFilter:v1`,
+ *   fall back to client-side BFS otherwise.
+ * - `"client-bfs"`: always use client-side BFS, even on capable backends.
+ * - `"backend-streaming"`: always prefer backend streaming; if the capability is absent,
+ *   logs a warning and falls back to BFS (never throws).
+ */
+export type TraversalMode = "auto" | "client-bfs" | "backend-streaming";
+
 /** Given the current tree state, build the request object to pass to
  * {@link loadTreeState} to load updated state. */
 export function constructTreeLoadingRequest(
@@ -257,16 +266,28 @@ export async function loadTreeState(
   loadingRequest: TreeLoadingRequest,
   stats?: TreeLoadingStat,
   capabilities: readonly string[] = [],
+  mode: TraversalMode = "auto",
+  logger?: { warn: (msg: string) => void },
 ): Promise<ExtendedResourceData[]> {
   const startTimestamp = Date.now();
   if (stats) stats.requests++;
 
   try {
-    if (supportsResourceTreeTraversal(capabilities)) {
-      return await loadTreeStateViaResourceTree(tx, loadingRequest, stats);
+    const wantsStreaming =
+      mode === "backend-streaming" ||
+      (mode === "auto" && supportsResourceTreeTraversal(capabilities));
+
+    if (wantsStreaming && !supportsResourceTreeTraversal(capabilities)) {
+      const msg =
+        "traversalMode=backend-streaming but backend lacks treeFilter:v1 capability; falling back to BFS";
+      if (logger) logger.warn(msg);
+      else console.warn(msg);
+      return await loadTreeStateViaBfs(tx, loadingRequest, stats);
     }
 
-    return await loadTreeStateViaBfs(tx, loadingRequest, stats);
+    return wantsStreaming
+      ? await loadTreeStateViaResourceTree(tx, loadingRequest, stats)
+      : await loadTreeStateViaBfs(tx, loadingRequest, stats);
   } finally {
     if (stats) stats.millisSpent += Date.now() - startTimestamp;
   }

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -81,6 +81,10 @@ export type TreeLoadingStat = {
   prunedFields: number;
   finalResourcesSkipped: number;
   millisSpent: number;
+  /** Stop-marker frames whose id was already final locally and were skipped. */
+  stopMarkersSkipped: number;
+  /** Number of follow-up resourceTree() calls issued to resolve unknown stop markers. */
+  stopMarkerFollowUpRoundTrips: number;
 };
 
 export function initialTreeLoadingStat(): TreeLoadingStat {
@@ -95,6 +99,8 @@ export function initialTreeLoadingStat(): TreeLoadingStat {
     prunedFields: 0,
     finalResourcesSkipped: 0,
     millisSpent: 0,
+    stopMarkersSkipped: 0,
+    stopMarkerFollowUpRoundTrips: 0,
   };
 }
 
@@ -108,7 +114,9 @@ export function formatTreeLoadingStat(stat: TreeLoadingStat): string {
   result += `Data Bytes: ${stat.retrievedResourceDataBytes}\n`;
   result += `KV Bytes: ${stat.retrievedKeyValueBytes}\n`;
   result += `Pruned fields: ${stat.prunedFields}\n`;
-  result += `Final resources skipped: ${stat.finalResourcesSkipped}`;
+  result += `Final resources skipped: ${stat.finalResourcesSkipped}\n`;
+  result += `Stop markers skipped: ${stat.stopMarkersSkipped}\n`;
+  result += `Stop marker follow-up round-trips: ${stat.stopMarkerFollowUpRoundTrips}`;
   return result;
 }
 
@@ -202,6 +210,65 @@ async function loadTreeStateViaBfs(
   return result;
 }
 
+
+type ResourceTreeFrame = ExtendedResourceData & { frameKind: string; traverseWasStopped: boolean };
+
+async function processResourceTreeStream(
+  treeItems: AsyncIterable<ResourceTreeFrame>,
+  finalResources: Set<SignedResourceId>,
+  pruningFunction: PruningFunction | undefined,
+  stats: TreeLoadingStat | undefined,
+): Promise<{ result: ExtendedResourceData[]; followUpSeeds: SignedResourceId[] }> {
+  const result: ExtendedResourceData[] = [];
+  const followUpSeeds: SignedResourceId[] = [];
+
+  for await (const frame of treeItems) {
+    if (frame.frameKind === 'stopMarker') {
+      if (finalResources.has(frame.id)) {
+        if (stats) stats.stopMarkersSkipped++;
+        continue;
+      }
+      followUpSeeds.push(frame.id);
+      continue;
+    }
+
+    // Normal resource frame.
+    if (finalResources.has(frame.id)) {
+      if (stats) stats.finalResourcesSkipped++;
+      continue;
+    }
+
+    let nextResource: ExtendedResourceData = {
+      id: frame.id,
+      type: frame.type,
+      kind: frame.kind,
+      data: frame.data,
+      resourceReady: frame.resourceReady,
+      error: frame.error,
+      originalResourceId: frame.originalResourceId,
+      // traverseWasStopped: backend matched traverse stop rules — children were not streamed.
+      // Mark as terminal; fields are resolved below.
+      final: frame.final || frame.traverseWasStopped,
+      inputsLocked: frame.inputsLocked,
+      outputsLocked: frame.outputsLocked,
+      fields: frame.fields,
+      kv: frame.kv,
+    };
+
+    // Apply field rules: traverseWasStopped drops all fields to keep the refCount
+    // invariant; pruning function further filters the remaining fields.
+    const rawFields = frame.traverseWasStopped ? [] : nextResource.fields;
+    const resolvedFields = pruningFunction !== undefined ? pruningFunction({ ...nextResource, fields: rawFields }) : rawFields;
+    if (stats) stats.prunedFields += nextResource.fields.length - resolvedFields.length;
+    nextResource = { ...nextResource, fields: resolvedFields };
+
+    collectStatsForResource(nextResource, stats);
+    result.push(nextResource);
+  }
+
+  return { result, followUpSeeds };
+}
+
 async function loadTreeStateViaResourceTree(
   tx: PlTransaction,
   loadingRequest: TreeLoadingRequest,
@@ -210,50 +277,35 @@ async function loadTreeStateViaResourceTree(
   const { seedResources, finalResources, pruningFunction, fieldFilters, traverseStopRules } =
     loadingRequest;
 
-  const result: ExtendedResourceData[] = [];
+  const treeAny = tx as any;
 
-  const treeItems = (tx as any).resourceTree(seedResources, {
+  // Round 0: initial tree traversal.
+  const treeItems = treeAny.resourceTree(seedResources, {
     includeKv: true,
     fieldFilters,
     traverseStopRules,
-  }) as AsyncIterable<ExtendedResourceData & { traverseWasStopped: boolean }>;
+  });
 
-  // ResourceTree yields incrementally; this loop consumes stream frames one by one.
-  for await (const item of treeItems) {
-    if (finalResources.has(item.id)) {
-      if (stats) stats.finalResourcesSkipped++;
-      continue;
-    }
-
-    let nextResource: ExtendedResourceData = {
-      id: item.id,
-      type: item.type,
-      kind: item.kind,
-      data: item.data,
-      resourceReady: item.resourceReady,
-      error: item.error,
-      originalResourceId: item.originalResourceId,
-      // traverseWasStopped means backend matched traverse stop rules for this node.
-      // We propagate this into `final` so the tree can treat this node as terminal.
-      final: item.final || item.traverseWasStopped,
-      inputsLocked: item.inputsLocked,
-      outputsLocked: item.outputsLocked,
-      fields: item.fields,
-      kv: item.kv,
-      traverseWasStopped: item.traverseWasStopped,
-    };
-
-    if (pruningFunction !== undefined) {
-      const fieldsAfterPruning = pruningFunction(nextResource);
-      if (stats) stats.prunedFields += nextResource.fields.length - fieldsAfterPruning.length;
-      nextResource = { ...nextResource, fields: fieldsAfterPruning };
-    }
-
-    collectStatsForResource(nextResource, stats);
-    result.push(nextResource);
-  }
-
+  const { result, followUpSeeds } = await processResourceTreeStream(treeItems, finalResources, pruningFunction, stats);
   if (stats) stats.roundTrips++;
+
+  // Single follow-up for unknown stop markers.
+  // traverseStopRules is omitted so the server performs a full traversal and
+  // cannot emit further stop markers — one round is sufficient.
+  // Old backends emit no stop-marker frames, so followUpSeeds stays empty
+  // and this block is skipped — backward compatible.
+  if (followUpSeeds.length > 0) {
+    const followUpItems = treeAny.resourceTree(followUpSeeds, {
+      includeKv: true,
+      fieldFilters,
+    });
+    const { result: followUpResult } = await processResourceTreeStream(followUpItems, finalResources, pruningFunction, stats);
+    result.push(...followUpResult);
+    if (stats) {
+      stats.roundTrips++;
+      stats.stopMarkerFollowUpRoundTrips++;
+    }
+  }
 
   return result;
 }

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -140,14 +140,21 @@ async function loadTreeStateViaBfs(
 ): Promise<ExtendedResourceData[]> {
   const { seedResources, finalResources, pruningFunction } = loadingRequest;
 
+  // Limits the number of concurrent gRPC fetches to bound peak memory
+  // from in-flight request/response buffers.
   const limiter = new ConcurrencyLimitingExecutor(100);
+
+  // Promises of resource states, in the order they were requested.
   const pending = new Denque<Promise<ExtendedResourceData | undefined>>();
 
-  let roundTripToggle = true;
+  // vars to calculate number of roundtrips for stats
+  let roundTripToggle: boolean = true;
   let numberOfRoundTrips = 0;
 
+  // tracking resources we already requested or queued
   const requested = new Set<SignedResourceId>();
 
+  /** Mark a resource for fetching. Deduplicates and respects final-resource set. */
   const requestState = (rid: OptionalSignedResourceId) => {
     if (isNullSignedResourceId(rid) || requested.has(rid)) return;
 
@@ -163,11 +170,14 @@ async function loadTreeStateViaBfs(
         const resourceData = tx.getResourceDataIfExists(rid, true);
         const kvData = tx.listKeyValuesIfResourceExists(rid);
 
+        // counting round-trip (begin)
         const addRT = roundTripToggle;
         if (roundTripToggle) roundTripToggle = false;
 
         const [resource, kv] = await Promise.all([resourceData, kvData]);
 
+        // counting round-trip, actually incrementing counter and returning toggle back,
+        // so the next request can acquire it
         if (addRT) {
           numberOfRoundTrips++;
           roundTripToggle = true;
@@ -181,27 +191,37 @@ async function loadTreeStateViaBfs(
     );
   };
 
+  // sending seed requests
   seedResources.forEach((rid) => requestState(rid));
 
   const result: ExtendedResourceData[] = [];
   let nextPromise: Promise<ExtendedResourceData | undefined> | undefined;
   while ((nextPromise = pending.shift()) !== undefined) {
+    // at this point we pause and wait for the next requested resource state to arrive
     let nextResource = await nextPromise;
-    if (nextResource === undefined) continue;
+    if (nextResource === undefined)
+      // ignoring resources that were not found (this may happen for seed resource ids)
+      continue;
 
     if (pruningFunction !== undefined) {
+      // apply field pruning, if requested
       const fieldsAfterPruning = pruningFunction(nextResource);
+      // collecting stats
       if (stats) stats.prunedFields += nextResource.fields.length - fieldsAfterPruning.length;
       nextResource = { ...nextResource, fields: fieldsAfterPruning };
     }
 
+    // continue traversal over the referenced resources
     requestState(nextResource.error);
     for (const field of nextResource.fields) {
       requestState(field.value);
       requestState(field.error);
     }
 
+    // collecting stats
     collectStatsForResource(nextResource, stats);
+
+    // aggregating the state
     result.push(nextResource);
   }
 
@@ -222,6 +242,12 @@ async function processResourceTreeStream(
   const result: ExtendedResourceData[] = [];
   const followUpSeeds: SignedResourceId[] = [];
 
+  // backend returns two types of frames:
+  // - 'resource' frames contain the resource state and are processed normally
+  // - 'stopMarker' frames indicate resources that are ignored due stop rules fired
+  //
+  // Usually stop rules indicates the resources with final state. In that case middle layer
+  // should make a decision: has it already loaded the resource or should it be requested for get the latest state?
   for await (const frame of treeItems) {
     if (frame.frameKind === 'stopMarker') {
       if (finalResources.has(frame.id)) {

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -3,6 +3,7 @@ import type {
   Filter,
   OptionalSignedResourceId,
   PlTransaction,
+  ResourceTreeFrame,
   SignedResourceId,
 } from "@milaboratories/pl-client";
 import Denque from "denque";
@@ -230,8 +231,6 @@ async function loadTreeStateViaBfs(
   return result;
 }
 
-type ResourceTreeFrame = ExtendedResourceData & { frameKind: string; traverseWasStopped: boolean };
-
 async function processResourceTreeStream(
   treeItems: AsyncIterable<ResourceTreeFrame>,
   finalResources: Set<SignedResourceId>,
@@ -306,10 +305,8 @@ async function loadTreeStateViaResourceTree(
   const { seedResources, finalResources, pruningFunction, fieldFilter, traverseStopRules } =
     loadingRequest;
 
-  const treeAny = tx as any;
-
   // Round 0: initial tree traversal.
-  const treeItems = treeAny.resourceTree(seedResources, {
+  const treeItems = tx.resourceTree(seedResources, {
     includeKv: true,
     fieldFilter,
     traverseStopRules,
@@ -326,7 +323,7 @@ async function loadTreeStateViaResourceTree(
   // Client must request full resource tree in case when stop-marker seeds are returned,
   // to ensure all resources are loaded and stop-marker frames are processed.
   if (followUpSeeds.length > 0) {
-    const followUpItems = treeAny.resourceTree(followUpSeeds, {
+    const followUpItems = tx.resourceTree(followUpSeeds, {
       includeKv: true,
       fieldFilter,
     });

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -1,5 +1,6 @@
 import type {
   FieldData,
+  Filter,
   OptionalSignedResourceId,
   PlTransaction,
   SignedResourceId,
@@ -23,19 +24,23 @@ export interface TreeLoadingRequest {
    * be retrieved for them. */
   readonly finalResources: Set<SignedResourceId>;
 
-  /** This function is applied to each resource data field list, before
-   * using it continue traversal. This modification also is applied to
-   * output data to make result self-consistent in terms that it will contain
-   * all referenced resources, this is required to be able to pass it to tree
-   * to update the state. */
+  /** Applied to each resource field list in fallback BFS mode and to streamed results. */
   readonly pruningFunction?: PruningFunction;
+
+  /** ResourceTree field filters passed to the backend when supported. */
+  readonly fieldFilters?: Filter[];
+
+  /** ResourceTree traversal stop rules passed to the backend when supported. */
+  readonly traverseStopRules?: Filter;
 }
+
+const CapabilityTreeFilter = "treeFilter:v1";
 
 /** Given the current tree state, build the request object to pass to
  * {@link loadTreeState} to load updated state. */
 export function constructTreeLoadingRequest(
   tree: PlTreeState,
-  pruningFunction?: PruningFunction,
+  options: Pick<TreeLoadingRequest, "pruningFunction" | "fieldFilters" | "traverseStopRules"> = {},
 ): TreeLoadingRequest {
   const seedResources: SignedResourceId[] = [];
   const finalResources = new Set<SignedResourceId>();
@@ -47,7 +52,13 @@ export function constructTreeLoadingRequest(
   // if tree is empty, seeding tree reconstruction from the specified root
   if (seedResources.length === 0 && finalResources.size === 0) seedResources.push(tree.root);
 
-  return { seedResources, finalResources, pruningFunction };
+  return {
+    seedResources,
+    finalResources,
+    pruningFunction: options.pruningFunction,
+    fieldFilters: options.fieldFilters,
+    traverseStopRules: options.traverseStopRules,
+  };
 }
 
 export type TreeLoadingStat = {
@@ -92,37 +103,34 @@ export function formatTreeLoadingStat(stat: TreeLoadingStat): string {
   return result;
 }
 
-/** Given the transaction (preferably read-only) and loading request, executes
- * the tree traversal algorithm, and collects fresh states of resources
- * to update the tree state. */
-export async function loadTreeState(
+function supportsResourceTreeTraversal(capabilities: readonly string[] = []): boolean {
+  return capabilities.includes(CapabilityTreeFilter);
+}
+
+function collectStatsForResource(resource: ExtendedResourceData, stats?: TreeLoadingStat) {
+  if (!stats) return;
+  stats.retrievedResources++;
+  stats.retrievedFields += resource.fields.length;
+  stats.retrievedKeyValues += resource.kv.length;
+  stats.retrievedResourceDataBytes += resource.data?.length ?? 0;
+  for (const kv of resource.kv) stats.retrievedKeyValueBytes += kv.value.length;
+}
+
+async function loadTreeStateViaBfs(
   tx: PlTransaction,
   loadingRequest: TreeLoadingRequest,
   stats?: TreeLoadingStat,
 ): Promise<ExtendedResourceData[]> {
-  // saving start timestamp to add time spent in this function to the stats at the end of the method
-  const startTimestamp = Date.now();
-
-  // counting the request
-  if (stats) stats.requests++;
-
   const { seedResources, finalResources, pruningFunction } = loadingRequest;
 
-  // Limits the number of concurrent gRPC fetches to bound peak memory
-  // from in-flight request/response buffers.
   const limiter = new ConcurrencyLimitingExecutor(100);
-
-  // Promises of resource states, in the order they were requested.
   const pending = new Denque<Promise<ExtendedResourceData | undefined>>();
 
-  // vars to calculate number of roundtrips for stats
-  let roundTripToggle: boolean = true;
+  let roundTripToggle = true;
   let numberOfRoundTrips = 0;
 
-  // tracking resources we already requested or queued
   const requested = new Set<SignedResourceId>();
 
-  /** Mark a resource for fetching. Deduplicates and respects final-resource set. */
   const requestState = (rid: OptionalSignedResourceId) => {
     if (isNullSignedResourceId(rid) || requested.has(rid)) return;
 
@@ -138,14 +146,11 @@ export async function loadTreeState(
         const resourceData = tx.getResourceDataIfExists(rid, true);
         const kvData = tx.listKeyValuesIfResourceExists(rid);
 
-        // counting round-trip (begin)
         const addRT = roundTripToggle;
         if (roundTripToggle) roundTripToggle = false;
 
         const [resource, kv] = await Promise.all([resourceData, kvData]);
 
-        // counting round-trip, actually incrementing counter and returning toggle back,
-        // so the next request can acquire it
         if (addRT) {
           numberOfRoundTrips++;
           roundTripToggle = true;
@@ -159,51 +164,109 @@ export async function loadTreeState(
     );
   };
 
-  // sending seed requests
   seedResources.forEach((rid) => requestState(rid));
 
   const result: ExtendedResourceData[] = [];
   let nextPromise: Promise<ExtendedResourceData | undefined> | undefined;
   while ((nextPromise = pending.shift()) !== undefined) {
-    // at this point we pause and wait for the next requested resource state to arrive
     let nextResource = await nextPromise;
-    if (nextResource === undefined)
-      // ignoring resources that were not found (this may happen for seed resource ids)
-      continue;
+    if (nextResource === undefined) continue;
 
     if (pruningFunction !== undefined) {
-      // apply field pruning, if requested
       const fieldsAfterPruning = pruningFunction(nextResource);
-      // collecting stats
       if (stats) stats.prunedFields += nextResource.fields.length - fieldsAfterPruning.length;
       nextResource = { ...nextResource, fields: fieldsAfterPruning };
     }
 
-    // continue traversal over the referenced resources
     requestState(nextResource.error);
     for (const field of nextResource.fields) {
       requestState(field.value);
       requestState(field.error);
     }
 
-    // collecting stats
-    if (stats) {
-      stats.retrievedResources++;
-      stats.retrievedFields += nextResource.fields.length;
-      stats.retrievedKeyValues += nextResource.kv.length;
-      stats.retrievedResourceDataBytes += nextResource.data?.length ?? 0;
-      for (const kv of nextResource.kv) stats.retrievedKeyValueBytes += kv.value.length;
-    }
-
-    // aggregating the state
+    collectStatsForResource(nextResource, stats);
     result.push(nextResource);
   }
 
-  // adding the time we spent in this method to stats
-  if (stats) {
-    stats.millisSpent += Date.now() - startTimestamp;
-    stats.roundTrips += numberOfRoundTrips;
-  }
+  if (stats) stats.roundTrips += numberOfRoundTrips;
 
   return result;
+}
+
+async function loadTreeStateViaResourceTree(
+  tx: PlTransaction,
+  loadingRequest: TreeLoadingRequest,
+  stats?: TreeLoadingStat,
+): Promise<ExtendedResourceData[]> {
+  const { seedResources, finalResources, pruningFunction, fieldFilters, traverseStopRules } =
+    loadingRequest;
+
+  const result: ExtendedResourceData[] = [];
+
+  const treeItems = (tx as any).resourceTree(seedResources, {
+    includeKv: true,
+    fieldFilters,
+    traverseStopRules,
+  }) as AsyncIterable<ExtendedResourceData & { traverseWasStopped: boolean }>;
+
+  // ResourceTree yields incrementally; this loop consumes stream frames one by one.
+  for await (const item of treeItems) {
+    if (finalResources.has(item.id)) {
+      if (stats) stats.finalResourcesSkipped++;
+      continue;
+    }
+
+    let nextResource: ExtendedResourceData = {
+      id: item.id,
+      type: item.type,
+      kind: item.kind,
+      data: item.data,
+      resourceReady: item.resourceReady,
+      error: item.error,
+      originalResourceId: item.originalResourceId,
+      // traverseWasStopped means backend matched traverse stop rules for this node.
+      // We propagate this into `final` so the tree can treat this node as terminal.
+      final: item.final || item.traverseWasStopped,
+      inputsLocked: item.inputsLocked,
+      outputsLocked: item.outputsLocked,
+      fields: item.fields,
+      kv: item.kv,
+    };
+
+    if (pruningFunction !== undefined) {
+      const fieldsAfterPruning = pruningFunction(nextResource);
+      if (stats) stats.prunedFields += nextResource.fields.length - fieldsAfterPruning.length;
+      nextResource = { ...nextResource, fields: fieldsAfterPruning };
+    }
+
+    collectStatsForResource(nextResource, stats);
+    result.push(nextResource);
+  }
+
+  if (stats) stats.roundTrips++;
+
+  return result;
+}
+
+/** Given the transaction (preferably read-only) and loading request, executes
+ * the tree traversal algorithm, and collects fresh states of resources
+ * to update the tree state. */
+export async function loadTreeState(
+  tx: PlTransaction,
+  loadingRequest: TreeLoadingRequest,
+  stats?: TreeLoadingStat,
+  capabilities: readonly string[] = [],
+): Promise<ExtendedResourceData[]> {
+  const startTimestamp = Date.now();
+  if (stats) stats.requests++;
+
+  try {
+    if (supportsResourceTreeTraversal(capabilities)) {
+      return await loadTreeStateViaResourceTree(tx, loadingRequest, stats);
+    }
+
+    return await loadTreeStateViaBfs(tx, loadingRequest, stats);
+  } finally {
+    if (stats) stats.millisSpent += Date.now() - startTimestamp;
+  }
 }

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -13,6 +13,11 @@ import { PlTreeState, TreeStateUpdateError } from "./state";
 import type { PruningFunction, TraversalMode, TreeLoadingStat } from "./sync";
 import { constructTreeLoadingRequest, initialTreeLoadingStat, loadTreeState } from "./sync";
 import * as tp from "node:timers/promises";
+
+/** Hard floor between consecutive tree-refresh calls.
+ * Applies even when {@link scheduleOnNextState} has woken the loop early,
+ * preventing tight polling loops during rapid state transitions. */
+const MIN_POLLING_INTERVAL_MS = 100;
 import type { MiLogger } from "@milaboratories/ts-helpers";
 
 type StatLoggingMode = "cumulative" | "per-request";
@@ -239,23 +244,40 @@ export class SynchronizedTreeState {
 
       if (!this.keepRunning || this.terminated) break;
 
+      // Phase 1: mandatory floor — always wait at least MIN_POLLING_INTERVAL_MS.
+      // Not interruptible by scheduleOnNextState; only termination aborts it.
+      try {
+        await tp.setTimeout(MIN_POLLING_INTERVAL_MS, undefined, {
+          signal: this.abortController.signal,
+        });
+      } catch (e: unknown) {
+        if (!isTimeoutOrCancelError(e)) throw new Error("Unexpected error", { cause: e });
+        if (this.abortController.signal.aborted) break;
+      }
+
+      if (!this.keepRunning || this.terminated) break;
+
+      // Phase 2: optional remainder up to pollingInterval — interruptible by
+      // scheduleOnNextState so that an external nudge wakes the loop promptly.
       if (this.scheduledOnNextState.length === 0) {
-        try {
-          this.currentLoopDelayInterrupt = new AbortController();
-          await tp.setTimeout(this.pollingInterval, undefined, {
-            signal: AbortSignal.any([
-              this.abortController.signal,
-              this.currentLoopDelayInterrupt.signal,
-            ]),
-          });
-        } catch (e: unknown) {
-          if (!isTimeoutOrCancelError(e)) throw new Error("Unexpected error", { cause: e });
-          // If the main abort controller fired, this is a permanent termination
-          if (this.abortController.signal.aborted) break;
-          // Otherwise it was just the loop delay interrupt (scheduleOnNextState),
-          // continue to the next iteration
-        } finally {
-          this.currentLoopDelayInterrupt = undefined;
+        const remaining = Math.max(0, this.pollingInterval - MIN_POLLING_INTERVAL_MS);
+        if (remaining > 0) {
+          try {
+            this.currentLoopDelayInterrupt = new AbortController();
+            await tp.setTimeout(remaining, undefined, {
+              signal: AbortSignal.any([
+                this.abortController.signal,
+                this.currentLoopDelayInterrupt.signal,
+              ]),
+            });
+          } catch (e: unknown) {
+            if (!isTimeoutOrCancelError(e)) throw new Error("Unexpected error", { cause: e });
+            if (this.abortController.signal.aborted) break;
+            // Otherwise it was just the loop delay interrupt (scheduleOnNextState),
+            // continue to the next iteration
+          } finally {
+            this.currentLoopDelayInterrupt = undefined;
+          }
         }
       }
     }

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -29,8 +29,8 @@ export type SynchronizedTreeOps = {
   /** Pruning function for legacy fallback path. */
   pruning?: PruningFunction;
 
-  /** ResourceTree field filters for modern backend path. */
-  fieldFilters?: Filter[];
+  /** ResourceTree field filter for modern backend path. */
+  fieldFilter?: Filter;
 
   /** ResourceTree traversal stop rules for modern backend path. */
   traverseStopRules?: Filter;
@@ -60,7 +60,7 @@ export class SynchronizedTreeState {
   private state: PlTreeState;
   private readonly pollingInterval: number;
   private readonly pruning?: PruningFunction;
-  private readonly fieldFilters?: Filter[];
+  private readonly fieldFilter?: Filter;
   private readonly traverseStopRules?: Filter;
   private readonly traversalMode: TraversalMode;
   private readonly logStat?: StatLoggingMode;
@@ -76,7 +76,7 @@ export class SynchronizedTreeState {
     const {
       finalPredicateOverride,
       pruning,
-      fieldFilters,
+      fieldFilter,
       traverseStopRules,
       traversalMode,
       pollingInterval,
@@ -84,7 +84,7 @@ export class SynchronizedTreeState {
       logStat,
     } = ops;
     this.pruning = pruning;
-    this.fieldFilters = fieldFilters;
+    this.fieldFilter = fieldFilter;
     this.traverseStopRules = traverseStopRules;
     this.traversalMode = traversalMode ?? "auto";
     this.pollingInterval = pollingInterval;
@@ -154,7 +154,7 @@ export class SynchronizedTreeState {
     if (this.terminated) throw new Error("tree synchronization is terminated");
     const request = constructTreeLoadingRequest(this.state, {
       pruningFunction: this.pruning,
-      fieldFilters: this.fieldFilters,
+      fieldFilter: this.fieldFilter,
       traverseStopRules: this.traverseStopRules,
     });
     const data = await this.pl.withReadTx(

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -6,6 +6,7 @@ import type {
   SignedResourceId,
   TxOps,
 } from "@milaboratories/pl-client";
+import type { Filter } from "@milaboratories/pl-client";
 import { isTimeoutOrCancelError } from "@milaboratories/pl-client";
 import type { ExtendedResourceData } from "./state";
 import { PlTreeState, TreeStateUpdateError } from "./state";
@@ -20,9 +21,14 @@ export type SynchronizedTreeOps = {
   /** Override final predicate from the PlClient */
   finalPredicateOverride?: FinalResourceDataPredicate;
 
-  /** Pruning function to limit set of fields through which tree will
-   * traverse during state synchronization */
+  /** Pruning function for legacy fallback path. */
   pruning?: PruningFunction;
+
+  /** ResourceTree field filters for modern backend path. */
+  fieldFilters?: Filter[];
+
+  /** ResourceTree traversal stop rules for modern backend path. */
+  traverseStopRules?: Filter;
 
   /** Interval after last sync to sleep before the next one */
   pollingInterval: number;
@@ -46,6 +52,8 @@ export class SynchronizedTreeState {
   private state: PlTreeState;
   private readonly pollingInterval: number;
   private readonly pruning?: PruningFunction;
+  private readonly fieldFilters?: Filter[];
+  private readonly traverseStopRules?: Filter;
   private readonly logStat?: StatLoggingMode;
   private readonly hooks: PollingComputableHooks;
   private readonly abortController = new AbortController();
@@ -56,8 +64,18 @@ export class SynchronizedTreeState {
     ops: SynchronizedTreeOps,
     private readonly logger?: MiLogger,
   ) {
-    const { finalPredicateOverride, pruning, pollingInterval, stopPollingDelay, logStat } = ops;
+    const {
+      finalPredicateOverride,
+      pruning,
+      fieldFilters,
+      traverseStopRules,
+      pollingInterval,
+      stopPollingDelay,
+      logStat,
+    } = ops;
     this.pruning = pruning;
+    this.fieldFilters = fieldFilters;
+    this.traverseStopRules = traverseStopRules;
     this.pollingInterval = pollingInterval;
     this.finalPredicate = finalPredicateOverride ?? pl.finalPredicate;
     this.logStat = logStat;
@@ -123,11 +141,15 @@ export class SynchronizedTreeState {
   /** Executed from the main loop, and initialization procedure. */
   private async refresh(stats?: TreeLoadingStat, txOps?: TxOps): Promise<void> {
     if (this.terminated) throw new Error("tree synchronization is terminated");
-    const request = constructTreeLoadingRequest(this.state, this.pruning);
+    const request = constructTreeLoadingRequest(this.state, {
+      pruningFunction: this.pruning,
+      fieldFilters: this.fieldFilters,
+      traverseStopRules: this.traverseStopRules,
+    });
     const data = await this.pl.withReadTx(
       "ReadingTree",
       async (tx) => {
-        return await loadTreeState(tx, request, stats);
+        return await loadTreeState(tx, request, stats, this.pl.serverInfo.capabilities ?? []);
       },
       txOps,
     );

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -10,7 +10,7 @@ import type { Filter } from "@milaboratories/pl-client";
 import { isTimeoutOrCancelError } from "@milaboratories/pl-client";
 import type { ExtendedResourceData } from "./state";
 import { PlTreeState, TreeStateUpdateError } from "./state";
-import type { PruningFunction, TreeLoadingStat } from "./sync";
+import type { PruningFunction, TraversalMode, TreeLoadingStat } from "./sync";
 import { constructTreeLoadingRequest, initialTreeLoadingStat, loadTreeState } from "./sync";
 import * as tp from "node:timers/promises";
 import type { MiLogger } from "@milaboratories/ts-helpers";
@@ -40,6 +40,9 @@ export type SynchronizedTreeOps = {
 
   /** Timeout for initial tree loading. If not specified, will use default for RO tx from pl-client. */
   initialTreeLoadingTimeout?: number;
+
+  /** Controls which tree-loading path to use.  Default `"auto"`. */
+  traversalMode?: TraversalMode;
 };
 
 type ScheduledRefresh = {
@@ -54,6 +57,7 @@ export class SynchronizedTreeState {
   private readonly pruning?: PruningFunction;
   private readonly fieldFilters?: Filter[];
   private readonly traverseStopRules?: Filter;
+  private readonly traversalMode: TraversalMode;
   private readonly logStat?: StatLoggingMode;
   private readonly hooks: PollingComputableHooks;
   private readonly abortController = new AbortController();
@@ -69,6 +73,7 @@ export class SynchronizedTreeState {
       pruning,
       fieldFilters,
       traverseStopRules,
+      traversalMode,
       pollingInterval,
       stopPollingDelay,
       logStat,
@@ -76,6 +81,7 @@ export class SynchronizedTreeState {
     this.pruning = pruning;
     this.fieldFilters = fieldFilters;
     this.traverseStopRules = traverseStopRules;
+    this.traversalMode = traversalMode ?? "auto";
     this.pollingInterval = pollingInterval;
     this.finalPredicate = finalPredicateOverride ?? pl.finalPredicate;
     this.logStat = logStat;
@@ -149,7 +155,14 @@ export class SynchronizedTreeState {
     const data = await this.pl.withReadTx(
       "ReadingTree",
       async (tx) => {
-        return await loadTreeState(tx, request, stats, this.pl.serverInfo.capabilities ?? []);
+        return await loadTreeState(
+          tx,
+          request,
+          stats,
+          this.pl.serverInfo.capabilities ?? [],
+          this.traversalMode,
+          this.logger,
+        );
       },
       txOps,
     );


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a server-side streaming traversal path for the "load tree" operation, replacing the client-side BFS with an incremental `resourceTree` stream gated by a `treeFilter:v1` capability flag. It adds a new `AsyncMessageStream` class, `PlTransaction.resourceTree()`, a `treeFilter` builder, proto extensions for filter/seed/KV/stop-marker fields, and a `MI_TREE_TRAVERSAL` env-var override.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The new backend-streaming path can silently return incomplete tree data when `seedResources` has more than one entry on a server that advertises `treeFilter:v1` but not `treeSeeds:v1`; this is unlikely to trigger on a fully-updated cluster but could in a rolling upgrade window.

The core streaming machinery (`AsyncMessageStream`, `sendStream`, `resourceTree`) is well-structured and the fallback to BFS is correctly gated. The risk area is `loadTreeStateViaResourceTree` in `sync.ts`: the single-capability guard conflates field-filter support with multi-seed support, so in a mixed-version deployment the fast path silently uses only the first seed and misses the rest of the tree. This would surface as stale/partial state rather than an error, making it hard to detect in testing.

lib/node/pl-tree/src/sync.ts — specifically the `supportsResourceTreeTraversal` guard and the `tx as any` cast in `loadTreeStateViaResourceTree`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-tree/src/sync.ts | Adds the `loadTreeStateViaResourceTree` fast path, follow-up seed handling for stop-markers, and a `TraversalMode` env-var override; contains a capability-check gap that can silently truncate multi-seed traversals on partially-capable servers, and uses `as any` to call `resourceTree()` which suppresses type checking. |
| lib/node/pl-client/src/core/ll_transaction.ts | Adds `AsyncMessageStream` (push/pull async queue backed by Denque) and a new `sendStream()` method that dispatches the new `multiStream` handler mode; the handler dispatch logic and error propagation are correct but the stream class has a shared-state concern for multiple iterators and a silent queue-drop on fail(). |
| lib/node/pl-client/src/core/transaction.ts | Adds the `resourceTree()` streaming method with correct seed mapping, stop-marker handling, and iterator delegation; the first seed is duplicated in both `resourceId` and `seeds[]` intentionally for backward compatibility. |
| lib/node/pl-client/src/core/tree_filter.ts | New builder module for `ResourceAPI_Tree_Filter` predicates; well-structured with clear typed helpers and matching unit tests. |
| lib/node/pl-client/proto/plapi/plapiproto/api.proto | Extends `ResourceAPI.Tree.Request` with `field_filter`, `include_kv`, `traverse_stop_rules`, `seeds`; adds `Filter`, `SeedResource`, `KV` messages; makes `Response.resource` optional and adds stop-marker fields; adds `capabilities` to `MaintenanceAPI.Ping.Response`. |
| lib/node/pl-middle-layer/src/debug/index.ts | Adds `parseTraversalMode()` to parse the `MI_TREE_TRAVERSAL` env var with graceful fallback to "auto" on invalid values; clean implementation with good guard logic. |
| lib/node/pl-client/src/core/ll_client.ts | Small fix to normalise the REST ping response by ensuring `capabilities` defaults to `[]` when absent from old servers. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ML as MiddleLayer
    participant Sync as loadTreeState
    participant Tx as PlTransaction
    participant LL as LLPlTransaction
    participant Srv as gRPC Server

    ML->>Sync: loadTreeState(tx, request, capabilities)
    alt treeFilter:v1 advertised
        Sync->>Tx: "resourceTree(seeds, {fieldFilter, traverseStopRules})"
        Tx->>LL: "sendStream({ resourceTree })"
        LL->>Srv: TxAPI ClientMessage
        loop streaming frames
            Srv-->>LL: TxAPI ServerMessage (multi)
            LL-->>Tx: AsyncMessageStream.push(frame)
            Tx-->>Sync: ResourceTreeFrame
        end
        Srv-->>LL: TxAPI ServerMessage (isLast)
        LL-->>Tx: AsyncMessageStream.end()
        alt followUpSeeds non-empty
            Sync->>Tx: "resourceTree(followUpSeeds, {fieldFilter})"
            Note over Tx,Srv: second round-trip, no traverseStopRules
        end
    else no treeFilter:v1
        Sync->>Tx: getResourceData / listKeyValues (BFS)
    end
    Sync-->>ML: ExtendedResourceData[]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Fnode%2Fpl-tree%2Fsrc%2Fsync.ts%3A123-125%0A**Multi-seed%20traversal%20silently%20incomplete%20on%20partial-capability%20server**%0A%0A%60supportsResourceTreeTraversal%60%20only%20checks%20for%20%60%22treeFilter%3Av1%22%60%2C%20but%20the%20%60seeds%5B%5D%60%20field%20in%20the%20request%20requires%20%60%22treeSeeds%3Av1%22%60.%20On%20a%20server%20that%20advertises%20%60treeFilter%3Av1%60%20but%20not%20%60treeSeeds%3Av1%60%2C%20the%20client%20picks%20the%20backend-streaming%20path%20and%20populates%20%60seeds%3A%20seedResources%60%20with%20every%20non-final%20resource%2C%20but%20the%20server%20silently%20falls%20back%20to%20the%20single%20%60resource_id%60%20field%20%28the%20first%20seed%29.%20Every%20call%20after%20the%20first%20tree%20load%20will%20have%20%60seedResources.length%20%3E%201%60%2C%20causing%20the%20traversal%20to%20silently%20return%20only%20the%20subtree%20rooted%20at%20the%20first%20seed%20and%20miss%20all%20others.%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Fnode%2Fpl-tree%2Fsrc%2Fsync.ts%3A281-288%0A**%60tx%20as%20any%60%20hides%20type%20errors%20and%20diverges%20from%20the%20exported%20%60ResourceTreeFrame%60%20union**%0A%0A%60PlTransaction.resourceTree%28%29%60%20is%20a%20public%2C%20typed%20method%2C%20so%20%60tx%20as%20any%60%20is%20not%20needed%20and%20bypasses%20the%20compiler.%20As%20a%20side-effect%2C%20%60treeItems%60%20is%20inferred%20as%20%60any%60%20instead%20of%20%60AsyncIterable%3CResourceTreeFrame%3E%60%20%28the%20exported%20discriminated%20union%20from%20%60transaction.ts%60%29%2C%20so%20the%20local%20alias%20%60type%20ResourceTreeFrame%20%3D%20ExtendedResourceData%20%26%20%7B%20...%20%7D%60%20shadows%20the%20real%20type.%20Stop-marker%20frames%20produced%20by%20%60resourceTree%28%29%60%20carry%20only%20%60%7B%20frameKind%2C%20id%2C%20traverseWasStopped%20%7D%60%2C%20not%20the%20full%20%60ExtendedResourceData%60%20shape%3B%20the%20intersection%20type%20hides%20this%20mismatch%2C%20and%20any%20future%20code%20added%20between%20the%20%60frameKind%60%20check%20and%20the%20field%20access%20will%20compile%20but%20read%20%60undefined%60%20at%20runtime.%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fll_transaction.ts%3A86-96%0A**Queued%20items%20silently%20discarded%20when%20%60fail%28%29%60%20races%20ahead%20of%20the%20queue%20drain**%0A%0A%60fail%28%29%60%20sets%20%60this.failure%60%20before%20the%20queued%20items%20are%20consumed.%20The%20%60next%28%29%60%20method%20checks%20%60this.failure%60%20first%2C%20so%20any%20frames%20already%20buffered%20in%20%60this.queue%60%20at%20the%20time%20the%20error%20is%20signalled%20are%20silently%20dropped%20%E2%80%94%20the%20consumer%20only%20sees%20the%20error%2C%20never%20the%20buffered%20frames.%20For%20the%20streaming%20%60resourceTree%60%20use-case%20this%20is%20likely%20acceptable%20%28the%20response%20is%20corrupt%20anyway%29%2C%20but%20the%20behaviour%20differs%20from%20the%20%60end%28%29%60%20path%20where%20queued%20items%20are%20drained%20first.%20A%20short%20comment%20clarifying%20the%20intentional%20%22fail-fast%2C%20drop%20buffered%20items%22%20semantics%20would%20prevent%20future%20readers%20from%20trying%20to%20%22fix%22%20it.%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fll_transaction.ts%3A110-134%0A**%60%5BSymbol.asyncIterator%5D%28%29%60%20creates%20independent%20iterator%20objects%20that%20share%20mutable%20state**%0A%0AEach%20call%20to%20%60%5BSymbol.asyncIterator%5D%28%29%60%20returns%20a%20new%20object%20whose%20%60next%2Freturn%2Fthrow%60%20closures%20close%20over%20%60this%60%20%28the%20shared%20%60AsyncMessageStream%60%29.%20If%20two%20iterators%20are%20obtained%20and%20advanced%20concurrently%2C%20the%20second%20%60next%28%29%60%20call%20overwrites%20%60this.waitingResolve%60%2F%60this.waitingReject%60%2C%20causing%20the%20first%20waiter%20to%20be%20orphaned%20and%20never%20settle.%20The%20current%20consumers%20%28%60for%20await%60%20in%20a%20single%20place%29%20are%20safe%2C%20but%20the%20class%20implements%20%60AsyncIterable%3CT%3E%60%20%E2%80%94%20the%20standard%20contract%20implies%20independent%20iterators.%20Either%20explicitly%20implement%20%60AsyncIterator%3CT%3E%60%20%28not%20%60AsyncIterable%3CT%3E%60%29%2C%20or%20document%20that%20only%20one%20live%20iterator%20is%20supported%20at%20a%20time.%0A%0A&repo=milaboratory%2Fplatforma&pr=1633&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
lib/node/pl-tree/src/sync.ts:123-125
**Multi-seed traversal silently incomplete on partial-capability server**

`supportsResourceTreeTraversal` only checks for `"treeFilter:v1"`, but the `seeds[]` field in the request requires `"treeSeeds:v1"`. On a server that advertises `treeFilter:v1` but not `treeSeeds:v1`, the client picks the backend-streaming path and populates `seeds: seedResources` with every non-final resource, but the server silently falls back to the single `resource_id` field (the first seed). Every call after the first tree load will have `seedResources.length > 1`, causing the traversal to silently return only the subtree rooted at the first seed and miss all others.

### Issue 2 of 4
lib/node/pl-tree/src/sync.ts:281-288
**`tx as any` hides type errors and diverges from the exported `ResourceTreeFrame` union**

`PlTransaction.resourceTree()` is a public, typed method, so `tx as any` is not needed and bypasses the compiler. As a side-effect, `treeItems` is inferred as `any` instead of `AsyncIterable<ResourceTreeFrame>` (the exported discriminated union from `transaction.ts`), so the local alias `type ResourceTreeFrame = ExtendedResourceData & { ... }` shadows the real type. Stop-marker frames produced by `resourceTree()` carry only `{ frameKind, id, traverseWasStopped }`, not the full `ExtendedResourceData` shape; the intersection type hides this mismatch, and any future code added between the `frameKind` check and the field access will compile but read `undefined` at runtime.

### Issue 3 of 4
lib/node/pl-client/src/core/ll_transaction.ts:86-96
**Queued items silently discarded when `fail()` races ahead of the queue drain**

`fail()` sets `this.failure` before the queued items are consumed. The `next()` method checks `this.failure` first, so any frames already buffered in `this.queue` at the time the error is signalled are silently dropped — the consumer only sees the error, never the buffered frames. For the streaming `resourceTree` use-case this is likely acceptable (the response is corrupt anyway), but the behaviour differs from the `end()` path where queued items are drained first. A short comment clarifying the intentional "fail-fast, drop buffered items" semantics would prevent future readers from trying to "fix" it.

### Issue 4 of 4
lib/node/pl-client/src/core/ll_transaction.ts:110-134
**`[Symbol.asyncIterator]()` creates independent iterator objects that share mutable state**

Each call to `[Symbol.asyncIterator]()` returns a new object whose `next/return/throw` closures close over `this` (the shared `AsyncMessageStream`). If two iterators are obtained and advanced concurrently, the second `next()` call overwrites `this.waitingResolve`/`this.waitingReject`, causing the first waiter to be orphaned and never settle. The current consumers (`for await` in a single place) are safe, but the class implements `AsyncIterable<T>` — the standard contract implies independent iterators. Either explicitly implement `AsyncIterator<T>` (not `AsyncIterable<T>`), or document that only one live iterator is supported at a time.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: prettier formatting"](https://github.com/milaboratory/platforma/commit/47baa4513cdd94763a9aebeb406a9bb1ddd54b48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31759772)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->