### PR TITLE
feat(workflow-tengo): re-export hasGpu from the exec library

### DIFF
--- a/.changeset/gpu-flag-exec-has-gpu.md
+++ b/.changeset/gpu-flag-exec-has-gpu.md
@@ -1,0 +1,16 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+Re-export `hasGpu` from the `exec` library so block code reads `exec.hasGpu` instead of pulling the feature-flag catalogue directly. Feature flags are an internal mechanism — exposing the public GPU-availability signal through `exec` keeps the block-developer surface aligned with `exec.builder().gpuMemory()`, the call it gates.
+
+```go
+exec := import("@platforma-sdk/workflow-tengo:exec")
+
+builder := exec.builder().software(sw).cpu(8).mem("24GiB")
+if exec.hasGpu {
+    builder = builder.gpuMemory("16GiB")
+}
+```
+
+`feats.hasGpu` continues to exist; new block code should prefer `exec.hasGpu`.

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -19,6 +19,7 @@ constants := import(":constants")
 monetization := import(":exec.monetization_internal")
 execConstants := import(":exec.constants")
 units := import(":units")
+feats := import(":feats")
 
 /**
  * Creates a new builder for constructing and executing commands.
@@ -1220,5 +1221,11 @@ builder := func() {
 }
 
 export ll.toStrict({
-	builder: builder
+	builder: builder,
+
+	// True when at least one backend runner advertises GPU availability.
+	// Gate .gpuMemory() calls in blocks that have a CPU fallback path:
+	//   if exec.hasGpu { builder = builder.gpuMemory("16GiB") }
+	// Calling .gpuMemory() against a backend without GPU produces a permanent error.
+	hasGpu: feats.hasGpu
 })

--- a/sdk/workflow-tengo/src/feats.lib.tengo
+++ b/sdk/workflow-tengo/src/feats.lib.tengo
@@ -68,9 +68,9 @@ export ll.toStrict({
 	isDockerAvailable:        _isEnabled("dockerSupport"),
 
 	// true when at least one backend runner advertises GPU availability.
-	// Use to gate .gpuMemory() calls in blocks that have a CPU fallback path:
-	//   if feats.hasGpu { builder = builder.gpuMemory("16GiB") }
-	// Calling .gpuMemory() against a backend without GPU produces a permanent error.
+	// Internal flag — block code should read `exec.hasGpu` instead of importing
+	// this catalogue directly, to keep feature-flag plumbing out of the public
+	// block-developer surface.
 	hasGpu:                   _isEnabled("gpuAvailable"),
 
 	// true when backend supports 'secret' argType for environment variables

--- a/tests/workflow-tengo/src/exec/run/hello_gpu_limits.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/hello_gpu_limits.tpl.tengo
@@ -1,7 +1,6 @@
 self := import("@platforma-sdk/workflow-tengo:tpl")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 exec := import("@platforma-sdk/workflow-tengo:exec")
-feats := import("@platforma-sdk/workflow-tengo:feats")
 
 self.defineOutputs(["gpuMemory"])
 
@@ -11,7 +10,7 @@ self.body(func(inputs) {
 	/* Checks that the SDK builder chain does not break when .gpuMemory()
 	 * is wired in, mirroring what blocks like clonotype-space do.
 	 * Calling .gpuMemory() against a backend without GPU is a permanent error
-	 * from the runner driver, so we MUST gate with feats.hasGpu — same rule
+	 * from the runner driver, so we MUST gate with exec.hasGpu — same rule
 	 * blocks follow.
 	 * The hello-world echo of inputs.gpuMemory verifies the chain end-to-end
 	 * regardless of whether GPU was actually requested. */
@@ -20,7 +19,7 @@ self.body(func(inputs) {
 		cpu(1).
 		mem("2GiB")
 
-	if feats.hasGpu {
+	if exec.hasGpu {
 		builder = builder.gpuMemory(inputs.gpuMemory)
 	}
 


### PR DESCRIPTION
> We talked about hasGpu() tengo function with CTO and he asked me "Let's
> then at least re-export the flag from exec library. Feature flags are
> internal things, and block developers should not use them directly to
> keep a clear separation of layers." implement it

Block code now reads `exec.hasGpu` instead of importing the `feats` flag catalogue. The flag still lives in feats — its source of truth is unchanged — but the public block-developer surface goes through `exec`, alongside the `exec.builder().gpuMemory()` call it gates. Feature-flag plumbing stays internal.

- exec/index.lib.tengo: import :feats, re-export hasGpu on the exec module.
- feats.lib.tengo: doc comment points block code at exec.hasGpu.
- tests/.../hello_gpu_limits.tpl.tengo: switch to exec.hasGpu to exercise the new public path end-to-end.
- changeset: minor bump for workflow-tengo.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR re-exports `feats.hasGpu` through the `exec` library so block developers can write `exec.hasGpu` rather than importing the internal feature-flag catalogue directly. The source of truth (`feats._isEnabled("gpuAvailable")`) is unchanged; `exec.hasGpu` is a one-liner alias.

- `exec/index.lib.tengo`: imports `:feats` and adds `hasGpu: feats.hasGpu` to the strict export map alongside the existing `builder` export.
- `feats.lib.tengo`: doc comment updated to direct block code toward `exec.hasGpu`; the flag itself is unchanged.
- `hello_gpu_limits.tpl.tengo`: test drops the `feats` import and switches to `exec.hasGpu` to exercise the new public path end-to-end.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line re-export that does not alter any runtime logic.

The re-export delegates directly to `feats.hasGpu`, which is itself a thin wrapper around the existing `_isEnabled("gpuAvailable")` call. No logic changes, no new failure modes. The test file correctly removes the now-redundant `feats` import and exercises the new path. The changeset is appropriately marked minor.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/exec/index.lib.tengo | Adds `feats` import and re-exports `feats.hasGpu` as `exec.hasGpu`; minimal, correct change. |
| sdk/workflow-tengo/src/feats.lib.tengo | Doc comment on `hasGpu` updated to redirect block developers to `exec.hasGpu`; no logic change. |
| tests/workflow-tengo/src/exec/run/hello_gpu_limits.tpl.tengo | Drops `feats` import, switches guard from `feats.hasGpu` to `exec.hasGpu`; correctly exercises the new public path. |
| .changeset/gpu-flag-exec-has-gpu.md | Minor-bump changeset for `@platforma-sdk/workflow-tengo` with accurate description and usage example. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Block Developer Code] -->|exec.hasGpu| B[exec/index.lib.tengo]
    B -->|feats.hasGpu| C[feats.lib.tengo]
    C -->|_isEnabled| D["plapi feature flag\n'gpuAvailable'"]
    B -->|builder| E[exec.builder API]
    E -->|.gpuMemory| F[GPU-enabled runner]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(workflow-tengo): re-export hasGpu f..."](https://github.com/milaboratory/platforma/commit/9f7b4728ef1410063e7b243a9fec4c595073f4f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31772210)</sub>

<!-- /greptile_comment -->