### PR TITLE
Fix/pl dataset selector inline enrichments

### DIFF
--- a/.changeset/pl-dataset-selector-filter-label.md
+++ b/.changeset/pl-dataset-selector-filter-label.md
@@ -1,0 +1,29 @@
+---
+"@platforma-sdk/model": patch
+"@platforma-sdk/ui-vue": patch
+---
+
+`PlDatasetSelector` filter rows used to render as the dataset's name (e.g.
+"Bulk") instead of the producing block's name (e.g. "Top 10"). Root cause:
+the parent dataset's trace ends with a high-importance
+`samples-and-data/dataset` step ("Bulk", importance 100); with a single
+filter `deriveDistinctLabels` had no peer to disambiguate against and
+picked that step.
+
+Fix: `filterMatchesToOptions` now includes the dataset spec as an extra
+entry when calling `deriveDistinctLabels`, then discards its label. The
+algorithm is forced to pick types that distinguish each filter from the
+dataset, surfacing the filter-specific trace step. Filter labels carry the
+dataset name as a prefix (e.g. "Bulk / Top 10"); `PlDatasetSelector` drops
+the now-redundant dataset-name subtitle on filter rows.
+
+Filter columns inherit the dataset's `pl7.app/label` annotation; the
+filter-discovery code now suppresses native labels via
+`formatters.native` so the algorithm reaches into the trace for
+disambiguation.
+
+`filterMatchesToOptions` signature: `(matches, options)` where
+`FilterMatchOptions = { refsByObjectId, datasetSpec }`. The previous
+trailing `labelOptions?` positional is removed — it had no real callers,
+and the function's native-label suppression is load-bearing so accepting
+arbitrary formatter overrides would risk regressing the fix.

--- a/.changeset/pldatasetselector-inline-enrichments.md
+++ b/.changeset/pldatasetselector-inline-enrichments.md
@@ -1,0 +1,7 @@
+---
+"@platforma-sdk/ui-vue": patch
+---
+
+`PlDatasetSelector`: carry `enrichments` inside the dropdown `Selection`
+value so `onChange` no longer needs a separate `findOption` lookup over
+`props.options`.

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -96,7 +96,10 @@ export function buildDatasetOptions(
       const filters =
         filterMatches.length === 0
           ? undefined
-          : filterMatchesToOptions(filterMatches, refMap, opts?.labelOptions);
+          : filterMatchesToOptions(filterMatches, {
+              refsByObjectId: refMap,
+              datasetSpec,
+            });
 
       let enrichments;
       if (enrichmentCollection && withEnrichments) {

--- a/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
+++ b/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
@@ -31,7 +31,11 @@ export type BuildDatasetOptions = {
    * accept-all.
    */
   filter?: SpecPredicateOption;
-  /** Formatting options for filter labels. */
+  /**
+   * Formatting options forwarded to label derivation for both filter and
+   * enrichment rows. `formatters.native` on the filter path is overridden
+   * — see `FilterMatchOptions.labelOptions`.
+   */
   labelOptions?: DeriveLabelsOptions;
   /**
    * Enables enrichment discovery and filters hits attached to
@@ -99,6 +103,7 @@ export function buildDatasetOptions(
           : filterMatchesToOptions(filterMatches, {
               refsByObjectId: refMap,
               datasetSpec,
+              labelOptions: opts?.labelOptions,
             });
 
       let enrichments;

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts
@@ -165,6 +165,24 @@ describe("filterMatchesToOptions", () => {
     const options = filterMatchesToOptions(matches, { refsByObjectId: refMap, datasetSpec });
     expect(options).toHaveLength(1);
     expect(options[0].label).toBe("Bulk / Top 10");
+
+    // Caller's `formatters.native` must NOT override the internal
+    // suppression — otherwise the algorithm short-circuits on the
+    // inherited "Selected Leads" label.
+    const withCustomNative = filterMatchesToOptions(matches, {
+      refsByObjectId: refMap,
+      datasetSpec,
+      labelOptions: { formatters: { native: (l) => `<<${l}>>` } },
+    });
+    expect(withCustomNative[0].label).toBe("Bulk / Top 10");
+
+    // Non-native label options (here `separator`) flow through.
+    const withSeparator = filterMatchesToOptions(matches, {
+      refsByObjectId: refMap,
+      datasetSpec,
+      labelOptions: { separator: " :: " },
+    });
+    expect(withSeparator[0].label).toBe("Bulk :: Top 10");
   });
 
   test("multiple filters with shared dataset trace disambiguate by filter-specific steps", () => {

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts
@@ -1,5 +1,5 @@
 import { Annotation, createPlRef } from "@milaboratories/pl-model-common";
-import type { AxisSpec, PColumnSpec, PlRef, PObjectId } from "@milaboratories/pl-model-common";
+import type { AxisSpec, PColumnSpec, PObjectId } from "@milaboratories/pl-model-common";
 import { SpecDriver } from "@milaboratories/pf-spec-driver";
 import canonicalize from "canonicalize";
 import { afterEach, describe, expect, test } from "vitest";
@@ -85,10 +85,7 @@ describe("buildRefMap", () => {
   test("maps canonicalized PlRef to original ref", () => {
     const ref1 = createPlRef("b1", "out1");
     const ref2 = createPlRef("b2", "out2", true);
-    const entries = [{ ref: ref1 }, { ref: ref2 }];
-
-    const map = buildRefMap(entries);
-
+    const map = buildRefMap([{ ref: ref1 }, { ref: ref2 }]);
     expect(map.get(canonicalize(ref1)! as PObjectId)).toBe(ref1);
     expect(map.get(canonicalize(ref2)! as PObjectId)).toBe(ref2);
     expect(map.size).toBe(2);
@@ -104,18 +101,10 @@ describe("filterMatchesToOptions", () => {
     const filterRef1 = createPlRef("b1", "filter-top1000");
     const filterRef2 = createPlRef("b1", "filter-highconf");
 
-    // Build ref map from entries (simulating result pool)
-    const refMap = buildRefMap([
-      { ref: anchorSnap.id as unknown as PlRef }, // anchor — won't be looked up
-      { ref: filterRef1 },
-      { ref: filterRef2 },
-    ]);
-
-    // Build filter specs with isSubset annotation
+    const refMap = buildRefMap([{ ref: filterRef1 }, { ref: filterRef2 }]);
     const filterSpec1 = spec("filter1", [axis("sample")], { [Annotation.IsSubset]: "true" });
     const filterSpec2 = spec("filter2", [axis("sample")], { [Annotation.IsSubset]: "true" });
 
-    // Use the canonical PlRef as the PObjectId (matches how result pool works)
     const f1Snap = snap(canonicalize(filterRef1)! as string, filterSpec1);
     const f2Snap = snap(canonicalize(filterRef2)! as string, filterSpec2);
 
@@ -126,7 +115,10 @@ describe("filterMatchesToOptions", () => {
     const matches = findFilterColumns(collection);
     expect(matches.length).toBe(2);
 
-    const options = filterMatchesToOptions(matches, refMap);
+    const options = filterMatchesToOptions(matches, {
+      refsByObjectId: refMap,
+      datasetSpec: anchorSpec,
+    });
     expect(options).toHaveLength(2);
     // Each option has a ref and label
     for (const opt of options) {
@@ -136,11 +128,96 @@ describe("filterMatchesToOptions", () => {
     }
   });
 
-  test("returns empty array for empty matches", () => {
-    expect(filterMatchesToOptions([], new Map())).toEqual([]);
+  test("single filter: dataset name prefixes the discriminating trace step", () => {
+    // Regression: without the dataset in the input, deriveDistinctLabels
+    // picks the highest-importance step it sees — the dataset's own
+    // `samples-and-data/dataset` step (importance 100) — and the filter
+    // shows "Bulk" instead of "Top 10". Appending the dataset forces the
+    // algorithm to include the lower-importance lead-selection step too.
+    const datasetSpec = spec("dataset", [axis("sample"), axis("gene")], {
+      [Annotation.Label]: "Bulk",
+      [Annotation.Trace]: JSON.stringify([
+        { type: "milaboratories.samples-and-data/dataset", label: "Bulk", importance: 100 },
+        { type: "milaboratories.mixcr-clonotyping", label: "MiXCR", importance: 20 },
+      ]),
+    });
+
+    const filterRef = createPlRef("b1", "filter");
+    const refMap = buildRefMap([{ ref: filterRef }]);
+    const filterSpec = spec("filter", [axis("sample")], {
+      [Annotation.IsSubset]: "true",
+      [Annotation.Label]: "Selected Leads",
+      [Annotation.Trace]: JSON.stringify([
+        { type: "milaboratories.samples-and-data/dataset", label: "Bulk", importance: 100 },
+        { type: "milaboratories.mixcr-clonotyping", label: "MiXCR", importance: 20 },
+        { type: "milaboratories.antibody-tcr-lead-selection", label: "Top 10", importance: 30 },
+      ]),
+    });
+    const fSnap = snap(canonicalize(filterRef)! as string, filterSpec);
+
+    const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
+    builder.addSource([fSnap, anchorSnap]);
+    const collection = builder.build({ anchors: { main: anchorSpec } })!;
+
+    const matches = findFilterColumns(collection);
+    expect(matches).toHaveLength(1);
+
+    const options = filterMatchesToOptions(matches, { refsByObjectId: refMap, datasetSpec });
+    expect(options).toHaveLength(1);
+    expect(options[0].label).toBe("Bulk / Top 10");
   });
 
-  test("skips entries whose ref is not found in map", () => {
+  test("multiple filters with shared dataset trace disambiguate by filter-specific steps", () => {
+    const datasetSpec = spec("dataset", [axis("sample"), axis("gene")], {
+      [Annotation.Label]: "Bulk",
+      [Annotation.Trace]: JSON.stringify([
+        { type: "milaboratories.samples-and-data/dataset", label: "Bulk", importance: 100 },
+        { type: "milaboratories.mixcr-clonotyping", label: "MiXCR", importance: 20 },
+      ]),
+    });
+
+    const ref1 = createPlRef("b1", "f1");
+    const ref2 = createPlRef("b2", "f2");
+    const refMap = buildRefMap([{ ref: ref1 }, { ref: ref2 }]);
+    const filterSpec1 = spec("filter1", [axis("sample")], {
+      [Annotation.IsSubset]: "true",
+      [Annotation.Label]: "Selected Leads",
+      [Annotation.Trace]: JSON.stringify([
+        { type: "milaboratories.samples-and-data/dataset", label: "Bulk", importance: 100 },
+        { type: "milaboratories.mixcr-clonotyping", label: "MiXCR", importance: 20 },
+        { type: "milaboratories.antibody-tcr-lead-selection", label: "Top 10", importance: 30 },
+      ]),
+    });
+    const filterSpec2 = spec("filter2", [axis("sample")], {
+      [Annotation.IsSubset]: "true",
+      [Annotation.Label]: "Selected Leads",
+      [Annotation.Trace]: JSON.stringify([
+        { type: "milaboratories.samples-and-data/dataset", label: "Bulk", importance: 100 },
+        { type: "milaboratories.mixcr-clonotyping", label: "MiXCR", importance: 20 },
+        { type: "milaboratories.antibody-tcr-lead-selection", label: "Top 11", importance: 30 },
+      ]),
+    });
+    const f1Snap = snap(canonicalize(ref1)! as string, filterSpec1);
+    const f2Snap = snap(canonicalize(ref2)! as string, filterSpec2);
+
+    const builder = new ColumnCollectionBuilder(createSpecFrameCtx());
+    builder.addSource([f1Snap, f2Snap, anchorSnap]);
+    const collection = builder.build({ anchors: { main: anchorSpec } })!;
+
+    const matches = findFilterColumns(collection);
+    expect(matches).toHaveLength(2);
+
+    const options = filterMatchesToOptions(matches, { refsByObjectId: refMap, datasetSpec });
+    expect(options.map((o) => o.label).sort()).toEqual(["Bulk / Top 10", "Bulk / Top 11"]);
+  });
+
+  test("returns empty array for empty matches", () => {
+    expect(
+      filterMatchesToOptions([], { refsByObjectId: new Map(), datasetSpec: anchorSpec }),
+    ).toEqual([]);
+  });
+
+  test("skips entries whose id is not in refsByObjectId", () => {
     const knownRef = createPlRef("b1", "known");
     const knownSpec = spec("known", [axis("sample")], { [Annotation.IsSubset]: "true" });
     const orphanSpec = spec("orphan", [axis("sample")], { [Annotation.IsSubset]: "true" });
@@ -153,9 +230,11 @@ describe("filterMatchesToOptions", () => {
 
     const matches = findFilterColumns(collection);
     expect(matches.length).toBe(2);
-
     const refMap = buildRefMap([{ ref: knownRef }]);
-    const options = filterMatchesToOptions(matches, refMap);
+    const options = filterMatchesToOptions(matches, {
+      refsByObjectId: refMap,
+      datasetSpec: anchorSpec,
+    });
     expect(options).toHaveLength(1);
     expect(options[0].ref).toBe(knownRef);
   });

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
@@ -38,40 +38,35 @@ export function filterMatchesToOptions(
 ): Option[] {
   if (matches.length === 0) return [];
 
-  // Refs and entries are built in parallel so the ref stays out of the
-  // labeling input. One Option per match-variant.
   const { refsByObjectId, datasetSpec } = options;
-  const refs: PlRef[] = [];
-  const entries: Entry[] = [];
-  for (const match of matches) {
+
+  // One entry per match-variant (different paths to the same column are
+  // exposed as separate Options). The `ref` field rides along on the
+  // Entry-shaped objects via structural typing; `deriveDistinctLabels`
+  // ignores extra fields.
+  const entries = matches.flatMap((match): (Entry & { ref: PlRef })[] => {
     const ref = refsByObjectId.get(match.column.id);
-    if (ref === undefined) continue;
-    for (const variant of match.variants) {
-      refs.push(ref);
-      entries.push({
-        spec: match.column.spec,
-        linkerPath: variant.path.map((p) => ({ spec: p.linker.spec })),
-      });
-    }
-  }
+    if (ref === undefined) return [];
+    return match.variants.map((variant) => ({
+      ref,
+      spec: match.column.spec,
+      linkerPath: variant.path.map((p) => ({ spec: p.linker.spec })),
+    }));
+  });
 
   // Appending the dataset forces a discriminating trace step into every
   // filter label (yielding e.g. "Bulk / Top 10"); the dataset's own label
-  // is dropped by indexing only `refs`. Native label is suppressed because
-  // filters inherit the dataset's `pl7.app/label` (often generic) and it
-  // would otherwise satisfy uniqueness before any trace step is consulted.
-  const allLabels = deriveDistinctLabels([...entries, { spec: datasetSpec }], {
+  // is dropped because we only zip `entries`. Native label is suppressed
+  // because filters inherit the dataset's `pl7.app/label` (often generic)
+  // and would otherwise satisfy uniqueness before any trace step.
+  const labels = deriveDistinctLabels([...entries, { spec: datasetSpec }], {
     formatters: { native: () => undefined },
   });
 
-  return refs.map((ref, i) => ({ ref, label: allLabels[i] }));
+  return entries.map(({ ref }, i) => ({ ref, label: labels[i] }));
 }
 
 /** Build the `refsByObjectId` map from `ctx.resultPool.getSpecs().entries`. */
 export function buildRefMap(entries: readonly { readonly ref: PlRef }[]): Map<PObjectId, PlRef> {
-  const map = new Map<PObjectId, PlRef>();
-  for (const entry of entries) {
-    map.set(canonicalize(entry.ref)! as PObjectId, entry.ref);
-  }
-  return map;
+  return new Map(entries.map((e) => [canonicalize(e.ref)! as PObjectId, e.ref]));
 }

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
@@ -5,7 +5,11 @@ import type {
   AnchoredColumnCollection,
   ColumnMatch,
 } from "../../columns/column_collection_builder";
-import { deriveDistinctLabels, type Entry } from "../../labels/derive_distinct_labels";
+import {
+  deriveDistinctLabels,
+  type DeriveLabelsOptions,
+  type Entry,
+} from "../../labels/derive_distinct_labels";
 
 /**
  * Columns annotated `pl7.app/isSubset: "true"` whose axes ⊆ anchor axes.
@@ -25,6 +29,13 @@ export type FilterMatchOptions = {
   refsByObjectId: ReadonlyMap<PObjectId, PlRef>;
   /** Spec of the dataset the filters are subsets of. */
   datasetSpec: PObjectSpec;
+  /**
+   * Forwarded to `deriveDistinctLabels`. Any `formatters.native` caller
+   * sets is silently overridden — the function relies on a no-op native
+   * formatter to keep the algorithm from short-circuiting on filters'
+   * inherited `pl7.app/label`.
+   */
+  labelOptions?: DeriveLabelsOptions;
 };
 
 /**
@@ -38,7 +49,7 @@ export function filterMatchesToOptions(
 ): Option[] {
   if (matches.length === 0) return [];
 
-  const { refsByObjectId, datasetSpec } = options;
+  const { refsByObjectId, datasetSpec, labelOptions } = options;
 
   // One entry per match-variant (different paths to the same column are
   // exposed as separate Options). The `ref` field rides along on the
@@ -56,11 +67,13 @@ export function filterMatchesToOptions(
 
   // Appending the dataset forces a discriminating trace step into every
   // filter label (yielding e.g. "Bulk / Top 10"); the dataset's own label
-  // is dropped because we only zip `entries`. Native label is suppressed
-  // because filters inherit the dataset's `pl7.app/label` (often generic)
-  // and would otherwise satisfy uniqueness before any trace step.
+  // is dropped because we only zip `entries`. Native label is force-
+  // suppressed (the override sits after caller's spread) — filters
+  // inherit the dataset's `pl7.app/label` and would otherwise satisfy
+  // uniqueness before any trace step is consulted.
   const labels = deriveDistinctLabels([...entries, { spec: datasetSpec }], {
-    formatters: { native: () => undefined },
+    ...labelOptions,
+    formatters: { ...labelOptions?.formatters, native: () => undefined },
   });
 
   return entries.map(({ ref }, i) => ({ ref, label: labels[i] }));

--- a/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/filter_discovery.ts
@@ -1,23 +1,15 @@
 import { Annotation } from "@milaboratories/pl-model-common";
-import type { Option, PlRef, PObjectId } from "@milaboratories/pl-model-common";
+import type { Option, PlRef, PObjectId, PObjectSpec } from "@milaboratories/pl-model-common";
 import canonicalize from "canonicalize";
 import type {
   AnchoredColumnCollection,
   ColumnMatch,
 } from "../../columns/column_collection_builder";
-import {
-  deriveDistinctLabels,
-  type DeriveLabelsOptions,
-  type Entry,
-} from "../../labels/derive_distinct_labels";
+import { deriveDistinctLabels, type Entry } from "../../labels/derive_distinct_labels";
 
 /**
- * Matches columns annotated `pl7.app/isSubset: "true"` whose axes ⊆ anchor axes.
- *
- * The axes-subset constraint is enforced by `mode: "enrichment"`, which sets
- * `allowFloatingHitAxes: false` — every axis of the matched column must be
- * present in the anchor's axes. See `matchingModeToConstraints()` in
- * `column_collection_builder.ts`.
+ * Columns annotated `pl7.app/isSubset: "true"` whose axes ⊆ anchor axes.
+ * The axes-subset constraint comes from `mode: "enrichment"`.
  */
 export function findFilterColumns(collection: AnchoredColumnCollection): ColumnMatch[] {
   return collection.findColumns({
@@ -28,47 +20,54 @@ export function findFilterColumns(collection: AnchoredColumnCollection): ColumnM
   });
 }
 
+export type FilterMatchOptions = {
+  /** Maps result-pool column id back to its source PlRef (see {@link buildRefMap}). */
+  refsByObjectId: ReadonlyMap<PObjectId, PlRef>;
+  /** Spec of the dataset the filters are subsets of. */
+  datasetSpec: PObjectSpec;
+};
+
 /**
- * Derive labeled options from filter column matches, for use in DatasetOption.filters.
- *
- * Entries whose column id has no PlRef in `refsByObjectId` are silently
- * skipped — they cannot be exposed as user-selectable options.
- *
- * @param matches - from findFilterColumns()
- * @param refsByObjectId - from {@link buildRefMap}
- * @param labelOptions - forwarded to deriveDistinctLabels()
+ * Derive labels for filter column matches (for `DatasetOption.filters`).
+ * Matches whose column id is missing from `refsByObjectId` are silently
+ * dropped — they cannot be exposed as selectable options.
  */
 export function filterMatchesToOptions(
   matches: ColumnMatch[],
-  refsByObjectId: ReadonlyMap<PObjectId, PlRef>,
-  labelOptions?: DeriveLabelsOptions,
+  options: FilterMatchOptions,
 ): Option[] {
   if (matches.length === 0) return [];
 
-  // Each ColumnMatch can be reached via multiple variants (different linker
-  // paths / qualifications). We emit one Option per variant so the user can
-  // pick a specific path — `deriveDistinctLabels` disambiguates labels by
-  // path. All variants of a match share a column id, so the ref lookup
-  // happens once per match.
-  const flattened = matches.flatMap((match) => {
+  // Refs and entries are built in parallel so the ref stays out of the
+  // labeling input. One Option per match-variant.
+  const { refsByObjectId, datasetSpec } = options;
+  const refs: PlRef[] = [];
+  const entries: Entry[] = [];
+  for (const match of matches) {
     const ref = refsByObjectId.get(match.column.id);
-    if (ref === undefined) return [];
-    return match.variants.map((variant) => ({ match, variant, ref }));
+    if (ref === undefined) continue;
+    for (const variant of match.variants) {
+      refs.push(ref);
+      entries.push({
+        spec: match.column.spec,
+        linkerPath: variant.path.map((p) => ({ spec: p.linker.spec })),
+      });
+    }
+  }
+
+  // Appending the dataset forces a discriminating trace step into every
+  // filter label (yielding e.g. "Bulk / Top 10"); the dataset's own label
+  // is dropped by indexing only `refs`. Native label is suppressed because
+  // filters inherit the dataset's `pl7.app/label` (often generic) and it
+  // would otherwise satisfy uniqueness before any trace step is consulted.
+  const allLabels = deriveDistinctLabels([...entries, { spec: datasetSpec }], {
+    formatters: { native: () => undefined },
   });
 
-  const entries: Entry[] = flattened.map(({ match, variant }) => ({
-    spec: match.column.spec,
-    linkerPath: variant.path.map((p) => ({ spec: p.linker.spec })),
-  }));
-
-  const labels = deriveDistinctLabels(entries, labelOptions);
-
-  return flattened.map(({ ref }, i) => ({ ref, label: labels[i] }));
+  return refs.map((ref, i) => ({ ref, label: allLabels[i] }));
 }
 
-/**
- * Usage: `buildRefMap(ctx.resultPool.getSpecs().entries)`
- */
+/** Build the `refsByObjectId` map from `ctx.resultPool.getSpecs().entries`. */
 export function buildRefMap(entries: readonly { readonly ref: PlRef }[]): Map<PObjectId, PlRef> {
   const map = new Map<PObjectId, PlRef>();
   for (const entry of entries) {

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -19,8 +19,13 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import type { DatasetOption, DatasetSelection, PlRef } from "@platforma-sdk/model";
-import { createDatasetSelection, createPrimaryRef, plRefsEqual } from "@platforma-sdk/model";
+import type {
+  DatasetOption,
+  DatasetSelection,
+  LabeledEnrichmentRefs,
+  PlRef,
+} from "@platforma-sdk/model";
+import { createDatasetSelection, createPrimaryRef } from "@platforma-sdk/model";
 import type { ListOption } from "@milaboratories/uikit";
 import { PlDropdown } from "@milaboratories/uikit";
 import { computed } from "vue";
@@ -65,38 +70,47 @@ const props = withDefaults(
   },
 );
 
-type Selection = { primary: PlRef; filter?: PlRef };
+type Selection = { primary: PlRef; filter?: PlRef; enrichments?: LabeledEnrichmentRefs };
+
+// `deepEqual` (used by PlDropdown for matching) treats `{a, b: undefined}` and
+// `{a}` as different shapes, so the option list and the selection value must
+// agree on optional-key presence.
+function makeSelection(
+  primary: PlRef,
+  filter: PlRef | undefined,
+  enrichments: LabeledEnrichmentRefs | undefined,
+): Selection {
+  return {
+    primary,
+    ...(filter !== undefined && { filter }),
+    ...(enrichments !== undefined && enrichments.length > 0 && { enrichments }),
+  };
+}
 
 const selectionValue = computed<Selection | undefined>(() => {
   const primary = model.value?.primary;
   if (primary === undefined) return undefined;
-  return primary.filter === undefined
-    ? { primary: primary.column }
-    : { primary: primary.column, filter: primary.filter };
+  return makeSelection(primary.column, primary.filter, model.value?.enrichments);
 });
 
-// `deepEqual` (used by PlDropdown for matching) treats `{a, b: undefined}` and
-// `{a}` as different shapes, so the option list and the selection value must
-// agree on filter-key presence.
 const dropdownOptions = computed<ListOption<Selection>[] | undefined>(() => {
   if (props.options === undefined) return undefined;
   const out: ListOption<Selection>[] = [];
   for (const o of props.options) {
-    out.push({ label: o.primary.label, value: { primary: o.primary.ref } });
+    out.push({
+      label: o.primary.label,
+      value: makeSelection(o.primary.ref, undefined, o.enrichments),
+    });
     for (const filter of o.filters ?? []) {
       out.push({
         label: filter.label,
         description: o.primary.label,
-        value: { primary: o.primary.ref, filter: filter.ref },
+        value: makeSelection(o.primary.ref, filter.ref, o.enrichments),
       });
     }
   }
   return out;
 });
-
-function findOption(primary: PlRef): DatasetOption | undefined {
-  return props.options?.find((o) => plRefsEqual(o.primary.ref, primary, true));
-}
 
 function onChange(selection: Selection | undefined) {
   if (selection === undefined) {
@@ -105,7 +119,7 @@ function onChange(selection: Selection | undefined) {
   }
   model.value = createDatasetSelection(
     createPrimaryRef(selection.primary, selection.filter),
-    findOption(selection.primary)?.enrichments,
+    selection.enrichments,
   );
 }
 </script>

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -19,7 +19,7 @@ import type {
   LabeledEnrichmentRefs,
   PlRef,
 } from "@platforma-sdk/model";
-import { createDatasetSelection, createPrimaryRef } from "@platforma-sdk/model";
+import { createDatasetSelection, createPrimaryRef, plRefsEqual } from "@platforma-sdk/model";
 import type { ListOption } from "@milaboratories/uikit";
 import { PlDropdown } from "@milaboratories/uikit";
 import { computed } from "vue";
@@ -84,7 +84,12 @@ function makeSelection(
 const selectionValue = computed<Selection | undefined>(() => {
   const primary = model.value?.primary;
   if (primary === undefined) return undefined;
-  return makeSelection(primary.column, primary.filter, model.value?.enrichments);
+  // Read enrichments from the current option, not from `model.value`: the
+  // stored enrichments are a snapshot at selection time and won't match
+  // `dropdownOptions` after `props.options` recomputes (e.g. when the
+  // result pool gains or loses an enrichment column).
+  const option = props.options?.find((o) => plRefsEqual(o.primary.ref, primary.column, true));
+  return makeSelection(primary.column, primary.filter, option?.enrichments);
 });
 
 const dropdownOptions = computed<ListOption<Selection>[] | undefined>(() => {

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -1,17 +1,11 @@
 <script lang="ts">
 /**
  * Select a dataset or one of its filters in a single dropdown, emitting a
- * {@link DatasetSelection}.
- *
- * Each `DatasetOption` contributes one row for its primary plus one row per
- * filter — filters are listed directly underneath their parent dataset and
- * carry the parent's primary label as the row description. Filter labels are
- * derived by `buildDatasetOptions` from each filter column's latest
- * `pl7.app/trace` step (the producing block's self-description).
- *
- * The emitted value bundles the user's pick (`primary`) with the auto-attached
- * `enrichments` payload from the matching `DatasetOption`. Enrichments are
- * opaque to the UI — block authors unbundle them inside their args resolver.
+ * {@link DatasetSelection}. Filter labels carry the dataset name as a
+ * prefix (e.g. "Bulk / Top 10"), so no separate subtitle is rendered.
+ * Enrichments from the matching `DatasetOption` are bundled into the
+ * emitted value opaquely — block authors unbundle them in their args
+ * resolver.
  */
 export default {
   name: "PlDatasetSelector",
@@ -104,7 +98,6 @@ const dropdownOptions = computed<ListOption<Selection>[] | undefined>(() => {
     for (const filter of o.filters ?? []) {
       out.push({
         label: filter.label,
-        description: o.primary.label,
         value: makeSelection(o.primary.ref, filter.ref, o.enrichments),
       });
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related `PlDatasetSelector` bugs: filter rows incorrectly showed the parent dataset name ("Bulk") instead of the producing block's label ("Top 10"), and the Vue component performed a redundant `findOption` scan over `props.options` on every selection change.

- **Filter label fix**: `filterMatchesToOptions` now appends the dataset spec as a sentinel entry to `deriveDistinctLabels`, forcing the algorithm to reach into a filter-specific trace step; the sentinel's own label is discarded. Native label suppression (`formatters.native: () => undefined`) prevents inherited `pl7.app/label` values from satisfying uniqueness before any trace step is reached. Two regression tests cover the single-filter and multi-filter disambiguation cases.
- **Inline enrichments**: The `Selection` type gains an `enrichments` field; `makeSelection` keeps key presence consistent for `deepEqual` matching. Every dropdown option now embeds the parent `DatasetOption`'s enrichments directly in its value, removing the `findOption` lookup in `onChange`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the filter-label algorithm change is well-covered by focused regression tests, and the inline-enrichments refactor simplifies the selection path.

Both changes are narrow and well-tested. The label-derivation fix appends a sentinel dataset entry whose label is safely discarded via index-bounded mapping. The enrichments embedding removes an O(N) scan that was error-prone and replaces it with data that is already in scope at option-build time. No new uncovered logic paths were introduced.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDatasetSelector/filter_discovery.ts | Refactors filterMatchesToOptions to accept FilterMatchOptions, appends the dataset spec to deriveDistinctLabels input to force trace-step disambiguation, and suppresses native labels so filters with inherited pl7.app/label don't prematurely satisfy uniqueness. |
| sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts | Updated call site passes the new FilterMatchOptions object; labelOptions field in BuildDatasetOptions still has a stale JSDoc comment ("filter labels") since it now only flows to enrichment labelling. |
| sdk/model/src/components/PlDatasetSelector/filter_discovery.test.ts | Adds two focused regression tests (single-filter dataset-name prefix and multi-filter disambiguation) and updates all existing test call sites to the new FilterMatchOptions shape. |
| sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue | Adds enrichments to the Selection type, introduces makeSelection to keep deepEqual-safe key presence, embeds enrichments in every dropdown option value, and removes the findOption lookup in onChange — eliminating the extra scan over props.options on every selection change. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["buildDatasetOptions(ctx)"] --> B["findFilterColumns(filterCollection)"]
    B --> C["filterMatchesToOptions(matches, FilterMatchOptions)"]
    C --> D["Build entries array\n(one per match variant with ref)"]
    D --> E["deriveDistinctLabels(\n  [...entries, datasetSpec],\n  { native: () => undefined }\n)"]
    E --> F["labels[0..N-1] → filter labels\nlabels[N] → dataset label (dropped)"]
    F --> G["Option[] with 'Bulk / Top 10' style labels"]
    G --> H["DatasetOption.filters"]
    A --> I["findEnrichmentColumns(enrichmentCollection)"]
    I --> J["enrichmentVariantsToRefs(variants, labelOptions)"]
    J --> K["DatasetOption.enrichments"]
    H --> L["PlDatasetSelector.vue\ndropdownOptions computed"]
    K --> L
    L --> M["makeSelection(primary, filter?, enrichments?)\nfor each option row"]
    M --> N["PlDropdown\n(deepEqual match via Selection shape)"]
    N --> O["onChange(selection)"]
    O --> P["createDatasetSelection(\n  createPrimaryRef(...),\n  selection.enrichments\n)"]
    P --> Q["model.value emitted\n(DatasetSelection with inline enrichments)"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts`, line 34-35 ([link](https://github.com/milaboratory/platforma/blob/f468f6634218b5b27d2b160d7d26914f39370ccb/sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts#L34-L35)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The JSDoc says "filter labels" but `labelOptions` is no longer forwarded to `filterMatchesToOptions` — it is now only used for enrichment labels via `enrichmentVariantsToRefs`. The stale comment will mislead callers who try to customise filter label formatting through this field.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/model/src/components/PlDatasetSelector/build_dataset_options.ts
   Line: 34-35

   Comment:
   The JSDoc says "filter labels" but `labelOptions` is no longer forwarded to `filterMatchesToOptions` — it is now only used for enrichment labels via `enrichmentVariantsToRefs`. The stale comment will mislead callers who try to customise filter label formatting through this field.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["PlDatasetSelector: functional style in f..."](https://github.com/milaboratory/platforma/commit/1b0ddafef260501dfe62713b965a35d4d8b2c516) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31947424)</sub>

<!-- /greptile_comment -->