### PR TITLE
Fix/correct deriving labels if we have duplicated columns in pool

### DIFF
--- a/.changeset/fix-pframe-survive-incomplete-data.md
+++ b/.changeset/fix-pframe-survive-incomplete-data.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Tolerate incomplete PColumn data when building PFrames: on parse failure (e.g. resource not ready, partial fields), fall back to empty `JsonDataInfo` for that column instead of failing the whole frame.

--- a/.changeset/fix-redundant-linker-suffix.md
+++ b/.changeset/fix-redundant-linker-suffix.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Fix `deriveDistinctLabels` adding redundant "via …" linker suffix to records whose native label is already unique when other records collide on a shared linker.

--- a/lib/node/pl-middle-layer/src/pool/data.ts
+++ b/lib/node/pl-middle-layer/src/pool/data.ts
@@ -100,8 +100,8 @@ const BinaryPartitionedValuesFieldSuffix = ".values";
 
 export function parseDataInfoResource(
   data: PlTreeNodeAccessor,
-): PFrameInternal.DataInfo<BlobResourceRef> {
-  if (!data.getIsReadyOrError()) throw new PFrameDriverError("Data not ready.");
+): undefined | PFrameInternal.DataInfo<BlobResourceRef> {
+  if (!data.getIsReadyOrError()) return undefined;
 
   const resourceData = data.getDataAsJson();
   if (resourceData === undefined)

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -312,13 +312,15 @@ export async function createPFrameDriver(params: {
   });
 
   const resolveDataInfo = (spec: PColumnSpec, data: PColumnDataUniversal<PlTreeNodeAccessor>) => {
-    return isPlTreeNodeAccessor(data)
-      ? parseDataInfoResource(data)
-      : isDataInfo(data)
-        ? data.type === "ParquetPartitioned"
-          ? mapDataInfo(data, (a) => traverseParquetChunkResource(a))
-          : mapDataInfo(data, (a) => makeLocalBlobRef(a))
-        : makeJsonDataInfo(spec, data);
+    if (isPlTreeNodeAccessor(data)) {
+      return parseDataInfoResource(data) ?? makeJsonDataInfo(spec, []);
+    }
+
+    return isDataInfo(data)
+      ? data.type === "ParquetPartitioned"
+        ? mapDataInfo(data, (a) => traverseParquetChunkResource(a))
+        : mapDataInfo(data, (a) => makeLocalBlobRef(a))
+      : makeJsonDataInfo(spec, data);
   };
 
   return new AbstractPFrameDriver({

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -706,6 +706,28 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
     expect(deriveDistinctLabels(entries)).toEqual(["Read counts", "Read counts via Sample mapper"]);
   });
 
+  test("linker suffix is NOT added to records whose native label is already unique, even when other records collide", () => {
+    // Repro for "Cluster Id via Clone to cluster link" bug:
+    // - "Representative Sequence" exists both as a direct column and via a linker → collision
+    //   forces algorithm to include LINKER_TYPE in the type set.
+    // - As a side effect, every linked entry gets the "via …" suffix appended — including
+    //   ones whose native label ("Cluster Id") is unique and needs no disambiguation.
+    const linker = linkerSpec("Clone to cluster link");
+    const entries: Entry[] = [
+      { spec: labeledSpec("Representative Sequence", "rep_direct") },
+      {
+        spec: labeledSpec("Representative Sequence", "rep_linked"),
+        linkerPath: [{ spec: linker }],
+      },
+      { spec: labeledSpec("Cluster Id", "cluster_id"), linkerPath: [{ spec: linker }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Representative Sequence",
+      "Representative Sequence via Clone to cluster link",
+      "Cluster Id",
+    ]);
+  });
+
   test("two linker paths → both get distinguishing via-suffix", () => {
     const s = labeledSpec("Counts");
     const entries: Entry[] = [

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -152,7 +152,16 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
         forcedSet,
         separator,
       );
-      return build(minimized, false) ?? throwError("Failed to derive unique labels");
+      const minimizedLabels =
+        build(minimized, false) ?? throwError("Failed to derive unique labels");
+      return dropRedundantLinkerSuffix(
+        records,
+        minimized,
+        forceTraceElements,
+        forcedSet,
+        separator,
+        minimizedLabels,
+      );
     }
 
     additionalType++;
@@ -171,7 +180,15 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
     forcedSet,
     separator,
   );
-  return build(minimized, true) ?? throwError("Failed to derive unique labels");
+  const minimizedLabels = build(minimized, true) ?? throwError("Failed to derive unique labels");
+  return dropRedundantLinkerSuffix(
+    records,
+    minimized,
+    forceTraceElements,
+    forcedSet,
+    separator,
+    minimizedLabels,
+  );
 }
 
 // --- Pure helpers ---
@@ -359,6 +376,44 @@ function classifyTypes(
   return { mainTypes, secondaryTypes };
 }
 
+function renderRecordLabel(
+  record: EnrichedRecord,
+  includedTypes: Set<string>,
+  forceTraceElements: Set<string> | undefined,
+  separator: string,
+): string | undefined {
+  const traceParts: string[] = [];
+  const anchorParts: string[] = [];
+  let linkerLabel: string | undefined;
+  let hitLabel: string | undefined;
+
+  for (const ft of record.fullTrace) {
+    if (!(includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type))) continue;
+    if (ft.type === LINKER_TYPE) linkerLabel = ft.label;
+    else if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
+    else if (isAnchorQualType(ft.type)) anchorParts.push(ft.label);
+    else traceParts.push(ft.label);
+  }
+
+  const isEmpty =
+    traceParts.length === 0 &&
+    anchorParts.length === 0 &&
+    linkerLabel === undefined &&
+    hitLabel === undefined;
+
+  if (isEmpty) return undefined;
+
+  let label = traceParts.join(separator);
+  const append = (part: string) => {
+    label = label.length === 0 ? part : `${label} ${part}`;
+  };
+  if (linkerLabel !== undefined) append(linkerLabel);
+  for (const a of anchorParts) append(a);
+  if (hitLabel !== undefined) append(hitLabel);
+
+  return label;
+}
+
 function buildLabels(
   records: EnrichedRecord[],
   includedTypes: Set<string>,
@@ -369,43 +424,58 @@ function buildLabels(
   const result: string[] = [];
 
   for (const r of records) {
-    const traceParts: string[] = [];
-    const anchorParts: string[] = [];
-    let linkerLabel: string | undefined;
-    let hitLabel: string | undefined;
-
-    for (const ft of r.fullTrace) {
-      if (!(includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type))) continue;
-      if (ft.type === LINKER_TYPE) linkerLabel = ft.label;
-      else if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
-      else if (isAnchorQualType(ft.type)) anchorParts.push(ft.label);
-      else traceParts.push(ft.label);
-    }
-
-    const isEmpty =
-      traceParts.length === 0 &&
-      anchorParts.length === 0 &&
-      linkerLabel === undefined &&
-      hitLabel === undefined;
-
-    if (isEmpty) {
+    const rendered = renderRecordLabel(r, includedTypes, forceTraceElements, separator);
+    if (rendered === undefined) {
       if (!force) return undefined;
       result.push("Unlabeled");
       continue;
     }
-
-    let label = traceParts.join(separator);
-    const append = (part: string) => {
-      label = label.length === 0 ? part : `${label} ${part}`;
-    };
-    if (linkerLabel !== undefined) append(linkerLabel);
-    for (const a of anchorParts) append(a);
-    if (hitLabel !== undefined) append(hitLabel);
-
-    result.push(label);
+    result.push(rendered);
   }
 
   return result;
+}
+
+/**
+ * Drop the "via …" linker suffix from records whose label is already unique without it.
+ *
+ * Global minimization may include `LINKER_TYPE_FULL` solely to resolve a collision between a
+ * subset of records — but `buildLabels` then renders the suffix on every record that carries a
+ * linker trace entry, including ones whose stem is already unique. We strip the suffix where it
+ * isn't load-bearing while keeping the symmetric rendering required by `linkerForced` /
+ * `forceTraceElements`.
+ *
+ * Rule: a record's linker suffix is redundant iff its stem (label rendered without LINKER) does
+ * not appear anywhere else in the set.
+ */
+function dropRedundantLinkerSuffix(
+  records: EnrichedRecord[],
+  globalTypeSet: Set<string>,
+  forceTraceElements: Set<string> | undefined,
+  forcedSet: Set<string>,
+  separator: string,
+  labels: string[],
+): string[] {
+  if (!globalTypeSet.has(LINKER_TYPE_FULL)) return labels;
+  if (forcedSet.has(LINKER_TYPE_FULL) || forceTraceElements?.has(LINKER_TYPE)) return labels;
+
+  const setWithoutLinker = new Set(globalTypeSet);
+  setWithoutLinker.delete(LINKER_TYPE_FULL);
+
+  const stems = records.map((r) =>
+    renderRecordLabel(r, setWithoutLinker, forceTraceElements, separator),
+  );
+
+  const stemOccurrences = new Map<string, number>();
+  for (const s of stems) {
+    if (s !== undefined) stemOccurrences.set(s, (stemOccurrences.get(s) ?? 0) + 1);
+  }
+
+  return labels.map((label, i) => {
+    const stem = stems[i];
+    if (stem === undefined) return label;
+    return stemOccurrences.get(stem) === 1 ? stem : label;
+  });
 }
 
 function countUniqueLabels(result: string[] | undefined): number {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent bugs: (1) `deriveDistinctLabels` was adding a redundant \"via …\" linker suffix to records whose native label was already unique when other records shared a different collision, and (2) `parseDataInfoResource` now tolerates incomplete/not-ready PColumn data by returning `undefined` and falling back to empty `JsonDataInfo` instead of throwing.

- **`derive_distinct_labels.ts`**: Extracts `renderRecordLabel` from `buildLabels`, then adds `dropRedundantLinkerSuffix` which removes the \"via …\" suffix from records whose stem is already unique — guarded by `forcedSet` and `forceTraceElements`.
- **`data.ts` / `driver.ts`**: `parseDataInfoResource` signature widens to `undefined | DataInfo<BlobResourceRef>`; the single call site uses `?? makeJsonDataInfo(spec, [])` as fallback.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The `data.ts`/`driver.ts` change is a clean resilience fix; the label-derivation change is correct for all standard inputs but has a narrow uniqueness gap in `dropRedundantLinkerSuffix`.

Both fixes address real bugs and are accompanied by tests. The pool data change is straightforward. The label-derivation change is logically sound for all standard use-cases, but `dropRedundantLinkerSuffix` can produce duplicate labels in a narrow edge case involving `"via "`-prefixed native labels or custom linker formatters.

sdk/model/src/labels/derive_distinct_labels.ts — the `dropRedundantLinkerSuffix` uniqueness invariant is worth a second look for the edge case described in the review comment.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/labels/derive_distinct_labels.ts | Core fix: adds `renderRecordLabel` (extracted) and `dropRedundantLinkerSuffix`; uniqueness invariant is preserved in the common case but has a narrow edge case with custom `formatters.linker` or "via "-prefixed native labels. |
| sdk/model/src/labels/derive_distinct_labels.test.ts | Adds a targeted regression test for the "Cluster Id via Clone to cluster link" bug; existing tests for forced linker and two-path cases are preserved. |
| lib/node/pl-middle-layer/src/pool/data.ts | Return type of `parseDataInfoResource` widened to `undefined | DataInfo`; not-ready path now returns undefined instead of throwing. |
| lib/node/pl-middle-layer/src/pool/driver.ts | Call site updated to handle the new `undefined` return with `?? makeJsonDataInfo(spec, [])` fallback; only one caller exists so the change is fully contained. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["deriveDistinctLabels(entries)"] --> B{mainTypes empty?}
    B -- Yes --> C["build with LABEL_TYPE_FULL, force=true"]
    B -- No --> D["Iterate over type combinations"]
    D --> E{candidateResult unique?}
    E -- No --> D
    E -- Yes --> F["minimizeTypeSet(currentSet)"]
    F --> G["build(minimized, false)"]
    G --> H["dropRedundantLinkerSuffix(...)"]
    H --> I{LINKER_TYPE_FULL in set?}
    I -- No --> J["return labels unchanged"]
    I -- Yes --> K{forcedSet or forceTraceElements has LINKER?}
    K -- Yes --> J
    K -- No --> L["Compute stems without linker"]
    L --> M["Count stem occurrences"]
    M --> N["stem unique? use stem : keep full label"]
    N --> O["Return final labels"]

    P["parseDataInfoResource(data)"] --> Q{data.getIsReadyOrError?}
    Q -- No --> R["return undefined"]
    Q -- Yes --> S["parse and return DataInfo"]

    T["resolveDataInfo(spec, data)"] --> U{isPlTreeNodeAccessor?}
    U -- Yes --> V["parseDataInfoResource(data)"]
    V --> W{undefined?}
    W -- Yes --> X["makeJsonDataInfo(spec, []) fallback"]
    W -- No --> Y["use DataInfo"]
    U -- No --> Z{isDataInfo?}
    Z -- Yes --> AA["map DataInfo"]
    Z -- No --> AB["makeJsonDataInfo(spec, data)"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/model/src/labels/derive_distinct_labels.ts:451-479
**Potential uniqueness violation when a stem matches another record's full label**

`dropRedundantLinkerSuffix` guarantees uniqueness only when every record whose linker-only content equals another record's stem also has a non-`undefined` stem. There is a narrow counter-example even with the default formatter: if a native label happens to start with `"via "` (e.g. `"via Clone to cluster link"`) and another record has only a linker trace entry producing the same string (`"via Clone to cluster link"`), then:

1. Record A: stem = `"via Clone to cluster link"` (count = 1) → stripped to `"via Clone to cluster link"`.
2. Record B: stem = `undefined` (linker-only) → kept at its full label `"via Clone to cluster link"`.

Both labels become `"via Clone to cluster link"`, breaking uniqueness. The same pattern applies whenever a custom `formatters.linker` omits the `"via "` prefix and its output matches a native label.

A guard such as checking that `stems[i]` does not appear in any other record's full label before accepting the substitution would make the invariant unconditional.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset for PFrame incomplete-d..."](https://github.com/milaboratory/platforma/commit/9b404b88776cf8680a274c62b1416cdcc15b0111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31968308)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->