### PR TITLE
Fix: pframe survive incomplete data

### DIFF
--- a/.changeset/fix-pframe-survive-incomplete-data.md
+++ b/.changeset/fix-pframe-survive-incomplete-data.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Tolerate incomplete PColumn data when building PFrames: on parse failure (e.g. resource not ready, partial fields), fall back to empty `JsonDataInfo` for that column instead of failing the whole frame.

--- a/lib/node/pl-middle-layer/src/pool/data.ts
+++ b/lib/node/pl-middle-layer/src/pool/data.ts
@@ -100,8 +100,8 @@ const BinaryPartitionedValuesFieldSuffix = ".values";
 
 export function parseDataInfoResource(
   data: PlTreeNodeAccessor,
-): PFrameInternal.DataInfo<BlobResourceRef> {
-  if (!data.getIsReadyOrError()) throw new PFrameDriverError("Data not ready.");
+): undefined | PFrameInternal.DataInfo<BlobResourceRef> {
+  if (!data.getIsReadyOrError()) return undefined;
 
   const resourceData = data.getDataAsJson();
   if (resourceData === undefined)

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -312,13 +312,15 @@ export async function createPFrameDriver(params: {
   });
 
   const resolveDataInfo = (spec: PColumnSpec, data: PColumnDataUniversal<PlTreeNodeAccessor>) => {
-    return isPlTreeNodeAccessor(data)
-      ? parseDataInfoResource(data)
-      : isDataInfo(data)
-        ? data.type === "ParquetPartitioned"
-          ? mapDataInfo(data, (a) => traverseParquetChunkResource(a))
-          : mapDataInfo(data, (a) => makeLocalBlobRef(a))
-        : makeJsonDataInfo(spec, data);
+    if (isPlTreeNodeAccessor(data)) {
+      return parseDataInfoResource(data) ?? makeJsonDataInfo(spec, []);
+    }
+
+    return isDataInfo(data)
+      ? data.type === "ParquetPartitioned"
+        ? mapDataInfo(data, (a) => traverseParquetChunkResource(a))
+        : mapDataInfo(data, (a) => makeLocalBlobRef(a))
+      : makeJsonDataInfo(spec, data);
   };
 
   return new AbstractPFrameDriver({


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes PFrame construction resilient to columns whose backing resources haven't loaded yet. Instead of throwing `PFrameDriverError("Data not ready.")` and aborting the whole frame, the driver now substitutes an empty `JsonDataInfo` for any not-ready column, allowing the rest of the frame to be served immediately.

- `parseDataInfoResource` in `data.ts` changes its return type to `undefined | DataInfo<BlobResourceRef>`, returning `undefined` only when `getIsReadyOrError()` is false; all other error paths (unsupported type, missing JSON, partial fields) still throw.
- `resolveDataInfo` in `driver.ts` uses the nullish-coalescing operator to replace a `undefined` result with `makeJsonDataInfo(spec, [])`, producing an empty column. The `PFramePool` key is derived from column data content, so the pool will naturally create a fresh frame with real data once the resource transitions to ready.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The fallback to empty data is narrowly scoped to the not-yet-ready case, all other error paths still throw, and the PFramePool key derivation ensures the frame is rebuilt once the resource becomes ready.

The change is small and focused, with correct type-safety throughout. The only outstanding item is the absence of a diagnostic log at the fallback site in driver.ts, which would help distinguish transient loading from a permanently stuck resource.

lib/node/pl-middle-layer/src/pool/driver.ts — the fallback line in resolveDataInfo would benefit from a debug log for observability.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/pool/data.ts | parseDataInfoResource now returns undefined instead of throwing when the resource is not yet ready (getIsReadyOrError() is false); all other error paths still throw. |
| lib/node/pl-middle-layer/src/pool/driver.ts | resolveDataInfo uses the ?? operator to substitute makeJsonDataInfo(spec, []) when parseDataInfoResource returns undefined; no diagnostic logging at the fallback site. |
| .changeset/fix-pframe-survive-incomplete-data.md | Changeset entry for the patch; description is mostly accurate though it mentions "partial fields" as a handled case when the code only handles the not-ready state. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant resolveDataInfo
    participant parseDataInfoResource
    participant makeJsonDataInfo
    participant PFramePool

    Caller->>resolveDataInfo: spec, PlTreeNodeAccessor
    resolveDataInfo->>parseDataInfoResource: data accessor
    alt resource not ready
        parseDataInfoResource-->>resolveDataInfo: undefined
        resolveDataInfo->>makeJsonDataInfo: spec, []
        makeJsonDataInfo-->>resolveDataInfo: empty JsonDataInfo
        resolveDataInfo-->>PFramePool: empty DataInfo
    else resource ready or error
        parseDataInfoResource-->>resolveDataInfo: DataInfo or throws
        resolveDataInfo-->>PFramePool: real DataInfo
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/node/pl-middle-layer/src/pool/driver.ts:315-317
No diagnostic is emitted when the fallback to empty data is triggered. Since `logger` is already in scope, a single line here would make it much easier to distinguish between "resource is still loading" and "resource is permanently stuck" when debugging unexpected empty columns in production.

```suggestion
    if (isPlTreeNodeAccessor(data)) {
      const dataInfo = parseDataInfoResource(data);
      if (dataInfo === undefined) {
        logger("debug", `PColumn resource not ready, falling back to empty JsonDataInfo`);
        return makeJsonDataInfo(spec, []);
      }
      return dataInfo;
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: changeset for PFrame incomplete-d..."](https://github.com/milaboratory/platforma/commit/365884c827f4446f3b9b32eb3320df8025d9fcac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31983320)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->