### PR TITLE
PlDatasetSelector - returned description for filter variants

### DIFF
--- a/.changeset/purple-donuts-fold.md
+++ b/.changeset/purple-donuts-fold.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/ui-vue": patch
+---
+
+PlDatasetSelector - returned description for filter variants

--- a/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
+++ b/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
@@ -103,6 +103,7 @@ const dropdownOptions = computed<ListOption<Selection>[] | undefined>(() => {
     for (const filter of o.filters ?? []) {
       out.push({
         label: filter.label,
+        description: o.primary.label,
         value: makeSelection(o.primary.ref, filter.ref, o.enrichments),
       });
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores the `description` field on filter-variant entries in the `PlDatasetSelector` dropdown so the parent dataset's name is surfaced as a subtitle alongside each filter option.

- `PlDatasetSelector.vue`: adds `description: o.primary.label` to every filter `ListOption`, making the dataset name visible as a subtitle in the dropdown when a filter row is rendered.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line addition that populates a description field on filter dropdown entries.

The code change is minimal and targeted: it adds the parent dataset label as a description on each filter option. The only thing to follow up on is the stale JSDoc that still describes the old prefix-based approach, but that has no runtime impact.

The module-level JSDoc in PlDatasetSelector.vue still describes the old prefix approach and would benefit from a small update.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue | Adds `description: o.primary.label` to filter dropdown entries so the parent dataset name appears as a subtitle. One-line logic change; the module-level JSDoc comment is now stale (says no subtitle is rendered). |
| .changeset/purple-donuts-fold.md | Patch-level changeset entry for @platforma-sdk/ui-vue, correctly categorised as a patch. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[props.options] --> B{for each DatasetOption}
    B --> C[Push primary option\nlabel: o.primary.label\nvalue: makeSelection primary]
    B --> D{for each filter}
    D --> E[Push filter option\nlabel: filter.label\ndescription: o.primary.label NEW\nvalue: makeSelection primary+filter]
    C --> F[dropdownOptions array]
    E --> F
    F --> G[PlDropdown renders list]
    G --> H[Primary row: label only]
    G --> I[Filter row: label + subtitle\nsubtitle = dataset name]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue`, line 3-5 ([link](https://github.com/milaboratory/platforma/blob/db35329fac88de6e0c95d4e933076f5d3057fd30/sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue#L3-L5)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The module-level JSDoc still says "Filter labels carry the dataset name as a prefix (e.g. 'Bulk / Top 10'), so no separate subtitle is rendered." — this is now incorrect. The PR adds `description: o.primary.label` on each filter option, which renders the dataset name as a separate subtitle/description field. The comment should reflect the new rendering approach.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue
   Line: 3-5

   Comment:
   The module-level JSDoc still says "Filter labels carry the dataset name as a prefix (e.g. 'Bulk / Top 10'), so no separate subtitle is rendered." — this is now incorrect. The PR adds `description: o.primary.label` on each filter option, which renders the dataset name as a separate subtitle/description field. The comment should reflect the new rendering approach.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/ui-vue/src/components/PlDatasetSelector/PlDatasetSelector.vue:3-5
The module-level JSDoc still says "Filter labels carry the dataset name as a prefix (e.g. 'Bulk / Top 10'), so no separate subtitle is rendered." — this is now incorrect. The PR adds `description: o.primary.label` on each filter option, which renders the dataset name as a separate subtitle/description field. The comment should reflect the new rendering approach.

```suggestion
 * Select a dataset or one of its filters in a single dropdown, emitting a
 * {@link DatasetSelection}. Filter options show their own label with the
 * parent dataset name rendered as a description/subtitle below.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["PlDatasetSelector - returned description..."](https://github.com/milaboratory/platforma/commit/db35329fac88de6e0c95d4e933076f5d3057fd30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31991513)</sub>

<!-- /greptile_comment -->