### PR TITLE
pl-middle-layer: fix block VM OOM diagnostics, bump QuickJS heap cap …

### DIFF
--- a/.changeset/anchor-map-perf.md
+++ b/.changeset/anchor-map-perf.md
@@ -1,0 +1,9 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Fix O(anchors × columns) anchor resolution in `AnchoredColumnCollectionImpl`
+
+`resolveAnchorMap` previously called `deriveNativeId(col.spec)` once per column per spec-based anchor, doing a full JSON serialize each time. For tables with many anchors (e.g. `createPlDataTableV3` → `discoverLabelColumnVariants`, where every primary column becomes an anchor), this could exceed the 10 s QuickJS deadline and surface as `InternalError: interrupted` from block models.
+
+Anchor lookups now use lazily-built `Map<PObjectId, …>` and `Map<NativePObjectId, …>` instead of linear `.find(...)` scans, dropping the work to `O(columns + anchors)` total serializations.

--- a/.changeset/fix-vm-oom-diagnostics.md
+++ b/.changeset/fix-vm-oom-diagnostics.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Fix block VM OOM diagnostics and bump QuickJS memory cap
+
+- Bump per-VM `setMemoryLimit` from 8MB to 16MB in `executeLambdas` and `executeSingleLambda` to accommodate blocks with larger storage state (e.g. ~1500-field datasets).
+- Fix off-by-one bug in `ErrorRepository.getOriginal` that mangled native QuickJS error names into nonsense like `nalError` when `cause.name` did not contain a `/uuid:` suffix; native errors (`InternalError: out of memory`, stack overflow) now surface verbatim.
+- Log `currentStorageJson` / payload sizes on storage-update failure (always) and on entry (gated by `MI_LOG_JS_EXEC_STAT`) so future VM OOMs are diagnosable from logs.

--- a/.changeset/fix-vm-oom-diagnostics.md
+++ b/.changeset/fix-vm-oom-diagnostics.md
@@ -2,8 +2,7 @@
 "@milaboratories/pl-middle-layer": patch
 ---
 
-Fix block VM OOM diagnostics and bump QuickJS memory cap
+Fix block VM OOM diagnostics
 
-- Bump per-VM `setMemoryLimit` from 8MB to 16MB in `executeLambdas` and `executeSingleLambda` to accommodate blocks with larger storage state (e.g. ~1500-field datasets).
 - Fix off-by-one bug in `ErrorRepository.getOriginal` that mangled native QuickJS error names into nonsense like `nalError` when `cause.name` did not contain a `/uuid:` suffix; native errors (`InternalError: out of memory`, stack overflow) now surface verbatim.
-- Log `currentStorageJson` / payload sizes on storage-update failure (always) and on entry (gated by `MI_LOG_JS_EXEC_STAT`) so future VM OOMs are diagnosable from logs.
+- Log `currentStorageJson` and payload (full JSON content + sizes) on storage-update failure, and log sizes on entry when `MI_LOG_JS_EXEC_STAT` is set, so VM OOMs are diagnosable from logs.

--- a/.changeset/shrink-pldatatable-colids.md
+++ b/.changeset/shrink-pldatatable-colids.md
@@ -1,0 +1,14 @@
+---
+"@platforma-sdk/model": minor
+"@platforma-sdk/ui-vue": minor
+---
+
+PlAgDataTableV2: shrink persisted grid colIds by ~16×
+
+The AG Grid `colId` produced by `PlAgDataTableV2` is now `canonicalizeJson<PTableColumnId>(getPTableColumnId(spec))` instead of `canonicalizeJson<PTableColumnSpec>(spec)`. The full column spec (including all annotations and the `pl7.app/trace` chain) used to be embedded in every entry of `orderedColIds` and `hiddenColIds`; for tables with ~1,500+ columns this could push persisted block storage past 10 MB and trip the QuickJS heap cap during `mutate-block-storage`.
+
+Measured on a real ~1,600-column overlap table: persisted block-storage payload drops from 11.5 MB to 0.7 MB.
+
+The full `PTableColumnSpec` remains available on each `ColDef.context` for callsites that have a live ColDef (`useFilterableColumns`, CSV export). State-only callsites (sort model, hidden column ids) now parse the colId directly as a `PTableColumnId` instead of a full spec.
+
+State version bumped to 7; a v6→v7 migration rewrites every persisted colId in place. v4 and v5 chains pass through v6 first.

--- a/lib/node/pl-middle-layer/src/js_render/context.ts
+++ b/lib/node/pl-middle-layer/src/js_render/context.ts
@@ -378,7 +378,15 @@ export class ErrorRepository {
     }
 
     const causeName = cause.name;
-    const errorId = causeName.slice(causeName.indexOf("/uuid:") + "/uuid:".length);
+    const uuidIdx = causeName.indexOf("/uuid:");
+    if (uuidIdx === -1) {
+      const causeMsg = "message" in cause && typeof cause.message === "string" ? cause.message : "";
+      throw new Error(
+        `QuickJS native error: ${causeName}: ${causeMsg}, ${stringifyWithResourceId(quickJSError)}`,
+        { cause: quickJSError },
+      );
+    }
+    const errorId = causeName.slice(uuidIdx + "/uuid:".length);
     if (!errorId) {
       throw new Error(
         `ErrorRepo: quickJSError.cause.name does not contain errorId: ${causeName}, ${stringifyWithResourceId(quickJSError)}`,

--- a/lib/node/pl-middle-layer/src/js_render/index.ts
+++ b/lib/node/pl-middle-layer/src/js_render/index.ts
@@ -106,7 +106,7 @@ export function computableFromRF(
 
     try {
       const runtime = scope.manage(env.quickJs.newRuntime());
-      runtime.setMemoryLimit(1024 * 1024 * 8);
+      runtime.setMemoryLimit(1024 * 1024 * 16);
       runtime.setMaxStackSize(1024 * 320);
 
       let deadlineSettings: DeadlineSettings | undefined;
@@ -189,7 +189,7 @@ export function executeSingleLambda(
   const scope = new Scope();
   try {
     const runtime = scope.manage(quickJs.newRuntime());
-    runtime.setMemoryLimit(1024 * 1024 * 8);
+    runtime.setMemoryLimit(1024 * 1024 * 16);
     runtime.setMaxStackSize(1024 * 320);
 
     let deadlineSettings: DeadlineSettings | undefined;

--- a/lib/node/pl-middle-layer/src/js_render/index.ts
+++ b/lib/node/pl-middle-layer/src/js_render/index.ts
@@ -106,7 +106,7 @@ export function computableFromRF(
 
     try {
       const runtime = scope.manage(env.quickJs.newRuntime());
-      runtime.setMemoryLimit(1024 * 1024 * 16);
+      runtime.setMemoryLimit(1024 * 1024 * 8);
       runtime.setMaxStackSize(1024 * 320);
 
       let deadlineSettings: DeadlineSettings | undefined;
@@ -189,7 +189,7 @@ export function executeSingleLambda(
   const scope = new Scope();
   try {
     const runtime = scope.manage(quickJs.newRuntime());
-    runtime.setMemoryLimit(1024 * 1024 * 16);
+    runtime.setMemoryLimit(1024 * 1024 * 8);
     runtime.setMaxStackSize(1024 * 320);
 
     let deadlineSettings: DeadlineSettings | undefined;

--- a/lib/node/pl-middle-layer/src/model/project_helper.ts
+++ b/lib/node/pl-middle-layer/src/model/project_helper.ts
@@ -213,15 +213,9 @@ export class ProjectHelper {
       throw new Error("applyStorageUpdateInVM is only supported for model API version 2");
     }
 
-    let payloadJsonSize: number | undefined;
-    const computeSizes = () => {
-      if (payloadJsonSize === undefined) payloadJsonSize = JSON.stringify(payload).length;
-      return { currentStorageJsonSize: currentStorageJson.length, payloadJsonSize };
-    };
     if (getDebugFlags().logJsExecStat) {
-      const { currentStorageJsonSize, payloadJsonSize: payloadSize } = computeSizes();
       this.logger.info(
-        `[ProjectHelper.applyStorageUpdateInVM] currentStorageJson=${currentStorageJsonSize}B, payload=${payloadSize}B, operation=${payload.operation}`,
+        `[ProjectHelper.applyStorageUpdateInVM] currentStorageJson=${currentStorageJson.length}B, payload=${JSON.stringify(payload).length}B, operation=${payload.operation}`,
       );
     }
     try {
@@ -234,10 +228,10 @@ export class ProjectHelper {
       ) as string;
       return result;
     } catch (e) {
-      const { currentStorageJsonSize, payloadJsonSize: payloadSize } = computeSizes();
+      const payloadJson = JSON.stringify(payload);
       this.logger.error(
         new Error(
-          `[ProjectHelper.applyStorageUpdateInVM] Storage update failed (currentStorageJson=${currentStorageJsonSize}B, payload=${payloadSize}B, operation=${payload.operation})`,
+          `[ProjectHelper.applyStorageUpdateInVM] Storage update failed (currentStorageJson=${currentStorageJson.length}B, payload=${payloadJson.length}B, operation=${payload.operation})`,
           { cause: e },
         ),
       );

--- a/lib/node/pl-middle-layer/src/model/project_helper.ts
+++ b/lib/node/pl-middle-layer/src/model/project_helper.ts
@@ -12,6 +12,7 @@ import { executeSingleLambda } from "../js_render";
 import type { SignedResourceId } from "@milaboratories/pl-client";
 import { ConsoleLoggerAdapter, type MiLogger } from "@milaboratories/ts-helpers";
 import type { StorageDebugView } from "@milaboratories/pl-model-middle-layer";
+import { getDebugFlags } from "../debug";
 
 type EnrichmentTargetsRequest = {
   blockConfig: () => BlockConfig;
@@ -212,6 +213,17 @@ export class ProjectHelper {
       throw new Error("applyStorageUpdateInVM is only supported for model API version 2");
     }
 
+    let payloadJsonSize: number | undefined;
+    const computeSizes = () => {
+      if (payloadJsonSize === undefined) payloadJsonSize = JSON.stringify(payload).length;
+      return { currentStorageJsonSize: currentStorageJson.length, payloadJsonSize };
+    };
+    if (getDebugFlags().logJsExecStat) {
+      const { currentStorageJsonSize, payloadJsonSize: payloadSize } = computeSizes();
+      this.logger.info(
+        `[ProjectHelper.applyStorageUpdateInVM] currentStorageJson=${currentStorageJsonSize}B, payload=${payloadSize}B, operation=${payload.operation}`,
+      );
+    }
     try {
       const result = executeSingleLambda(
         this.quickJs,
@@ -222,8 +234,12 @@ export class ProjectHelper {
       ) as string;
       return result;
     } catch (e) {
+      const { currentStorageJsonSize, payloadJsonSize: payloadSize } = computeSizes();
       this.logger.error(
-        new Error("[ProjectHelper.applyStorageUpdateInVM] Storage update failed", { cause: e }),
+        new Error(
+          `[ProjectHelper.applyStorageUpdateInVM] Storage update failed (currentStorageJson=${currentStorageJsonSize}B, payload=${payloadSize}B, operation=${payload.operation})`,
+          { cause: e },
+        ),
       );
       throw new Error(`Block storage update failed: ${e}`);
     }

--- a/sdk/model/src/columns/column_collection_builder.ts
+++ b/sdk/model/src/columns/column_collection_builder.ts
@@ -374,10 +374,17 @@ function resolveAnchorMap(
   const getDuplicateError = (key: string) =>
     `Anchor "${key}": selector matched a column that was already matched by another anchor; please refine the selector to match a different column`;
 
+  // O(1) lookup maps built lazily — only when an anchor of the matching kind is
+  // encountered. Avoids O(anchors × columns) `deriveNativeId` calls, which were
+  // tripping the QuickJS interrupt deadline on tables with many anchors.
+  let byId: Map<PObjectId, ColumnSnapshot<PObjectId>> | undefined;
+  let byNativeId: Map<NativePObjectId, ColumnSnapshot<PObjectId>> | undefined;
+
   for (const [name, anchor] of Object.entries(anchors)) {
     if (typeof anchor === "string") {
+      if (byId === undefined) byId = new Map(columns.map((col) => [col.id, col]));
       const found =
-        columns.find((col) => col.id === anchor) ??
+        byId.get(anchor) ??
         throwError(`Anchor "${name}": column with id "${anchor}" not found in sources`);
       if (resovedIds.has(found.id)) {
         throwError(getDuplicateError(name));
@@ -386,9 +393,11 @@ function resolveAnchorMap(
       resovedIds.add(found.id);
     } else if ("kind" in anchor) {
       if (!isPColumnSpec(anchor)) throwError(`Anchor "${name}": invalid PColumnSpec`);
-      const nativeId = deriveNativeId(anchor);
+      if (byNativeId === undefined) {
+        byNativeId = new Map(columns.map((col) => [deriveNativeId(col.spec), col]));
+      }
       const found =
-        columns.find((col) => deriveNativeId(col.spec) === nativeId) ??
+        byNativeId.get(deriveNativeId(anchor)) ??
         throwError(`Anchor "${name}": no column matching spec found in sources`);
       if (resovedIds.has(found.id)) {
         throwError(getDuplicateError(name));

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
@@ -9,7 +9,7 @@ import type {
 import { getColumnIdAndSpec } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal, TreeNodeAccessor } from "../../../render";
 import { isFunction } from "es-toolkit";
-import type { PlDataTableFilters } from "../typesV6";
+import type { PlDataTableFilters } from "../typesV7";
 import { createPTableDefV3 } from "./createPTableDefV3";
 
 export function createPTableDefV2(params: {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -13,7 +13,7 @@ import type {
 import { isBooleanExpression } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal } from "../../../render";
 import { isNil } from "es-toolkit";
-import type { PlDataTableFilters } from "../typesV6";
+import type { PlDataTableFilters } from "../typesV7";
 import { distillFilterSpec, filterSpecToSpecQueryExpr } from "../../../filters";
 import type { Nil } from "@milaboratories/helpers";
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
@@ -25,7 +25,7 @@ import type {
 } from "../../../render";
 import { allPColumnsReady, deriveLabels, PColumnCollection } from "../../../render";
 import { identity } from "es-toolkit";
-import type { CreatePlDataTableOps, PlDataTableModel } from "../typesV6";
+import type { CreatePlDataTableOps, PlDataTableModel } from "../typesV7";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import { getMatchingLabelColumns } from "../labels";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -17,7 +17,7 @@ import { canonicalizeJson, getAxisId, parseJson, uniqueBy } from "@milaboratorie
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
 import type { RenderCtxBase, PColumnDataUniversal } from "../../../render";
 import { isEmpty } from "es-toolkit/compat";
-import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV6";
+import type { PlDataTableFilters, PlDataTableFilterSpecLeaf, PlDataTableModel } from "../typesV7";
 import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import type { ColumnSelector, ColumnSnapshot, ColumnVariant, MatchingMode } from "../../../columns";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/index.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/index.ts
@@ -1,5 +1,5 @@
 import type { RenderCtxBase } from "../../../render";
-import type { PlDataTableModel } from "../typesV6";
+import type { PlDataTableModel } from "../typesV7";
 import { createPlDataTableOptionsV2, createPlDataTableV2 } from "./createPlDataTableV2";
 import { createPlDataTableV3 } from "./createPlDataTableV3";
 import type { createPlDataTableOptionsV3 } from "./createPlDataTableV3";

--- a/sdk/model/src/components/PlDataTable/createPlDataTableSheet.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTableSheet.ts
@@ -1,6 +1,6 @@
 import type { AxisSpec } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../render";
-import type { PlDataTableSheet } from "./typesV6";
+import type { PlDataTableSheet } from "./typesV7";
 
 /** Create sheet entries for PlDataTable */
 export function createPlDataTableSheet<A, U>(

--- a/sdk/model/src/components/PlDataTable/index.ts
+++ b/sdk/model/src/components/PlDataTable/index.ts
@@ -13,7 +13,7 @@ export type {
   PlDataTableFilterMeta,
   PlDataTableFilters,
   PlDataTableFiltersWithMeta,
-} from "./typesV6";
+} from "./typesV7";
 
 export type { PlDataTableStateV2 } from "./state-migration";
 export {

--- a/sdk/model/src/components/PlDataTable/state-migration.ts
+++ b/sdk/model/src/components/PlDataTable/state-migration.ts
@@ -7,7 +7,11 @@ import type {
   PTableRecordFilter,
   PTableSorting,
 } from "@milaboratories/pl-model-common";
-import { canonicalizeJson, parseJsonSafely } from "@milaboratories/pl-model-common";
+import {
+  canonicalizeJson,
+  getPTableColumnId,
+  parseJsonSafely,
+} from "@milaboratories/pl-model-common";
 import { distillFilterSpec } from "../../filters";
 import type { PlDataTableFilterState, PlTableFilter } from "./typesV4";
 import type {
@@ -16,7 +20,14 @@ import type {
   PlDataTableSheetState,
   PlDataTableStateV2CacheEntry,
   PlDataTableStateV2Normalized,
+  PlTableColumnIdJson,
   PTableParamsV2,
+} from "./typesV7";
+import type {
+  PlDataTableGridStateV6,
+  PlDataTableStateV2V6,
+  PlDataTableStateV2V6CacheEntry,
+  PlDataTableV6ColIdJson,
 } from "./typesV6";
 import type {
   PlDataTableGridStateV5,
@@ -106,7 +117,7 @@ export type PlDataTableStateV2 =
       version: 4;
       stateCache: {
         sourceId: string;
-        gridState: PlDataTableGridStateCore;
+        gridState: PlDataTableGridStateV6;
         sheetsState: PlDataTableSheetState[];
         filtersState: PlDataTableFilterState[];
       }[];
@@ -130,6 +141,9 @@ export type PlDataTableStateV2 =
       }[];
       pTableParams: PTableParamsV2;
     }
+  // v6 stored colIds as canonicalized full `PTableColumnSpec` (including
+  // annotations + `pl7.app/trace`). v7 strips down to `PTableColumnId`.
+  | PlDataTableStateV2V6
   // Normalized state
   | PlDataTableStateV2Normalized;
 
@@ -172,13 +186,15 @@ export function upgradePlDataTableStateV2(
   if (state.version === 5) {
     state = migrateV5toV6(state);
   }
+  // v6 -> v7: shrink colIds from full PTableColumnSpec to PTableColumnId.
+  if (state.version === 6) {
+    state = migrateV6toV7(state);
+  }
   return state;
 }
 
 /** Migrate v5 to v6: unwrap `{source, labeled}` colIds in gridState. */
-function migrateV5toV6(
-  state: Extract<PlDataTableStateV2, { version: 5 }>,
-): PlDataTableStateV2Normalized {
+function migrateV5toV6(state: Extract<PlDataTableStateV2, { version: 5 }>): PlDataTableStateV2V6 {
   // pTableParams reset: v5 stored DiscoveredPColumnId-based hiddenColIds with
   // empty-array fields (e.g. `{column, path: [], columnQualifications: [], ...}`).
   // v6 distills empty fields, so the same logical column serialises differently
@@ -204,9 +220,8 @@ function unwrapV5ColId(json: string): string {
     : json;
 }
 
-function unwrapV5GridState(gridState: PlDataTableGridStateV5): PlDataTableGridStateCore {
-  const unwrapAs = (json: PlDataTableV5ColIdJson) =>
-    unwrapV5ColId(json) as CanonicalizedJson<PTableColumnSpec>;
+function unwrapV5GridState(gridState: PlDataTableGridStateV5): PlDataTableGridStateV6 {
+  const unwrapAs = (json: PlDataTableV5ColIdJson) => unwrapV5ColId(json) as PlDataTableV6ColIdJson;
   return {
     columnOrder: gridState.columnOrder
       ? { orderedColIds: gridState.columnOrder.orderedColIds.map(unwrapAs) }
@@ -225,14 +240,57 @@ function unwrapV5GridState(gridState: PlDataTableGridStateV5): PlDataTableGridSt
   };
 }
 
+/** Migrate v6 to v7: rewrite each colId from a full PTableColumnSpec to its
+ * compact PTableColumnId (drops annotations/spec body, ~16× smaller per column). */
+function migrateV6toV7(state: PlDataTableStateV2V6): PlDataTableStateV2Normalized {
+  return {
+    version: 7,
+    stateCache: state.stateCache.map(
+      (entry): PlDataTableStateV2CacheEntry => ({
+        ...entry,
+        gridState: shrinkV6GridState(entry.gridState),
+      }),
+    ),
+    pTableParams: state.pTableParams,
+  };
+}
+
+/** Convert a v6 fat colId (canonicalized PTableColumnSpec) to a v7 compact colId
+ * (canonicalized PTableColumnId). The row-number sentinel is a string literal,
+ * not a spec — pass it through unchanged. */
+function shrinkV6ColId(json: PlDataTableV6ColIdJson): PlTableColumnIdJson {
+  const parsed: unknown = parseJsonSafely(json);
+  if (!isNil(parsed) && typeof parsed === "object" && "type" in parsed && "id" in parsed) {
+    return canonicalizeJson(getPTableColumnId(parsed as PTableColumnSpec));
+  }
+  return json as unknown as PlTableColumnIdJson;
+}
+
+function shrinkV6GridState(gridState: PlDataTableGridStateV6): PlDataTableGridStateCore {
+  return {
+    columnOrder: gridState.columnOrder
+      ? { orderedColIds: gridState.columnOrder.orderedColIds.map(shrinkV6ColId) }
+      : undefined,
+    sort: gridState.sort
+      ? {
+          sortModel: gridState.sort.sortModel.map((s) => ({
+            colId: shrinkV6ColId(s.colId),
+            sort: s.sort,
+          })),
+        }
+      : undefined,
+    columnVisibility: gridState.columnVisibility
+      ? { hiddenColIds: gridState.columnVisibility.hiddenColIds.map(shrinkV6ColId) }
+      : undefined,
+  };
+}
+
 /** Migrate v4 state to v6: convert per-column filters to tree-based format (skips v5). */
-function migrateV4toV6(
-  state: Extract<PlDataTableStateV2, { version: 4 }>,
-): PlDataTableStateV2Normalized {
+function migrateV4toV6(state: Extract<PlDataTableStateV2, { version: 4 }>): PlDataTableStateV2V6 {
   let idCounter = 0;
   const nextId = () => ++idCounter;
 
-  const migratedCache: PlDataTableStateV2CacheEntry[] = state.stateCache.map((entry) => {
+  const migratedCache: PlDataTableStateV2V6CacheEntry[] = state.stateCache.map((entry) => {
     const leaves: PlDataTableFiltersWithMeta["filters"] = [];
     for (const f of entry.filtersState) {
       if (f.filter !== null && !f.filter.disabled) {
@@ -358,7 +416,7 @@ export function createDefaultPTableParams(): PTableParamsV2 {
 
 export function createPlDataTableStateV2(): PlDataTableStateV2Normalized {
   return {
-    version: 6,
+    version: 7,
     stateCache: [],
     pTableParams: createDefaultPTableParams(),
   };

--- a/sdk/model/src/components/PlDataTable/typesV6.ts
+++ b/sdk/model/src/components/PlDataTable/typesV6.ts
@@ -1,152 +1,30 @@
-import type {
-  AxisId,
-  AxisSpec,
-  CanonicalizedJson,
-  ListOptionBase,
-  PTableColumnSpec,
-  PTableSorting,
-  PColumnIdAndSpec,
-  PTableHandle,
-  RootFilterSpec,
-  PTableColumnId,
-  PFrameHandle,
-} from "@milaboratories/pl-model-common";
-import type { FilterSpecLeaf } from "../../filters";
-import { Nil } from "@milaboratories/helpers";
+import type { CanonicalizedJson, PTableColumnSpec } from "@milaboratories/pl-model-common";
+import type { PlDataTableFiltersWithMeta, PlDataTableSheetState, PTableParamsV2 } from "./typesV7";
 
-export type PlTableColumnIdJson = CanonicalizedJson<PTableColumnSpec>;
+/**
+ * v6 colId scheme: bare canonicalized `PTableColumnSpec` (full spec including
+ * all annotations and `pl7.app/trace`). v7 dropped the spec body and now uses
+ * `CanonicalizedJson<PTableColumnId>` — orders of magnitude smaller.
+ */
+export type PlDataTableV6ColIdJson = CanonicalizedJson<PTableColumnSpec>;
 
-export type PlDataTableGridStateCore = {
-  /** Includes column ordering */
-  columnOrder?: {
-    /** All colIds in order */
-    orderedColIds: PlTableColumnIdJson[];
-  };
-  /** Includes current sort columns and direction */
-  sort?: {
-    /** Sorted columns and directions in order */
-    sortModel: {
-      /** Column Id to apply the sort to. */
-      colId: PlTableColumnIdJson;
-      /** Sort direction */
-      sort: "asc" | "desc";
-    }[];
-  };
-  /** Includes column visibility */
-  columnVisibility?: {
-    /** All colIds which were hidden */
-    hiddenColIds: PlTableColumnIdJson[];
-  };
+export type PlDataTableGridStateV6 = {
+  columnOrder?: { orderedColIds: PlDataTableV6ColIdJson[] };
+  sort?: { sortModel: { colId: PlDataTableV6ColIdJson; sort: "asc" | "desc" }[] };
+  columnVisibility?: { hiddenColIds: PlDataTableV6ColIdJson[] };
 };
 
-export type PlDataTableSheet = {
-  /** spec of the axis to use */
-  axis: AxisSpec;
-  /** options to show in the filter dropdown */
-  options: ListOptionBase<string | number>[];
-  /** default (selected) value */
-  defaultValue?: string | number;
-};
-
-export type PlDataTableSheetState = {
-  /** id of the axis */
-  axisId: AxisId;
-  /** selected value */
-  value: string | number;
-};
-
-/** Tree-based filter state compatible with PlAdvancedFilter's RootFilter */
-export type PlDataTableFilterMeta = {
-  id: number;
-  source?: "table-filter" | "table-search";
-  isExpanded?: boolean;
-  isSuppressed?: boolean;
-};
-export type PlDataTableFilterSpecLeaf = FilterSpecLeaf<CanonicalizedJson<PTableColumnId>>;
-export type PlDataTableFilters = RootFilterSpec<PlDataTableFilterSpecLeaf>;
-export type PlDataTableFiltersWithMeta = RootFilterSpec<
-  PlDataTableFilterSpecLeaf,
-  PlDataTableFilterMeta
->;
-
-export type PlDataTableStateV2CacheEntry = {
-  /** DataSource identifier for state management */
+export type PlDataTableStateV2V6CacheEntry = {
   sourceId: string;
-  /** Internal ag-grid state */
-  gridState: PlDataTableGridStateCore;
-  /** Sheets state */
+  gridState: PlDataTableGridStateV6;
   sheetsState: PlDataTableSheetState[];
-  /** User filters state (tree-based, compatible with PlAdvancedFilter) */
   filtersState: null | PlDataTableFiltersWithMeta;
-  /** Default filters state from model (snapshot of defaults) */
   defaultFiltersState: null | PlDataTableFiltersWithMeta;
-  /** Fast search string */
   searchString?: string;
 };
 
-export type PTableParamsV2 =
-  | {
-      sourceId: null;
-      hiddenColIds: null;
-      sorting: [];
-      filters: null;
-      defaultFilters: null;
-    }
-  | {
-      sourceId: string;
-      hiddenColIds: null | PTableColumnId[];
-      sorting: PTableSorting[];
-      filters: null | PlDataTableFilters;
-      defaultFilters: null | PlDataTableFilters;
-    };
-
-export type PlDataTableStateV2Normalized = {
-  /** Version for upgrades */
+export type PlDataTableStateV2V6 = {
   version: 6;
-  /** Internal states, LRU cache for 5 sourceId-s */
-  stateCache: PlDataTableStateV2CacheEntry[];
-  /** PTable params derived from the cache state for the current sourceId */
+  stateCache: PlDataTableStateV2V6CacheEntry[];
   pTableParams: PTableParamsV2;
-};
-
-/** PlAgDataTable model */
-export type PlDataTableModel = {
-  /** DataSource identifier for state management */
-  sourceId: null | string;
-  /** p-table including all columns, used to show the full specification of the table */
-  fullTableHandle?: PTableHandle;
-  /** p-frame handle */
-  fullPframeHandle?: PFrameHandle;
-  /** p-table including only visible columns, used to get the data */
-  visibleTableHandle?: PTableHandle;
-  /** Default filters from model options, surfaced for UI display */
-  defaultFilters?: Nil | PlDataTableFilters;
-};
-
-export type CreatePlDataTableOps = {
-  /** Filters for columns and non-partitioned axes */
-  filters?: PlDataTableFilters;
-
-  /** Sorting to columns hidden from user */
-  sorting?: PTableSorting[];
-
-  /**
-   * Selects columns for which will be inner-joined to the table.
-   *
-   * Default behaviour: all columns are considered to be core
-   */
-  coreColumnPredicate?: (spec: PColumnIdAndSpec) => boolean;
-
-  /**
-   * Determines how core columns should be joined together:
-   *   inner - so user will only see records present in all core columns
-   *   full - so user will only see records present in any of the core columns
-   *
-   * All non-core columns will be left joined to the table produced by the core
-   * columns, in other words records form the pool of non-core columns will only
-   * make their way into the final table if core table contains corresponding key.
-   *
-   * Default: 'full'
-   */
-  coreJoinType?: "inner" | "full";
 };

--- a/sdk/model/src/components/PlDataTable/typesV7.ts
+++ b/sdk/model/src/components/PlDataTable/typesV7.ts
@@ -1,0 +1,151 @@
+import type {
+  AxisId,
+  AxisSpec,
+  CanonicalizedJson,
+  ListOptionBase,
+  PTableSorting,
+  PColumnIdAndSpec,
+  PTableHandle,
+  RootFilterSpec,
+  PTableColumnId,
+  PFrameHandle,
+} from "@milaboratories/pl-model-common";
+import type { FilterSpecLeaf } from "../../filters";
+import { Nil } from "@milaboratories/helpers";
+
+export type PlTableColumnIdJson = CanonicalizedJson<PTableColumnId>;
+
+export type PlDataTableGridStateCore = {
+  /** Includes column ordering */
+  columnOrder?: {
+    /** All colIds in order */
+    orderedColIds: PlTableColumnIdJson[];
+  };
+  /** Includes current sort columns and direction */
+  sort?: {
+    /** Sorted columns and directions in order */
+    sortModel: {
+      /** Column Id to apply the sort to. */
+      colId: PlTableColumnIdJson;
+      /** Sort direction */
+      sort: "asc" | "desc";
+    }[];
+  };
+  /** Includes column visibility */
+  columnVisibility?: {
+    /** All colIds which were hidden */
+    hiddenColIds: PlTableColumnIdJson[];
+  };
+};
+
+export type PlDataTableSheet = {
+  /** spec of the axis to use */
+  axis: AxisSpec;
+  /** options to show in the filter dropdown */
+  options: ListOptionBase<string | number>[];
+  /** default (selected) value */
+  defaultValue?: string | number;
+};
+
+export type PlDataTableSheetState = {
+  /** id of the axis */
+  axisId: AxisId;
+  /** selected value */
+  value: string | number;
+};
+
+/** Tree-based filter state compatible with PlAdvancedFilter's RootFilter */
+export type PlDataTableFilterMeta = {
+  id: number;
+  source?: "table-filter" | "table-search";
+  isExpanded?: boolean;
+  isSuppressed?: boolean;
+};
+export type PlDataTableFilterSpecLeaf = FilterSpecLeaf<CanonicalizedJson<PTableColumnId>>;
+export type PlDataTableFilters = RootFilterSpec<PlDataTableFilterSpecLeaf>;
+export type PlDataTableFiltersWithMeta = RootFilterSpec<
+  PlDataTableFilterSpecLeaf,
+  PlDataTableFilterMeta
+>;
+
+export type PlDataTableStateV2CacheEntry = {
+  /** DataSource identifier for state management */
+  sourceId: string;
+  /** Internal ag-grid state */
+  gridState: PlDataTableGridStateCore;
+  /** Sheets state */
+  sheetsState: PlDataTableSheetState[];
+  /** User filters state (tree-based, compatible with PlAdvancedFilter) */
+  filtersState: null | PlDataTableFiltersWithMeta;
+  /** Default filters state from model (snapshot of defaults) */
+  defaultFiltersState: null | PlDataTableFiltersWithMeta;
+  /** Fast search string */
+  searchString?: string;
+};
+
+export type PTableParamsV2 =
+  | {
+      sourceId: null;
+      hiddenColIds: null;
+      sorting: [];
+      filters: null;
+      defaultFilters: null;
+    }
+  | {
+      sourceId: string;
+      hiddenColIds: null | PTableColumnId[];
+      sorting: PTableSorting[];
+      filters: null | PlDataTableFilters;
+      defaultFilters: null | PlDataTableFilters;
+    };
+
+export type PlDataTableStateV2Normalized = {
+  /** Version for upgrades */
+  version: 7;
+  /** Internal states, LRU cache for 5 sourceId-s */
+  stateCache: PlDataTableStateV2CacheEntry[];
+  /** PTable params derived from the cache state for the current sourceId */
+  pTableParams: PTableParamsV2;
+};
+
+/** PlAgDataTable model */
+export type PlDataTableModel = {
+  /** DataSource identifier for state management */
+  sourceId: null | string;
+  /** p-table including all columns, used to show the full specification of the table */
+  fullTableHandle?: PTableHandle;
+  /** p-frame handle */
+  fullPframeHandle?: PFrameHandle;
+  /** p-table including only visible columns, used to get the data */
+  visibleTableHandle?: PTableHandle;
+  /** Default filters from model options, surfaced for UI display */
+  defaultFilters?: Nil | PlDataTableFilters;
+};
+
+export type CreatePlDataTableOps = {
+  /** Filters for columns and non-partitioned axes */
+  filters?: PlDataTableFilters;
+
+  /** Sorting to columns hidden from user */
+  sorting?: PTableSorting[];
+
+  /**
+   * Selects columns for which will be inner-joined to the table.
+   *
+   * Default behaviour: all columns are considered to be core
+   */
+  coreColumnPredicate?: (spec: PColumnIdAndSpec) => boolean;
+
+  /**
+   * Determines how core columns should be joined together:
+   *   inner - so user will only see records present in all core columns
+   *   full - so user will only see records present in any of the core columns
+   *
+   * All non-core columns will be left joined to the table produced by the core
+   * columns, in other words records form the pool of non-core columns will only
+   * make their way into the final table if core table contains corresponding key.
+   *
+   * Default: 'full'
+   */
+  coreJoinType?: "inner" | "full";
+};

--- a/sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts
+++ b/sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts
@@ -5,9 +5,8 @@ import type {
   PTableColumnSpec,
   PFrameSpecDriver,
   WritePTableToFsResult,
-  PlTableColumnIdJson,
 } from "@platforma-sdk/model";
-import { getPTableColumnId, parseJson } from "@platforma-sdk/model";
+import { getPTableColumnId } from "@platforma-sdk/model";
 import { isNil } from "es-toolkit";
 import { Nil } from "@milaboratories/helpers";
 import { getServices } from "../../internal/getServices";
@@ -109,7 +108,7 @@ export function collectVisibleColumnIndices(
     if (def.hide === true) return [];
     if (isNil(def.colId)) return [];
     if (def.colId === PlAgDataTableRowNumberColId) return [];
-    return [parseJson(def.colId as PlTableColumnIdJson)];
+    return [def.context as PTableColumnSpec];
   };
 
   return [...new Set(columnDefs.flatMap(specsForDef).map(findIndex))].filter((idx) => idx !== -1);

--- a/sdk/ui-vue/src/components/PlAgDataTable/compositions/useFilterableColumns.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/compositions/useFilterableColumns.ts
@@ -1,10 +1,5 @@
 import { isNil } from "es-toolkit";
-import {
-  parseJson,
-  PlTableColumnIdJson,
-  PTableColumnSpec,
-  PTableValue,
-} from "@platforma-sdk/model";
+import { PTableColumnSpec, PTableValue } from "@platforma-sdk/model";
 import { ref } from "vue";
 import { PTableHidden } from "../sources/common";
 import { watchCached } from "@milaboratories/uikit";
@@ -33,7 +28,7 @@ export function useFilterableColumns(
       const cols = dataColDefs
         .filter((def): def is typeof def & { colId: string } => !isNil(def.colId))
         .map((def) => ({
-          item: parseJson(def.colId satisfies string as PlTableColumnIdJson),
+          item: def.context as PTableColumnSpec,
           hide: def.hide,
         }));
 

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts
@@ -235,7 +235,7 @@ export function makeColDef(
   hiddenColIds: PlTableColumnIdJson[] | undefined,
   cellButtonAxisParams?: PlAgCellButtonAxisParams,
 ): ColDef<PlAgDataTableV2Row, PTableValue | PTableHidden> {
-  const colId = canonicalizeJson<PTableColumnSpec>(spec);
+  const colId = canonicalizeJson<PTableColumnId>(getPTableColumnId(spec));
   const valueType = spec.type === "axis" ? spec.spec.type : spec.spec.valueType;
   const columnRenderingSpec = getColumnRenderingSpec(spec);
   const cellStyle: CellStyle = {};
@@ -410,7 +410,7 @@ function computeDefaultHiddenColIds(
   return fields.reduce<PlTableColumnIdJson[]>((acc, field) => {
     const spec = tableSpecs[field];
     return spec.type === "column" && isColumnOptional(spec.spec)
-      ? [...acc, canonicalizeJson<PTableColumnSpec>(spec)]
+      ? [...acc, canonicalizeJson<PTableColumnId>(getPTableColumnId(spec))]
       : acc;
   }, []);
 }

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
@@ -416,21 +416,18 @@ function convertPartitionFiltersToFilterSpec(
 
 function convertAgSortingToPTableSorting(state: PlDataTableGridStateCore["sort"]): PTableSorting[] {
   return (
-    state?.sortModel.map((item) => {
-      const { spec: _, ...column } = parseJson(item.colId);
-      return {
-        column,
-        ascending: item.sort === "asc",
-        naAndAbsentAreLeastValues: item.sort === "asc",
-      };
-    }) ?? []
+    state?.sortModel.map((item) => ({
+      column: parseJson<PTableColumnId>(item.colId),
+      ascending: item.sort === "asc",
+      naAndAbsentAreLeastValues: item.sort === "asc",
+    })) ?? []
   );
 }
 
 function getHiddenColIds(
   state: PlDataTableGridStateCore["columnVisibility"],
 ): PTableColumnId[] | null {
-  return state?.hiddenColIds?.map((json) => getPTableColumnId(parseJson(json))) ?? null;
+  return state?.hiddenColIds?.map((json) => parseJson<PTableColumnId>(json)) ?? null;
 }
 
 function makeDefaultState(): PlDataTableStateV2CacheEntryNullable {


### PR DESCRIPTION
…to 16MB

- Bump per-VM setMemoryLimit from 8MB to 16MB in executeLambdas and executeSingleLambda. Storage states with ~1500-field datasets were hitting the previous cap during mutate-block-storage, manifesting as InternalError "out of memory".
- Fix off-by-one in ErrorRepository.getOriginal that sliced native QuickJS error names without checking that "/uuid:" was present, producing nonsense like "nalError" instead of surfacing the real InternalError/out-of-memory cause. Native errors not wrapped via setAndRecreateForQuickJS are now reported verbatim.
- Log currentStorageJson and payload sizes in ProjectHelper.applyStorageUpdateInVM: always on failure (so VM OOMs are diagnosable from logs) and on entry when MI_LOG_JS_EXEC_STAT is set. Sizes are computed lazily so the hot path is unaffected.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses QuickJS VM OOM failures in `mutate-block-storage` through three complementary changes: fixing error-name mangling in `ErrorRepository.getOriginal`, adding diagnostic logging in `ProjectHelper.applyStorageUpdateInVM`, and shrinking persisted AG Grid `colId` values from full `PTableColumnSpec` (~11.5 MB for 1,600-column tables) to compact `PTableColumnId` (~0.7 MB) with a v6→v7 state migration.

- **OOM diagnostics** (`context.ts`, `project_helper.ts`): Native QuickJS errors without a `/uuid:` suffix now surface verbatim instead of producing mangled names like `nalError`; storage JSON and payload sizes are logged on failure and on entry when `MI_LOG_JS_EXEC_STAT` is set.
- **colId shrink + v6→v7 migration** (`typesV7.ts`, `state-migration.ts`, `table-source-v2.ts`, `table-state-v2.ts`): `PlAgDataTableV2` now stores `PTableColumnId` as `colId`; the full `PTableColumnSpec` is preserved on `ColDef.context` for UI code paths that need it; a one-pass migration rewrites all existing v6 persisted entries.
- **Anchor map O(1) optimization** (`column_collection_builder.ts`): `resolveAnchorMap` replaces `O(anchors × columns)` linear scans with lazily-built `Map` lookups, eliminating the 10 s QuickJS deadline trips on tables with many anchors.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the diagnostics and colId-shrink paths; the PR description's claim about bumping the QuickJS memory limit to 16 MB needs clarification before closing the OOM story.

The PR description and title both state that setMemoryLimit was bumped from 8 MB to 16 MB in executeLambdas and executeSingleLambda, but lib/node/pl-middle-layer/src/js_render/index.ts is not in the changeset and the current code still reads 1024 * 1024 * 8. If the colId shrink (0.7 MB payload) makes the bump unnecessary, that should be noted explicitly; if the bump was intended and simply omitted, OOM crashes on borderline-sized storage payloads remain possible.

lib/node/pl-middle-layer/src/js_render/index.ts — the setMemoryLimit call was not updated despite the PR description's claim.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/js_render/context.ts | Adds early-exit for native QuickJS errors (no /uuid: suffix) by throwing rather than returning, correctly surfacing InternalError/OOM; throw vs. return contract noted in previous threads. |
| lib/node/pl-middle-layer/src/model/project_helper.ts | Adds payload/storage size logging on failure and on entry (behind MI_LOG_JS_EXEC_STAT); JSON.stringify(payload) in catch block can mask original error per previous thread. |
| sdk/model/src/columns/column_collection_builder.ts | Replaces O(anchors × columns) linear scans with lazily-built Maps; correct and safe for all practical inputs. |
| sdk/model/src/components/PlDataTable/state-migration.ts | Adds v6→v7 migration that rewrites fat PTableColumnSpec colIds to compact PTableColumnId colIds; migrateV4toV6 now produces PlDataTableStateV2V6 as an intermediate step before v7. |
| sdk/model/src/components/PlDataTable/typesV7.ts | New file: typesV7.ts holds PlDataTableStateV2Normalized (version 7) using compact PTableColumnId colIds; typesV6.ts is now a thin adapter for v6 legacy types only. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-source-v2.ts | makeColDef now sets colId to compact PTableColumnId and full spec on context; computeDefaultHiddenColIds updated consistently. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts | Sort/hidden colId parsing simplified to direct PTableColumnId parse now that colIds no longer carry full specs. |
| sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts | CSV exporter now reads full spec from ColDef.context instead of parsing the (now compact) colId string. |
| sdk/ui-vue/src/components/PlAgDataTable/compositions/useFilterableColumns.ts | Uses ColDef.context for full spec instead of parsing colId string, consistent with the new colId scheme. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["sdk/PlDataTable: shrink persisted colIds..."](https://github.com/milaboratory/platforma/commit/24ad0ed939dfdf58a874248187e906a0d773aa21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32282825)</sub>

<!-- /greptile_comment -->