### PR TITLE
exec.writeFile: canonical-encode maps and arrays for stable bytes

### DIFF
--- a/.changeset/writefile-canonical-json.md
+++ b/.changeset/writefile-canonical-json.md
@@ -1,0 +1,9 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+`exec.builder().writeFile(name, data)` now accepts maps and arrays directly and serializes them via `canonical.encode` (sorted keys at every level). Previously, callers wrote `writeFile(name, json.encode(value))` and relied on Tengo stdlib `json.encode`, which preserves Go's randomized map iteration order — so the file bytes (and the exec step's dedup CID) varied across runs of identical input.
+
+Strings, bytes, and resource references pass through unchanged.
+
+Migrated all internal call sites in the SDK (`pframes/util.lib.tengo`, `pframes/xsv-import-file.lib.tengo`, `pt/workflow-run.tpl.tengo`) to pass the map/array directly. External callers that already use `writeFile(name, json.encode(value))` are not broken — but should migrate to `writeFile(name, value)` to get CID stability.

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -16,6 +16,7 @@ render := import(":render")
 enum := import("enum")
 oop := import(":oop")
 constants := import(":constants")
+canonical := import(":canonical")
 monetization := import(":exec.monetization_internal")
 execConstants := import(":exec.constants")
 units := import(":units")
@@ -796,11 +797,20 @@ builder := func() {
 		 * When called with the same fileName multiple times,
 		 * the last call will overwrite the previous ones.
 		 *
+		 * Maps and arrays are serialized via `canonical.encode` (sorted keys at
+		 * every level) so the resulting bytes — and therefore the exec step's
+		 * dedup CID — are stable across runs. Callers that previously did
+		 * `writeFile(name, json.encode(value))` should pass `value` directly.
+		 *
 		 * @param fileName: string - the name of the content.
-		 * @param data: bytes|reference - a primitive tengo value (map or array) or a reference to
-		 *        a resource from which data we create a file.
+		 * @param data: string|bytes|map|array|reference - the content to write.
+		 *        Maps and arrays are canonicalized to JSON; strings / bytes /
+		 *        references are passed through unchanged.
 		 */
 		writeFile: func(fileName, data, ...opts) {
+			if is_map(data) || is_array(data) {
+				data = canonical.encode(data)
+			}
 			validation.assertType(data, ["or",
 				"string",
 				"bytes",

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -808,7 +808,11 @@ builder := func() {
 		 *        references are passed through unchanged.
 		 */
 		writeFile: func(fileName, data, ...opts) {
-			if is_map(data) || is_array(data) {
+			// Auto-encode value-like inputs (regular / immutable / strict maps
+			// and arrays) into canonical JSON. Explicitly exclude smart
+			// references — they're implemented as strict maps and would
+			// otherwise be stringified, breaking downstream resource handling.
+			if (ll.isMap(data) || is_array(data)) && !smart.isReference(data) {
 				data = canonical.encode(data)
 			}
 			validation.assertType(data, ["or",

--- a/sdk/workflow-tengo/src/pframes/util.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/util.lib.tengo
@@ -510,17 +510,17 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		jdataFile := "res" + data.id + ".jdata"
 
 		// write jdata
-		execBuilder.writeFile(makePath(jdataFile), json.encode(data.getDataAsJson().data))
+		execBuilder.writeFile(makePath(jdataFile), data.getDataAsJson().data)
 
 		// write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "JsonPartitioned",
 			partitionKeyLength: 0,
 			parts: { "[]": jdataFile }
-		}))
+		})
 
 		// write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
 	} else if (data.checkResourceType(constants.RTYPE_P_COLUMN_DATA_JSON_PARTITIONED)) {
 
@@ -540,14 +540,14 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
         }
 
         // write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "JsonPartitioned",
 			partitionKeyLength: data.getDataAsJson().partitionKeyLength,
 			parts: parts
-		}))
+		})
 
         // write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
 	} else if (data.checkResourceType(constants.RTYPE_P_COLUMN_DATA_JSON_SUPER_PARTITIONED)) {
 
@@ -577,14 +577,14 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		}
 
 		// write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "JsonPartitioned",
 			partitionKeyLength: superPartitionKeyLength + partitionKeyLength,
 			parts: parts
-		}))
+		})
 
         // write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
     } else if (data.checkResourceType(constants.RTYPE_P_COLUMN_DATA_BINARY_PARTITIONED)) {
 
@@ -620,14 +620,14 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
         }
 
         // write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "BinaryPartitioned",
 			partitionKeyLength: data.getDataAsJson().partitionKeyLength,
 			parts: parts
-		}))
+		})
 
         // write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
 	} else if (data.checkResourceType(constants.RTYPE_P_COLUMN_DATA_BINARY_SUPER_PARTITIONED)) {
 
@@ -678,14 +678,14 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		}
 
 		// write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "BinaryPartitioned",
 			partitionKeyLength: superPartitionKeyLength + partitionKeyLength,
 			parts: parts
-		}))
+		})
 
         // write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
 	} else if (data.checkResourceType(constants.RTYPE_P_COLUMN_DATA_PARQUET_PARTITIONED)) {
 
@@ -709,14 +709,14 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
         }
 
         // write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "ParquetPartitioned",
 			partitionKeyLength: data.getDataAsJson().partitionKeyLength,
 			parts: parts
-		}))
+		})
 
         // write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
 	} else if (data.checkResourceType(constants.RTYPE_P_COLUMN_DATA_PARQUET_SUPER_PARTITIONED)) {
 
@@ -752,14 +752,14 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		}
 
 		// write data info
-		execBuilder.writeFile(makePath(name + ".datainfo"), json.encode({
+		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "ParquetPartitioned",
 			partitionKeyLength: superPartitionKeyLength + partitionKeyLength,
 			parts: parts
-		}))
+		})
 
         // write spec
-		execBuilder.writeFile(makePath(name + ".spec"), json.encode(spec))
+		execBuilder.writeFile(makePath(name + ".spec"), spec)
 
 	} else {
 		ll.panic("unsupported p-column data type: %v", data.info().Type)

--- a/sdk/workflow-tengo/src/pframes/xsv-import-file.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/xsv-import-file.lib.tengo
@@ -4,7 +4,6 @@ exec := import(":exec")
 validation := import(":validation")
 objects := import(":objects")
 util := import(":pframes.util")
-json := import("json")
 constants := import(":pframes.constants")
 execConstants := import(":exec.constants")
 xsvImportPt := import(":pframes.xsv-import-pt")
@@ -187,7 +186,7 @@ importFile := func(xsvFile, xsvType, spec, ...ops) {
 		arg("-p").arg("spec.json").
 		arg("-o").arg("out").
 		addFile(xsvFileName, xsvFile).
-		writeFile("spec.json", json.encode(pureSpec)).
+		writeFile("spec.json", pureSpec).
 		processWorkdir("pf", importDirTpl, pureSpec)
 
 	if ops.queue != undefined {

--- a/sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo
+++ b/sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo
@@ -1,6 +1,5 @@
 assets := import(":assets")
 exec := import(":exec")
-json := import("json")
 ll := import(":ll")
 util := import(":pt.util")
 pframesUtil := import(":pframes.util")
@@ -41,7 +40,7 @@ self.body(func(inputs) {
         arg("workflow_sc.json").
         arg("--frame-dir").arg(inFramesFolder).
         arg("--spill-dir").arg(spillFolder).
-        writeFile("workflow_sc.json", json.encode(workflowJsonStruct));
+        writeFile("workflow_sc.json", workflowJsonStruct);
     if !is_undefined(cpu) {
         ptCmd.cpu(cpu)
     }


### PR DESCRIPTION
## Summary

- `exec.builder().writeFile(name, data)` now accepts maps and arrays directly and serializes them via `canonical.encode` (sorted keys at every level). Strings, bytes, and resource references pass through unchanged.
- Migrated all internal SDK call sites (`pframes/util.lib.tengo`, `pframes/xsv-import-file.lib.tengo`, `pt/workflow-run.tpl.tengo`) to drop the `json.encode(...)` wrapper.

## Why

Tengo stdlib `json.encode` preserves Go's randomized map iteration order. Calling `writeFile(name, json.encode(value))` produced different bytes on each run for identical input — the file's hash varies → the exec step's dedup CID varies → cached work is missed on every re-run.

`tx.createValue(RTYPE_JSON, ...)` resources don't have this problem: the backend canonicalizes JSON bytes before CID computation ([resource_singleton.go:110](../pl/platform/core/transaction/resource_singleton.go#L110), [resource_structural.go:218](../pl/platform/core/transaction/resource_structural.go#L218), via `mijson.CanonizeIfJSON`). But raw bytes written to an exec workdir become a `RTYPE_BINARY_VALUE` resource, which is *not* JSON-canonicalized — so non-canonical `json.encode` output propagates directly into the exec input's hash.

This patch fixes that at the SDK boundary: callers pass a Tengo map; the SDK canonicalizes deterministically before storing the bytes.

## Backward compatibility

- Existing `writeFile(name, "raw string")` / `writeFile(name, bytesRef)` / `writeFile(name, referenceRef)` callers unchanged.
- Existing `writeFile(name, json.encode(value))` callers still work — they just don't gain stability. Migration is one-line: drop the `json.encode(...)` wrapper.

## Test plan

- [x] `pnpm type-check` — clean.
- [x] `pnpm test` — 154/154 PASS.
- [x] `pnpm build` — produces dist artifacts.
- [ ] Manual: re-run a block that hits xsv.importFile twice on identical input, confirm exec-step CID matches and dedup hits.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a non-deterministic CID problem: `exec.builder().writeFile(name, data)` now accepts Tengo maps/arrays and serializes them through `canonical.encode` (sorted keys at every level) instead of relying on the caller to wrap with `json.encode`, which preserved Go's randomized map-iteration order. All internal SDK call sites in `pframes/util.lib.tengo`, `pframes/xsv-import-file.lib.tengo`, and `pt/workflow-run.tpl.tengo` are migrated to pass the map directly, with the `json` stdlib import removed from the two files that no longer need it.

- `exec/index.lib.tengo`: imports `:canonical` and adds an `is_map || is_array` guard in `writeFile` that canonicalizes before the existing type assertion; strings, bytes, and references pass through unchanged.
- `pframes/util.lib.tengo`: removes 14 `json.encode(...)` wrappers around `writeFile` calls for `.spec` and `.datainfo` files; the file retains its `json` import for unrelated `json.encode`/`json.decode` calls used for partition-key serialization.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The fix is tightly scoped to the writeFile boundary and the underlying canonical.encode implementation sorts keys via an already-tested quicksort, handles nested structures recursively, and delegates primitives to json.encode.

The change is small, well-tested (154/154 pass), and addresses a real correctness problem. The canonical.encode logic has its own test suite covering maps, nested structures, arrays, and edge cases. No logic errors, type mismatches, or missed migration sites were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/exec/index.lib.tengo | Imports :canonical and adds is_map/is_array guard in writeFile to canonicalize before the existing type assertion; logic is correct and backward-compatible. |
| sdk/workflow-tengo/src/pframes/util.lib.tengo | Removes json.encode wrappers on all writeFile calls for .spec and .datainfo files; retains json import which is still used for partition-key encode/decode elsewhere in the file. |
| sdk/workflow-tengo/src/pframes/xsv-import-file.lib.tengo | Removes json import and the json.encode wrapper on the single writeFile("spec.json", ...) call; straightforward one-liner migration. |
| sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo | Removes json import and the json.encode wrapper on writeFile("workflow_sc.json", ...); clean migration with no other affected logic. |
| .changeset/writefile-canonical-json.md | Changeset entry correctly marks this as a minor bump and describes both the problem and the backward-compatibility guarantee. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["writeFile(fileName, data, ...opts)"] --> B{is_map OR is_array?}
    B -- yes --> C["data = canonical.encode(data)\n(sorted keys, recursive)"]
    B -- no --> D["data unchanged\n(string / bytes / reference)"]
    C --> E["validation.assertType(data,\n[string | bytes | reference])"]
    D --> E
    E --> F["filesToWrite[fileName] = data"]

    subgraph canonical.encode
        G[map?] -- yes --> H["maps.getKeys → quickSortInPlace\nbuild JSON with sorted keys\nrecurse into values"]
        G -- array? --> I["preserve order\nrecurse into elements"]
        G -- primitive --> J["json.encode(value)"]
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["exec.writeFile: canonical-encode maps an..."](https://github.com/milaboratory/platforma/commit/63bfbdc52442181a0130acf9d1ef1467fe7dea11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32503469)</sub>

<!-- /greptile_comment -->