### PR TITLE
spike: slim facade — bundler comparison (sum/enter-numbers-v3)

### DIFF
--- a/etc/blocks/.gitignore
+++ b/etc/blocks/.gitignore
@@ -1,1 +1,3 @@
 block-pack/
+dist-dbg/
+dist-rdp/

--- a/etc/blocks/enter-numbers-v3/block/build-facade.mjs
+++ b/etc/blocks/enter-numbers-v3/block/build-facade.mjs
@@ -1,0 +1,84 @@
+// Scratch facade-bundle build for the slim-facade spike.
+// Runs both bundlers side-by-side. Output is for inspection only.
+//
+//   pnpm build:facade
+//
+// Produces:
+//   dist-dbg/index.d.ts   — dts-bundle-generator output
+//   dist-rdp/index.d.ts   — rolldown-plugin-dts output
+//
+// Both bundlers configured to fully inline @platforma-sdk/model and the
+// sibling model package so the facade is self-contained.
+
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateDtsBundle } from "dts-bundle-generator";
+import { rolldown } from "rolldown";
+import { dts } from "rolldown-plugin-dts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
+
+const entryTs = resolve(__dirname, "src/index.ts");
+const tsconfigPath = resolve(__dirname, "tsconfig.json");
+
+const modelPkgName = Object.keys(pkg.dependencies ?? {}).find((n) => n.endsWith(".model"));
+if (!modelPkgName) throw new Error("Could not find sibling .model package in dependencies.");
+
+const inlineList = ["@platforma-sdk/model", modelPkgName];
+
+console.log(`Facade source:  ${entryTs}`);
+console.log(`Inlining:       ${inlineList.join(", ")}`);
+
+// ---------------------------------------------------------------------------
+// dts-bundle-generator
+// ---------------------------------------------------------------------------
+{
+  const outDir = resolve(__dirname, "dist-dbg");
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+
+  const t0 = Date.now();
+  const [content] = generateDtsBundle(
+    [
+      {
+        filePath: entryTs,
+        libraries: { inlinedLibraries: inlineList },
+        output: { sortNodes: false, noBanner: false },
+      },
+    ],
+    { preferredConfigPath: tsconfigPath, followSymlinks: true },
+  );
+  writeFileSync(resolve(outDir, "index.d.ts"), content);
+  console.log(`dts-bundle-generator   → dist-dbg/index.d.ts   (${Date.now() - t0} ms, ${content.length} bytes)`);
+}
+
+// ---------------------------------------------------------------------------
+// rolldown-plugin-dts
+// ---------------------------------------------------------------------------
+{
+  const outDir = resolve(__dirname, "dist-rdp");
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+
+  const t0 = Date.now();
+  const bundle = await rolldown({
+    input: entryTs,
+    // Force every package to be resolved and pulled into the bundle so the
+    // facade is self-contained. Default Rolldown behavior would keep
+    // non-relative imports external.
+    external: () => false,
+    plugins: [
+      dts({
+        tsconfig: tsconfigPath,
+        emitDtsOnly: true,
+        sourcemap: false,
+      }),
+    ],
+  });
+  await bundle.write({ dir: outDir, format: "es" });
+  await bundle.close();
+  const out = readFileSync(resolve(outDir, "index.d.ts"), "utf-8");
+  console.log(`rolldown-plugin-dts    → dist-rdp/index.d.ts   (${Date.now() - t0} ms, ${out.length} bytes)`);
+}

--- a/etc/blocks/enter-numbers-v3/block/package.json
+++ b/etc/blocks/enter-numbers-v3/block/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf ./block-pack && block-tools pack"
+    "build": "rm -rf ./block-pack && block-tools pack",
+    "build:facade": "node ./build-facade.mjs"
   },
   "files": [
     "index.d.ts",
@@ -16,7 +17,12 @@
     "@milaboratories/milaboratories.test-enter-numbers-v3.ui": "workspace:*"
   },
   "devDependencies": {
-    "@platforma-sdk/block-tools": "workspace:*"
+    "@milaboratories/ts-configs": "workspace:*",
+    "@platforma-sdk/block-tools": "workspace:*",
+    "dts-bundle-generator": "^9.5.1",
+    "rolldown": "^1.0.1",
+    "rolldown-plugin-dts": "^0.25.1",
+    "typescript": "catalog:"
   },
   "block": {
     "components": {

--- a/etc/blocks/enter-numbers-v3/block/src/index.ts
+++ b/etc/blocks/enter-numbers-v3/block/src/index.ts
@@ -2,7 +2,6 @@ import type { InferDataType, InferHrefType, InferOutputsType } from "@platforma-
 import type {
   BlockData,
   EnterNumbersRef,
-  SortedNumbers,
 } from "@milaboratories/milaboratories.test-enter-numbers-v3.model";
 import { platforma } from "@milaboratories/milaboratories.test-enter-numbers-v3.model";
 
@@ -44,7 +43,7 @@ export type HrefOf<S> = S extends { href: infer H } ? H : never;
  */
 export type BlockOutputs = InferOutputsType<typeof platforma>;
 
-export type { BlockData, EnterNumbersRef, SortedNumbers };
+export type { BlockData, EnterNumbersRef };
 
 const __facadeDir__ = new URL(".", import.meta.url).pathname;
 

--- a/etc/blocks/enter-numbers-v3/block/src/index.ts
+++ b/etc/blocks/enter-numbers-v3/block/src/index.ts
@@ -1,0 +1,60 @@
+import type { InferDataType, InferHrefType, InferOutputsType } from "@platforma-sdk/model";
+import type {
+  BlockData,
+  EnterNumbersRef,
+  SortedNumbers,
+} from "@milaboratories/milaboratories.test-enter-numbers-v3.model";
+import { platforma } from "@milaboratories/milaboratories.test-enter-numbers-v3.model";
+
+/**
+ * Spec marker for the Enter Numbers v3 block. Phantom type — encodes the
+ * outputs, data, and href shapes so consumers (tests, MCP, other blocks)
+ * can reach them via the `OutputsOf` / `DataOf` / `HrefOf` generators.
+ *
+ * Spike probe — top-level alias JSDoc with rich content.
+ */
+export interface EnterNumbersV3Spec {
+  /** Nominal tag pinning this Spec to the enter-numbers-v3 block. */
+  readonly __block: "enter-numbers-v3";
+  /** Outputs reachable through the block's workflow run. */
+  outputs: InferOutputsType<typeof platforma>;
+  /** Persistent block state (data) — see {@link BlockData}. */
+  data: InferDataType<typeof platforma>;
+  /** Hrefs the block UI advertises. */
+  href: InferHrefType<typeof platforma>;
+}
+
+/** Universal Spec twin — every facade exports `BlockSpec` as an alias of its block-named Spec. */
+export type BlockSpec = EnterNumbersV3Spec;
+
+/** Extract the outputs shape from a block Spec. */
+export type OutputsOf<S> = S extends { outputs: infer O } ? O : never;
+
+/** Extract the data (block state) shape from a block Spec. */
+export type DataOf<S> = S extends { data: infer D } ? D : never;
+
+/** Extract the href shape from a block Spec. */
+export type HrefOf<S> = S extends { href: infer H } ? H : never;
+
+/**
+ * Outputs of this block. Convenience alias equal to `OutputsOf<BlockSpec>`.
+ * The shape is derived via `InferOutputsType<typeof platforma>` — JSDoc
+ * placed on the individual `.output(...)` builders in the model package must
+ * survive into the bundled facade `.d.ts`.
+ */
+export type BlockOutputs = InferOutputsType<typeof platforma>;
+
+export type { BlockData, EnterNumbersRef, SortedNumbers };
+
+const __facadeDir__ = new URL(".", import.meta.url).pathname;
+
+/**
+ * Dev-v2 block spec — folder-based, resolved relative to the facade directory.
+ *
+ * Phase C will replace the runtime side with a registry-aware dispatcher;
+ * Phase B keeps the existing dev-v2 shape unchanged.
+ */
+export const blockSpec = {
+  type: "dev-v2" as const,
+  folder: __facadeDir__,
+};

--- a/etc/blocks/enter-numbers-v3/block/tsconfig.json
+++ b/etc/blocks/enter-numbers-v3/block/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@milaboratories/ts-configs/node",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist-types",
+    "customConditions": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "dist-types", "dist-dbg", "dist-rdp", "**/*.test.ts"]
+}

--- a/etc/blocks/enter-numbers-v3/model/package.json
+++ b/etc/blocks/enter-numbers-v3/model/package.json
@@ -16,8 +16,7 @@
     "fmt": "ts-builder format"
   },
   "dependencies": {
-    "@platforma-sdk/model": "workspace:*",
-    "zod": "catalog:"
+    "@platforma-sdk/model": "workspace:*"
   },
   "devDependencies": {
     "@milaboratories/build-configs": "workspace:*",

--- a/etc/blocks/enter-numbers-v3/model/src/index.ts
+++ b/etc/blocks/enter-numbers-v3/model/src/index.ts
@@ -27,21 +27,6 @@ export type BlockData = {
   description: string;
 };
 
-/**
- * Sorted view of the numbers entered by the user. Returned by the `numbers`
- * output lambda so the inferred property of `BlockOutputs` carries this named
- * type and its JSDoc.
- *
- * Spike probe — named return type whose JSDoc must propagate downstream
- * through `InferOutputsType`.
- */
-export type SortedNumbers = {
-  /** Numbers in ascending order. */
-  values: readonly number[];
-  /** Count of unique values in `values`. */
-  unique: number;
-};
-
 // Define data model with migrations from v1 to current
 const dataModel = new DataModelBuilder()
   .from<BlockDataV1>("v1")
@@ -72,12 +57,7 @@ export const platforma = BlockModelV3.create(dataModel)
     return { evenNumbers: data.numbers.toSorted().filter((n) => n % 2 === 0) };
   })
 
-  .output("numbers", (ctx): SortedNumbers | undefined => {
-    const raw = ctx.outputs?.resolve("numbers")?.getDataAsJson<number[]>();
-    if (raw === undefined) return undefined;
-    const values = [...raw].sort((a, b) => a - b);
-    return { values, unique: new Set(values).size };
-  })
+  .output("numbers", (ctx) => ctx.outputs?.resolve("numbers")?.getDataAsJson<number[]>())
 
   .output("activeArgs", (ctx) => ctx.activeArgs)
 

--- a/etc/blocks/enter-numbers-v3/model/src/index.ts
+++ b/etc/blocks/enter-numbers-v3/model/src/index.ts
@@ -1,6 +1,5 @@
 import type { InferHrefType, InferOutputsType } from "@platforma-sdk/model";
 import { BlockModelV3, DataModelBuilder } from "@platforma-sdk/model";
-import { z } from "zod";
 
 // Data version 1: just numbers
 type BlockDataV1 = {
@@ -13,14 +12,35 @@ type BlockDataV2 = {
   labels: string[];
 };
 
-// Data version 3 (current): added description
-export const $BlockData = z.object({
-  numbers: z.array(z.coerce.number()),
-  labels: z.array(z.string()),
-  description: z.string(),
-});
+/**
+ * Persistent block state for enter-numbers-v3. Version 3 of the schema.
+ *
+ * Spike probe — JSDoc on the alias and on each property must reach the
+ * bundled facade `.d.ts` through `InferDataType<typeof platforma>`.
+ */
+export type BlockData = {
+  /** Raw numbers entered by the user, in input order. */
+  numbers: number[];
+  /** Optional labels paired with each number. Empty until user provides one. */
+  labels: string[];
+  /** Human-friendly description of the dataset. */
+  description: string;
+};
 
-export type BlockData = z.infer<typeof $BlockData>;
+/**
+ * Sorted view of the numbers entered by the user. Returned by the `numbers`
+ * output lambda so the inferred property of `BlockOutputs` carries this named
+ * type and its JSDoc.
+ *
+ * Spike probe — named return type whose JSDoc must propagate downstream
+ * through `InferOutputsType`.
+ */
+export type SortedNumbers = {
+  /** Numbers in ascending order. */
+  values: readonly number[];
+  /** Count of unique values in `values`. */
+  unique: number;
+};
 
 // Define data model with migrations from v1 to current
 const dataModel = new DataModelBuilder()
@@ -52,7 +72,12 @@ export const platforma = BlockModelV3.create(dataModel)
     return { evenNumbers: data.numbers.toSorted().filter((n) => n % 2 === 0) };
   })
 
-  .output("numbers", (ctx) => ctx.outputs?.resolve("numbers")?.getDataAsJson<number[]>())
+  .output("numbers", (ctx): SortedNumbers | undefined => {
+    const raw = ctx.outputs?.resolve("numbers")?.getDataAsJson<number[]>();
+    if (raw === undefined) return undefined;
+    const values = [...raw].sort((a, b) => a - b);
+    return { values, unique: new Set(values).size };
+  })
 
   .output("activeArgs", (ctx) => ctx.activeArgs)
 
@@ -91,3 +116,17 @@ export const platforma = BlockModelV3.create(dataModel)
 
 export type BlockOutputs = InferOutputsType<typeof platforma>;
 export type Href = InferHrefType<typeof platforma>;
+
+/**
+ * Reference shape exposed by this block — nominal record pinning the entered
+ * numbers to the block identity.
+ *
+ * Spike probe — JSDoc on a hand-written helper type re-exported through the
+ * facade. Both alias-level JSDoc and per-property JSDoc must survive.
+ */
+export type EnterNumbersRef = {
+  /** Nominal tag pinning this ref to the enter-numbers-v3 block. */
+  readonly kind: "enter-numbers-v3";
+  /** Sorted numbers from the most recent run. */
+  numbers: readonly number[];
+};

--- a/etc/blocks/sum-numbers-v3/block/build-facade.mjs
+++ b/etc/blocks/sum-numbers-v3/block/build-facade.mjs
@@ -1,0 +1,84 @@
+// Scratch facade-bundle build for the slim-facade spike.
+// Runs both bundlers side-by-side. Output is for inspection only.
+//
+//   pnpm build:facade
+//
+// Produces:
+//   dist-dbg/index.d.ts   — dts-bundle-generator output
+//   dist-rdp/index.d.ts   — rolldown-plugin-dts output
+//
+// Both bundlers configured to fully inline @platforma-sdk/model and the
+// sibling model package so the facade is self-contained.
+
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateDtsBundle } from "dts-bundle-generator";
+import { rolldown } from "rolldown";
+import { dts } from "rolldown-plugin-dts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
+
+const entryTs = resolve(__dirname, "src/index.ts");
+const tsconfigPath = resolve(__dirname, "tsconfig.json");
+
+const modelPkgName = Object.keys(pkg.dependencies ?? {}).find((n) => n.endsWith(".model"));
+if (!modelPkgName) throw new Error("Could not find sibling .model package in dependencies.");
+
+const inlineList = ["@platforma-sdk/model", modelPkgName];
+
+console.log(`Facade source:  ${entryTs}`);
+console.log(`Inlining:       ${inlineList.join(", ")}`);
+
+// ---------------------------------------------------------------------------
+// dts-bundle-generator
+// ---------------------------------------------------------------------------
+{
+  const outDir = resolve(__dirname, "dist-dbg");
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+
+  const t0 = Date.now();
+  const [content] = generateDtsBundle(
+    [
+      {
+        filePath: entryTs,
+        libraries: { inlinedLibraries: inlineList },
+        output: { sortNodes: false, noBanner: false },
+      },
+    ],
+    { preferredConfigPath: tsconfigPath, followSymlinks: true },
+  );
+  writeFileSync(resolve(outDir, "index.d.ts"), content);
+  console.log(`dts-bundle-generator   → dist-dbg/index.d.ts   (${Date.now() - t0} ms, ${content.length} bytes)`);
+}
+
+// ---------------------------------------------------------------------------
+// rolldown-plugin-dts
+// ---------------------------------------------------------------------------
+{
+  const outDir = resolve(__dirname, "dist-rdp");
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+
+  const t0 = Date.now();
+  const bundle = await rolldown({
+    input: entryTs,
+    // Force every package to be resolved and pulled into the bundle so the
+    // facade is self-contained. Default Rolldown behavior would keep
+    // non-relative imports external.
+    external: () => false,
+    plugins: [
+      dts({
+        tsconfig: tsconfigPath,
+        emitDtsOnly: true,
+        sourcemap: false,
+      }),
+    ],
+  });
+  await bundle.write({ dir: outDir, format: "es" });
+  await bundle.close();
+  const out = readFileSync(resolve(outDir, "index.d.ts"), "utf-8");
+  console.log(`rolldown-plugin-dts    → dist-rdp/index.d.ts   (${Date.now() - t0} ms, ${out.length} bytes)`);
+}

--- a/etc/blocks/sum-numbers-v3/block/package.json
+++ b/etc/blocks/sum-numbers-v3/block/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rm -rf ./block-pack && block-tools pack"
+    "build": "rm -rf ./block-pack && block-tools pack",
+    "build:facade": "node ./build-facade.mjs"
   },
   "files": [
     "index.d.ts",
@@ -16,7 +17,12 @@
     "@milaboratories/milaboratories.test-sum-numbers-v3.ui": "workspace:*"
   },
   "devDependencies": {
-    "@platforma-sdk/block-tools": "workspace:*"
+    "@milaboratories/ts-configs": "workspace:*",
+    "@platforma-sdk/block-tools": "workspace:*",
+    "dts-bundle-generator": "^9.5.1",
+    "rolldown": "^1.0.1",
+    "rolldown-plugin-dts": "^0.25.1",
+    "typescript": "catalog:"
   },
   "block": {
     "components": {

--- a/etc/blocks/sum-numbers-v3/block/src/index.ts
+++ b/etc/blocks/sum-numbers-v3/block/src/index.ts
@@ -1,0 +1,60 @@
+import type { InferDataType, InferHrefType, InferOutputsType } from "@platforma-sdk/model";
+import type {
+  BlockData,
+  SumNumbersRef,
+  SumOutcome,
+} from "@milaboratories/milaboratories.test-sum-numbers-v3.model";
+import { platforma } from "@milaboratories/milaboratories.test-sum-numbers-v3.model";
+
+/**
+ * Spec marker for the Sum Numbers v3 block. Phantom type — encodes the
+ * outputs, data, and href shapes so consumers (tests, MCP, other blocks)
+ * can reach them via the `OutputsOf` / `DataOf` / `HrefOf` generators.
+ *
+ * Spike probe — top-level alias JSDoc with rich content.
+ */
+export interface SumNumbersV3Spec {
+  /** Nominal tag pinning this Spec to the sum-numbers-v3 block. */
+  readonly __block: "sum-numbers-v3";
+  /** Outputs reachable through the block's workflow run. */
+  outputs: InferOutputsType<typeof platforma>;
+  /** Persistent block state (data) — see {@link BlockData}. */
+  data: InferDataType<typeof platforma>;
+  /** Hrefs the block UI advertises. */
+  href: InferHrefType<typeof platforma>;
+}
+
+/** Universal Spec twin — every facade exports `BlockSpec` as an alias of its block-named Spec. */
+export type BlockSpec = SumNumbersV3Spec;
+
+/** Extract the outputs shape from a block Spec. */
+export type OutputsOf<S> = S extends { outputs: infer O } ? O : never;
+
+/** Extract the data (block state) shape from a block Spec. */
+export type DataOf<S> = S extends { data: infer D } ? D : never;
+
+/** Extract the href shape from a block Spec. */
+export type HrefOf<S> = S extends { href: infer H } ? H : never;
+
+/**
+ * Outputs of this block. Convenience alias equal to `OutputsOf<BlockSpec>`.
+ * The shape is derived via `InferOutputsType<typeof platforma>` — JSDoc
+ * placed on the individual `.output(...)` builders in the model package must
+ * survive into the bundled facade `.d.ts`.
+ */
+export type BlockOutputs = InferOutputsType<typeof platforma>;
+
+export type { BlockData, SumNumbersRef, SumOutcome };
+
+const __facadeDir__ = new URL(".", import.meta.url).pathname;
+
+/**
+ * Dev-v2 block spec — folder-based, resolved relative to the facade directory.
+ *
+ * Phase C will replace the runtime side with a registry-aware dispatcher;
+ * Phase B keeps the existing dev-v2 shape unchanged.
+ */
+export const blockSpec = {
+  type: "dev-v2" as const,
+  folder: __facadeDir__,
+};

--- a/etc/blocks/sum-numbers-v3/block/tsconfig.json
+++ b/etc/blocks/sum-numbers-v3/block/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@milaboratories/ts-configs/node",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist-types",
+    "customConditions": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "dist-types", "dist-dbg", "dist-rdp", "**/*.test.ts"]
+}

--- a/etc/blocks/sum-numbers-v3/model/package.json
+++ b/etc/blocks/sum-numbers-v3/model/package.json
@@ -16,8 +16,7 @@
     "fmt": "ts-builder format"
   },
   "dependencies": {
-    "@platforma-sdk/model": "workspace:*",
-    "zod": "catalog:"
+    "@platforma-sdk/model": "workspace:*"
   },
   "devDependencies": {
     "@milaboratories/build-configs": "workspace:*",

--- a/etc/blocks/sum-numbers-v3/model/src/index.ts
+++ b/etc/blocks/sum-numbers-v3/model/src/index.ts
@@ -6,13 +6,32 @@ import {
   PlRef,
   readAnnotation,
 } from "@platforma-sdk/model";
-import { z } from "zod";
 
-export const BlockData = z.object({
-  sources: z.array(PlRef).optional(),
-});
+/**
+ * Persistent block state — user input for the sum-numbers-v3 block.
+ *
+ * Spike probe — JSDoc on the alias and on each property must reach the
+ * bundled facade `.d.ts` through `InferDataType<typeof platforma>`.
+ */
+export type BlockData = {
+  /** Refs the user picked as input sources. Empty until at least one is selected. */
+  sources?: PlRef[];
+};
 
-export type BlockData = z.infer<typeof BlockData>;
+/**
+ * Outcome shape produced by the workflow once the run completes. Returned by
+ * the `sum` output lambda so the inferred property of `BlockOutputs` carries
+ * this named type and its JSDoc.
+ *
+ * Spike probe — named return type whose JSDoc must propagate downstream
+ * through `InferOutputsType`.
+ */
+export type SumOutcome = {
+  /** Computed sum of all input numbers. */
+  sum: number;
+  /** Number of input values used. */
+  count: number;
+};
 
 const dataModel = new DataModelBuilder().from<BlockData>("v1").init(() => ({ sources: undefined }));
 
@@ -55,7 +74,11 @@ export const platforma = BlockModelV3.create(dataModel)
       })),
   )
 
-  .output("sum", (ctx) => ctx.outputs?.resolve("sum")?.getDataAsJson<number>())
+  .output("sum", (ctx): SumOutcome | undefined => {
+    const sum = ctx.outputs?.resolve("sum")?.getDataAsJson<number>();
+    if (sum === undefined) return undefined;
+    return { sum, count: ctx.args?.sources?.length ?? 0 };
+  })
 
   .output("prerunArgsJson", (ctx) =>
     ctx.prerun?.resolve("prerunArgsJson")?.getDataAsJson<Record<string, unknown>>(),
@@ -73,3 +96,17 @@ export const platforma = BlockModelV3.create(dataModel)
 
 export type BlockOutputs = InferOutputsType<typeof platforma>;
 export type Href = InferHrefType<typeof platforma>;
+
+/**
+ * Reference shape exposed by this block — nominal record so downstream blocks
+ * can pin against it regardless of future shape changes.
+ *
+ * Spike probe — JSDoc on a hand-written helper type re-exported through the
+ * facade. Both alias-level JSDoc and per-property JSDoc must survive.
+ */
+export type SumNumbersRef = {
+  /** Nominal tag pinning this ref to the sum-numbers-v3 block. */
+  readonly kind: "sum-numbers-v3";
+  /** Sum value, populated once the workflow run completes. */
+  sum: number | undefined;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,18 +546,30 @@ importers:
         specifier: workspace:*
         version: link:../../../../sdk/model
     devDependencies:
+      '@milaboratories/ts-configs':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-configs
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../../../tools/block-tools
+      dts-bundle-generator:
+        specifier: ^9.5.1
+        version: 9.5.1
+      rolldown:
+        specifier: ^1.0.1
+        version: 1.0.1
+      rolldown-plugin-dts:
+        specifier: ^0.25.1
+        version: 0.25.1(rolldown@1.0.1)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   etc/blocks/enter-numbers-v3/model:
     dependencies:
       '@platforma-sdk/model':
         specifier: workspace:*
         version: link:../../../../sdk/model
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@milaboratories/build-configs':
         specifier: workspace:*
@@ -1203,18 +1215,30 @@ importers:
         specifier: workspace:*
         version: link:../../../../sdk/model
     devDependencies:
+      '@milaboratories/ts-configs':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-configs
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../../../tools/block-tools
+      dts-bundle-generator:
+        specifier: ^9.5.1
+        version: 9.5.1
+      rolldown:
+        specifier: ^1.0.1
+        version: 1.0.1
+      rolldown-plugin-dts:
+        specifier: ^0.25.1
+        version: 0.25.1(rolldown@1.0.1)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   etc/blocks/sum-numbers-v3/model:
     dependencies:
       '@platforma-sdk/model':
         specifier: workspace:*
         version: link:../../../../sdk/model
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@milaboratories/build-configs':
         specifier: workspace:*
@@ -4301,6 +4325,10 @@ packages:
     resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@babel/generator@8.0.0-rc.5':
+    resolution: {integrity: sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
@@ -4327,6 +4355,10 @@ packages:
     resolution: {integrity: sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@babel/helper-string-parser@8.0.0-rc.5':
+    resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -4334,6 +4366,10 @@ packages:
   '@babel/helper-validator-identifier@8.0.0-rc.3':
     resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.5':
+    resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -4351,6 +4387,16 @@ packages:
   '@babel/parser@8.0.0-rc.3':
     resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  '@babel/parser@8.0.0-rc.4':
+    resolution: {integrity: sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  '@babel/parser@8.0.0-rc.5':
+    resolution: {integrity: sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/runtime@7.25.6':
@@ -4372,6 +4418,10 @@ packages:
   '@babel/types@8.0.0-rc.3':
     resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/types@8.0.0-rc.5':
+    resolution: {integrity: sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
@@ -4451,14 +4501,23 @@ packages:
   '@dabh/diagnostics@2.0.3':
     resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.23.1':
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
@@ -5029,6 +5088,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -5070,6 +5135,9 @@ packages:
 
   '@oxc-project/types@0.123.0':
     resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
+
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
   '@oxfmt/binding-android-arm-eabi@0.35.0':
     resolution: {integrity: sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA==}
@@ -5497,8 +5565,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
     resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -5509,8 +5589,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
     resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -5521,8 +5613,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5533,8 +5637,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -5545,8 +5661,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5557,8 +5685,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -5568,8 +5708,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
     resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -5580,11 +5731,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-rc.13':
     resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-node-resolve@16.0.1':
     resolution: {integrity: sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==}
@@ -7130,9 +7290,23 @@ packages:
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
+  dts-bundle-generator@9.5.1:
+    resolution: {integrity: sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
     engines: {node: '>=20.19.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
+  dts-resolver@3.0.0:
+    resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
+    engines: {node: ^22.18.0 || >=24.0.0}
     peerDependencies:
       oxc-resolver: '>=11.0.0'
     peerDependenciesMeta:
@@ -7483,6 +7657,10 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
 
   git-hooks-list@3.1.0:
     resolution: {integrity: sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==}
@@ -8624,8 +8802,32 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown-plugin-dts@0.25.1:
+    resolution: {integrity: sha512-zK82aC/8z1iVW+g0bCnlQZq04Y5bNeL/RcRwTYBwsnU6wH0N+6vpIFkN7JC0kYRS5qKA+pxQyfIPvXJ6Q5xSpQ==}
+    engines: {node: ^22.18.0 || >=24.0.0}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0
+      typescript: ^5.0.0 || ^6.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown@1.0.0-rc.13:
     resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -10478,6 +10680,15 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0-rc.5':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.5
+      '@babel/types': 8.0.0-rc.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.0
@@ -10508,9 +10719,13 @@ snapshots:
 
   '@babel/helper-string-parser@8.0.0-rc.3': {}
 
+  '@babel/helper-string-parser@8.0.0-rc.5': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.3': {}
+
+  '@babel/helper-validator-identifier@8.0.0-rc.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -10526,6 +10741,14 @@ snapshots:
   '@babel/parser@8.0.0-rc.3':
     dependencies:
       '@babel/types': 8.0.0-rc.3
+
+  '@babel/parser@8.0.0-rc.4':
+    dependencies:
+      '@babel/types': 8.0.0-rc.5
+
+  '@babel/parser@8.0.0-rc.5':
+    dependencies:
+      '@babel/types': 8.0.0-rc.5
 
   '@babel/runtime@7.25.6':
     dependencies:
@@ -10558,6 +10781,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
+
+  '@babel/types@8.0.0-rc.5':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-rc.5
+      '@babel/helper-validator-identifier': 8.0.0-rc.5
 
   '@balena/dockerignore@1.0.2': {}
 
@@ -10727,9 +10955,20 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -10739,6 +10978,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11288,6 +11532,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@2.0.1': {}
@@ -11352,6 +11603,8 @@ snapshots:
   '@one-ini/wasm@0.1.1': {}
 
   '@oxc-project/types@0.123.0': {}
+
+  '@oxc-project/types@0.130.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.35.0':
     optional: true
@@ -11749,37 +12002,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.1':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
@@ -11789,15 +12078,30 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-node-resolve@16.0.1(rollup@4.60.1)':
     dependencies:
@@ -13630,7 +13934,14 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
+  dts-bundle-generator@9.5.1:
+    dependencies:
+      typescript: 5.9.3
+      yargs: 17.7.2
+
   dts-resolver@2.1.3: {}
+
+  dts-resolver@3.0.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14027,6 +14338,10 @@ snapshots:
   get-stream@6.0.1: {}
 
   get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -15141,6 +15456,23 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.25.1(rolldown@1.0.1)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.5
+      '@babel/helper-validator-identifier': 8.0.0-rc.5
+      '@babel/parser': 8.0.0-rc.4
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.1
+      rolldown: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+      vue-tsc: 3.2.6(typescript@5.9.3)
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown@1.0.0-rc.13:
     dependencies:
       '@oxc-project/types': 0.123.0
@@ -15161,6 +15493,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
+
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
 
   rollup-plugin-copy@3.5.0:
     dependencies:


### PR DESCRIPTION
## Summary

Branch-only scratch from the **slim-facade spike** (Phases A+B). Bundles each test block's facade with both `dts-bundle-generator` and `rolldown-plugin-dts` for side-by-side inspection.

**Not for merge** — productionization plan lives in `docs/mitxt/work/2026-05-13-test-framework/facade-build-plan.md` (separate repo). This PR is the empirical artifact backing that plan.

## What's in

Per-block (`sum-numbers-v3`, `enter-numbers-v3`):

- `block/src/index.ts` — facade source. Exports `BlockSpec` (block-named twin + universal alias), `OutputsOf` / `DataOf` / `HrefOf` generators, `BlockData`, hand-written model helpers, placeholder `blockSpec` value.
- `block/tsconfig.json` — declaration-emit tsconfig extending `@milaboratories/ts-configs/node`.
- `block/build-facade.mjs` — scratch dual-bundler driver invoked by `pnpm build:facade`. Outputs land in `dist-dbg/` (dts-bundle-generator) and `dist-rdp/` (rolldown-plugin-dts); both gitignored.
- `block/package.json` — local devDeps for the two bundlers and TS.
- `model/src/index.ts` — Zod removed (not in use). `BlockData` hand-authored with per-field JSDoc. `SumOutcome` (sum-numbers-v3 only) added as a JSDoc-propagation probe through `InferRenderFunctionReturn`.

## Findings (short)

- **Bundler choice: `rolldown-plugin-dts`.** More aggressive default inlining (`external: () => false` → zero external imports). Same toolchain we already use in ts-builder.
- JSDoc preservation: parity between the two bundlers on every probe.
- `DataOf<BlockSpec>` propagation works end-to-end — `BlockData` alias survives through `PlatformaV3<BlockData, …>` slot, JSDoc reaches consumer.
- `OutputsOf<BlockSpec>[K]` loses alias regardless of bundler — root cause is SDK-level expansion in `InferRenderFunctionReturn<RF>` during model `.d.ts` emit. SDK reshape needed; tracked separately.

Full Phase B results table and findings in `spike-slim-facade-plan.md` (`docs/mitxt/`).

## What's not in

- No ts-builder target — productionization is the next step, not this PR.
- No JS-side facade rewrite — `block/index.js` untouched.
- No cross-block test — folded into the productionization plan's test list.