### PR TITLE
MILAB-6225: Add federative envelope handling to Ls API

### DIFF
--- a/.changeset/social-bars-beam.md
+++ b/.changeset/social-bars-beam.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-middle-layer": minor
+"@milaboratories/pl-drivers": minor
+---
+
+support file link signing

--- a/lib/node/pl-drivers/proto/shared/lsapi/openapi.yaml
+++ b/lib/node/pl-drivers/proto/shared/lsapi/openapi.yaml
@@ -59,6 +59,14 @@ components:
         isDir:
           type: boolean
           description: is_dir is true for an item that can have subitems.
+        additionalInfo:
+          type: object
+          additionalProperties:
+            type: string
+          description: |-
+            additional_info carries the signed identity envelope for federative storages.
+             KV schema: v=1, path, uid, sid, role, exp, kid, signed, sig.
+             Empty for non-federative storages. Verifiers MUST ignore unknown keys.
         fullName:
           type: string
           description: |-

--- a/lib/node/pl-drivers/proto/shared/lsapi/protocol.proto
+++ b/lib/node/pl-drivers/proto/shared/lsapi/protocol.proto
@@ -34,6 +34,13 @@ message LsAPI {
     // is_dir is true for an item that can have subitems.
     bool is_dir = 3;
 
+    // additional_info carries the signed identity envelope for federative storages.
+    // KV schema is authoritative in pl/util/storage/v4sign/envelope.go:
+    //   v=1, path, uid, sid (optional), role (optional), exp (unix-sec decimal), kid,
+    //   signed=path,uid,sid,role,exp,kid, sig (base64url HMAC-SHA256).
+    // Empty for non-federative storages. Verifiers MUST ignore unknown keys.
+    map<string, string> additional_info = 8;
+
     // full_name is the full name of the item, relative to the storage root.
     // It is <directory> + <name>.
     // The <delimiter>, used in names, is storage-specific and is NOT guaranteed to be '/'.
@@ -66,7 +73,7 @@ message LsAPI {
       // Location to list, relative to the storage root. Only items that have <full_name> starting
       // with <location> are included in the list response.
       string location = 2;
-      
+
       // // limit amount of items returned by server in single response.
       // // The default and maximum limit may differ for different storage types.
       // // If the storage has its own restrictions on <limit> value (<storage limit>),

--- a/lib/node/pl-drivers/src/clients/ls_api.ts
+++ b/lib/node/pl-drivers/src/clients/ls_api.ts
@@ -68,6 +68,7 @@ export class ClientLs {
         name: item.name,
         size: BigInt(item.size),
         isDir: item.isDir,
+        additionalInfo: item.additionalInfo ?? {},
         fullName: item.fullName,
         directory: item.directory,
         lastModified: parseTimestamp(item.lastModified),

--- a/lib/node/pl-drivers/src/drivers/helpers/ls_remote_import_handle.test.ts
+++ b/lib/node/pl-drivers/src/drivers/helpers/ls_remote_import_handle.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { createIndexImportHandle, parseIndexHandle } from "./ls_remote_import_handle";
+
+// Golden URL for the no-envelope case — guards against accidental key injection or ordering drift.
+// Value: index://index/<url-encoded JSON of {storageId:"s3",path:"x/y"}>
+const GOLDEN_NO_ENVELOPE = `index://index/${encodeURIComponent(JSON.stringify({ storageId: "s3", path: "x/y" }))}`;
+
+describe("createIndexImportHandle", () => {
+  test("round-trips additionalInfo envelope", () => {
+    const envelope = { uid: "u", sid: "s", sig: "abc123", exp: "9999999999", kid: "k", v: "1" };
+    const handle = createIndexImportHandle("s3", "x/y", envelope);
+    const parsed = parseIndexHandle(handle);
+    expect(parsed.storageId).toBe("s3");
+    expect(parsed.path).toBe("x/y");
+    expect(parsed.additionalInfo).toEqual(envelope);
+  });
+
+  test("no-arg case is byte-identical to golden (regression guard)", () => {
+    const handle = createIndexImportHandle("s3", "x/y");
+    expect(handle).toBe(GOLDEN_NO_ENVELOPE);
+  });
+
+  test("empty map is pruned — byte-identical to no-arg golden", () => {
+    const handle = createIndexImportHandle("s3", "x/y", {});
+    expect(handle).toBe(GOLDEN_NO_ENVELOPE);
+  });
+
+  test("absent envelope: decoded handle has no additionalInfo key", () => {
+    const handle = createIndexImportHandle("s3", "x/y");
+    const parsed = parseIndexHandle(handle);
+    expect(parsed.additionalInfo).toBeUndefined();
+    // Confirm the key is truly absent from decoded JSON (not just undefined)
+    expect(Object.prototype.hasOwnProperty.call(parsed, "additionalInfo")).toBe(false);
+  });
+
+  test("parseIndexHandle accepts old handle without additionalInfo", () => {
+    // Simulate a handle that was created before this change (no additionalInfo key in JSON)
+    const oldJson = JSON.stringify({ storageId: "legacy", path: "a/b" });
+    const oldHandle =
+      `index://index/${encodeURIComponent(oldJson)}` as import("@milaboratories/pl-model-common").ImportFileHandleIndex;
+    const parsed = parseIndexHandle(oldHandle);
+    expect(parsed.storageId).toBe("legacy");
+    expect(parsed.path).toBe("a/b");
+    expect(parsed.additionalInfo).toBeUndefined();
+  });
+});

--- a/lib/node/pl-drivers/src/drivers/helpers/ls_remote_import_handle.ts
+++ b/lib/node/pl-drivers/src/drivers/helpers/ls_remote_import_handle.ts
@@ -5,11 +5,17 @@ import { ImportFileHandleIndexData, ImportFileHandleUploadData } from "../types"
 export function createIndexImportHandle(
   storageId: string,
   path: string,
+  additionalInfo?: Record<string, string>,
 ): sdk.ImportFileHandleIndex {
   const data: ImportFileHandleIndexData = {
     storageId: storageId,
     path: path,
   };
+
+  // Only embed the envelope when non-empty; preserves byte-identical URL for non-federative storages.
+  if (additionalInfo && Object.keys(additionalInfo).length > 0) {
+    data.additionalInfo = additionalInfo;
+  }
 
   return `index://index/${encodeURIComponent(JSON.stringify(data))}`;
 }

--- a/lib/node/pl-drivers/src/drivers/ls.test.ts
+++ b/lib/node/pl-drivers/src/drivers/ls.test.ts
@@ -1,10 +1,13 @@
 import { ConsoleLoggerAdapter, HmacSha256Signer } from "@milaboratories/ts-helpers";
-import { LsDriver } from "./ls";
+import { LsDriver, type LsEntryWithFileStats } from "./ls";
 import { TestHelpers } from "@milaboratories/pl-client";
 import * as path from "node:path";
-import { test, expect } from "vitest";
+import { test, expect, describe } from "vitest";
 import { isImportFileHandleIndex, isImportFileHandleUpload } from "@milaboratories/pl-model-common";
+import type { StorageHandle } from "@milaboratories/pl-model-common";
 import * as env from "../test_env";
+import { parseIndexHandle } from "./helpers/ls_remote_import_handle";
+import { createRemoteStorageHandle } from "./helpers/ls_storage_entry";
 
 const assetsPath = path.resolve("../../../assets");
 
@@ -139,5 +142,137 @@ test("should ok when get file using local dialog, and read its content", async (
 
     const multiResult = await driver.showOpenMultipleFilesDialog();
     expect(multiResult.files![0]).toStrictEqual(result.file);
+  });
+});
+
+// Unit tests: verify that LsDriver.listFiles and listRemoteFilesWithFileStats correctly
+// thread additionalInfo from gRPC list items into the index:// handle.
+describe("LsDriver additionalInfo threading", () => {
+  const envelope = { uid: "u1", sid: "s1", sig: "sigval", exp: "9999999999", kid: "k1", v: "1" };
+
+  const storageInfo = {
+    storageId: "test-storage",
+    storageName: "Test Storage",
+    resourceId: "res-id" as any,
+    resourceType: { name: "LS/test-storage", version: "1" },
+  };
+
+  // Builds a minimal LsDriver instance with an injected mock lsClient via private-constructor bypass.
+  function makeMockDriver(listResponse: { items: any[]; delimiter: string }): LsDriver {
+    const mockLsClient = {
+      list: async () => listResponse,
+      close: () => {},
+    };
+    const mockUserResources = {
+      getDataLibraries: async () => new Map([[storageInfo.storageId, storageInfo]]),
+    };
+    const signer = new HmacSha256Signer("test");
+    // Bypass private constructor for unit testing only.
+    return new (LsDriver as any)(
+      new ConsoleLoggerAdapter(),
+      mockLsClient,
+      mockUserResources,
+      signer,
+      new Map(),
+      new Map(),
+      () => Promise.resolve(undefined),
+    ) as LsDriver;
+  }
+
+  function makeRemoteHandle(): StorageHandle {
+    return createRemoteStorageHandle(storageInfo) as StorageHandle;
+  }
+
+  test("listFiles: handle carries additionalInfo envelope from gRPC item", async () => {
+    const driver = makeMockDriver({
+      delimiter: "/",
+      items: [
+        {
+          name: "file.txt",
+          size: 100n,
+          isDir: false,
+          additionalInfo: envelope,
+          fullName: "dir/file.txt",
+          directory: "dir/",
+          version: "v1",
+        },
+      ],
+    });
+
+    const result = await driver.listFiles(makeRemoteHandle(), "dir/");
+    expect(result.entries).toHaveLength(1);
+
+    const parsed = parseIndexHandle(result.entries[0].handle as any);
+    expect(parsed.additionalInfo).toEqual(envelope);
+  });
+
+  test("listFiles: handle has no additionalInfo when item has empty envelope", async () => {
+    const driver = makeMockDriver({
+      delimiter: "/",
+      items: [
+        {
+          name: "plain.txt",
+          size: 50n,
+          isDir: false,
+          additionalInfo: {},
+          fullName: "plain.txt",
+          directory: "",
+          version: "v1",
+        },
+      ],
+    });
+
+    const result = await driver.listFiles(makeRemoteHandle(), "");
+    expect(result.entries).toHaveLength(1);
+
+    const parsed = parseIndexHandle(result.entries[0].handle as any);
+    expect(parsed.additionalInfo).toBeUndefined();
+  });
+
+  test("listRemoteFilesWithFileStats: handle carries additionalInfo envelope", async () => {
+    const driver = makeMockDriver({
+      delimiter: "/",
+      items: [
+        {
+          name: "data.csv",
+          size: 200n,
+          isDir: false,
+          additionalInfo: envelope,
+          fullName: "data.csv",
+          directory: "",
+          version: "v2",
+        },
+      ],
+    });
+
+    const result = await driver.listRemoteFilesWithFileStats(makeRemoteHandle(), "");
+    expect(result.entries).toHaveLength(1);
+    expect((result.entries[0] as LsEntryWithFileStats).size).toBe(200);
+
+    const parsed = parseIndexHandle(result.entries[0].handle as any);
+    expect(parsed.additionalInfo).toEqual(envelope);
+  });
+
+  test("listRemoteFilesWithFileStats: no additionalInfo when absent in item", async () => {
+    const driver = makeMockDriver({
+      delimiter: "/",
+      items: [
+        {
+          name: "plain.csv",
+          size: 10n,
+          isDir: false,
+          additionalInfo: {},
+          fullName: "plain.csv",
+          directory: "",
+          version: "v1",
+        },
+      ],
+    });
+
+    const result = await driver.listRemoteFilesWithFileStats(makeRemoteHandle(), "");
+    expect(result.entries).toHaveLength(1);
+
+    const parsed = parseIndexHandle(result.entries[0].handle as any);
+    expect(parsed.additionalInfo).toBeUndefined();
   });
 });

--- a/lib/node/pl-drivers/src/drivers/ls.test.ts
+++ b/lib/node/pl-drivers/src/drivers/ls.test.ts
@@ -153,7 +153,8 @@ describe("LsDriver additionalInfo threading", () => {
   const storageInfo = {
     storageId: "test-storage",
     storageName: "Test Storage",
-    resourceId: "res-id" as any,
+    // Signed resource id format "<globalId>|<signatureHex>" — required by asSignedResourceId.
+    resourceId: "res-id|deadbeef" as any,
     resourceType: { name: "LS/test-storage", version: "1" },
   };
 

--- a/lib/node/pl-drivers/src/drivers/ls.ts
+++ b/lib/node/pl-drivers/src/drivers/ls.ts
@@ -34,18 +34,18 @@ export interface InternalLsDriver extends sdk.LsDriver {
    * */
   getLocalFileHandle(localPath: string): Promise<sdk.LocalImportFileHandle>;
 
-  listRemoteFilesWithAdditionalInfo(
+  listRemoteFilesWithFileStats(
     storage: sdk.StorageHandle,
     fullPath: string,
-  ): Promise<ListRemoteFilesResultWithAdditionalInfo>;
+  ): Promise<ListRemoteFilesResultWithFileStats>;
 }
 
-export type ListRemoteFilesResultWithAdditionalInfo = {
+export type ListRemoteFilesResultWithFileStats = {
   parent?: string;
-  entries: LsEntryWithAdditionalInfo[];
+  entries: LsEntryWithFileStats[];
 };
 
-export type LsEntryWithAdditionalInfo = sdk.LsEntry & {
+export type LsEntryWithFileStats = sdk.LsEntry & {
   size: number;
 };
 
@@ -217,7 +217,7 @@ export class LsDriver implements InternalLsDriver {
           type: e.isDir ? "dir" : "file",
           name: e.name,
           fullPath: e.fullName,
-          handle: createIndexImportHandle(storageData.storageId, e.fullName),
+          handle: createIndexImportHandle(storageData.storageId, e.fullName, e.additionalInfo),
         })),
       };
     }
@@ -249,10 +249,10 @@ export class LsDriver implements InternalLsDriver {
     return { entries };
   }
 
-  public async listRemoteFilesWithAdditionalInfo(
+  public async listRemoteFilesWithFileStats(
     storageHandle: sdk.StorageHandle,
     fullPath: string,
-  ): Promise<ListRemoteFilesResultWithAdditionalInfo> {
+  ): Promise<ListRemoteFilesResultWithFileStats> {
     const storageData = parseStorageHandle(storageHandle);
     if (!storageData.isRemote) {
       throw new Error(`Storage ${storageData.name} is not remote`);
@@ -266,7 +266,7 @@ export class LsDriver implements InternalLsDriver {
         type: e.isDir ? "dir" : "file",
         name: e.name,
         fullPath: e.fullName,
-        handle: createIndexImportHandle(storageData.storageId, e.fullName),
+        handle: createIndexImportHandle(storageData.storageId, e.fullName, e.additionalInfo),
         size: Number(e.size),
       })),
     };

--- a/lib/node/pl-drivers/src/drivers/types.ts
+++ b/lib/node/pl-drivers/src/drivers/types.ts
@@ -54,6 +54,11 @@ export const ImportFileHandleIndexData = z.object({
   storageId: z.string(),
   /** Path inside storage */
   path: z.string(),
+  /**
+   * Federative identity envelope from LsAPI.List.Response.ListItem.additional_info.
+   * Absent for non-federative storages (backwards compatible: old handles parse unchanged).
+   */
+  additionalInfo: z.record(z.string(), z.string()).optional(),
 });
 export type ImportFileHandleIndexData = z.infer<typeof ImportFileHandleIndexData>;
 

--- a/lib/node/pl-drivers/src/proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/lsapi/protocol.ts
+++ b/lib/node/pl-drivers/src/proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/lsapi/protocol.ts
@@ -41,6 +41,16 @@ export interface LsAPI_ListItem {
      */
     isDir: boolean;
     /**
+     * additional_info carries the signed identity envelope for federative storages.
+     * KV schema: v=1, path, uid, sid, role, exp, kid, signed, sig.
+     * Empty for non-federative storages. Verifiers MUST ignore unknown keys.
+     *
+     * @generated from protobuf field: map<string, string> additional_info = 8
+     */
+    additionalInfo: {
+        [key: string]: string;
+    };
+    /**
      * full_name is the full name of the item, relative to the storage root.
      * It is <directory> + <name>.
      * The <delimiter>, used in names, is storage-specific and is NOT guaranteed to be '/'.
@@ -169,6 +179,7 @@ class LsAPI_ListItem$Type extends MessageType<LsAPI_ListItem> {
             { no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "size", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 3, name: "is_dir", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 8, name: "additional_info", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "scalar", T: 9 /*ScalarType.STRING*/ } },
             { no: 10, name: "full_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 11, name: "directory", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 12, name: "last_modified", kind: "message", T: () => Timestamp },
@@ -180,6 +191,7 @@ class LsAPI_ListItem$Type extends MessageType<LsAPI_ListItem> {
         message.name = "";
         message.size = 0n;
         message.isDir = false;
+        message.additionalInfo = {};
         message.fullName = "";
         message.directory = "";
         message.version = "";
@@ -200,6 +212,9 @@ class LsAPI_ListItem$Type extends MessageType<LsAPI_ListItem> {
                     break;
                 case /* bool is_dir */ 3:
                     message.isDir = reader.bool();
+                    break;
+                case /* map<string, string> additional_info */ 8:
+                    this.binaryReadMap8(message.additionalInfo, reader, options);
                     break;
                 case /* string full_name */ 10:
                     message.fullName = reader.string();
@@ -224,6 +239,22 @@ class LsAPI_ListItem$Type extends MessageType<LsAPI_ListItem> {
         }
         return message;
     }
+    private binaryReadMap8(map: LsAPI_ListItem["additionalInfo"], reader: IBinaryReader, options: BinaryReadOptions): void {
+        let len = reader.uint32(), end = reader.pos + len, key: keyof LsAPI_ListItem["additionalInfo"] | undefined, val: LsAPI_ListItem["additionalInfo"][any] | undefined;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case 1:
+                    key = reader.string();
+                    break;
+                case 2:
+                    val = reader.string();
+                    break;
+                default: throw new globalThis.Error("unknown map entry field for MiLaboratories.Controller.Shared.LsAPI.ListItem.additional_info");
+            }
+        }
+        map[key ?? ""] = val ?? "";
+    }
     internalBinaryWrite(message: LsAPI_ListItem, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string name = 1; */
         if (message.name !== "")
@@ -234,6 +265,9 @@ class LsAPI_ListItem$Type extends MessageType<LsAPI_ListItem> {
         /* bool is_dir = 3; */
         if (message.isDir !== false)
             writer.tag(3, WireType.Varint).bool(message.isDir);
+        /* map<string, string> additional_info = 8; */
+        for (let k of globalThis.Object.keys(message.additionalInfo))
+            writer.tag(8, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.additionalInfo[k]).join();
         /* string full_name = 10; */
         if (message.fullName !== "")
             writer.tag(10, WireType.LengthDelimited).string(message.fullName);

--- a/lib/node/pl-drivers/src/proto-rest/lsapi.ts
+++ b/lib/node/pl-drivers/src/proto-rest/lsapi.ts
@@ -42,6 +42,14 @@ export interface components {
       /** @description is_dir is true for an item that can have subitems. */
       isDir: boolean;
       /**
+       * @description additional_info carries the signed identity envelope for federative storages.
+       *      KV schema: v=1, path, uid, sid, role, exp, kid, signed, sig.
+       *      Empty for non-federative storages. Verifiers MUST ignore unknown keys.
+       */
+      additionalInfo?: {
+        [key: string]: string;
+      };
+      /**
        * @description full_name is the full name of the item, relative to the storage root.
        *      It is <directory> + <name>.
        *      The <delimiter>, used in names, is storage-specific and is NOT guaranteed to be '/'.

--- a/lib/node/pl-middle-layer/src/network_check/template.ts
+++ b/lib/node/pl-middle-layer/src/network_check/template.ts
@@ -20,7 +20,7 @@ import {
   isUpload,
   uploadBlob,
   type ClientUpload,
-  type LsEntryWithAdditionalInfo,
+  type LsEntryWithFileStats,
 } from "@milaboratories/pl-drivers";
 import type { Signer } from "@milaboratories/ts-helpers";
 import { notEmpty, type MiLogger } from "@milaboratories/ts-helpers";
@@ -386,7 +386,7 @@ export async function chooseFile(
   maxSize: number,
   minLsRequests: number,
 ): Promise<{
-  file: LsEntryWithAdditionalInfo | undefined;
+  file: LsEntryWithFileStats | undefined;
   nLsRequests: number;
   nCheckedFiles: number;
 }> {
@@ -395,7 +395,7 @@ export async function chooseFile(
   // return small file in case we don't have many normal-sized files.
   // While we'll download only a small range of bytes from the file,
   // we don't want to return a big file in case the underlying S3 doesn't support range requests.
-  let smallFile: LsEntryWithAdditionalInfo | undefined;
+  let smallFile: LsEntryWithFileStats | undefined;
   let nCheckedFiles = 0;
   let maxNLsRequests = 0;
 
@@ -423,9 +423,9 @@ export async function* listFilesSequence(
   storage: StorageEntry,
   parent: string,
   nLsRequests: number,
-): AsyncGenerator<{ file: LsEntryWithAdditionalInfo; nLsRequests: number }, void, unknown> {
+): AsyncGenerator<{ file: LsEntryWithFileStats; nLsRequests: number }, void, unknown> {
   nLsRequests++;
-  const files = await lsDriver.listRemoteFilesWithAdditionalInfo(storage.handle, parent);
+  const files = await lsDriver.listRemoteFilesWithFileStats(storage.handle, parent);
 
   for (const file of files.entries) {
     if (file.type === "file" && file.fullPath.startsWith(parent)) {


### PR DESCRIPTION
- Extend Ls API to carry additionalInfo envelope for federative storages
- Switch list results to a file-stats variant and propagate envelopes
- Pass envelope through to index handles when present
- Update REST/GRPC schemas to include additionalInfo
- Add tests to verify envelope threading and absence when empty

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the Ls API to carry a federative identity envelope (`additionalInfo`, a `map<string, string>`) through the full stack — proto definition, gRPC and REST codegen, TypeScript client, and index handle serialisation — so that downstream consumers can verify signed identity envelopes from federative storages.

- **Proto / schema layer**: `additional_info = 8` added to `LsAPI_ListItem` in `.proto`, OpenAPI YAML, and both generated TypeScript stubs (gRPC and REST).
- **Handle serialisation**: `createIndexImportHandle` now accepts an optional `additionalInfo` map and only embeds it when non-empty, keeping existing URLs byte-identical.
- **Driver rename + threading**: `listRemoteFilesWithAdditionalInfo` is renamed to `listRemoteFilesWithFileStats`; both `listFiles` and `listRemoteFilesWithFileStats` now forward `e.additionalInfo` to the handle builder.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The data flow and serialisation are correct; the hand-written protobuf map decoder in protocol.ts will throw a hard error on any unrecognised field number, which is unsafe for forward compatibility.

The hand-written `binaryReadMap8` in the generated gRPC file unconditionally throws on unknown field numbers rather than skipping them. Every other field in the same generated file respects `options.readUnknownField`. Under normal proto version alignment this path never triggers, but it is a latent runtime breakage that needs fixing before this decoder is relied on in production for federative storages.

lib/node/pl-drivers/src/proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/lsapi/protocol.ts — the `binaryReadMap8` default case needs attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-drivers/src/proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/lsapi/protocol.ts | Adds `additionalInfo` map field (field 8) to `LsAPI_ListItem` with a hand-written `binaryReadMap8` decoder. The decoder throws on any unrecognised field number instead of skipping it per proto3 spec, which could break parsing under version skew. |
| lib/node/pl-drivers/src/drivers/helpers/ls_remote_import_handle.ts | Adds optional `additionalInfo` parameter to `createIndexImportHandle`; only embeds it when non-empty, preserving byte-identical URLs for non-federative storages. |
| lib/node/pl-drivers/src/drivers/ls.ts | Renames `listRemoteFilesWithAdditionalInfo` to `listRemoteFilesWithFileStats` and threads `e.additionalInfo` into both list methods; two TODO-4 comments remain in production call sites. |
| lib/node/pl-drivers/src/drivers/types.ts | Adds optional `additionalInfo: z.record(z.string(), z.string())` to `ImportFileHandleIndexData` Zod schema; backwards compatible. |
| lib/node/pl-drivers/src/drivers/ls.test.ts | Extends existing test file with `LsDriver additionalInfo threading` suite covering envelope propagation in both list methods. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Backend as gRPC/REST Backend
    participant Client as ClientLs (ls_api.ts)
    participant Driver as LsDriver (ls.ts)
    participant Handle as createIndexImportHandle
    participant Consumer as Downstream Consumer

    Backend->>Client: "LsAPI_ListItem { additionalInfo, fullName, ... }"
    Client->>Driver: items with additionalInfo map
    Driver->>Handle: createIndexImportHandle(storageId, fullName, additionalInfo)
    Note over Handle: non-empty? embed in JSON, else omit
    Handle-->>Driver: index://index/encoded-JSON
    Driver-->>Consumer: "LsEntry { handle, type, name, fullPath }"
    Consumer->>Consumer: "parseIndexHandle -> { storageId, path, additionalInfo? }"
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fnode%2Fpl-drivers%2Fsrc%2Fproto-grpc%2Fgithub.com%2Fmilaboratory%2Fpl%2Fcontrollers%2Fshared%2Fgrpc%2Flsapi%2Fprotocol.ts%3A242-257%0A**Unconditional%20throw%20on%20unknown%20fields%20breaks%20proto3%20forward%20compatibility**%0A%0AThe%20%60default%60%20case%20throws%20unconditionally%20regardless%20of%20the%20%60options.readUnknownField%60%20configuration%2C%20while%20the%20outer%20%60internalBinaryRead%60%20properly%20gates%20on%20%60options.readUnknownField%60.%20Any%20wire%20format%20that%20carries%20an%20unexpected%20field%20number%20in%20the%20%60additional_info%60%20map%20entry%20%E2%80%94%20due%20to%20proto%20version%20skew%2C%20future%20extensions%2C%20or%20a%20misbehaving%20upstream%20%E2%80%94%20will%20throw%20a%20hard%20error%20instead%20of%20skipping%20the%20field%20as%20proto3%20requires.%20The%20%60options%60%20argument%20is%20accepted%20but%20ignored%20in%20this%20path.%20The%20standard%20fix%20is%20to%20call%20%60reader.skip%28wireType%29%60%20%28with%20optional%20%60UnknownFieldHandler.onRead%60%29%20rather%20than%20throwing.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fnode%2Fpl-drivers%2Fsrc%2Fdrivers%2Fls.ts%3A220-221%0AThese%20%60TODO-4%60%20references%20are%20left%20in%20production%20code%20paths%20and%20will%20appear%20in%20every%20%60listFiles%60%20and%20%60listRemoteFilesWithFileStats%60%20call.%20If%20this%20work%20item%20has%20a%20separate%20tracking%20ticket%2C%20the%20comment%20should%20reference%20that%20ticket%20explicitly%3B%20if%20it%20was%20already%20resolved%20in%20this%20PR%2C%20the%20TODO%20can%20be%20removed.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20handle%3A%20createIndexImportHandle%28storageData.storageId%2C%20e.fullName%2C%20e.additionalInfo%29%2C%0A%60%60%60%0A%0A&repo=milaboratory%2Fplatforma&pr=1647&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pl-drivers/src/proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/lsapi/protocol.ts:242-257
**Unconditional throw on unknown fields breaks proto3 forward compatibility**

The `default` case throws unconditionally regardless of the `options.readUnknownField` configuration, while the outer `internalBinaryRead` properly gates on `options.readUnknownField`. Any wire format that carries an unexpected field number in the `additional_info` map entry — due to proto version skew, future extensions, or a misbehaving upstream — will throw a hard error instead of skipping the field as proto3 requires. The `options` argument is accepted but ignored in this path. The standard fix is to call `reader.skip(wireType)` (with optional `UnknownFieldHandler.onRead`) rather than throwing.

### Issue 2 of 2
lib/node/pl-drivers/src/drivers/ls.ts:220-221
These `TODO-4` references are left in production code paths and will appear in every `listFiles` and `listRemoteFilesWithFileStats` call. If this work item has a separate tracking ticket, the comment should reference that ticket explicitly; if it was already resolved in this PR, the TODO can be removed.

```suggestion
          handle: createIndexImportHandle(storageData.storageId, e.fullName, e.additionalInfo),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\[MILAB-6225\]: Add federative envelope ha..."](https://github.com/milaboratory/platforma/commit/504a380558567133e98a495f63ecd7cd59e091be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32837115)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->