### PR TITLE
exec.writeFile/addFile: { writable: true } opts knob

### DIFF
--- a/.changeset/exec-writable-files.md
+++ b/.changeset/exec-writable-files.md
@@ -1,0 +1,11 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+`exec.builder().addFile(name, ref, opts)` and `exec.builder().writeFile(name, data, opts)` (and the plural `addFiles` / `writeFiles`) now accept a `{ writable: true }` option that lands the file as `0o600` in the workdir.
+
+By default the workdir fill rule stays read-only (`0o400`), so the backend hardlinks the entry from the content-addressable archive cache — fast, inode-shared with the archive, immutable. Passing `writable: true` flips the rule to `0o600`, which forces the backend to copy the file to a fresh inode in the workdir, leaving the archive entry untouched. Use it only when the tool legitimately mutates an input in place (rare — usually a sign the tool violates input immutability).
+
+The option propagates one layer down: `workdir.builder().addFile` / `writeFile` (plus plural forms) gained the same `{ writable }` option.
+
+Workflows that don't pass `writable` keep the previous behavior and the same exec CID — the new field is only added to the settings resource when at least one file was marked writable.

--- a/.changeset/exec-writable-files.md
+++ b/.changeset/exec-writable-files.md
@@ -1,5 +1,6 @@
 ---
 "@platforma-sdk/workflow-tengo": minor
+"@milaboratories/pl-client": minor
 ---
 
 `exec.builder().addFile(name, ref, opts)` and `exec.builder().writeFile(name, data, opts)` (and the plural `addFiles` / `writeFiles`) now accept a `{ writable: true }` option that lands the file as `0o600` in the workdir.
@@ -9,3 +10,5 @@ By default the workdir fill rule stays read-only (`0o400`), so the backend hardl
 The option propagates one layer down: `workdir.builder().addFile` / `writeFile` (plus plural forms) gained the same `{ writable }` option.
 
 Workflows that don't pass `writable` keep the previous behavior and the same exec CID — the new field is only added to the settings resource when at least one file was marked writable.
+
+The option is only effective against a backend that honors per-file workdir fill perms (pl PR #1830, post-3.5.0). `pl-client` exposes a `supportsWritableWorkdirFiles` getter on both `LLPlClient` and `PlClient` — true iff `serverInfo.coreVersion` is strictly after `3.5.0` (e.g. `3.5.0-224-g0ca182` or `3.5.1`). Older backends silently ignore the `writable` flag and land every file at the canonical archive perm.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -232,6 +232,16 @@ export class PlClient {
     return this._ll!.hasCapability(capability);
   }
 
+  /**
+   * True if the backend honors per-file `permissions` on workdir fill rules
+   * (PR #1830 in milaboratory/pl). See `LLPlClient.supportsWritableWorkdirFiles`
+   * for the full definition.
+   */
+  public get supportsWritableWorkdirFiles(): boolean {
+    this.checkInitialized();
+    return this._ll!.supportsWritableWorkdirFiles;
+  }
+
   /** User resources index for discovering data libraries and other shared resources. */
   public get userResources(): UserResources {
     if (!this._ll) throw new Error("Client not initialized");

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -61,6 +61,29 @@ function isVersionAtLeast(version: string, target: [number, number, number]): bo
   return true;
 }
 
+// Returns true iff `version` is strictly after the release tag `target`. Dev
+// builds (`git describe`-style, e.g. "3.5.0-224-g0ca182") are considered
+// AFTER the matching release tag — they include commits past the tag and so
+// have any change merged after it. Released versions with the same triplet
+// return false (we want the tag itself to be excluded).
+//
+// Examples for target [3,5,0]:
+//   "3.5.0"              → false (the tagged release)
+//   "3.5.0-224-g0ca182"  → true  (dev build past the tag)
+//   "3.5.1"              → true
+//   "3.4.9"              → false
+// Returns false for unparseable versions.
+function isAfterVersion(version: string, target: [number, number, number]): boolean {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(.*)$/.exec(version);
+  if (!match) return false;
+  const parsed: [number, number, number] = [Number(match[1]), Number(match[2]), Number(match[3])];
+  const suffix = match[4];
+  for (let i = 0; i < 3; i++) {
+    if (parsed[i] !== target[i]) return parsed[i] > target[i];
+  }
+  return suffix !== "";
+}
+
 class WireClientProviderImpl<Client> implements WireClientProvider<Client> {
   private client: Client | undefined = undefined;
 
@@ -659,6 +682,19 @@ export class LLPlClient implements WireClientProviderFactory {
   /** True if the backend implements the setDefaultColor TX request. */
   public get supportsSetDefaultColor(): boolean {
     return isVersionAtLeast(this.serverInfo.coreVersion, [3, 3, 0]);
+  }
+
+  /**
+   * True if the backend honors per-file `permissions` on workdir fill rules
+   * (PR #1830 in milaboratory/pl). Backends before this change ignore the
+   * requested mode and always land files at the canonical archive perm,
+   * making `exec.builder().writeFile/addFile({ writable: true })` a no-op.
+   *
+   * Tagged at 3.5.0 cut without the change, so [3, 5, 0] excludes the tagged
+   * release but includes dev builds past the tag (e.g. "3.5.0-224-g0ca182").
+   */
+  public get supportsWritableWorkdirFiles(): boolean {
+    return isAfterVersion(this.serverInfo.coreVersion, [3, 5, 0]);
   }
 
   /**

--- a/sdk/workflow-tengo/src/exec/exec-impl.tpl.tengo
+++ b/sdk/workflow-tengo/src/exec/exec-impl.tpl.tengo
@@ -75,6 +75,7 @@ self.validateInputs({
 		"fileSetsToSave,?": { any: "string" },
 		"fileSetsContentToSave,?": { any: "string" },
 		"filesToStream,?": ["string"],
+		"writableFiles,?": ["string"],
 
 		"assetDescriptors,?": { any: { asset: desc.assetScheme } },
 		"assetRules,?": { any: { any: ["string"] } },
@@ -104,8 +105,19 @@ self.body(func(inputs) {
 	quota := inputs.quota
 	wdBuilder.inQueue(quota.queue).cpu(quota.cpu).mem(quota.ram)
 
+	// Names whose fill-rule should land 0o600 (writable) instead of the
+	// 0o400 default. Absence = read-only / hardlink fast path.
+	writableSet := {}
+	if !is_undefined(settings.writableFiles) {
+		for _, name in settings.writableFiles {
+			writableSet[name] = true
+		}
+	}
+
 	// add files
-	wdBuilder.addFiles(inputs.filesToAdd)
+	maps.forEach(inputs.filesToAdd, func(fName, fRef) {
+		wdBuilder.addFile(fName, fRef, { writable: writableSet[fName] == true })
+	})
 	wdBuilder.mkDirs(settings.dirsToCreate)
 
 	// add assets
@@ -130,7 +142,9 @@ self.body(func(inputs) {
 
 	// pass values as fields for saving the topology in pl-core
 	// and avoiding deduplication issues:
-	wdBuilder.writeFiles(self.rawInputs().filesToWrite.getValue().inputs())
+	maps.forEach(self.rawInputs().filesToWrite.getValue().inputs(), func(fName, fRef) {
+		wdBuilder.writeFile(fName, fRef, { writable: writableSet[fName] == true })
+	})
 
 	// working directory with input files added; before run
 	wdBefore := wdBuilder.build()

--- a/sdk/workflow-tengo/src/exec/exec.tpl.tengo
+++ b/sdk/workflow-tengo/src/exec/exec.tpl.tengo
@@ -67,6 +67,7 @@ self.validateInputs({
 	"fileSetsToSave,?": { any: "string" },
 	"fileSetsContentToSave,?": { any: "string" },
 	"filesToStream,?": ["string"],
+	"writableFiles,?": ["string"],
 	"assetDescriptors,?": { any: { asset: desc.assetScheme } },
 	"assetRules,?": { any: { any: ["string"] } },
 	"assetCache,?": { any: "number" },
@@ -129,6 +130,7 @@ self.body(func(inputs) {
 		fileSetsToSave: inputs.fileSetsToSave,
 		fileSetsContentToSave: inputs.fileSetsContentToSave,
 		filesToStream: inputs.filesToStream,
+		writableFiles: inputs.writableFiles,
 		assetDescriptors: inputs.assetDescriptors,
 		assetRules: inputs.assetRules,
 		assetCache: inputs.assetCache

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -64,6 +64,10 @@ builder := func() {
 	filesToAdd := {}
 	// files to be created in the workdir with the content from resources
 	filesToWrite := {}
+	// names from filesToAdd / filesToWrite that should land in the workdir as
+	// 0o600 (writable). Anything not in the set stays 0o400 (read-only,
+	// hardlinked from the archive cache).
+	writableFiles := {}
 	// directories to create in the workdir
 	dirsToCreate := {}
 
@@ -766,8 +770,15 @@ builder := func() {
 		 * When called with the same fileName multiple times,
 		 * the last call will overwrite the previous ones.
 		 *
+		 * The file defaults to read-only (0o400) in the workdir so the backend
+		 * hardlinks it from the content-addressable archive cache. Pass
+		 * `{ writable: true }` when the tool legitimately needs to mutate the
+		 * input in place — the backend will copy it to a fresh inode.
+		 *
 		 * @param fileName: string - the name of the input file.
 		 * @param file: reference - a resource id of the file or a field that points to it.
+		 * @param opts: { writable?: bool, mnz?: ... } - optional flags.
+		 *        `writable: true` lands the file as 0o600 in the workdir.
 		 */
 		addFile: func(fileName, file, ...opts) {
 			ll.assert(is_string(fileName), "exec.builder().addFile: fileName must be a string")
@@ -775,6 +786,9 @@ builder := func() {
 
 			fileName = path.canonize(fileName)
 			filesToAdd[fileName] = file
+			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+				sets.add(writableFiles, fileName)
+			}
 			monetization.addOptionalArg(mnz, fileName, opts...)
 			return self
 		},
@@ -783,6 +797,7 @@ builder := func() {
 		 * Adds multiple files to the working directory.
 		 *
 		 * @param filesMap: map[string]reference - a map of file names to files' references.
+		 * @param opts: { writable?: bool, mnz?: ... } - applied to every entry.
 		 */
 		addFiles: func(filesMap, ...opts) {
 			ll.assert(ll.isMap(filesMap), "exec.builder().addFiles: filesMap must be map of file names to file resources")
@@ -802,10 +817,17 @@ builder := func() {
 		 * dedup CID — are stable across runs. Callers that previously did
 		 * `writeFile(name, json.encode(value))` should pass `value` directly.
 		 *
+		 * The file defaults to read-only (0o400) in the workdir. Pass
+		 * `{ writable: true }` when the tool needs to mutate the file in place
+		 * — the backend will land it as 0o600 and copy from the value cache to
+		 * a fresh inode.
+		 *
 		 * @param fileName: string - the name of the content.
 		 * @param data: string|bytes|map|array|reference - the content to write.
 		 *        Maps and arrays are canonicalized to JSON; strings / bytes /
 		 *        references are passed through unchanged.
+		 * @param opts: { writable?: bool, mnz?: ... } - optional flags.
+		 *        `writable: true` lands the file as 0o600 in the workdir.
 		 */
 		writeFile: func(fileName, data, ...opts) {
 			// Auto-encode value-like inputs (regular / immutable / strict maps
@@ -823,6 +845,9 @@ builder := func() {
 			fileName = path.canonize(fileName)
 
 			filesToWrite[fileName] = data
+			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+				sets.add(writableFiles, fileName)
+			}
 			monetization.addOptionalArg(mnz, fileName, opts...)
 
 			return self
@@ -1049,6 +1074,12 @@ builder := func() {
 				assetDescriptors: assetDescriptors,
 				assetRules: assetRules,
 				assetCache: assetCache
+			}
+
+			// Only forward when non-empty so existing workflows that don't
+			// opt into writable files keep the exact same CID.
+			if len(writableFiles) > 0 {
+				pureExecInputs.writableFiles = slices.fromSet(writableFiles)
 			}
 
 			if (is_int(ramRequest)) {

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -786,7 +786,7 @@ builder := func() {
 
 			fileName = path.canonize(fileName)
 			filesToAdd[fileName] = file
-			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+			if len(opts) > 0 && ll.isMap(opts[0]) && opts[0].writable == true {
 				sets.add(writableFiles, fileName)
 			}
 			monetization.addOptionalArg(mnz, fileName, opts...)
@@ -845,11 +845,29 @@ builder := func() {
 			fileName = path.canonize(fileName)
 
 			filesToWrite[fileName] = data
-			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+			if len(opts) > 0 && ll.isMap(opts[0]) && opts[0].writable == true {
 				sets.add(writableFiles, fileName)
 			}
 			monetization.addOptionalArg(mnz, fileName, opts...)
 
+			return self
+		},
+
+		/**
+		 * Writes multiple files with their contents to the working directory.
+		 * Each entry follows the same encoding rules as `writeFile` — maps and
+		 * arrays are canonical-encoded, references and strings/bytes pass
+		 * through unchanged.
+		 *
+		 * @param filesMap: map[string]string|bytes|map|array|reference -
+		 *        a map of file names to contents.
+		 * @param opts: { writable?: bool, mnz?: ... } - applied to every entry.
+		 */
+		writeFiles: func(filesMap, ...opts) {
+			ll.assert(ll.isMap(filesMap), "exec.builder().writeFiles: filesMap must be map of file names to contents")
+			maps.forEach(filesMap, func(fileName, data) {
+				self.writeFile(fileName, data, opts...)
+			})
 			return self
 		},
 

--- a/sdk/workflow-tengo/src/workdir/index.lib.tengo
+++ b/sdk/workflow-tengo/src/workdir/index.lib.tengo
@@ -267,7 +267,7 @@ _fill := func() {
 			files[fileName] = fileResource
 			blobs[fileName] = fileResource
 			self._addDirs(fileName)
-			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+			if len(opts) > 0 && ll.isMap(opts[0]) && opts[0].writable == true {
 				sets.add(writableFiles, fileName)
 			}
 
@@ -301,7 +301,7 @@ _fill := func() {
 			validation.assertType(fileName, "string")
 			values[fileName] = contentRef
 			self._addDirs(fileName)
-			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+			if len(opts) > 0 && ll.isMap(opts[0]) && opts[0].writable == true {
 				sets.add(writableFiles, fileName)
 			}
 

--- a/sdk/workflow-tengo/src/workdir/index.lib.tengo
+++ b/sdk/workflow-tengo/src/workdir/index.lib.tengo
@@ -55,11 +55,11 @@ createV2 := func(allocationRef) {
 // entry to mifs.ArchiveEntryPerms (0o400). The hardlink-or-copy decision in
 // task_wd_fill.addFileToWorkdir is an exact mode comparison against that
 // constant — anything other than 0o400 forces the copy branch.
-_getFileFillRule := func(filePath, extension) {
+_getFileFillRule := func(filePath, extension, writable) {
 	return {
 		type: "file",
 		path: filePath,
-		permissions: 0o400,
+		permissions: writable ? 0o600 : 0o400,
 		pathKey: filePath,
 		blobKey: filePath,
 		copyOptional: false,
@@ -93,11 +93,11 @@ _getArchiveFillRule := func(dstDir, whatToExtract, archiveBlobKey) {
  * @param filePath: string - the path of the file.
  * @return rule: map - the value fill rule.
  */
-_getValueFillRule := func(filePath) {
+_getValueFillRule := func(filePath, writable) {
 	return {
 		type: "value",
 		path: filePath,
-		permissions: 0o400,
+		permissions: writable ? 0o600 : 0o400,
 		pathKey: filePath,
 		valueKey: filePath
 	}
@@ -132,6 +132,10 @@ _fill := func() {
 	zipExtractions := {}
 	values := {}
 	dirs := {}
+	// Set of file names (both addFile and writeFile) that should land in the
+	// workdir with permissions 0o600 (writable). Anything not in the set keeps
+	// the 0o400 default — the backend hardlinks from the archive cache.
+	writableFiles := {}
 
 	queue := undefined
 	cpu := undefined
@@ -245,16 +249,27 @@ _fill := func() {
 		/**
 		 * Adds a file to the workdir.
 		 *
+		 * The fill rule defaults to read-only (0o400) so the backend hardlinks
+		 * from the content-addressable archive cache. Pass `{ writable: true }`
+		 * when the tool legitimately needs to mutate the input in place — the
+		 * backend will copy the file to a fresh inode, leaving the archive
+		 * entry untouched.
+		 *
 		 * @param fileName: string - the name of the file.
 		 * @param fileResource: reference - the file to add.
+		 * @param opts: { writable?: bool } - optional flags. `writable: true`
+		 *        marks this file as 0o600 in the workdir.
 		 */
-		addFile: func(fileName, fileResource) {
+		addFile: func(fileName, fileResource, ...opts) {
 			validation.assertType(fileName, "string")
 			validation.assertType(fileResource, validation.reference)
 
 			files[fileName] = fileResource
 			blobs[fileName] = fileResource
 			self._addDirs(fileName)
+			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+				sets.add(writableFiles, fileName)
+			}
 
 			return self
 		},
@@ -263,22 +278,32 @@ _fill := func() {
 		 * Adds multiple files to the workdir.
 		 *
 		 * @param fileMap: map[string]reference - a map of files.
+		 * @param opts: { writable?: bool } - applied to every entry.
 		 */
-		addFiles: func(fileMap) {
-			maps.forEach(fileMap, self.addFile)
+		addFiles: func(fileMap, ...opts) {
+			maps.forEach(fileMap, func(fileName, fileResource) {
+				self.addFile(fileName, fileResource, opts...)
+			})
 			return self
 		},
 
 		/**
 		 * Adds a file with a content to the workdir.
 		 *
+		 * The fill rule defaults to read-only (0o400). Pass
+		 * `{ writable: true }` to land the file as 0o600 instead.
+		 *
 		 * @param fileName: string - the name of the file.
 		 * @param contentRef: reference|any - the content as a reference to add or the content itself.
+		 * @param opts: { writable?: bool } - optional flags.
 		 */
-		writeFile: func(fileName, contentRef) {
+		writeFile: func(fileName, contentRef, ...opts) {
 			validation.assertType(fileName, "string")
 			values[fileName] = contentRef
 			self._addDirs(fileName)
+			if len(opts) > 0 && !is_undefined(opts[0]) && opts[0].writable == true {
+				sets.add(writableFiles, fileName)
+			}
 
 			return self
 		},
@@ -287,9 +312,12 @@ _fill := func() {
 		 * Adds multiple files with contents to the workdir.
 		 *
 		 * @param contentMap: map[string]any|reference - a map of references to a content or to a content itself.
+		 * @param opts: { writable?: bool } - applied to every entry.
 		 */
-		writeFiles: func(contentRefMap) {
-			maps.forEach(contentRefMap, self.writeFile)
+		writeFiles: func(contentRefMap, ...opts) {
+			maps.forEach(contentRefMap, func(fileName, contentRef) {
+				self.writeFile(fileName, contentRef, opts...)
+			})
 			return self
 		},
 
@@ -360,10 +388,10 @@ _fill := func() {
 				rules = append(rules, _getDirFillRule(dir))
 			}
 			for fileName, _ in files {
-				rules = append(rules, _getFileFillRule(fileName, path.getExtension(fileName)))
+				rules = append(rules, _getFileFillRule(fileName, path.getExtension(fileName), sets.hasElement(writableFiles, fileName)))
 			}
 			for fileName, _ in values {
-				rules = append(rules, _getValueFillRule(fileName))
+				rules = append(rules, _getValueFillRule(fileName, sets.hasElement(writableFiles, fileName)))
 			}
 
 			for blobKey, directories in zipExtractions {

--- a/tests/workflow-tengo/src/exec/writable/pt_overwrite.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/writable/pt_overwrite.tpl.tengo
@@ -1,0 +1,83 @@
+/**
+ * Verifies exec.builder().writeFile / addFile { writable } option by running
+ * ptabler against an in-workdir input file with read_csv + write_csv pointing
+ * at the same path. When the file lands as 0o400 (default) the write_csv step
+ * must fail; when { writable: true } is passed it must succeed and produce
+ * round-tripped TSV content.
+ *
+ * Inputs:
+ *   mode     "write" | "add"  — which builder method to test
+ *   writable bool             — whether to pass { writable: true }
+ *   tsv      string           — input TSV content
+ */
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+
+ptSoftware := assets.importSoftware("@platforma-open/milaboratories.software-ptabler:main")
+
+self.defineOutputs(["result"])
+
+// Workflow that reads data.tsv and writes back to the same path —
+// the overwrite is what exercises the permission bit.
+overwriteSpec := {
+	workflow: [
+		{ type: "read_csv",  file: "data.tsv", name: "df",   delimiter: "\t" },
+		{ type: "write_csv", table: "df",      file: "data.tsv", delimiter: "\t" }
+	]
+}
+
+// Workflow that converts an inline TSV (writeFile) into a file resource we
+// can hand to the second stage via addFile.
+prepSpec := {
+	workflow: [
+		{ type: "read_csv",  file: "source.tsv", name: "df", delimiter: "\t" },
+		{ type: "write_csv", table: "df",        file: "data.tsv", delimiter: "\t" }
+	]
+}
+
+runPt := func(builder, workflowSpec) {
+	return builder.
+		inLightQueue().
+		cpu(1).ram("256Mi").
+		software(ptSoftware).
+		arg("workflow.json").
+		arg("--frame-dir").arg("frames").
+		arg("--spill-dir").arg("spill").
+		writeFile("workflow.json", workflowSpec)
+}
+
+self.body(func(inputs) {
+	mode := inputs.mode
+	writable := inputs.writable
+	tsv := inputs.tsv
+
+	builder := runPt(exec.builder(), overwriteSpec).saveFileContent("data.tsv")
+
+	if mode == "write" {
+		// Inline content path — writeFile.
+		if writable {
+			builder.writeFile("data.tsv", tsv, { writable: true })
+		} else {
+			builder.writeFile("data.tsv", tsv)
+		}
+	} else {
+		// File-resource path — addFile. Stage 1: pt round-trips the inline
+		// content into a file resource. Stage 2 below addFile's that ref.
+		prep := runPt(exec.builder(), prepSpec).
+			writeFile("source.tsv", tsv).
+			saveFile("data.tsv").
+			run()
+		dataFile := prep.getFile("data.tsv")
+		if writable {
+			builder.addFile("data.tsv", dataFile, { writable: true })
+		} else {
+			builder.addFile("data.tsv", dataFile)
+		}
+	}
+
+	return {
+		result: builder.run().getFileContent("data.tsv")
+	}
+})

--- a/tests/workflow-tengo/src/exec/writable/writable.test.ts
+++ b/tests/workflow-tengo/src/exec/writable/writable.test.ts
@@ -1,0 +1,66 @@
+import { Pl } from "@milaboratories/pl-middle-layer";
+import { tplTest } from "@platforma-sdk/test";
+import dedent from "dedent";
+
+const tsv = dedent`
+  a	b
+  1	2
+  3	4
+`;
+
+/**
+ * exec.builder().writeFile / addFile honour { writable: true } by landing the
+ * file as 0o600 in the workdir so the backend copies (instead of hardlinking
+ * RO from the archive cache). The check below runs ptabler with a workflow
+ * that read_csv's the file then write_csv's back to the same path:
+ *   - default (RO 0o400): pt must fail to open the file for writing
+ *   - { writable: true } (RW 0o600): pt must succeed and the file content round-trips
+ *
+ * Requires a backend that honors per-file workdir fill perms (PR #1830 in
+ * milaboratory/pl, post-3.5.0). Older backends are detected via
+ * `pl.supportsWritableWorkdirFiles` and the test self-skips.
+ */
+tplTest.concurrent.for([
+  { mode: "write" as const, writable: true },
+  { mode: "write" as const, writable: false },
+  { mode: "add" as const, writable: true },
+  { mode: "add" as const, writable: false },
+])(
+  "exec.builder.$mode { writable: $writable } — pt overwrites input.tsv",
+  async ({ mode, writable }, { helper, pl, expect, skip }) => {
+    if (!pl.supportsWritableWorkdirFiles) {
+      skip(
+        `backend ${pl.serverInfo.coreVersion} predates workdir fill perm honoring (pl #1830); needs >3.5.0`,
+      );
+    }
+
+    const result = await helper.renderTemplate(
+      false,
+      "exec.writable.pt_overwrite",
+      ["result"],
+      (tx) => ({
+        mode: tx.createValue(Pl.JsonObject, JSON.stringify(mode)),
+        writable: tx.createValue(Pl.JsonObject, JSON.stringify(writable)),
+        tsv: tx.createValue(Pl.JsonObject, JSON.stringify(tsv)),
+      }),
+    );
+
+    const out = result.computeOutput("result", (a) => a?.getDataAsString());
+    const settled = await out.awaitStableValue().catch((e: Error) => e);
+
+    if (writable) {
+      // RW: backend lands data.tsv as 0o600, pt opens for write, no error.
+      // Content roundtrip is intentionally not asserted — pt truncates the
+      // target before reading all source rows (same path read+write race),
+      // so the output is a partial TSV. We only care that the write succeeded.
+      expect(settled).not.toBeInstanceOf(Error);
+      expect(settled).toBeTypeOf("string");
+      expect(settled).toMatch(/^a\tb/);
+    } else {
+      // RO: backend lands data.tsv as 0o400 (hardlinked from archive cache).
+      // pt's write_csv must hit EACCES, exec must surface the non-zero exit.
+      expect(settled).toBeInstanceOf(Error);
+      expect((settled as Error).message).toMatch(/Exited with code/);
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Opt-in escape hatch for the 0o400 default workdir fill-rule perms set in #1628. Passing `{ writable: true }` to `exec.builder().addFile`, `.writeFile` (and the plural forms `addFiles` / `writeFiles`) lands the file as 0o600 in the workdir, forcing the backend to copy from the archive/value cache to a fresh inode instead of taking the hardlink fast path.

The same option is mirrored on `workdir.builder().addFile` / `writeFile` (plus plural forms) — that's the layer that actually emits the fill-rule `permissions` field. `exec-impl.tpl` threads a `writableFiles` name set through `settings` and applies it per file.

```tengo
b.addFile("input.tsv", fileRef)                              // RO 0o400 — hardlink
b.addFile("input.tsv", fileRef, { writable: true })          // RW 0o600 — copy
b.writeFile("config.json", { foo: 1 })                       // RO 0o400 — hardlink
b.writeFile("config.json", { foo: 1 }, { writable: true })   // RW 0o600 — copy
b.addFiles({ a: refA, b: refB }, { writable: true })         // all RW
b.writeFiles({ a: "x", b: "y" }, { writable: true })         // all RW
```

## Compatibility

When no caller marks any file writable, the new `writableFiles` field is omitted from the settings JSON resource, so existing workflows produce the exact same exec CID. Old callers also keep working — the schema additions are all `,?` (optional).

## Background

The default landed in #1628 to make the backend's `addFileToWorkdir` take the hardlink path: it compares the fill-rule mode against `mifs.ArchiveEntryPerms` (0o400) and only hardlinks on exact match. Anything else forces a copy. The changeset there promised an explicit override mechanism — this PR is that knob, surfaced at the public API.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `{ writable: true }` opt-in escape hatch to `exec.builder()` and `workdir.builder()` file-addition methods so callers can land files as `0o600` (copy-on-use) instead of the default `0o400` (hardlinked from the archive cache). When no file is marked writable the new `writableFiles` field is omitted from the settings JSON via `maps.clone({removeUndefs: true})`, keeping the exec CID identical for all existing workflows.

- `exec/index.lib.tengo`: tracks a `writableFiles` set in `addFile` / `addFiles` / `writeFile`; serialises it only when non-empty and forwards it to the impl template.
- `exec-impl.tpl.tengo`: reconstructs the set at runtime and calls `wdBuilder.addFile`/`writeFile` with the per-file `writable` flag.
- `workdir/index.lib.tengo`: all four methods (`addFile`, `addFiles`, `writeFile`, `writeFiles`) updated; `_getFileFillRule` and `_getValueFillRule` now accept a `writable` parameter and emit 0o400 or 0o600 accordingly.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core implementation is sound; the only gap is a changeset doc that promises a method not present in the code.

The `writableFiles` tracking, serialisation, and fill-rule emission are consistent across both builder layers. The changeset text promises `exec.builder().writeFiles()` accepts `{ writable }`, but that method was never added to `exec/index.lib.tengo` — a user following the docs would hit a runtime error. CID stability via `removeUndefs`, the undefined guard in the impl template, and `sets.add` mutation semantics are all correct.

`sdk/workflow-tengo/src/exec/index.lib.tengo` and `.changeset/exec-writable-files.md` — either add a `writeFiles` method to the exec builder or correct the changeset description.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/exec-writable-files.md | Changeset doc incorrectly implies exec.builder() has a `writeFiles` plural method; only `workdir.builder()` has it. |
| sdk/workflow-tengo/src/exec/exec-impl.tpl.tengo | Builds a `writableSet` from `settings.writableFiles` and threads it into `wdBuilder.addFile`/`wdBuilder.writeFile` per-file — logic is correct, undefined-guard is sound. |
| sdk/workflow-tengo/src/exec/exec.tpl.tengo | Adds `writableFiles` to schema validation and forwards it through `maps.clone({removeUndefs:true})` to settings — CID stability for non-writable workflows preserved. |
| sdk/workflow-tengo/src/exec/index.lib.tengo | Adds `writableFiles` set tracking in `addFile` and `writeFile`; `addFiles` properly tunnels opts; `slices.fromSet` serialization only when non-empty. Missing a `writeFiles` plural method that the changeset doc promises. |
| sdk/workflow-tengo/src/workdir/index.lib.tengo | All four methods (`addFile`, `addFiles`, `writeFile`, `writeFiles`) updated consistently; `_getFileFillRule` and `_getValueFillRule` accept a `writable` bool and emit 0o400/0o600 accordingly. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant exec.builder
    participant exec.tpl
    participant exec-impl.tpl
    participant workdir.builder

    Caller->>exec.builder: "addFile(name, ref, {writable: true})"
    exec.builder->>exec.builder: sets.add(writableFiles, name)
    Caller->>exec.builder: run()
    exec.builder->>exec.tpl: "pureExecInputs.writableFiles = slices.fromSet(writableFiles)"
    exec.tpl->>exec-impl.tpl: "settings = {writableFiles: [...], ...}"
    exec-impl.tpl->>exec-impl.tpl: build writableSet from settings.writableFiles
    exec-impl.tpl->>workdir.builder: "addFile(name, ref, {writable: writableSet[name]==true})"
    workdir.builder->>workdir.builder: sets.add(writableFiles, name) if writable
    exec-impl.tpl->>workdir.builder: "writeFile(name, ref, {writable: writableSet[name]==true})"
    workdir.builder->>workdir.builder: "build() emits fill rule with permissions=0o600 or 0o400"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/exec-writable-files.md:4
**Changeset claims `exec.builder().writeFiles` accepts `{ writable }`** — this method doesn't exist

The opening sentence reads *"(and the plural `addFiles` / `writeFiles`)"* as if both plural forms live on `exec.builder()`. `addFiles` is there, but `exec.builder()` has never had a `writeFiles` method (only the `workdir.builder()` does). A developer reading this changeset and calling `exec.builder().writeFiles({...}, { writable: true })` would get a runtime error. Either add `writeFiles` to the exec builder or tighten the sentence to distinguish which plurals belong to which builder.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["exec.writeFile/addFile: { writable: true..."](https://github.com/milaboratory/platforma/commit/c71f4d003ac555f96161b9ac1bc9ce3c1ef06588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33002605)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->