### PR TITLE
Switch to treeFilter:v2 capability across codebase

### DIFF
--- a/.changeset/wild-shrimps-relax.md
+++ b/.changeset/wild-shrimps-relax.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-client": patch
+"@milaboratories/pl-tree": patch
+---
+
+project with errors could not open

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -916,7 +916,7 @@ message ResourceAPI {
 
       // Optional per-(resource, field) filter. Unset / nil means
       // "keep all fields" (current Tree behavior). Servers advertise
-      // support via "treeFilter:v1" in
+      // support via "treeFilter:v2" in
       // MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
       // field.
       //
@@ -1065,8 +1065,8 @@ message ResourceAPI {
 
       // Populated only on stop-marker frames (resource is unset).
       // Zero / empty on normal frames; use resource.resource_id instead.
-      uint64 resource_id        = 4;
-      bytes  resource_signature = 5;
+      uint64 resource_id = 4;
+      bytes resource_signature = 5;
     }
   }
 
@@ -1991,13 +1991,13 @@ message MaintenanceAPI {
       // per-token by the client:
       //   - Optimization hint. Client picks between a fast path and a
       //     fallback without probing by trial-and-error; missing tokens
-      //     just cause the fallback to run (e.g. "treeFilter:v1").
+      //     just cause the fallback to run (e.g. "treeFilter:v2").
       //   - Install-time gate. Client refuses to install a block whose
       //     manifest declares a required capability the server doesn't
       //     advertise; missing tokens fail closed (e.g. "wasm:v1").
       //
       // Each entry is an opaque token "<feature>:<version>" (e.g.
-      // "treeFilter:v1"). The field is unset on servers predating this
+      // "treeFilter:v2"). The field is unset on servers predating this
       // mechanism, which the client treats as "no optional capabilities
       // advertised" — fallback for hints, fail-closed for gates.
       //

--- a/lib/node/pl-client/src/core/capabilities.ts
+++ b/lib/node/pl-client/src/core/capabilities.ts
@@ -15,7 +15,7 @@
  *   - `@platforma-sdk/block-tools`       — copies it onto the published manifest
  *   - `@milaboratories/pl-middle-layer`  — checks it at install time
  */
-export type BackendCapability = "auth:v2" | "treeFilter:v1" | "wasm:v1";
+export type BackendCapability = "auth:v2" | "treeFilter:v2" | "wasm:v1";
 
 /** True iff `capabilities` advertises the requested token. */
 export function hasCapability(

--- a/lib/node/pl-client/src/core/unauth_client_branch.test.ts
+++ b/lib/node/pl-client/src/core/unauth_client_branch.test.ts
@@ -64,6 +64,6 @@ test("login falls back to getJwtToken when backend lacks auth:v2", async () => {
 test("hasCapability proxies to underlying LLPlClient", () => {
   const { client, ll } = makeStub({ hasAuthV2: true });
   expect(client.hasCapability("auth:v2")).toBe(true);
-  expect(client.hasCapability("treeFilter:v1")).toBe(false);
+  expect(client.hasCapability("treeFilter:v2")).toBe(false);
   expect(ll.hasCapability).toHaveBeenCalledWith("auth:v2");
 });

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1759,7 +1759,7 @@ export interface ResourceAPI_Tree_Request {
     /**
      * Optional per-(resource, field) filter. Unset / nil means
      * "keep all fields" (current Tree behavior). Servers advertise
-     * support via "treeFilter:v1" in
+     * support via "treeFilter:v2" in
      * MaintenanceAPI.Ping.Response.capabilities; old servers ignore this
      * field.
      *
@@ -4303,13 +4303,13 @@ export interface MaintenanceAPI_Ping_Response {
      * per-token by the client:
      *   - Optimization hint. Client picks between a fast path and a
      *     fallback without probing by trial-and-error; missing tokens
-     *     just cause the fallback to run (e.g. "treeFilter:v1").
+     *     just cause the fallback to run (e.g. "treeFilter:v2").
      *   - Install-time gate. Client refuses to install a block whose
      *     manifest declares a required capability the server doesn't
      *     advertise; missing tokens fail closed (e.g. "wasm:v1").
      *
      * Each entry is an opaque token "<feature>:<version>" (e.g.
-     * "treeFilter:v1"). The field is unset on servers predating this
+     * "treeFilter:v2"). The field is unset on servers predating this
      * mechanism, which the client treats as "no optional capabilities
      * advertised" — fallback for hints, fail-closed for gates.
      *

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -71,7 +71,7 @@ test("loadTreeState uses ResourceTree path with full options", async () => {
     traverseStopRules: {},
   } as unknown as Parameters<typeof loadTreeState>[1];
 
-  const result = await loadTreeState(tx, request, undefined, ["treeFilter:v1"]);
+  const result = await loadTreeState(tx, request, undefined, ["treeFilter:v2"]);
 
   expect(received).toEqual({
     seeds: ["NG:0x1", "NG:0x2"],
@@ -96,7 +96,7 @@ test("loadTreeState propagates ResourceTree stream failure", async () => {
     finalResources: new Set<string>(),
   } as unknown as Parameters<typeof loadTreeState>[1];
 
-  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"])).rejects.toThrow(
+  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v2"])).rejects.toThrow(
     "stream failed",
   );
 });
@@ -150,7 +150,7 @@ test("loadTreeState cancels ResourceTree iterator on pruning failure", async () 
     },
   } as unknown as Parameters<typeof loadTreeState>[1];
 
-  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v1"])).rejects.toThrow(
+  await expect(loadTreeState(tx, request, undefined, ["treeFilter:v2"])).rejects.toThrow(
     "pruning failed",
   );
   expect(returnCalled).toBe(true);
@@ -342,7 +342,7 @@ test("traversalMode=client-bfs forces BFS on capable backend", async () => {
   const { tx, calls } = buildMockTx({ capable: true });
   const mode: TraversalMode = "client-bfs";
 
-  const result = await loadTreeState(tx, baseRequest, undefined, ["treeFilter:v1"], mode);
+  const result = await loadTreeState(tx, baseRequest, undefined, ["treeFilter:v2"], mode);
 
   expect(result).toHaveLength(1);
   expect(calls.bfs).toBeGreaterThan(0);
@@ -362,14 +362,14 @@ test("traversalMode=backend-streaming falls back to BFS when capability is absen
   expect(calls.bfs).toBeGreaterThan(0);
   expect(calls.streaming).toBe(0);
   expect(warnings).toHaveLength(1);
-  expect(warnings[0]).toMatch(/treeFilter:v1/);
+  expect(warnings[0]).toMatch(/treeFilter:v2/);
 });
 
 test("traversalMode=backend-streaming uses streaming on capable backend", async () => {
   const { tx, calls } = buildMockTx({ capable: true });
   const mode: TraversalMode = "backend-streaming";
 
-  const result = await loadTreeState(tx, baseRequest, undefined, ["treeFilter:v1"], mode);
+  const result = await loadTreeState(tx, baseRequest, undefined, ["treeFilter:v2"], mode);
 
   expect(result).toHaveLength(1);
   expect(calls.streaming).toBeGreaterThan(0);
@@ -379,7 +379,7 @@ test("traversalMode=backend-streaming uses streaming on capable backend", async 
 test("traversalMode=auto default regression: streaming on capable, BFS on incapable", async () => {
   // capable backend → streaming
   const { tx: txCap, calls: callsCap } = buildMockTx({ capable: true });
-  await loadTreeState(txCap, baseRequest, undefined, ["treeFilter:v1"]);
+  await loadTreeState(txCap, baseRequest, undefined, ["treeFilter:v2"]);
   expect(callsCap.streaming).toBeGreaterThan(0);
   expect(callsCap.bfs).toBe(0);
 
@@ -393,7 +393,7 @@ test("traversalMode=auto default regression: streaming on capable, BFS on incapa
 // ─── Stop-marker handling tests ───────────────────────────────────────────────
 
 /** Capabilities for backends that support streaming traversal. */
-const stopMarkerCaps = ["treeFilter:v1"] as const;
+const stopMarkerCaps = ["treeFilter:v2"] as const;
 
 /** Minimal full-resource frame suitable for stop-marker tests. */
 function makeFullResource(
@@ -499,7 +499,7 @@ test("legacy-backend-compat: no stop markers in stream → no follow-up call", a
   } as unknown as Parameters<typeof loadTreeState>[1];
 
   const stats = initialTreeLoadingStat();
-  const result = await loadTreeState(tx, request, stats, ["treeFilter:v1"]);
+  const result = await loadTreeState(tx, request, stats, ["treeFilter:v2"]);
 
   expect(result).toHaveLength(1);
   expect(callCount).toBe(1);

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -36,7 +36,7 @@ export interface TreeLoadingRequest {
 }
 
 /** Controls which tree-loading path is used.
- * - `"auto"` (default): use backend streaming when the backend advertises `treeFilter:v1`,
+ * - `"auto"` (default): use backend streaming when the backend advertises `treeFilter:v2`,
  *   fall back to client-side BFS otherwise.
  * - `"client-bfs"`: always use client-side BFS, even on capable backends.
  * - `"backend-streaming"`: always prefer backend streaming; if the capability is absent,
@@ -120,7 +120,7 @@ export function formatTreeLoadingStat(stat: TreeLoadingStat): string {
 }
 
 function supportsResourceTreeTraversal(capabilities: readonly string[] = []): boolean {
-  return hasCapability(capabilities, "treeFilter:v1");
+  return hasCapability(capabilities, "treeFilter:v2");
 }
 
 function collectStatsForResource(resource: ExtendedResourceData, stats?: TreeLoadingStat) {
@@ -365,7 +365,7 @@ export async function loadTreeState(
 
     if (wantsStreaming && !supportsResourceTreeTraversal(capabilities)) {
       const msg =
-        "traversalMode=backend-streaming but backend lacks treeFilter:v1 capability; falling back to BFS";
+        "traversalMode=backend-streaming but backend lacks treeFilter:v2 capability; falling back to BFS";
       if (logger) logger.warn(msg);
       else console.warn(msg);
       return await loadTreeStateViaBfs(tx, loadingRequest, stats);


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps the backend capability token for server-side tree traversal from `treeFilter:v1` to `treeFilter:v2` across the entire client codebase. The change is applied consistently in the proto definition, the generated TypeScript types, the capability type union, the runtime capability check, the BFS-fallback warning message, and all associated tests.

- **`capabilities.ts`**: The `BackendCapability` union type is updated; no `treeFilter:v1` references remain anywhere in the repo, so no stale type sites exist.
- **`sync.ts`**: `supportsResourceTreeTraversal` now gates on `treeFilter:v2`; backends that still advertise only `treeFilter:v1` will correctly fall back to client-side BFS (the safe, slower path), as designed.
- **Tests** (`sync.test.ts`, `unauth_client_branch.test.ts`): All fixture capability arrays and regex assertions updated to match the new token.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are a consistent token rename with no logic modifications.

Every occurrence of the old capability token has been replaced — the repo-wide grep finds zero remaining treeFilter:v1 strings. The fallback path (client-side BFS) is unchanged and will activate for backends that still advertise the old token, so there is no risk of incorrect behavior. Tests are fully updated and cover the new token in all relevant scenarios.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/capabilities.ts | Updates the BackendCapability type union from "treeFilter:v1" to "treeFilter:v2" — the single source of truth for the capability token string. |
| lib/node/pl-tree/src/sync.ts | Updates supportsResourceTreeTraversal and the BFS-fallback warning message to reference treeFilter:v2; no logic changes. |
| lib/node/pl-client/proto/plapi/plapiproto/api.proto | Comment-only update renaming the capability example from treeFilter:v1 to treeFilter:v2; also removes unnecessary alignment whitespace in two field definitions. |
| lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts | JSDoc comment-only updates mirroring the proto changes; generated TypeScript interface documentation now references treeFilter:v2. |
| lib/node/pl-tree/src/sync.test.ts | All test capability fixtures and regex assertions updated from treeFilter:v1 to treeFilter:v2; complete and consistent. |
| lib/node/pl-client/src/core/unauth_client_branch.test.ts | Single test assertion updated to use treeFilter:v2; correctly verifies that the stub returns false for the new token when the backend lacks it. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client calls loadTreeState] --> B{traversalMode?}
    B -->|auto / backend-streaming| C{supportsResourceTreeTraversal}
    B -->|client-bfs| G[loadTreeStateViaBfs]
    C -->|hasCapability 'treeFilter:v2'| D{Capability present?}
    D -->|Yes - backend advertises treeFilter:v2| E[loadTreeStateViaStreaming]
    D -->|No - treeFilter:v1 or absent| F[Log warning if backend-streaming mode]
    F --> G[loadTreeStateViaBfs]
    E --> H[Return ExtendedResourceData array]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Switch to treeFilter:v2 capability acros..."](https://github.com/milaboratory/platforma/commit/f004daf793c7321a5bad7f15cc5e6ec3eafbcd25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33245808)</sub>

<!-- /greptile_comment -->