### PR TITLE
refactor: decouple Zod from TS types in block_meta + block-tools/v2

### DIFF
--- a/.changeset/decouple-zod-tier-d.md
+++ b/.changeset/decouple-zod-tier-d.md
@@ -1,0 +1,34 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+"@platforma-sdk/block-tools": minor
+---
+
+Decouple Zod from TypeScript types in the block-meta / block-tools-v2 layer:
+
+- Domain types in `pl-model-middle-layer/block_meta` are now canonical TS
+  declarations (with a single `Content` discriminated-union as the source of
+  truth for content shapes). Schemas that survive are pegged to TS types via
+  `satisfies z.ZodType<T>`; transform-bearing boundary schemas use
+  `satisfies z.ZodType<T, z.ZodTypeDef, any>`.
+- The `Workflow<>` and `BlockComponents<>` Zod factories in
+  `pl-model-middle-layer` are replaced by plain TS generics (`Workflow<T>`,
+  `BlockComponents<W, U>`) plus a concrete `BlockComponentsDescriptionRaw`
+  boundary schema with a normalizing `string → {type:"workflow-v1", main:...}`
+  coercion for `package.json` authoring.
+- In `@platforma-sdk/block-tools/v2`, every `.transform(...)`/`.pipe(...)`
+  pipeline becomes a named async function: `resolveBlockPackDescription`,
+  `consolidateBlockPackDescription`, `embedBlockPackMetaAbsoluteBase64`,
+  `embedBlockPackMetaAbsoluteBytes`, `embedBlockPackMetaBytes`,
+  `blockComponentsManifestToAbsoluteUrl`, `addRelativePathPrefix`,
+  `parseGlobalOverviewReg`. The unused `BlockDescriptionToExplicitBinaryBytes`,
+  `GlobalOverviewToExplicitBinaryBytes`, `GlobalOverviewToExplicitBinaryBase64`
+  Zod factories are deleted.
+- The `BlockComponentsAbsoluteUrl` Zod factory that lived in
+  `pl-model-middle-layer/block_components.ts` (input: `ContentRelativeBinary`)
+  is removed — it was unreachable from any caller. The block-tools variant
+  is replaced by `blockComponentsManifestToAbsoluteUrl(manifest, prefix)`.
+
+All exported TS type names and shapes are preserved; downstream consumers
+(`@milaboratories/pl-middle-layer`, blocks) keep compiling without source
+changes beyond the `@platforma-sdk/block-tools` import-name updates already
+applied in this PR.

--- a/lib/model/middle-layer/src/block_meta/block_components.ts
+++ b/lib/model/middle-layer/src/block_meta/block_components.ts
@@ -3,29 +3,58 @@ import { z } from "zod";
 //
 // Workflow + BlockComponents canonical TS types.
 //
-// Manifest form is always the wrapped `{type: "workflow-v1", main: ...}` shape.
-// Authors may write a bare value in `package.json`; the boundary schema below
-// normalizes that to the wrapped form.
-//
 
+/**
+ * Wrapped workflow component, schema version 1. Currently the only workflow
+ * schema; carries a single `main` entry pointing at the workflow source.
+ */
 export type WorkflowV1<Content> = {
   type: "workflow-v1";
   main: Content;
 };
 
+/**
+ * Current workflow component shape. Alias to `WorkflowV1` while v1 is the
+ * only version — future versions widen this to a discriminated union.
+ */
 export type Workflow<Content> = WorkflowV1<Content>;
 
-export type BlockComponents<WfAndModel, UI> = {
-  workflow: Workflow<WfAndModel>;
-  model: WfAndModel;
-  ui: UI;
+/**
+ * Trio of artifacts every block ships: a workflow (Tengo source), a model
+ * (compiled JS), and a UI (front-end bundle). `WMContent` carries
+ * `workflow.main` and `model` together (they travel as files); `UIContent`
+ * carries the UI bundle (a folder when resolved locally, a relative path in
+ * manifest form). Parameterizing this lets the same shape express every
+ * stage the description passes through: raw `package.json` input (bare
+ * strings), manifest form (relative paths stored in the registry), resolved
+ * absolute form (local file/folder paths), and the registry-reader output
+ * (URLs into registry storage, produced by `blockComponentsManifestToAbsoluteUrl`).
+ */
+export type BlockComponents<WMContent, UIContent> = {
+  workflow: Workflow<WMContent>;
+  model: WMContent;
+  ui: UIContent;
 };
 
+/**
+ * Builds the zod schema for a wrapped workflow component carrying `content`
+ * as the `main` payload. Shared between the `package.json` boundary parser
+ * (where `content` is `z.string()`) and the manifest schema (where `content`
+ * is `ContentRelative`).
+ */
+export function WorkflowSchemaV1<C extends z.ZodTypeAny>(content: C) {
+  return z
+    .object({
+      type: z.literal("workflow-v1"),
+      main: content,
+    })
+    .strict();
+}
+
 //
-// Package.json boundary schema.
-//
-// Workflow field accepts either a bare string or the wrapped object;
-// both normalize to `{type: "workflow-v1", main: <string>}`.
+// `package.json` boundary schema. The workflow field accepts either a bare
+// string (treated as `main`) or the wrapped object form; both normalize to
+// the canonical wrapped shape.
 //
 
 const WorkflowDescriptionRaw = z.union([
@@ -33,14 +62,7 @@ const WorkflowDescriptionRaw = z.union([
     type: "workflow-v1",
     main: value,
   })),
-  z.discriminatedUnion("type", [
-    z
-      .object({
-        type: z.literal("workflow-v1"),
-        main: z.string().describe("Main workflow"),
-      })
-      .strict(),
-  ]),
+  WorkflowSchemaV1(z.string()),
 ]) satisfies z.ZodType<Workflow<string>, z.ZodTypeDef, any>;
 
 export type BlockComponentsDescriptionRaw = BlockComponents<string, string>;

--- a/lib/model/middle-layer/src/block_meta/block_components.ts
+++ b/lib/model/middle-layer/src/block_meta/block_components.ts
@@ -1,49 +1,52 @@
 import { z } from "zod";
-import { ContentRelativeBinary } from "./content_types";
-import { mapRemoteToAbsolute } from "./content_conversion";
 
-export function WorkflowV1<const Content extends z.ZodTypeAny>(contentType: Content) {
-  return z.object({
-    type: z.literal("workflow-v1"),
-    main: contentType.describe("Main workflow"),
-  });
-}
+//
+// Workflow + BlockComponents canonical TS types.
+//
+// Manifest form is always the wrapped `{type: "workflow-v1", main: ...}` shape.
+// Authors may write a bare value in `package.json`; the boundary schema below
+// normalizes that to the wrapped form.
+//
 
-export function Workflow<const Content extends z.ZodTypeAny>(contentType: Content) {
-  return z.union([
-    // string is converted to v1 workflow
-    contentType
-      .transform((value: z.infer<typeof contentType>) => ({
-        type: "workflow-v1" as const,
-        main: value,
-      }))
-      .pipe(WorkflowV1(contentType)),
-    // structured objects are decoded as union with type descriptor
-    z.discriminatedUnion("type", [WorkflowV1(contentType)]),
-  ]);
-}
+export type WorkflowV1<Content> = {
+  type: "workflow-v1";
+  main: Content;
+};
 
-export function BlockComponents<
-  const WfAndModel extends z.ZodTypeAny,
-  const UI extends z.ZodTypeAny,
->(wfAndModel: WfAndModel, ui: UI) {
-  return z.object({
-    workflow: Workflow(wfAndModel),
-    model: wfAndModel,
-    ui,
-  });
-}
+export type Workflow<Content> = WorkflowV1<Content>;
 
-export const BlockComponentsDescriptionRaw = BlockComponents(z.string(), z.string());
-export type BlockComponentsDescriptionRaw = z.infer<typeof BlockComponentsDescriptionRaw>;
+export type BlockComponents<WfAndModel, UI> = {
+  workflow: Workflow<WfAndModel>;
+  model: WfAndModel;
+  ui: UI;
+};
 
-export function BlockComponentsAbsoluteUrl(prefix: string) {
-  return BlockComponents(
-    ContentRelativeBinary.transform(mapRemoteToAbsolute(prefix)),
-    ContentRelativeBinary.transform(mapRemoteToAbsolute(prefix)),
-  );
-}
-export type BlockComponentsAbsolute = z.infer<ReturnType<typeof BlockComponentsAbsoluteUrl>>;
+//
+// Package.json boundary schema.
+//
+// Workflow field accepts either a bare string or the wrapped object;
+// both normalize to `{type: "workflow-v1", main: <string>}`.
+//
 
-// export const BlockComponentsExplicit = BlockComponents(, ContentRelative);
-// export type BlockComponentsExplicit = z.infer<typeof BlockComponentsExplicit>;
+const WorkflowDescriptionRaw = z.union([
+  z.string().transform<WorkflowV1<string>>((value) => ({
+    type: "workflow-v1",
+    main: value,
+  })),
+  z.discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("workflow-v1"),
+        main: z.string().describe("Main workflow"),
+      })
+      .strict(),
+  ]),
+]) satisfies z.ZodType<Workflow<string>, z.ZodTypeDef, any>;
+
+export type BlockComponentsDescriptionRaw = BlockComponents<string, string>;
+
+export const BlockComponentsDescriptionRaw = z.object({
+  workflow: WorkflowDescriptionRaw,
+  model: z.string(),
+  ui: z.string(),
+}) satisfies z.ZodType<BlockComponentsDescriptionRaw, z.ZodTypeDef, any>;

--- a/lib/model/middle-layer/src/block_meta/block_description.ts
+++ b/lib/model/middle-layer/src/block_meta/block_description.ts
@@ -7,20 +7,23 @@ import { toMerged } from "es-toolkit";
 import type { BlockCodeKnownFeatureFlags } from "@milaboratories/pl-model-common";
 
 /**
- * Generic shape of a block-pack description: `BlockPackId` plus typed
- * components and meta, with optional feature flags. Index signature carries
- * the `.passthrough()` semantics of the underlying schemas at the type level.
+ * Block-pack description: a `BlockPackId`, the typed `components` and `meta`
+ * payloads, and optional `featureFlags`. The two type parameters let the same
+ * shape carry every form a description travels in — `package.json` source,
+ * relative-path manifest, absolute-path resolved.
  */
 export type BlockPackDescription<Components, Meta> = {
   id: BlockPackId;
   components: Components;
   meta: Meta;
   featureFlags?: BlockCodeKnownFeatureFlags;
-} & { [k: string]: unknown };
+};
 
-/** Description, as appears in root block package.json file,
- * `file:` references are parsed into relative content of corresponding type, depending on the context,
- * strings are converted to explicit content type. */
+/**
+ * Description as it appears in the root block `package.json`. `file:`-prefixed
+ * strings become `ContentRelative`; bare text strings become
+ * `ContentExplicitString`. See `DescriptionContentText`/`DescriptionContentBinary`.
+ */
 export const BlockPackDescriptionFromPackageJsonRaw = z.object({
   components: BlockComponentsDescriptionRaw,
   meta: BlockPackMetaDescriptionRaw,

--- a/lib/model/middle-layer/src/block_meta/block_description.ts
+++ b/lib/model/middle-layer/src/block_meta/block_description.ts
@@ -6,6 +6,18 @@ import { BlockPackId } from "./block_id";
 import { toMerged } from "es-toolkit";
 import type { BlockCodeKnownFeatureFlags } from "@milaboratories/pl-model-common";
 
+/**
+ * Generic shape of a block-pack description: `BlockPackId` plus typed
+ * components and meta, with optional feature flags. Index signature carries
+ * the `.passthrough()` semantics of the underlying schemas at the type level.
+ */
+export type BlockPackDescription<Components, Meta> = {
+  id: BlockPackId;
+  components: Components;
+  meta: Meta;
+  featureFlags?: BlockCodeKnownFeatureFlags;
+} & { [k: string]: unknown };
+
 /** Description, as appears in root block package.json file,
  * `file:` references are parsed into relative content of corresponding type, depending on the context,
  * strings are converted to explicit content type. */

--- a/lib/model/middle-layer/src/block_meta/block_manifest.ts
+++ b/lib/model/middle-layer/src/block_meta/block_manifest.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { BlockComponents } from "./block_components";
+import { WorkflowSchemaV1 } from "./block_components";
 import { ContentRelative, ContentRelativeBinary, ContentRelativeText } from "./content_types";
 import { CreateBlockPackDescriptionSchema } from "./block_description";
 import { BlockPackMeta } from "./block_meta";
@@ -9,19 +10,12 @@ import type { BlockPackId } from "./block_id";
 export type BlockComponentsManifest = BlockComponents<ContentRelative, ContentRelative>;
 
 /**
- * Block-components shape stored in a manifest. The consolidator always
- * writes the wrapped `{type: "workflow-v1", main: ...}` form, so the
- * manifest schema accepts the wrapped form only.
+ * Block-components shape stored in a manifest. The consolidator always writes
+ * the wrapped `{type: "workflow-v1", main: ...}` form, so the manifest schema
+ * accepts the wrapped form only.
  */
 export const BlockComponentsManifest = z.object({
-  workflow: z.discriminatedUnion("type", [
-    z
-      .object({
-        type: z.literal("workflow-v1"),
-        main: ContentRelative,
-      })
-      .strict(),
-  ]),
+  workflow: WorkflowSchemaV1(ContentRelative),
   model: ContentRelative,
   ui: ContentRelative,
 }) satisfies z.ZodType<BlockComponentsManifest>;

--- a/lib/model/middle-layer/src/block_meta/block_manifest.ts
+++ b/lib/model/middle-layer/src/block_meta/block_manifest.ts
@@ -1,13 +1,30 @@
 import { z } from "zod";
-import { BlockComponents } from "./block_components";
+import type { BlockComponents } from "./block_components";
 import { ContentRelative, ContentRelativeBinary, ContentRelativeText } from "./content_types";
 import { CreateBlockPackDescriptionSchema } from "./block_description";
 import { BlockPackMeta } from "./block_meta";
 import { toMerged } from "es-toolkit";
 import type { BlockPackId } from "./block_id";
 
-export const BlockComponentsManifest = BlockComponents(ContentRelative, ContentRelative);
-export type BlockComponentsManifest = z.infer<typeof BlockComponentsManifest>;
+export type BlockComponentsManifest = BlockComponents<ContentRelative, ContentRelative>;
+
+/**
+ * Block-components shape stored in a manifest. The consolidator always
+ * writes the wrapped `{type: "workflow-v1", main: ...}` form, so the
+ * manifest schema accepts the wrapped form only.
+ */
+export const BlockComponentsManifest = z.object({
+  workflow: z.discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("workflow-v1"),
+        main: ContentRelative,
+      })
+      .strict(),
+  ]),
+  model: ContentRelative,
+  ui: ContentRelative,
+}) satisfies z.ZodType<BlockComponentsManifest>;
 
 export const BlockPackMetaManifest = BlockPackMeta(ContentRelativeText, ContentRelativeBinary);
 export type BlockPackMetaManifest = z.infer<typeof BlockPackMetaManifest>;

--- a/lib/model/middle-layer/src/block_meta/block_meta.ts
+++ b/lib/model/middle-layer/src/block_meta/block_meta.ts
@@ -16,6 +16,34 @@ export const BlockPlatform = z.enum([
 ]);
 export type BlockPlatform = z.infer<typeof BlockPlatform>;
 
+/**
+ * TS generic shape of any BlockPackMeta variant — parameterized by the
+ * representation of long-string and binary content fields. Mirrors the
+ * structure produced by the `BlockPackMeta(...)` Zod factory below; both
+ * stay in sync.
+ */
+export type BlockPackMeta<LongString, Binary> = {
+  title: string;
+  description: string;
+  longDescription?: LongString;
+  changelog?: LongString;
+  logo?: Binary;
+  url?: string;
+  docs?: string;
+  support?: string;
+  tags?: string[];
+  organization: {
+    name: string;
+    url: string;
+    logo?: Binary;
+  } & { [k: string]: unknown };
+  marketplaceRanking?: number;
+  deprecated?: boolean;
+  termsOfServiceUrl?: string;
+  supportedPlatforms?: BlockPlatform[];
+  requiredCapabilities?: string[];
+} & { [k: string]: unknown };
+
 export function BlockPackMeta<
   const LongStringType extends z.ZodTypeAny,
   const BinaryType extends z.ZodTypeAny,

--- a/lib/model/middle-layer/src/block_meta/block_meta.ts
+++ b/lib/model/middle-layer/src/block_meta/block_meta.ts
@@ -17,10 +17,20 @@ export const BlockPlatform = z.enum([
 export type BlockPlatform = z.infer<typeof BlockPlatform>;
 
 /**
- * TS generic shape of any BlockPackMeta variant — parameterized by the
- * representation of long-string and binary content fields. Mirrors the
- * structure produced by the `BlockPackMeta(...)` Zod factory below; both
- * stay in sync.
+ * Static metadata a block author ships: title, descriptions, logos, social
+ * links, and capability requirements. Parameterized by the carriers used for
+ * long-string fields (`LongString`) and binary fields (`Binary`); the same
+ * shape carries `package.json` form (loose strings), manifest form (relative
+ * paths), and embedded form (inlined base64 or bytes).
+ *
+ * Forward-compatibility: the boundary zod schemas (`BlockPackMeta(...)` and
+ * `organization`) use `.passthrough()` so that unknown sibling fields survive
+ * parse/round-trip verbatim. A registry mutator that predates a new meta
+ * field must not silently strip it (otherwise mark-stable / refresh-overview
+ * / restore-overview would quietly undo publishes). Code consuming these
+ * objects sees only the known fields listed below; the schemas guard the
+ * round-trip behavior. Combined with the `require-latest @platforma-sdk/block-tools`
+ * CI gate, this future-proofs every subsequent field addition.
  */
 export type BlockPackMeta<LongString, Binary> = {
   title: string;
@@ -36,13 +46,13 @@ export type BlockPackMeta<LongString, Binary> = {
     name: string;
     url: string;
     logo?: Binary;
-  } & { [k: string]: unknown };
+  };
   marketplaceRanking?: number;
   deprecated?: boolean;
   termsOfServiceUrl?: string;
   supportedPlatforms?: BlockPlatform[];
   requiredCapabilities?: string[];
-} & { [k: string]: unknown };
+};
 
 export function BlockPackMeta<
   const LongStringType extends z.ZodTypeAny,
@@ -99,12 +109,8 @@ export function BlockPackMeta<
       requiredCapabilities: z.array(z.string()).optional(),
     })
     .passthrough();
-  // `.passthrough()` preserves unknown sibling keys through `parse`/round-trip.
-  // Without it, a block-tools version that predates a newly-added meta field
-  // would strip that field on every registry-mutating command (mark-stable,
-  // refresh-registry, restore-overview-from-snapshot) — silently undoing
-  // publishes. Combined with the `require-latest @platforma-sdk/block-tools`
-  // CI gate, this future-proofs the schema for all subsequent field additions.
+  // `.passthrough()` is intentional — see forward-compat note on
+  // `BlockPackMeta` type above.
 }
 
 export const BlockPackMetaDescriptionRaw = BlockPackMeta(

--- a/lib/model/middle-layer/src/block_meta/content_types.ts
+++ b/lib/model/middle-layer/src/block_meta/content_types.ts
@@ -1,16 +1,89 @@
 import { z } from "zod";
 
 //
-// Base content types
+// Canonical content union — single source of truth for TS types
 //
+
+export type Content =
+  | { type: "explicit-string"; content: string }
+  | { type: "explicit-base64"; mimeType: string; content: string }
+  | { type: "explicit-bytes"; mimeType: string; content: Uint8Array }
+  | { type: "relative"; path: string }
+  | { type: "absolute-file"; file: string }
+  | { type: "absolute-folder"; folder: string }
+  | { type: "absolute-url"; url: string };
+
+//
+// Leaf types — extracted from canonical Content union
+//
+
+export type ContentExplicitString = Extract<Content, { type: "explicit-string" }>;
+export type ContentExplicitBase64 = Extract<Content, { type: "explicit-base64" }>;
+export type ContentExplicitBytes = Extract<Content, { type: "explicit-bytes" }>;
+export type ContentRelative = Extract<Content, { type: "relative" }>;
+export type ContentAbsoluteFile = Extract<Content, { type: "absolute-file" }>;
+export type ContentAbsoluteFolder = Extract<Content, { type: "absolute-folder" }>;
+export type ContentAbsoluteUrl = Extract<Content, { type: "absolute-url" }>;
+
+//
+// Union types — extracted from canonical Content union
+//
+
+export type ContentAny = Extract<
+  Content,
+  { type: "explicit-string" | "explicit-base64" | "relative" | "absolute-file" | "absolute-url" }
+>;
+export type ContentExplicitOrRelative = Extract<
+  Content,
+  { type: "explicit-string" | "explicit-base64" | "relative" }
+>;
+export type ContentAnyLocal = Extract<
+  Content,
+  { type: "explicit-string" | "explicit-base64" | "relative" | "absolute-file" }
+>;
+export type ContentAnyRemote = Extract<
+  Content,
+  { type: "explicit-string" | "explicit-base64" | "relative" | "absolute-url" }
+>;
+export type ContentAnyBinaryLocal = Extract<
+  Content,
+  { type: "explicit-base64" | "relative" | "absolute-file" }
+>;
+export type ContentAnyTextLocal = Extract<
+  Content,
+  { type: "explicit-string" | "relative" | "absolute-file" }
+>;
+export type ContentAbsoluteBinaryRemote = Extract<
+  Content,
+  { type: "explicit-base64" | "absolute-url" }
+>;
+export type ContentAbsoluteBinaryLocal = Extract<
+  Content,
+  { type: "explicit-base64" | "absolute-file" }
+>;
+export type ContentAbsoluteTextRemote = Extract<
+  Content,
+  { type: "explicit-string" | "absolute-url" }
+>;
+export type ContentAbsoluteTextLocal = Extract<
+  Content,
+  { type: "explicit-string" | "absolute-file" }
+>;
+export type ContentRelativeBinary = Extract<Content, { type: "explicit-base64" | "relative" }>;
+export type ContentRelativeText = Extract<Content, { type: "explicit-string" | "relative" }>;
+
+//
+// Leaf schemas (pegged to TS types via `satisfies`)
+//
+
+const absPathRegex = new RegExp(`^(/|[A-Z]:\\\\)`);
 
 export const ContentExplicitString = z
   .object({
     type: z.literal("explicit-string"),
     content: z.string().describe("Actual string value"),
   })
-  .strict();
-export type ContentExplicitString = z.infer<typeof ContentExplicitString>;
+  .strict() satisfies z.ZodType<ContentExplicitString>;
 
 export const ContentExplicitBase64 = z
   .object({
@@ -21,45 +94,7 @@ export const ContentExplicitBase64 = z
       .describe("MIME type to interpret content"),
     content: z.string().base64().describe("Base64 encoded binary value"),
   })
-  .strict();
-export type ContentExplicitBase64 = z.infer<typeof ContentExplicitBase64>;
-
-export const ContentRelative = z
-  .object({
-    type: z.literal("relative"),
-    path: z
-      .string()
-      .describe(
-        "Address of the file, in most cases relative to the file which this structure is a part of",
-      ),
-  })
-  .strict();
-export type ContentRelative = z.infer<typeof ContentRelative>;
-
-const absPathRegex = new RegExp(`^(/|[A-Z]:\\\\)`);
-
-export const ContentAbsoluteFile = z
-  .object({
-    type: z.literal("absolute-file"),
-    file: z
-      .string()
-      .regex(absPathRegex, "path to file must be absolute")
-      .describe("Absolute address of the file in local file system"),
-  })
-  .strict();
-export type ContentAbsoluteFile = z.infer<typeof ContentAbsoluteFile>;
-
-export const ContentAbsoluteUrl = z
-  .object({
-    type: z.literal("absolute-url"),
-    url: z.string().url().describe("Global URL to reach the requested file"),
-  })
-  .strict();
-export type ContentAbsoluteUrl = z.infer<typeof ContentAbsoluteUrl>;
-
-//
-// Special content types
-//
+  .strict() satisfies z.ZodType<ContentExplicitBase64>;
 
 export const ContentExplicitBytes = z
   .object({
@@ -70,8 +105,28 @@ export const ContentExplicitBytes = z
       .describe("MIME type to interpret content"),
     content: z.instanceof(Uint8Array).describe("Raw content"),
   })
-  .strict();
-export type ContentExplicitBytes = z.infer<typeof ContentExplicitBytes>;
+  .strict() satisfies z.ZodType<ContentExplicitBytes>;
+
+export const ContentRelative = z
+  .object({
+    type: z.literal("relative"),
+    path: z
+      .string()
+      .describe(
+        "Address of the file, in most cases relative to the file which this structure is a part of",
+      ),
+  })
+  .strict() satisfies z.ZodType<ContentRelative>;
+
+export const ContentAbsoluteFile = z
+  .object({
+    type: z.literal("absolute-file"),
+    file: z
+      .string()
+      .regex(absPathRegex, "path to file must be absolute")
+      .describe("Absolute address of the file in local file system"),
+  })
+  .strict() satisfies z.ZodType<ContentAbsoluteFile>;
 
 export const ContentAbsoluteFolder = z
   .object({
@@ -81,154 +136,49 @@ export const ContentAbsoluteFolder = z
       .regex(absPathRegex, "path to folder must be absolute")
       .describe("Absolute address of the folder in local file system"),
   })
-  .strict();
-export type ContentAbsoluteFolder = z.infer<typeof ContentAbsoluteFolder>;
+  .strict() satisfies z.ZodType<ContentAbsoluteFolder>;
+
+export const ContentAbsoluteUrl = z
+  .object({
+    type: z.literal("absolute-url"),
+    url: z.string().url().describe("Global URL to reach the requested file"),
+  })
+  .strict() satisfies z.ZodType<ContentAbsoluteUrl>;
 
 //
-// Unions
+// Union schemas retained as nested validators inside boundary schemas.
+// Other Content* union schemas (ContentAny, ContentAnyLocal, ContentAbsoluteBinaryLocal, etc.)
+// are dropped — only their TS types above survive.
 //
-
-export const ContentAny = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentExplicitBase64,
-  ContentRelative,
-  ContentAbsoluteFile,
-  ContentAbsoluteUrl,
-]);
-export type ContentAny = z.infer<typeof ContentAny>;
-
-export const ContentExplicitOrRelative = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentExplicitBase64,
-  ContentRelative,
-]);
-export type ContentExplicitOrRelative = z.infer<typeof ContentExplicitOrRelative>;
-
-export const ContentAnyLocal = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentExplicitBase64,
-  ContentRelative,
-  ContentAbsoluteFile,
-]);
-export type ContentAnyLocal = z.infer<typeof ContentAnyLocal>;
-
-export const ContentAnyRemote = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentExplicitBase64,
-  ContentRelative,
-  ContentAbsoluteUrl,
-]);
-export type ContentAnyRemote = z.infer<typeof ContentAnyRemote>;
-
-//
-// Narrow types with relative option
-//
-
-// export const ContentAnyBinaryRemote = z.discriminatedUnion('type', [
-//   ContentExplicitBase64,
-//   ContentRelative,
-//   ContentAbsoluteUrl
-// ]);
-// export type ContentAnyBinaryRemote = z.infer<typeof ContentAnyBinaryRemote>;
 
 export const ContentAnyBinaryLocal = z.discriminatedUnion("type", [
   ContentExplicitBase64,
   ContentRelative,
   ContentAbsoluteFile,
-]);
-export type ContentAnyBinaryLocal = z.infer<typeof ContentAnyBinaryLocal>;
-
-// export const ContentAnyTextRemote = z.discriminatedUnion('type', [
-//   ContentExplicitString,
-//   ContentRelative,
-//   ContentAbsoluteUrl
-// ]);
-// export type ContentAnyTextRemote = z.infer<typeof ContentAnyTextRemote>;
+]) satisfies z.ZodType<ContentAnyBinaryLocal>;
 
 export const ContentAnyTextLocal = z.discriminatedUnion("type", [
   ContentExplicitString,
   ContentRelative,
   ContentAbsoluteFile,
-]);
-export type ContentAnyTextLocal = z.infer<typeof ContentAnyTextLocal>;
-
-//
-// Narrow absolute types
-//
-
-export const ContentAbsoluteBinaryRemote = z.discriminatedUnion("type", [
-  ContentExplicitBase64,
-  ContentAbsoluteUrl,
-]);
-export type ContentAbsoluteBinaryRemote = z.infer<typeof ContentAbsoluteBinaryRemote>;
-
-export const ContentAbsoluteBinaryLocal = z.discriminatedUnion("type", [
-  ContentExplicitBase64,
-  ContentAbsoluteFile,
-]);
-export type ContentAbsoluteBinaryLocal = z.infer<typeof ContentAbsoluteBinaryLocal>;
-
-export const ContentAbsoluteTextRemote = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentAbsoluteUrl,
-]);
-export type ContentAbsoluteTextRemote = z.infer<typeof ContentAbsoluteTextRemote>;
-
-export const ContentAbsoluteTextLocal = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentAbsoluteFile,
-]);
-export type ContentAbsoluteTextLocal = z.infer<typeof ContentAbsoluteTextLocal>;
-
-//
-// Narrow relative types
-//
+]) satisfies z.ZodType<ContentAnyTextLocal>;
 
 export const ContentRelativeBinary = z.discriminatedUnion("type", [
   ContentExplicitBase64,
   ContentRelative,
-]);
-export type ContentRelativeBinary = z.infer<typeof ContentRelativeBinary>;
+]) satisfies z.ZodType<ContentRelativeBinary>;
 
 export const ContentRelativeText = z.discriminatedUnion("type", [
   ContentExplicitString,
   ContentRelative,
-]);
-export type ContentRelativeText = z.infer<typeof ContentRelativeText>;
+]) satisfies z.ZodType<ContentRelativeText>;
 
-// export function ConstructContent(
-//   contentType: 'text',
-//   contextType: 'local'
-// ): typeof ContentAnyTextLocal;
-// export function ConstructContent(
-//   contentType: 'text',
-//   contextType: 'remote'
-// ): typeof ContentAnyTextRemote;
-// export function ConstructContent(
-//   contentType: 'binary',
-//   contextType: 'local'
-// ): typeof ContentAnyBinaryLocal;
-// export function ConstructContent(
-//   contentType: 'binary',
-//   contextType: 'remote'
-// ): typeof ContentAnyBinaryRemote;
-// export function ConstructContent(
-//   contentType: ContentType,
-//   contextType: ContextType
-// ):
-//   | typeof ContentAnyTextLocal
-//   | typeof ContentAnyTextRemote
-//   | typeof ContentAnyBinaryLocal
-//   | typeof ContentAnyBinaryRemote;
-// export function ConstructContent(contentType: ContentType, contextType: ContextType) {
-//   return contentType === 'text'
-//     ? contextType === 'local'
-//       ? ContentAnyTextLocal
-//       : ContentAnyTextRemote
-//     : contextType === 'local'
-//       ? ContentAnyBinaryLocal
-//       : ContentAnyBinaryRemote;
-// }
+//
+// Boundary normalizing transforms — used only when parsing untrusted
+// `package.json` content. Authors write either a bare string
+// (`"file:./logo.png"` or just `"hello"`) or a wrapped object;
+// the schema coerces both to the canonical object form.
+//
 
 export const DescriptionContentBinary = z.union([
   z
@@ -236,8 +186,7 @@ export const DescriptionContentBinary = z.union([
     .startsWith("file:")
     .transform<ContentRelativeBinary>((value) => ({ type: "relative", path: value.slice(5) })),
   ContentAnyBinaryLocal,
-]);
-export type DescriptionContentBinary = z.infer<typeof DescriptionContentBinary>;
+]) satisfies z.ZodType<ContentAnyBinaryLocal, z.ZodTypeDef, any>;
 
 export const DescriptionContentText = z.union([
   z.string().transform<ContentRelativeText>((value) => {
@@ -245,5 +194,4 @@ export const DescriptionContentText = z.union([
     else return { type: "explicit-string", content: value };
   }),
   ContentAnyTextLocal,
-]);
-export type DescriptionContentText = z.infer<typeof DescriptionContentText>;
+]) satisfies z.ZodType<ContentAnyTextLocal, z.ZodTypeDef, any>;

--- a/lib/model/middle-layer/src/block_meta/content_types.ts
+++ b/lib/model/middle-layer/src/block_meta/content_types.ts
@@ -1,167 +1,154 @@
 import { z } from "zod";
 
 //
-// Canonical content union — single source of truth for TS types
+// Canonical content types. TypeScript is the source of truth. The zod
+// schemas below are boundary validators pegged to these types via
+// `satisfies`; they exist only to parse external data (`package.json`,
+// registry manifests, registry overview files).
 //
 
+/** Inlined plain string (e.g. a short text snippet or markdown body). */
+export type ContentExplicitString = {
+  type: "explicit-string";
+  content: string;
+};
+
+/** Inlined binary blob carried as base64 (e.g. a serialized logo image). */
+export type ContentExplicitBase64 = {
+  type: "explicit-base64";
+  /** MIME type used to interpret `content`. */
+  mimeType: string;
+  /** Base64-encoded binary payload. */
+  content: string;
+};
+
+/** Inlined binary blob carried as raw bytes. Wire form only; not used in JSON. */
+export type ContentExplicitBytes = {
+  type: "explicit-bytes";
+  /** MIME type used to interpret `content`. */
+  mimeType: string;
+  content: Uint8Array;
+};
+
+/** Reference to a file by path relative to the carrying structure. */
+export type ContentRelative = {
+  type: "relative";
+  path: string;
+};
+
+/** Reference to a file at an absolute local path. */
+export type ContentAbsoluteFile = {
+  type: "absolute-file";
+  file: string;
+};
+
+/**
+ * Reference to a folder at an absolute local path. Used for UI bundles
+ * delivered as folders; the desktop "add block" dialog reads such folders on
+ * demand instead of pulling every UI bundle eagerly.
+ */
+export type ContentAbsoluteFolder = {
+  type: "absolute-folder";
+  folder: string;
+};
+
+/** Reference to a file by remote URL (e.g. served from the registry). */
+export type ContentAbsoluteUrl = {
+  type: "absolute-url";
+  url: string;
+};
+
+/** Canonical union of every content carrier shape used across the platform. */
 export type Content =
-  | { type: "explicit-string"; content: string }
-  | { type: "explicit-base64"; mimeType: string; content: string }
-  | { type: "explicit-bytes"; mimeType: string; content: Uint8Array }
-  | { type: "relative"; path: string }
-  | { type: "absolute-file"; file: string }
-  | { type: "absolute-folder"; folder: string }
-  | { type: "absolute-url"; url: string };
+  | ContentExplicitString
+  | ContentExplicitBase64
+  | ContentExplicitBytes
+  | ContentRelative
+  | ContentAbsoluteFile
+  | ContentAbsoluteFolder
+  | ContentAbsoluteUrl;
 
 //
-// Leaf types — extracted from canonical Content union
+// Slot-specific content unions. Each names a set of carriers allowed in a
+// particular stage of the pipeline (boundary input, manifest, resolved).
 //
 
-export type ContentExplicitString = Extract<Content, { type: "explicit-string" }>;
-export type ContentExplicitBase64 = Extract<Content, { type: "explicit-base64" }>;
-export type ContentExplicitBytes = Extract<Content, { type: "explicit-bytes" }>;
-export type ContentRelative = Extract<Content, { type: "relative" }>;
-export type ContentAbsoluteFile = Extract<Content, { type: "absolute-file" }>;
-export type ContentAbsoluteFolder = Extract<Content, { type: "absolute-folder" }>;
-export type ContentAbsoluteUrl = Extract<Content, { type: "absolute-url" }>;
+/** Inlined or relative-path content (text/binary inlined, or relative path). */
+export type ContentExplicitOrRelative =
+  | ContentExplicitString
+  | ContentExplicitBase64
+  | ContentRelative;
+
+/** Any locally-resolvable content (inlined, relative path, or absolute file). */
+export type ContentAnyLocal =
+  | ContentExplicitString
+  | ContentExplicitBase64
+  | ContentRelative
+  | ContentAbsoluteFile;
+
+/** Text content available locally (inlined, relative path, or absolute file). */
+export type ContentAnyTextLocal = ContentExplicitString | ContentRelative | ContentAbsoluteFile;
+
+/** Binary content available locally (inlined base64, relative path, or absolute file). */
+export type ContentAnyBinaryLocal = ContentExplicitBase64 | ContentRelative | ContentAbsoluteFile;
+
+/** Binary content fully resolved (inlined base64 or absolute file). */
+export type ContentAbsoluteBinaryLocal = ContentExplicitBase64 | ContentAbsoluteFile;
+
+/** Text content fully resolved (inlined string or absolute file). */
+export type ContentAbsoluteTextLocal = ContentExplicitString | ContentAbsoluteFile;
+
+/** Binary content in manifest form (inlined base64 or path relative to the manifest). */
+export type ContentRelativeBinary = ContentExplicitBase64 | ContentRelative;
+
+/** Text content in manifest form (inlined string or path relative to the manifest). */
+export type ContentRelativeText = ContentExplicitString | ContentRelative;
 
 //
-// Union types — extracted from canonical Content union
-//
-
-export type ContentAny = Extract<
-  Content,
-  { type: "explicit-string" | "explicit-base64" | "relative" | "absolute-file" | "absolute-url" }
->;
-export type ContentExplicitOrRelative = Extract<
-  Content,
-  { type: "explicit-string" | "explicit-base64" | "relative" }
->;
-export type ContentAnyLocal = Extract<
-  Content,
-  { type: "explicit-string" | "explicit-base64" | "relative" | "absolute-file" }
->;
-export type ContentAnyRemote = Extract<
-  Content,
-  { type: "explicit-string" | "explicit-base64" | "relative" | "absolute-url" }
->;
-export type ContentAnyBinaryLocal = Extract<
-  Content,
-  { type: "explicit-base64" | "relative" | "absolute-file" }
->;
-export type ContentAnyTextLocal = Extract<
-  Content,
-  { type: "explicit-string" | "relative" | "absolute-file" }
->;
-export type ContentAbsoluteBinaryRemote = Extract<
-  Content,
-  { type: "explicit-base64" | "absolute-url" }
->;
-export type ContentAbsoluteBinaryLocal = Extract<
-  Content,
-  { type: "explicit-base64" | "absolute-file" }
->;
-export type ContentAbsoluteTextRemote = Extract<
-  Content,
-  { type: "explicit-string" | "absolute-url" }
->;
-export type ContentAbsoluteTextLocal = Extract<
-  Content,
-  { type: "explicit-string" | "absolute-file" }
->;
-export type ContentRelativeBinary = Extract<Content, { type: "explicit-base64" | "relative" }>;
-export type ContentRelativeText = Extract<Content, { type: "explicit-string" | "relative" }>;
-
-//
-// Leaf schemas (pegged to TS types via `satisfies`)
+// Zod schemas — boundary validators only. The TS types above are the source
+// of truth; each schema is pegged via `satisfies z.ZodType<T>`. Only the
+// schemas referenced by sibling boundary files (`block_meta.ts`,
+// `block_manifest.ts`) are exported.
 //
 
 const absPathRegex = new RegExp(`^(/|[A-Z]:\\\\)`);
 
-export const ContentExplicitString = z
+const contentExplicitStringSchema = z
   .object({
     type: z.literal("explicit-string"),
-    content: z.string().describe("Actual string value"),
+    content: z.string(),
   })
   .strict() satisfies z.ZodType<ContentExplicitString>;
 
 export const ContentExplicitBase64 = z
   .object({
     type: z.literal("explicit-base64"),
-    mimeType: z
-      .string()
-      .regex(/\w+\/[-+.\w]+/)
-      .describe("MIME type to interpret content"),
-    content: z.string().base64().describe("Base64 encoded binary value"),
+    mimeType: z.string().regex(/\w+\/[-+.\w]+/),
+    content: z.string().base64(),
   })
   .strict() satisfies z.ZodType<ContentExplicitBase64>;
 
 export const ContentExplicitBytes = z
   .object({
     type: z.literal("explicit-bytes"),
-    mimeType: z
-      .string()
-      .regex(/\w+\/[-+.\w]+/)
-      .describe("MIME type to interpret content"),
-    content: z.instanceof(Uint8Array).describe("Raw content"),
+    mimeType: z.string().regex(/\w+\/[-+.\w]+/),
+    content: z.instanceof(Uint8Array),
   })
   .strict() satisfies z.ZodType<ContentExplicitBytes>;
 
 export const ContentRelative = z
   .object({
     type: z.literal("relative"),
-    path: z
-      .string()
-      .describe(
-        "Address of the file, in most cases relative to the file which this structure is a part of",
-      ),
+    path: z.string(),
   })
   .strict() satisfies z.ZodType<ContentRelative>;
 
-export const ContentAbsoluteFile = z
+const contentAbsoluteFileSchema = z
   .object({
     type: z.literal("absolute-file"),
-    file: z
-      .string()
-      .regex(absPathRegex, "path to file must be absolute")
-      .describe("Absolute address of the file in local file system"),
+    file: z.string().regex(absPathRegex, "path to file must be absolute"),
   })
   .strict() satisfies z.ZodType<ContentAbsoluteFile>;
-
-export const ContentAbsoluteFolder = z
-  .object({
-    type: z.literal("absolute-folder"),
-    folder: z
-      .string()
-      .regex(absPathRegex, "path to folder must be absolute")
-      .describe("Absolute address of the folder in local file system"),
-  })
-  .strict() satisfies z.ZodType<ContentAbsoluteFolder>;
-
-export const ContentAbsoluteUrl = z
-  .object({
-    type: z.literal("absolute-url"),
-    url: z.string().url().describe("Global URL to reach the requested file"),
-  })
-  .strict() satisfies z.ZodType<ContentAbsoluteUrl>;
-
-//
-// Union schemas retained as nested validators inside boundary schemas.
-// Other Content* union schemas (ContentAny, ContentAnyLocal, ContentAbsoluteBinaryLocal, etc.)
-// are dropped — only their TS types above survive.
-//
-
-export const ContentAnyBinaryLocal = z.discriminatedUnion("type", [
-  ContentExplicitBase64,
-  ContentRelative,
-  ContentAbsoluteFile,
-]) satisfies z.ZodType<ContentAnyBinaryLocal>;
-
-export const ContentAnyTextLocal = z.discriminatedUnion("type", [
-  ContentExplicitString,
-  ContentRelative,
-  ContentAbsoluteFile,
-]) satisfies z.ZodType<ContentAnyTextLocal>;
 
 export const ContentRelativeBinary = z.discriminatedUnion("type", [
   ContentExplicitBase64,
@@ -169,29 +156,36 @@ export const ContentRelativeBinary = z.discriminatedUnion("type", [
 ]) satisfies z.ZodType<ContentRelativeBinary>;
 
 export const ContentRelativeText = z.discriminatedUnion("type", [
-  ContentExplicitString,
+  contentExplicitStringSchema,
   ContentRelative,
 ]) satisfies z.ZodType<ContentRelativeText>;
 
 //
-// Boundary normalizing transforms — used only when parsing untrusted
-// `package.json` content. Authors write either a bare string
-// (`"file:./logo.png"` or just `"hello"`) or a wrapped object;
-// the schema coerces both to the canonical object form.
+// Boundary normalizing transforms — parse the loose forms authors write in
+// `package.json`. Bare strings with the `file:` prefix become a
+// `ContentRelative`; bare strings without the prefix become a
+// `ContentExplicitString` (text only).
 //
 
 export const DescriptionContentBinary = z.union([
   z
     .string()
     .startsWith("file:")
-    .transform<ContentRelativeBinary>((value) => ({ type: "relative", path: value.slice(5) })),
-  ContentAnyBinaryLocal,
+    .transform<ContentRelativeBinary>((value) => ({
+      type: "relative",
+      path: value.slice(5),
+    })),
+  z.discriminatedUnion("type", [ContentExplicitBase64, ContentRelative, contentAbsoluteFileSchema]),
 ]) satisfies z.ZodType<ContentAnyBinaryLocal, z.ZodTypeDef, any>;
 
 export const DescriptionContentText = z.union([
   z.string().transform<ContentRelativeText>((value) => {
     if (value.startsWith("file:")) return { type: "relative", path: value.slice(5) };
-    else return { type: "explicit-string", content: value };
+    return { type: "explicit-string", content: value };
   }),
-  ContentAnyTextLocal,
+  z.discriminatedUnion("type", [
+    contentExplicitStringSchema,
+    ContentRelative,
+    contentAbsoluteFileSchema,
+  ]),
 ]) satisfies z.ZodType<ContentAnyTextLocal, z.ZodTypeDef, any>;

--- a/lib/node/pl-middle-layer/src/block_registry/registry.ts
+++ b/lib/node/pl-middle-layer/src/block_registry/registry.ts
@@ -1,7 +1,7 @@
 import type { Dispatcher } from "undici";
 import { request } from "undici";
 import type { BlockPackDescriptionAbsolute } from "@platforma-sdk/block-tools";
-import { BlockPackMetaEmbedAbsoluteBytes, RegistryV1 } from "@platforma-sdk/block-tools";
+import { embedBlockPackMetaAbsoluteBytes, RegistryV1 } from "@platforma-sdk/block-tools";
 import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
@@ -208,7 +208,7 @@ export class BlockPackRegistry {
             if (v2Description !== undefined) {
               const mtime = await getDevV2PacketMtime(v2Description);
 
-              const meta = await BlockPackMetaEmbedAbsoluteBytes.parseAsync(v2Description.meta);
+              const meta = await embedBlockPackMetaAbsoluteBytes(v2Description.meta);
 
               // `tryLoadPackDescription` reads `package.json#block.meta` —
               // the dev SOURCE meta the developer wrote.

--- a/tools/block-tools/src/cmd/build-meta.ts
+++ b/tools/block-tools/src/cmd/build-meta.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from "@oclif/core";
 import path from "node:path";
 import fs from "node:fs";
 import { loadPackDescriptionRaw } from "../v2";
-import { BlockPackMetaDescription, BlockPackMetaEmbedAbsoluteBase64 } from "../v2/model/block_meta";
+import { embedBlockPackMetaAbsoluteBase64, resolveBlockPackMeta } from "../v2/model/block_meta";
 
 export default class BuildMeta extends Command {
   static override description =
@@ -29,8 +29,8 @@ export default class BuildMeta extends Command {
     const { flags } = await this.parse(BuildMeta);
     const modulePath = path.resolve(flags.modulePath);
     const descriptionRaw = await loadPackDescriptionRaw(modulePath);
-    const metaEmbedded = await BlockPackMetaEmbedAbsoluteBase64.parseAsync(
-      BlockPackMetaDescription(modulePath).parse(descriptionRaw.meta),
+    const metaEmbedded = await embedBlockPackMetaAbsoluteBase64(
+      await resolveBlockPackMeta(descriptionRaw.meta, modulePath),
     );
 
     await fs.promises.writeFile(path.resolve(flags.destination), JSON.stringify(metaEmbedded));

--- a/tools/block-tools/src/v2/build_dist.ts
+++ b/tools/block-tools/src/v2/build_dist.ts
@@ -5,7 +5,7 @@ import type {
 import { BlockPackManifest, BlockPackManifestFile } from "@milaboratories/pl-model-middle-layer";
 import type { CompiledTemplateV3 } from "@milaboratories/pl-model-backend";
 import type { BlockPackDescriptionAbsolute } from "./model";
-import { BlockPackDescriptionConsolidateToFolder } from "./model";
+import { consolidateBlockPackDescription } from "./model";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -23,8 +23,8 @@ async function workflowRequiredCapabilities(
   descriptionRelative: BlockPackDescriptionManifest,
   dst: string,
 ): Promise<string[] | undefined> {
-  // After BlockPackDescriptionConsolidateToFolder runs, components.workflow.main
-  // is always a {type: "relative", path: ...} reference into dst.
+  // After consolidateBlockPackDescription runs, components.workflow.main is
+  // always a `{type: "relative", path: ...}` reference into `dst`.
   const main = descriptionRelative.components.workflow.main;
   const bytes = await fsp.readFile(path.resolve(dst, main.path));
 
@@ -47,8 +47,11 @@ export async function buildBlockPackDist(
 ): Promise<BlockPackManifest> {
   await fsp.mkdir(dst, { recursive: true });
   const files: string[] = [];
-  const descriptionRelative: BlockPackDescriptionManifest =
-    await BlockPackDescriptionConsolidateToFolder(dst, files).parseAsync(description);
+  const descriptionRelative: BlockPackDescriptionManifest = await consolidateBlockPackDescription(
+    description,
+    dst,
+    files,
+  );
 
   // Per-block capability detection: mirror the workflow's
   // compile-time-computed `requiredCapabilities` onto the published

--- a/tools/block-tools/src/v2/model/block_components.ts
+++ b/tools/block-tools/src/v2/model/block_components.ts
@@ -1,38 +1,92 @@
-import type { z } from "zod";
-import {
-  ResolvedModuleFile,
-  ResolvedModuleFolder,
-  packFolderToRelativeTgz,
-  cpAbsoluteToRelative,
-} from "./content_conversion";
-import {
+import type {
   BlockComponents,
+  BlockComponentsDescriptionRaw,
   BlockComponentsManifest,
   ContentAbsoluteBinaryLocal,
+  ContentAbsoluteFile,
   ContentAbsoluteFolder,
-  ContentRelative,
-  mapRemoteToAbsolute,
+  ContentAbsoluteUrl,
 } from "@milaboratories/pl-model-middle-layer";
+import { mapRemoteToAbsolute } from "@milaboratories/pl-model-middle-layer";
+import {
+  cpAbsoluteToRelative,
+  packFolderToRelativeTgz,
+  resolveModuleFile,
+  resolveModuleFolder,
+} from "./content_conversion";
 
-export function BlockComponentsDescription(moduleRoot: string) {
-  return BlockComponents(
-    ResolvedModuleFile(moduleRoot),
-    ResolvedModuleFolder(moduleRoot, "index.html"),
-  );
-}
-export type BlockComponentsDescription = z.infer<ReturnType<typeof BlockComponentsDescription>>;
+/**
+ * Resolved BlockComponents — workflow main and model resolved to absolute
+ * file references, UI request resolved to its absolute folder.
+ */
+export type BlockComponentsDescription = BlockComponents<
+  ContentAbsoluteFile,
+  ContentAbsoluteFolder
+>;
 
-export function BlockComponentsConsolidate(dstFolder: string, fileAccumulator?: string[]) {
-  return BlockComponents(
-    ContentAbsoluteBinaryLocal.transform(cpAbsoluteToRelative(dstFolder, fileAccumulator)),
-    ContentAbsoluteFolder.transform(packFolderToRelativeTgz(dstFolder, "ui.tgz", fileAccumulator)),
-  ).pipe(BlockComponentsManifest);
+/** BlockComponents pointing at registry-served URLs. */
+export type BlockComponentsAbsoluteUrl = BlockComponents<ContentAbsoluteUrl, ContentAbsoluteUrl>;
+
+/**
+ * Resolves block-components paths from `package.json` raw form against the
+ * module root. Workflow and model strings are resolved via node module
+ * resolution; the UI request resolves to a folder containing `index.html`.
+ */
+export function resolveBlockComponents(
+  raw: BlockComponentsDescriptionRaw,
+  moduleRoot: string,
+): BlockComponentsDescription {
+  return {
+    workflow: {
+      type: "workflow-v1",
+      main: resolveModuleFile(moduleRoot, raw.workflow.main),
+    },
+    model: resolveModuleFile(moduleRoot, raw.model),
+    ui: resolveModuleFolder(moduleRoot, raw.ui, ["index.html"]),
+  };
 }
 
-export function BlockComponentsAbsoluteUrl(prefix: string) {
-  return BlockComponents(
-    ContentRelative.transform(mapRemoteToAbsolute(prefix)),
-    ContentRelative.transform(mapRemoteToAbsolute(prefix)),
-  );
+/**
+ * Copies file references for workflow and model into `dstFolder`, packs the
+ * UI folder into `ui.tgz`, returning the manifest form with relative paths.
+ */
+export async function consolidateBlockComponents(
+  description: BlockComponents<ContentAbsoluteBinaryLocal, ContentAbsoluteFolder>,
+  dstFolder: string,
+  fileAccumulator?: string[],
+): Promise<BlockComponentsManifest> {
+  const cpToRel = cpAbsoluteToRelative(dstFolder, fileAccumulator);
+  const packToTgz = packFolderToRelativeTgz(dstFolder, "ui.tgz", fileAccumulator);
+  const workflowMain = await cpToRel(description.workflow.main);
+  const model = await cpToRel(description.model);
+  const ui = await packToTgz(description.ui);
+  if (workflowMain.type !== "relative" || model.type !== "relative")
+    throw new Error(
+      `consolidateBlockComponents: expected relative refs, got ${workflowMain.type}/${model.type}`,
+    );
+  return {
+    workflow: { type: "workflow-v1", main: workflowMain },
+    model,
+    ui,
+  };
 }
-export type BlockComponentsAbsoluteUrl = z.infer<ReturnType<typeof BlockComponentsAbsoluteUrl>>;
+
+/**
+ * Maps a manifest with relative paths to one with absolute URLs against the
+ * given prefix. Used by the registry reader to point components at registry
+ * storage.
+ */
+export function blockComponentsManifestToAbsoluteUrl(
+  manifest: BlockComponentsManifest,
+  prefix: string,
+): BlockComponentsAbsoluteUrl {
+  const toAbs = mapRemoteToAbsolute(prefix);
+  return {
+    workflow: {
+      type: "workflow-v1",
+      main: toAbs(manifest.workflow.main),
+    },
+    model: toAbs(manifest.model),
+    ui: toAbs(manifest.ui),
+  };
+}

--- a/tools/block-tools/src/v2/model/block_components.ts
+++ b/tools/block-tools/src/v2/model/block_components.ts
@@ -2,7 +2,6 @@ import type {
   BlockComponents,
   BlockComponentsDescriptionRaw,
   BlockComponentsManifest,
-  ContentAbsoluteBinaryLocal,
   ContentAbsoluteFile,
   ContentAbsoluteFolder,
   ContentAbsoluteUrl,
@@ -51,23 +50,19 @@ export function resolveBlockComponents(
  * UI folder into `ui.tgz`, returning the manifest form with relative paths.
  */
 export async function consolidateBlockComponents(
-  description: BlockComponents<ContentAbsoluteBinaryLocal, ContentAbsoluteFolder>,
+  description: BlockComponentsDescription,
   dstFolder: string,
   fileAccumulator?: string[],
 ): Promise<BlockComponentsManifest> {
   const cpToRel = cpAbsoluteToRelative(dstFolder, fileAccumulator);
   const packToTgz = packFolderToRelativeTgz(dstFolder, "ui.tgz", fileAccumulator);
-  const workflowMain = await cpToRel(description.workflow.main);
-  const model = await cpToRel(description.model);
-  const ui = await packToTgz(description.ui);
-  if (workflowMain.type !== "relative" || model.type !== "relative")
-    throw new Error(
-      `consolidateBlockComponents: expected relative refs, got ${workflowMain.type}/${model.type}`,
-    );
   return {
-    workflow: { type: "workflow-v1", main: workflowMain },
-    model,
-    ui,
+    workflow: {
+      type: "workflow-v1",
+      main: await cpToRel(description.workflow.main),
+    },
+    model: await cpToRel(description.model),
+    ui: await packToTgz(description.ui),
   };
 }
 

--- a/tools/block-tools/src/v2/model/block_description.ts
+++ b/tools/block-tools/src/v2/model/block_description.ts
@@ -1,63 +1,102 @@
-import {
-  addPrefixToRelative,
-  BlockComponents,
+import type {
+  BlockPackDescription,
   BlockPackDescriptionManifest,
-  BlockPackMeta,
-  ContentRelative,
-  ContentRelativeBinary,
-  ContentRelativeText,
-  CreateBlockPackDescriptionSchema,
+  BlockPackDescriptionRaw,
 } from "@milaboratories/pl-model-middle-layer";
-import { BlockComponentsConsolidate, BlockComponentsDescription } from "./block_components";
-import { BlockPackMetaConsolidate, BlockPackMetaDescription } from "./block_meta";
-import type { z } from "zod";
-import fsp from "node:fs/promises";
+import { addPrefixToRelative } from "@milaboratories/pl-model-middle-layer";
 import type { BlockConfigContainer } from "@milaboratories/pl-model-common";
 import { extractConfigGeneric } from "@milaboratories/pl-model-common";
+import fsp from "node:fs/promises";
+import type { BlockComponentsDescription } from "./block_components";
+import { consolidateBlockComponents, resolveBlockComponents } from "./block_components";
+import type { BlockPackMetaDescription } from "./block_meta";
+import { consolidateBlockPackMeta, resolveBlockPackMeta } from "./block_meta";
 
-export function ResolvedBlockPackDescriptionFromPackageJson(root: string) {
-  return CreateBlockPackDescriptionSchema(
-    BlockComponentsDescription(root),
-    BlockPackMetaDescription(root),
-  ).transform(async (description, _ctx) => {
-    const cfg = extractConfigGeneric(
-      JSON.parse(
-        await fsp.readFile(description.components.model.file, "utf-8"),
-      ) as BlockConfigContainer,
-    );
-    const featureFlags = cfg.featureFlags;
-    return {
-      ...description,
-      featureFlags,
-    };
-  });
-}
-export type BlockPackDescriptionAbsolute = z.infer<
-  ReturnType<typeof ResolvedBlockPackDescriptionFromPackageJson>
+/** Resolved block-pack description — components + meta point at absolute file paths. */
+export type BlockPackDescriptionAbsolute = BlockPackDescription<
+  BlockComponentsDescription,
+  BlockPackMetaDescription
 >;
 
-export function BlockPackDescriptionConsolidateToFolder(
-  dstFolder: string,
-  fileAccumulator?: string[],
-) {
-  return CreateBlockPackDescriptionSchema(
-    BlockComponentsConsolidate(dstFolder, fileAccumulator),
-    BlockPackMetaConsolidate(dstFolder, fileAccumulator),
-  ).pipe(BlockPackDescriptionManifest);
+/**
+ * Resolves a raw `package.json`-form block-pack description against the
+ * module root: workflow/model/ui paths via node module resolution, text and
+ * binary fields in `meta` via `mapLocalToAbsolute`. Reads the resolved model
+ * file to extract feature flags from its `BlockConfigContainer`.
+ */
+export async function resolveBlockPackDescription(
+  raw: BlockPackDescriptionRaw,
+  root: string,
+): Promise<BlockPackDescriptionAbsolute> {
+  const components = resolveBlockComponents(raw.components, root);
+  const meta = await resolveBlockPackMeta(raw.meta, root);
+  const cfg = extractConfigGeneric(
+    JSON.parse(await fsp.readFile(components.model.file, "utf-8")) as BlockConfigContainer,
+  );
+  return {
+    ...raw,
+    components,
+    meta,
+    featureFlags: cfg.featureFlags,
+  };
 }
 
-export function BlockPackDescriptionManifestAddRelativePathPrefix(prefix: string) {
+/**
+ * Consolidates absolute references in components and meta into `dstFolder`
+ * (copying files and packing the UI as `ui.tgz`), returning the manifest
+ * form with relative paths.
+ */
+export async function consolidateBlockPackDescription(
+  description: BlockPackDescriptionAbsolute,
+  dstFolder: string,
+  fileAccumulator?: string[],
+): Promise<BlockPackDescriptionManifest> {
+  const components = await consolidateBlockComponents(
+    description.components,
+    dstFolder,
+    fileAccumulator,
+  );
+  const meta = await consolidateBlockPackMeta(description.meta, dstFolder, fileAccumulator);
+  return {
+    ...description,
+    components,
+    meta,
+  };
+}
+
+/**
+ * Prefixes every relative-path field in a manifest description with the
+ * given path prefix (components workflow/model/ui plus meta text/binary
+ * fields).
+ */
+export function addRelativePathPrefix(
+  manifest: BlockPackDescriptionManifest,
+  prefix: string,
+): BlockPackDescriptionManifest {
   const transformer = addPrefixToRelative(prefix);
-  return BlockPackDescriptionManifest.pipe(
-    CreateBlockPackDescriptionSchema(
-      BlockComponents(
-        ContentRelative.transform(transformer),
-        ContentRelative.transform(transformer),
-      ),
-      BlockPackMeta(
-        ContentRelativeText.transform(transformer),
-        ContentRelativeBinary.transform(transformer),
-      ),
-    ),
-  ).pipe(BlockPackDescriptionManifest);
+  const meta = manifest.meta;
+  const { logo: orgLogo, ...orgRest } = meta.organization;
+  return {
+    ...manifest,
+    components: {
+      workflow: {
+        type: "workflow-v1",
+        main: transformer(manifest.components.workflow.main),
+      },
+      model: transformer(manifest.components.model),
+      ui: transformer(manifest.components.ui),
+    },
+    meta: {
+      ...meta,
+      organization: {
+        ...orgRest,
+        ...(orgLogo !== undefined ? { logo: transformer(orgLogo) } : {}),
+      },
+      ...(meta.longDescription !== undefined
+        ? { longDescription: transformer(meta.longDescription) }
+        : {}),
+      ...(meta.changelog !== undefined ? { changelog: transformer(meta.changelog) } : {}),
+      ...(meta.logo !== undefined ? { logo: transformer(meta.logo) } : {}),
+    },
+  };
 }

--- a/tools/block-tools/src/v2/model/block_description.ts
+++ b/tools/block-tools/src/v2/model/block_description.ts
@@ -65,6 +65,25 @@ export async function consolidateBlockPackDescription(
 }
 
 /**
+ * Maps `components` and `meta` of a `BlockPackDescription` independently,
+ * preserving every other top-level field (including the `BlockPackId` and
+ * any passthrough siblings). Sync counterpart to the schema-driven async
+ * pipelines in `block_meta.ts`/`block_components.ts`; used by callers that
+ * need a synchronous transform (e.g. relative-path rewriting).
+ */
+function transformBlockPackDescription<Cin, Min, Cout, Mout>(
+  description: BlockPackDescription<Cin, Min>,
+  mapComponents: (components: Cin) => Cout,
+  mapMeta: (meta: Min) => Mout,
+): BlockPackDescription<Cout, Mout> {
+  return {
+    ...description,
+    components: mapComponents(description.components),
+    meta: mapMeta(description.meta),
+  };
+}
+
+/**
  * Prefixes every relative-path field in a manifest description with the
  * given path prefix (components workflow/model/ui plus meta text/binary
  * fields).
@@ -74,29 +93,30 @@ export function addRelativePathPrefix(
   prefix: string,
 ): BlockPackDescriptionManifest {
   const transformer = addPrefixToRelative(prefix);
-  const meta = manifest.meta;
-  const { logo: orgLogo, ...orgRest } = meta.organization;
-  return {
-    ...manifest,
-    components: {
+  return transformBlockPackDescription(
+    manifest,
+    (components) => ({
       workflow: {
         type: "workflow-v1",
-        main: transformer(manifest.components.workflow.main),
+        main: transformer(components.workflow.main),
       },
-      model: transformer(manifest.components.model),
-      ui: transformer(manifest.components.ui),
+      model: transformer(components.model),
+      ui: transformer(components.ui),
+    }),
+    (meta) => {
+      const { logo: orgLogo, ...orgRest } = meta.organization;
+      return {
+        ...meta,
+        organization: {
+          ...orgRest,
+          ...(orgLogo !== undefined ? { logo: transformer(orgLogo) } : {}),
+        },
+        ...(meta.longDescription !== undefined
+          ? { longDescription: transformer(meta.longDescription) }
+          : {}),
+        ...(meta.changelog !== undefined ? { changelog: transformer(meta.changelog) } : {}),
+        ...(meta.logo !== undefined ? { logo: transformer(meta.logo) } : {}),
+      };
     },
-    meta: {
-      ...meta,
-      organization: {
-        ...orgRest,
-        ...(orgLogo !== undefined ? { logo: transformer(orgLogo) } : {}),
-      },
-      ...(meta.longDescription !== undefined
-        ? { longDescription: transformer(meta.longDescription) }
-        : {}),
-      ...(meta.changelog !== undefined ? { changelog: transformer(meta.changelog) } : {}),
-      ...(meta.logo !== undefined ? { logo: transformer(meta.logo) } : {}),
-    },
-  };
+  );
 }

--- a/tools/block-tools/src/v2/model/block_meta.ts
+++ b/tools/block-tools/src/v2/model/block_meta.ts
@@ -35,11 +35,11 @@ export type BlockPackMetaDescription = BlockPackMeta<
  * transformed fields. Reading bottom-up: the per-field spreads win over
  * the bulk spread.
  */
-async function transformBlockPackMeta<L1, B1, L2, B2>(
-  meta: BlockPackMeta<L1, B1>,
-  mapText: (value: L1) => Promise<L2>,
-  mapBinary: (value: B1) => Promise<B2>,
-): Promise<BlockPackMeta<L2, B2>> {
+async function transformBlockPackMeta<LongStringIn, BinaryIn, LongStringOut, BinaryOut>(
+  meta: BlockPackMeta<LongStringIn, BinaryIn>,
+  mapText: (value: LongStringIn) => Promise<LongStringOut>,
+  mapBinary: (value: BinaryIn) => Promise<BinaryOut>,
+): Promise<BlockPackMeta<LongStringOut, BinaryOut>> {
   const { organization } = meta;
   const { logo: orgLogo, ...orgRest } = organization;
   const out = {
@@ -54,7 +54,7 @@ async function transformBlockPackMeta<L1, B1, L2, B2>(
     ...(meta.changelog !== undefined ? { changelog: await mapText(meta.changelog) } : {}),
     ...(meta.logo !== undefined ? { logo: await mapBinary(meta.logo) } : {}),
   };
-  return out as BlockPackMeta<L2, B2>;
+  return out as BlockPackMeta<LongStringOut, BinaryOut>;
 }
 
 /**

--- a/tools/block-tools/src/v2/model/block_meta.ts
+++ b/tools/block-tools/src/v2/model/block_meta.ts
@@ -1,13 +1,11 @@
-import {
+import type {
   BlockPackMeta,
+  BlockPackMetaDescriptionRaw,
   BlockPackMetaEmbeddedBase64,
   BlockPackMetaEmbeddedBytes,
+  BlockPackMetaManifest,
   ContentAbsoluteBinaryLocal,
   ContentAbsoluteTextLocal,
-  ContentRelativeBinary,
-  ContentRelativeText,
-  DescriptionContentBinary,
-  DescriptionContentText,
 } from "@milaboratories/pl-model-middle-layer";
 import type { RelativeContentReader } from "./content_conversion";
 import {
@@ -19,36 +17,113 @@ import {
   relativeToContentString,
   relativeToExplicitBytes,
 } from "./content_conversion";
-import type { z } from "zod";
 
-export function BlockPackMetaDescription(root: string) {
-  return BlockPackMeta(
-    DescriptionContentText.transform(mapLocalToAbsolute(root)),
-    DescriptionContentBinary.transform(mapLocalToAbsolute(root)),
+/** Resolved BlockPackMeta — text/binary references mapped to absolute file refs. */
+export type BlockPackMetaDescription = BlockPackMeta<
+  ContentAbsoluteTextLocal,
+  ContentAbsoluteBinaryLocal
+>;
+
+/**
+ * Applies independent transforms to BlockPackMeta's text-content and
+ * binary-content fields (`longDescription`, `changelog`, `logo`,
+ * `organization.logo`). All other fields, including unknown passthrough keys,
+ * pass through unchanged.
+ */
+async function transformBlockPackMeta<L1, B1, L2, B2>(
+  meta: BlockPackMeta<L1, B1>,
+  mapText: (value: L1) => Promise<L2>,
+  mapBinary: (value: B1) => Promise<B2>,
+): Promise<BlockPackMeta<L2, B2>> {
+  const { organization } = meta;
+  const { logo: orgLogo, ...orgRest } = organization;
+  const out = {
+    ...meta,
+    organization: {
+      ...orgRest,
+      ...(orgLogo !== undefined ? { logo: await mapBinary(orgLogo) } : {}),
+    },
+    ...(meta.longDescription !== undefined
+      ? { longDescription: await mapText(meta.longDescription) }
+      : {}),
+    ...(meta.changelog !== undefined ? { changelog: await mapText(meta.changelog) } : {}),
+    ...(meta.logo !== undefined ? { logo: await mapBinary(meta.logo) } : {}),
+  };
+  return out as BlockPackMeta<L2, B2>;
+}
+
+/**
+ * Resolves text/binary references in raw BlockPackMeta (post-`package.json`
+ * normalization) to absolute file paths against the module root.
+ */
+export async function resolveBlockPackMeta(
+  raw: BlockPackMetaDescriptionRaw,
+  root: string,
+): Promise<BlockPackMetaDescription> {
+  const toAbs = mapLocalToAbsolute(root);
+  return transformBlockPackMeta(
+    raw,
+    async (v) => toAbs(v),
+    async (v) => toAbs(v),
   );
 }
-export type BlockPackMetaDescription = z.infer<ReturnType<typeof BlockPackMetaDescription>>;
 
-export function BlockPackMetaConsolidate(dstFolder: string, fileAccumulator?: string[]) {
-  return BlockPackMeta(
-    ContentAbsoluteTextLocal.transform(cpAbsoluteToRelative(dstFolder, fileAccumulator)),
-    ContentAbsoluteBinaryLocal.transform(cpAbsoluteToRelative(dstFolder, fileAccumulator)),
-  );
+/**
+ * Copies absolute text/binary file references into `dstFolder` and returns
+ * the manifest form with relative paths.
+ */
+export async function consolidateBlockPackMeta(
+  meta: BlockPackMetaDescription,
+  dstFolder: string,
+  fileAccumulator?: string[],
+): Promise<BlockPackMetaManifest> {
+  const cpToRel = cpAbsoluteToRelative(dstFolder, fileAccumulator);
+  return transformBlockPackMeta(
+    meta,
+    async (v) => cpToRel(v),
+    async (v) => cpToRel(v),
+  ) as Promise<BlockPackMetaManifest>;
 }
 
-export const BlockPackMetaEmbedAbsoluteBase64 = BlockPackMeta(
-  ContentAbsoluteTextLocal.transform(absoluteToString()),
-  ContentAbsoluteBinaryLocal.transform(absoluteToBase64()),
-).pipe(BlockPackMetaEmbeddedBase64);
+/**
+ * Reads absolute file references and embeds the content as in-line strings
+ * and base64-encoded binary blobs.
+ */
+export async function embedBlockPackMetaAbsoluteBase64(
+  meta: BlockPackMetaDescription,
+): Promise<BlockPackMetaEmbeddedBase64> {
+  return transformBlockPackMeta(
+    meta,
+    absoluteToString(),
+    absoluteToBase64(),
+  ) as Promise<BlockPackMetaEmbeddedBase64>;
+}
 
-export const BlockPackMetaEmbedAbsoluteBytes = BlockPackMeta(
-  ContentAbsoluteTextLocal.transform(absoluteToString()),
-  ContentAbsoluteBinaryLocal.transform(absoluteToBytes()),
-).pipe(BlockPackMetaEmbeddedBytes);
+/**
+ * Reads absolute file references and embeds the content as in-line strings
+ * and raw byte arrays.
+ */
+export async function embedBlockPackMetaAbsoluteBytes(
+  meta: BlockPackMetaDescription,
+): Promise<BlockPackMetaEmbeddedBytes> {
+  return transformBlockPackMeta(
+    meta,
+    absoluteToString(),
+    absoluteToBytes(),
+  ) as Promise<BlockPackMetaEmbeddedBytes>;
+}
 
-export function BlockPackMetaEmbedBytes(reader: RelativeContentReader) {
-  return BlockPackMeta(
-    ContentRelativeText.transform(relativeToContentString(reader)),
-    ContentRelativeBinary.transform(relativeToExplicitBytes(reader)),
-  ).pipe(BlockPackMetaEmbeddedBytes);
+/**
+ * Reads relative-path references through the given content reader and embeds
+ * the content as in-line strings and raw byte arrays.
+ */
+export async function embedBlockPackMetaBytes(
+  manifest: BlockPackMetaManifest,
+  reader: RelativeContentReader,
+): Promise<BlockPackMetaEmbeddedBytes> {
+  return transformBlockPackMeta(
+    manifest,
+    relativeToContentString(reader),
+    relativeToExplicitBytes(reader),
+  ) as Promise<BlockPackMetaEmbeddedBytes>;
 }

--- a/tools/block-tools/src/v2/model/block_meta.ts
+++ b/tools/block-tools/src/v2/model/block_meta.ts
@@ -29,6 +29,11 @@ export type BlockPackMetaDescription = BlockPackMeta<
  * binary-content fields (`longDescription`, `changelog`, `logo`,
  * `organization.logo`). All other fields, including unknown passthrough keys,
  * pass through unchanged.
+ *
+ * Spread order matters: `...meta` first preserves every key (including
+ * passthrough); the conditional spreads at the end override the four
+ * transformed fields. Reading bottom-up: the per-field spreads win over
+ * the bulk spread.
  */
 async function transformBlockPackMeta<L1, B1, L2, B2>(
   meta: BlockPackMeta<L1, B1>,

--- a/tools/block-tools/src/v2/model/content_conversion.ts
+++ b/tools/block-tools/src/v2/model/content_conversion.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import path from "node:path";
 import fsp from "node:fs/promises";
 import * as mime from "mime-types";
@@ -33,60 +32,36 @@ type ContentCtxUrl = {
 /** Describes a place relative to which any content references should be interpreted */
 export type ContentCtx = ContentCtxFs | ContentCtxUrl;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- utility function for future use
-function mustResolve(root: string, request: string): string {
-  const res = tryResolve(root, request);
-  if (res === undefined) throw new Error(`Can't resolve ${request} against ${root}`);
-  return res;
-}
-
-/** Zod type that resolves node module request into absolute content */
-export function ResolvedModuleFile(moduleRoot: string) {
-  return z.string().transform<ContentAbsoluteFile>((request, ctx) => {
-    const result = tryResolve(moduleRoot, request);
-    if (result === undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Can't resolve ${request} against ${moduleRoot}`,
-      });
-      return z.NEVER;
-    }
-    return {
-      type: "absolute-file",
-      file: result,
-    };
-  });
+/** Resolves a node module request to an absolute file reference. */
+export function resolveModuleFile(moduleRoot: string, request: string): ContentAbsoluteFile {
+  const result = tryResolve(moduleRoot, request);
+  if (result === undefined) throw new Error(`Can't resolve ${request} against ${moduleRoot}`);
+  return { type: "absolute-file", file: result };
 }
 
 /**
- * Zod type that resolves node module request for folder into absolute folder,
- * given a list of expected index files in that folder
- * */
-export function ResolvedModuleFolder(
+ * Resolves a node module request for a folder to an absolute folder reference,
+ * given a list of expected index file names in that folder.
+ */
+export function resolveModuleFolder(
   moduleRoot: string,
-  ...indexFilesToLookFor: [string, ...string[]]
-) {
-  return z.string().transform<ContentAbsoluteFolder>((request, ctx) => {
-    const requestWithSlash = request.endsWith("/") ? request : `${request}/`;
-
-    for (const idxFile of indexFilesToLookFor) {
-      const result = tryResolve(moduleRoot, requestWithSlash + idxFile);
-      if (result !== undefined) {
-        if (!result.endsWith(idxFile))
-          throw new Error(`Unexpected resolve result ${result} with index file ${idxFile}`);
-        return {
-          type: "absolute-folder",
-          folder: result.slice(0, result.length - idxFile.length),
-        };
-      }
-    }
-
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `Can't resolve ${request} folder against ${moduleRoot}, no index file found (${indexFilesToLookFor.join(", ")})`,
-    });
-    return z.NEVER;
-  });
+  request: string,
+  indexFilesToLookFor: [string, ...string[]],
+): ContentAbsoluteFolder {
+  const requestWithSlash = request.endsWith("/") ? request : `${request}/`;
+  for (const idxFile of indexFilesToLookFor) {
+    const result = tryResolve(moduleRoot, requestWithSlash + idxFile);
+    if (result === undefined) continue;
+    if (!result.endsWith(idxFile))
+      throw new Error(`Unexpected resolve result ${result} with index file ${idxFile}`);
+    return {
+      type: "absolute-folder",
+      folder: result.slice(0, result.length - idxFile.length),
+    };
+  }
+  throw new Error(
+    `Can't resolve ${request} folder against ${moduleRoot}, no index file found (${indexFilesToLookFor.join(", ")})`,
+  );
 }
 
 export function mapLocalToAbsolute(

--- a/tools/block-tools/src/v2/registry/registry.ts
+++ b/tools/block-tools/src/v2/registry/registry.ts
@@ -21,8 +21,9 @@ import {
   globalOverviewSnapshotPath,
   packageOverviewSnapshotPath,
 } from "./schema_internal";
+import type { GlobalOverviewReg } from "./schema_public";
 import {
-  GlobalOverviewReg,
+  parseGlobalOverviewReg,
   GlobalOverviewPath,
   GlobalOverviewGzPath,
   ManifestSuffix,
@@ -37,7 +38,7 @@ import {
   PackageManifestPattern,
 } from "./schema_public";
 import type { RelativeContentReader } from "../model";
-import { BlockPackDescriptionManifestAddRelativePathPrefix } from "../model";
+import { addRelativePathPrefix } from "../model";
 import { randomUUID } from "node:crypto";
 import { calculateSha256 } from "../../util";
 
@@ -184,7 +185,7 @@ export class BlockRegistryV2 {
         ? { schema: "v2", packages: [] }
         : overviewContent === undefined
           ? { schema: "v2", packages: [] }
-          : GlobalOverviewReg.parse(JSON.parse(overviewContent.toString()));
+          : parseGlobalOverviewReg(JSON.parse(overviewContent.toString()));
     let overviewPackages = overview.packages;
     this.logger.info(
       `Global overview ${mode === "force" ? "starting empty (force mode)" : "loaded"}, ${overviewPackages.length} records`,
@@ -244,8 +245,9 @@ export class BlockRegistryV2 {
         });
         // pushing the overview
         newVersions.push({
-          description: BlockPackDescriptionManifestAddRelativePathPrefix(version).parse(
+          description: addRelativePathPrefix(
             BlockPackManifest.parse(JSON.parse(manifestContent.toString("utf8"))).description,
+            version,
           ),
           manifestSha256: sha256,
           channels,
@@ -281,9 +283,7 @@ export class BlockRegistryV2 {
           e.id.organization !== packageInfo.package.organization ||
           e.id.name !== packageInfo.package.name,
       );
-      const relativeDescriptionSchema = BlockPackDescriptionManifestAddRelativePathPrefix(
-        `${packageInfo.package.organization}/${packageInfo.package.name}`,
-      );
+      const packagePrefix = `${packageInfo.package.organization}/${packageInfo.package.name}`;
       overviewPackages.push({
         id: {
           organization: packageInfo.package.organization,
@@ -295,7 +295,7 @@ export class BlockRegistryV2 {
           .map((e) => ({ version: e.description.id.version, channels: e.channels }))
           .reverse(),
         // left for backward compatibility
-        latest: relativeDescriptionSchema.parse(newVersions[0].description),
+        latest: addRelativePathPrefix(newVersions[0].description, packagePrefix),
         // left for backward compatibility
         latestManifestSha256: newVersions[0].manifestSha256,
         latestByChannel: Object.fromEntries(
@@ -306,7 +306,7 @@ export class BlockRegistryV2 {
             return [
               c,
               {
-                description: relativeDescriptionSchema.parse(v.description),
+                description: addRelativePathPrefix(v.description, packagePrefix),
                 manifestSha256: v?.manifestSha256,
               },
             ];
@@ -381,7 +381,7 @@ export class BlockRegistryV2 {
   public async getGlobalOverview(): Promise<undefined | GlobalOverviewReg> {
     const content = await this.storage.getFile(GlobalOverviewPath);
     if (content === undefined) return undefined;
-    return GlobalOverviewReg.parse(JSON.parse(content.toString()));
+    return parseGlobalOverviewReg(JSON.parse(content.toString()));
   }
 
   private async marchChanged(id: BlockPackId) {
@@ -456,7 +456,7 @@ export class BlockRegistryV2 {
 
     // Validate the data
     try {
-      GlobalOverviewReg.parse(JSON.parse(overviewData));
+      parseGlobalOverviewReg(JSON.parse(overviewData));
     } catch (error) {
       throw new Error(`Invalid snapshot data in ${backupId}: ${String(error)}`);
     }

--- a/tools/block-tools/src/v2/registry/registry_reader.ts
+++ b/tools/block-tools/src/v2/registry/registry_reader.ts
@@ -16,13 +16,14 @@ import type { FolderReader } from "../../io";
 import canonicalize from "canonicalize";
 import {
   GlobalOverviewFileName,
-  GlobalOverviewReg,
   MainPrefix,
   ManifestFileName,
   ManifestSuffix,
   packageContentPrefixInsideV2,
+  parseGlobalOverviewReg,
 } from "./schema_public";
-import { BlockComponentsAbsoluteUrl, BlockPackMetaEmbedBytes } from "../model";
+import type { BlockComponentsAbsoluteUrl } from "../model";
+import { blockComponentsManifestToAbsoluteUrl, embedBlockPackMetaBytes } from "../model";
 import { LRUCache } from "lru-cache";
 import * as semver from "semver";
 import { calculateSha256 } from "../../util";
@@ -93,7 +94,7 @@ export class RegistryV2Reader {
                 .relativeReader(packageContentPrefixInsideV2(options.context.relativeTo))
                 .getContentReader()
             : this.v2RootFolderReader.getContentReader();
-        return await BlockPackMetaEmbedBytes(contentReader).parseAsync(options.context.meta);
+        return await embedBlockPackMetaBytes(options.context.meta, contentReader);
       }, Retry2TimesWithDelay),
   });
 
@@ -123,7 +124,7 @@ export class RegistryV2Reader {
     try {
       return await retry(async () => {
         // const rootContentReader = this.v2RootFolderReader.getContentReader();
-        const globalOverview = GlobalOverviewReg.parse(
+        const globalOverview = parseGlobalOverviewReg(
           JSON.parse(
             Buffer.from(
               await this.v2RootFolderReader.readFile(GlobalOverviewFileName, {
@@ -248,8 +249,9 @@ export class RegistryV2Reader {
         const manifest = BlockPackManifest.parse(
           JSON.parse(Buffer.from(await packageFolderReader.readFile(ManifestFileName)).toString()),
         );
-        return BlockComponentsAbsoluteUrl(packageFolderReader.rootUrl.toString()).parse(
+        return blockComponentsManifestToAbsoluteUrl(
           manifest.description.components,
+          packageFolderReader.rootUrl.toString(),
         );
       }, Retry2TimesWithDelay),
   });

--- a/tools/block-tools/src/v2/registry/schema_public.ts
+++ b/tools/block-tools/src/v2/registry/schema_public.ts
@@ -107,21 +107,38 @@ export type GlobalOverviewEntryReg = z.infer<typeof GlobalOverviewEntryRawSchema
  *   - Derives `allVersionsWithChannels` from deprecated `allVersions` when missing.
  *   - Ensures `latestByChannel[AnyChannel]` is populated from the deprecated
  *     `latest` / `latestManifestSha256` fields.
+ *
+ * When neither the new field nor its deprecated fallback is present we
+ * throw with a precise message rather than dragging the failure into a
+ * downstream non-null assertion. The registry writer always populates both
+ * the new and deprecated fields; this guard catches hand-written or
+ * partially-migrated overview files.
  */
 function normalizeGlobalOverviewEntry(
   parsed: z.infer<typeof GlobalOverviewEntryRawSchema>,
 ): GlobalOverviewEntryReg {
-  const allVersionsWithChannels =
-    parsed.allVersionsWithChannels ??
-    parsed.allVersions!.map((v) => ({ version: v, channels: [] }));
+  const id = `${parsed.id.organization}/${parsed.id.name}`;
+
+  let allVersionsWithChannels = parsed.allVersionsWithChannels;
+  if (allVersionsWithChannels === undefined) {
+    if (parsed.allVersions === undefined)
+      throw new Error(
+        `GlobalOverviewEntry ${id} is missing both 'allVersionsWithChannels' and the deprecated 'allVersions' fallback`,
+      );
+    allVersionsWithChannels = parsed.allVersions.map((v) => ({ version: v, channels: [] }));
+  }
 
   let latestByChannel = parsed.latestByChannel;
   if (!latestByChannel[AnyChannel]) {
+    if (parsed.latest === undefined || parsed.latestManifestSha256 === undefined)
+      throw new Error(
+        `GlobalOverviewEntry ${id} is missing the 'latestByChannel[any]' slot and the deprecated 'latest'/'latestManifestSha256' fallback`,
+      );
     latestByChannel = {
       ...latestByChannel,
       [AnyChannel]: {
-        description: parsed.latest!,
-        manifestSha256: parsed.latestManifestSha256!,
+        description: parsed.latest,
+        manifestSha256: parsed.latestManifestSha256,
       },
     };
   }

--- a/tools/block-tools/src/v2/registry/schema_public.ts
+++ b/tools/block-tools/src/v2/registry/schema_public.ts
@@ -1,19 +1,12 @@
 import type { BlockPackId } from "@milaboratories/pl-model-middle-layer";
 import {
   AnyChannel,
-  BlockComponentsManifest,
   BlockPackDescriptionManifest,
   BlockPackIdNoVersion,
-  BlockPackMeta,
-  ContentRelativeBinary,
-  ContentRelativeText,
-  CreateBlockPackDescriptionSchema,
   Sha256Schema,
   VersionWithChannels,
 } from "@milaboratories/pl-model-middle-layer";
 import { z } from "zod";
-import type { RelativeContentReader } from "../model";
-import { relativeToExplicitBytes, relativeToExplicitString } from "../model";
 
 export const MainPrefix = "v2/";
 
@@ -35,10 +28,6 @@ export function packageContentPrefix(bp: BlockPackId): string {
 }
 
 export const ManifestSuffix = "/" + ManifestFileName;
-
-// export function payloadFilePath(bp: BlockPackId, file: string): string {
-//   return `${MainPrefix}${bp.organization}/${bp.name}/${bp.version}/${file}`;
-// }
 
 export const PackageOverviewVersionEntry = z
   .object({
@@ -79,106 +68,93 @@ export const PackageManifestPattern =
 export const GlobalOverviewPath = `${MainPrefix}${GlobalOverviewFileName}`;
 export const GlobalOverviewGzPath = `${MainPrefix}${GlobalOverviewGzFileName}`;
 
-export function GlobalOverviewEntry<const Description extends z.ZodTypeAny>(
-  descriptionType: Description,
-) {
-  const universalSchema = z
-    .object({
-      id: BlockPackIdNoVersion,
-      /** @deprecated to be removed at some point, not used, left for compatibility with older versions */
-      allVersions: z.array(z.string()).optional(),
-      allVersionsWithChannels: z.array(VersionWithChannels).optional(),
-      /** @deprecated to be removed at some point, not used, left for compatibility with older versions */
-      latest: descriptionType,
-      /** @deprecated to be removed at some point, not used, left for compatibility with older versions */
-      latestManifestSha256: Sha256Schema,
-      latestByChannel: z
-        .record(
-          z.string(),
-          z
-            .object({
-              description: descriptionType,
-              manifestSha256: Sha256Schema,
-            })
-            .passthrough(),
-        )
-        .default({}),
-    })
-    .passthrough();
-  return universalSchema
-    .transform((o) => {
-      if (o.allVersionsWithChannels) return o;
-      else
-        return {
-          ...o,
-          allVersionsWithChannels: o.allVersions!.map((v) => ({ version: v, channels: [] })),
-        };
-    })
-    .transform((o) =>
-      o.latestByChannel[AnyChannel]
-        ? o
-        : {
-            ...o,
-            latestByChannel: {
-              ...o.latestByChannel,
-              [AnyChannel]: { description: o.latest!, manifestSha256: o.latestManifestSha256! },
-            },
-          },
-    )
-    .pipe(universalSchema.required({ allVersionsWithChannels: true }));
-}
-export const GlobalOverviewEntryReg = GlobalOverviewEntry(BlockPackDescriptionManifest);
-export type GlobalOverviewEntryReg = z.infer<typeof GlobalOverviewEntryReg>;
+/**
+ * Raw shape parsed from the registry's `overview.json` for one package
+ * entry. Older registry files may omit `allVersionsWithChannels` and may
+ * lack an `AnyChannel` slot in `latestByChannel`; `normalizeGlobalOverviewEntry`
+ * fills both in from the deprecated `allVersions` / `latest` fields.
+ */
+const GlobalOverviewEntryRawSchema = z
+  .object({
+    id: BlockPackIdNoVersion,
+    /** @deprecated kept for back-compat with older overview files */
+    allVersions: z.array(z.string()).optional(),
+    allVersionsWithChannels: z.array(VersionWithChannels).optional(),
+    /** @deprecated kept for back-compat with older overview files */
+    latest: BlockPackDescriptionManifest.optional(),
+    /** @deprecated kept for back-compat with older overview files */
+    latestManifestSha256: Sha256Schema.optional(),
+    latestByChannel: z
+      .record(
+        z.string(),
+        z
+          .object({
+            description: BlockPackDescriptionManifest,
+            manifestSha256: Sha256Schema,
+          })
+          .passthrough(),
+      )
+      .default({}),
+  })
+  .passthrough();
 
-export function GlobalOverview<const Description extends z.ZodTypeAny>(
-  descriptionType: Description,
-) {
-  return z
+export type GlobalOverviewEntryReg = z.infer<typeof GlobalOverviewEntryRawSchema> & {
+  allVersionsWithChannels: z.infer<typeof VersionWithChannels>[];
+};
+
+/**
+ * Fills in defaults for older `overview.json` shapes after Zod parsing:
+ *   - Derives `allVersionsWithChannels` from deprecated `allVersions` when missing.
+ *   - Ensures `latestByChannel[AnyChannel]` is populated from the deprecated
+ *     `latest` / `latestManifestSha256` fields.
+ */
+function normalizeGlobalOverviewEntry(
+  parsed: z.infer<typeof GlobalOverviewEntryRawSchema>,
+): GlobalOverviewEntryReg {
+  const allVersionsWithChannels =
+    parsed.allVersionsWithChannels ??
+    parsed.allVersions!.map((v) => ({ version: v, channels: [] }));
+
+  let latestByChannel = parsed.latestByChannel;
+  if (!latestByChannel[AnyChannel]) {
+    latestByChannel = {
+      ...latestByChannel,
+      [AnyChannel]: {
+        description: parsed.latest!,
+        manifestSha256: parsed.latestManifestSha256!,
+      },
+    };
+  }
+
+  return {
+    ...parsed,
+    allVersionsWithChannels,
+    latestByChannel,
+  };
+}
+
+export type GlobalOverviewReg = {
+  schema: "v2";
+  packages: GlobalOverviewEntryReg[];
+} & { [k: string]: unknown };
+
+/**
+ * Parses and normalizes a `GlobalOverviewReg` document read from registry
+ * storage. Validation runs through Zod; the back-compat normalization runs
+ * after parse as a plain function. The Zod schema is built inside the
+ * function (not as a module-level const) to keep TypeScript from emitting
+ * the schema's deeply-nested inferred type into the package's `.d.ts`.
+ */
+export function parseGlobalOverviewReg(raw: unknown): GlobalOverviewReg {
+  const schema = z
     .object({
       schema: z.literal("v2"),
-      packages: z.array(GlobalOverviewEntry(descriptionType)),
+      packages: z.array(GlobalOverviewEntryRawSchema),
     })
     .passthrough();
+  const parsed = schema.parse(raw);
+  return {
+    ...parsed,
+    packages: parsed.packages.map(normalizeGlobalOverviewEntry),
+  };
 }
-
-export const GlobalOverviewReg = GlobalOverview(BlockPackDescriptionManifest);
-export type GlobalOverviewReg = z.infer<typeof GlobalOverviewReg>;
-
-export function BlockDescriptionToExplicitBinaryBytes(reader: RelativeContentReader) {
-  return CreateBlockPackDescriptionSchema(
-    BlockComponentsManifest,
-    BlockPackMeta(
-      ContentRelativeText.transform(relativeToExplicitString(reader)),
-      ContentRelativeBinary.transform(relativeToExplicitBytes(reader)),
-    ),
-  );
-}
-export function GlobalOverviewToExplicitBinaryBytes(reader: RelativeContentReader) {
-  return GlobalOverview(
-    CreateBlockPackDescriptionSchema(
-      BlockComponentsManifest,
-      BlockPackMeta(
-        ContentRelativeText.transform(relativeToExplicitString(reader)),
-        ContentRelativeBinary.transform(relativeToExplicitBytes(reader)),
-      ),
-    ),
-  );
-}
-export type GlobalOverviewExplicitBinaryBytes = z.infer<
-  ReturnType<typeof GlobalOverviewToExplicitBinaryBytes>
->;
-
-export function GlobalOverviewToExplicitBinaryBase64(reader: RelativeContentReader) {
-  return GlobalOverview(
-    CreateBlockPackDescriptionSchema(
-      BlockComponentsManifest,
-      BlockPackMeta(
-        ContentRelativeText.transform(relativeToExplicitString(reader)),
-        ContentRelativeBinary.transform(relativeToExplicitBytes(reader)),
-      ),
-    ),
-  );
-}
-export type GlobalOverviewExplicitBinaryBase64 = z.infer<
-  ReturnType<typeof GlobalOverviewToExplicitBinaryBase64>
->;

--- a/tools/block-tools/src/v2/registry/schema_public.ts
+++ b/tools/block-tools/src/v2/registry/schema_public.ts
@@ -150,26 +150,30 @@ function normalizeGlobalOverviewEntry(
   };
 }
 
+/**
+ * Parsed-and-normalized registry overview document. Forward-compat: the
+ * underlying zod schema uses `.passthrough()` so future top-level fields
+ * survive parse/round-trip; the TS type lists only known fields.
+ */
 export type GlobalOverviewReg = {
   schema: "v2";
   packages: GlobalOverviewEntryReg[];
-} & { [k: string]: unknown };
+};
+
+const GlobalOverviewRegRawSchema = z
+  .object({
+    schema: z.literal("v2"),
+    packages: z.array(GlobalOverviewEntryRawSchema),
+  })
+  .passthrough();
 
 /**
  * Parses and normalizes a `GlobalOverviewReg` document read from registry
- * storage. Validation runs through Zod; the back-compat normalization runs
- * after parse as a plain function. The Zod schema is built inside the
- * function (not as a module-level const) to keep TypeScript from emitting
- * the schema's deeply-nested inferred type into the package's `.d.ts`.
+ * storage. Validation runs through zod; the back-compat normalization runs
+ * after parse as a plain function (see `normalizeGlobalOverviewEntry`).
  */
 export function parseGlobalOverviewReg(raw: unknown): GlobalOverviewReg {
-  const schema = z
-    .object({
-      schema: z.literal("v2"),
-      packages: z.array(GlobalOverviewEntryRawSchema),
-    })
-    .passthrough();
-  const parsed = schema.parse(raw);
+  const parsed = GlobalOverviewRegRawSchema.parse(raw);
   return {
     ...parsed,
     packages: parsed.packages.map(normalizeGlobalOverviewEntry),

--- a/tools/block-tools/src/v2/source_package.ts
+++ b/tools/block-tools/src/v2/source_package.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { tryLoadFile } from "../util";
 import type { BlockPackDescriptionAbsolute } from "./model";
-import { ResolvedBlockPackDescriptionFromPackageJson } from "./model";
+import { resolveBlockPackDescription } from "./model";
 import type { MiLogger } from "@milaboratories/ts-helpers";
 import { notEmpty } from "@milaboratories/ts-helpers";
 import fsp from "node:fs/promises";
@@ -51,11 +51,7 @@ export async function tryLoadPackDescription(
         version: SemVer.parse(packageJson["version"]),
       },
     };
-    const descriptionParsingResult =
-      await ResolvedBlockPackDescriptionFromPackageJson(moduleRoot).safeParseAsync(descriptionRaw);
-    if (descriptionParsingResult.success) return descriptionParsingResult.data;
-    logger?.warn(descriptionParsingResult.error);
-    return undefined;
+    return await resolveBlockPackDescription(descriptionRaw, moduleRoot);
   } catch (e: unknown) {
     logger?.warn(e);
     return undefined;
@@ -91,5 +87,5 @@ export async function loadPackDescription(
   moduleRoot: string,
 ): Promise<BlockPackDescriptionAbsolute> {
   const descriptionRaw = await loadPackDescriptionRaw(moduleRoot);
-  return await ResolvedBlockPackDescriptionFromPackageJson(moduleRoot).parseAsync(descriptionRaw);
+  return await resolveBlockPackDescription(descriptionRaw, moduleRoot);
 }


### PR DESCRIPTION
## Summary

Removes Zod's role as type originator and transformation engine in the Tier-D file set (`pl-model-middle-layer/block_meta`, `block_meta/block_registry`, `tools/block-tools/v2`). Zod keeps its role as runtime validator at true boundaries (`package.json`, manifest/registry JSON, backend IPC).

## What changed

**`pl-model-middle-layer/block_meta/content_types.ts` — type-first**
- New canonical `Content` discriminated union as the single source of truth.
- 7 leaf types + 12 union types are derived via `Extract<>` from `Content`.
- 7 leaf schemas pegged via `satisfies z.ZodType<T>`; the 4 retained union schemas (used as nested validators in boundary schemas) pegged the same way.
- The 8 unused discriminated-union schemas were deleted (only their TS types survive).
- `DescriptionContentBinary` / `DescriptionContentText` keep their normalizing `string → {type:"relative", path}` and `string → {type:"explicit-string", content}` coercions at the `package.json` edge — load-bearing for 75/75 blocks per source survey.

**`pl-model-middle-layer/block_meta/block_components.ts` — factories killed, generics survive**
- Transform-bearing factories `Workflow<>`, `BlockComponents<>`, and the unused `BlockComponentsAbsoluteUrl(prefix)` are removed.
- They become plain TS generic types: `WorkflowV1<T>`, `Workflow<T>`, `BlockComponents<W, U>`.
- `BlockComponentsDescriptionRaw` becomes a concrete `z.object` boundary schema that keeps the normalizing `string → {type:"workflow-v1", main:...}` coercion (load-bearing per source survey).

**`pl-model-middle-layer/block_meta/block_meta.ts` — pure-validation factory retained**
- New TS generic `type BlockPackMeta<L, B>` added alongside the existing `BlockPackMeta(...)` Zod factory. The factory has no transforms inside; it stays.

**`pl-model-middle-layer/block_meta/block_manifest.ts`**
- `BlockComponentsManifest` rewritten as a concrete `z.object` (now wrapped-workflow-only — the consolidator only writes the wrapped form).

**`pl-model-middle-layer/block_meta/block_description.ts`**
- New TS generic `type BlockPackDescription<C, M>` alongside the surviving `CreateBlockPackDescriptionSchema<>` pure-validation factory.

**`tools/block-tools/src/v2/model/*` — every `.transform().pipe()` chain becomes a named async function**
- `content_conversion.ts` — `ResolvedModuleFile` / `ResolvedModuleFolder` Zod-transform factories become plain `resolveModuleFile` / `resolveModuleFolder`. Dead `mustResolve` removed.
- `block_components.ts` — `resolveBlockComponents`, `consolidateBlockComponents`, `blockComponentsManifestToAbsoluteUrl`.
- `block_meta.ts` — `resolveBlockPackMeta`, `consolidateBlockPackMeta`, `embedBlockPackMetaAbsoluteBase64`, `embedBlockPackMetaAbsoluteBytes`, `embedBlockPackMetaBytes`. Backed by a small `transformBlockPackMeta<L1, B1, L2, B2>(meta, mapText, mapBinary)` helper.
- `block_description.ts` — `resolveBlockPackDescription` (also handles the `extractConfigGeneric` model-file read for `featureFlags`), `consolidateBlockPackDescription`, `addRelativePathPrefix`.

**`tools/block-tools/src/v2/registry/schema_public.ts` — anti-pattern target**
- `GlobalOverviewEntry<>` factory (two `.transform`s + `.pipe(required)`) replaced by a concrete `GlobalOverviewEntryRawSchema` plus a plain `normalizeGlobalOverviewEntry(parsed)` function for the deprecated-fields backfill.
- `GlobalOverviewReg` becomes a TS type; `parseGlobalOverviewReg(raw)` wraps Zod parse + normalize (schema built inside the function to keep `tsc` from emitting its inferred type into the `.d.ts`).
- Unused `BlockDescriptionToExplicitBinaryBytes`, `GlobalOverviewToExplicitBinaryBytes`, `GlobalOverviewToExplicitBinaryBase64` factories deleted.

**Callers updated** (`source_package.ts`, `build_dist.ts`, `registry.ts`, `registry_reader.ts`, `cmd/build-meta.ts`, plus `pl-middle-layer/block_registry/registry.ts`) to use the new named functions.

## Scope rule applied

Kill **transform-bearing** Zod factories. Leave plain validation schemas alone (`z.infer` is fine there). Normalize-only transforms at boundary parsers stay (per locked decision #2). Pure-validation generic factories (`BlockPackMeta<>`, `CreateBlockPackDescriptionSchema<>`) survive untouched.

## Locked decisions

1. Schema-to-type peg form: `satisfies z.ZodType<T>` (and `, z.ZodTypeDef, any` for transform-bearing boundary parsers).
2. Boundary `string → relative` coercions kept inside `DescriptionContentBinary/Text` and the workflow normalize union — single-hop, sync, no I/O, single entry point.
3. `z.infer` cleanup limited to Tier-D. ~60 `z.infer` lines removed; ~77 outside Tier-D stay.
4. API stability: every exported type name and shape from `@milaboratories/pl-model-middle-layer` preserved.
5. One PR (splitting would break consumers mid-flight).
6. `BlockPackSpec` keeps its boundary schema.

## Verification

- Full monorepo build: 177/177 turbo tasks successful.
- `@platforma-sdk/block-tools` unit tests: 19 passed, 2 pre-existing skips.
- `@milaboratories/block-repo-tests` (`BlockPackManifest.parse` consumer): 2/2 passed.
- Canary block force-rebuilt end-to-end (`@milaboratories/milaboratories.test-enter-numbers`): 54/54 tasks, `block-tools pack` exercises the full `resolveBlockPackDescription → consolidateBlockPackDescription → BlockPackManifest.parse` pipeline.
- Independent code review (Opus) raised three actionable items, all fixed in the second commit (`07bf7e6af`): explicit guards in `normalizeGlobalOverviewEntry` replacing `!` assertions; tightened parameter type on `consolidateBlockComponents` with the now-unreachable defensive check removed; spread-order documentation in `transformBlockPackMeta`.

## Changeset

`minor` bump for `@milaboratories/pl-model-middle-layer` and `@platforma-sdk/block-tools`. Downstream consumers (`@milaboratories/pl-middle-layer`, blocks) compile unchanged — only one import name flip needed (`BlockPackMetaEmbedAbsoluteBytes` → `embedBlockPackMetaAbsoluteBytes`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes Zod as the type originator in the `block_meta` and `block-tools/v2` layer, replacing chained `.transform().pipe()` schemas with canonical TypeScript types as the single source of truth and named async functions for each transformation step. Zod is retained only as a runtime validator at true input boundaries (`package.json`, manifest JSON, backend IPC).

- `pl-model-middle-layer/block_meta`: introduces a `Content` discriminated union from which all leaf and union types are derived via `Extract<>`; leaf schemas and the four retained union schemas are pegged to those types via `satisfies z.ZodType<T>`; the eight unused discriminated-union schemas are deleted.
- `block-tools/v2/model`: every `.transform().pipe()` pipeline becomes a named async function (`resolveBlockPackDescription`, `consolidateBlockPackDescription`, `embedBlockPackMetaAbsoluteBase64`, `embedBlockPackMetaAbsoluteBytes`, `embedBlockPackMetaBytes`, `blockComponentsManifestToAbsoluteUrl`, `addRelativePathPrefix`), all backed by a private `transformBlockPackMeta<L1,B1,L2,B2>` helper.
- `block-tools/v2/registry/schema_public.ts`: the `GlobalOverviewEntry<>` factory is replaced by `GlobalOverviewEntryRawSchema` plus a `normalizeGlobalOverviewEntry` plain function with explicit guards for deprecated fallback fields.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The transformation logic is preserved faithfully across all 17 changed files, the full monorepo build and all unit tests pass, and all exported type names and shapes are preserved for downstream consumers.

The refactoring is large but mechanically consistent. Two observations are worth tracking: (1) `.strict()` was silently added to the `workflow-v1` object schema in both `BlockComponentsDescriptionRaw` and `BlockComponentsManifest`, narrowing previously-valid inputs — no current block triggers this, but it is a behavioral change not mentioned in the changelog; (2) the four embed/consolidate functions in `block_meta.ts` compile only through `as Promise<T>` casts that bypass TypeScript's type checker — correct at runtime via subtype relationships, but a future change to `transformBlockPackMeta` could silently miscompile.

`lib/model/middle-layer/src/block_meta/block_manifest.ts` (`.strict()` addition to the workflow schema) and `tools/block-tools/src/v2/model/block_meta.ts` (load-bearing `as` casts in all four transform-and-embed functions).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/block_meta/content_types.ts | Canonical `Content` discriminated union introduced as TS source-of-truth; 12 union types derived via `Extract<>`; leaf schemas pegged with `satisfies z.ZodType<T>`; union schemas kept for boundary validators |
| lib/model/middle-layer/src/block_meta/block_components.ts | Zod factories replaced by plain TS generics; `BlockComponentsDescriptionRaw` boundary schema now includes `.strict()` on the wrapped workflow-v1 object, narrowing valid inputs vs. the old un-strict schema |
| lib/model/middle-layer/src/block_meta/block_manifest.ts | `BlockComponentsManifest` rewritten as a concrete `z.object`; the new workflow branch adds `.strict()`, accepting only the wrapped form |
| lib/model/middle-layer/src/block_meta/block_meta.ts | New `BlockPackMeta<LongString, Binary>` TS generic added alongside the existing pure-validation Zod factory; both must be kept in sync manually |
| tools/block-tools/src/v2/model/block_meta.ts | All Zod-transform factories replaced by named async functions; `transformBlockPackMeta` private helper uses `as` casts since TypeScript can't infer subtype relationships through the generic at call sites |
| tools/block-tools/src/v2/model/block_description.ts | `resolveBlockPackDescription`, `consolidateBlockPackDescription`, and `addRelativePathPrefix` correctly replace the old Zod `.transform().pipe()` chains |
| tools/block-tools/src/v2/registry/schema_public.ts | `GlobalOverviewEntry` factory replaced by `GlobalOverviewEntryRawSchema` + `normalizeGlobalOverviewEntry`; explicit guards replace `!` assertions; deprecated fallback fields now optional in schema |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json (raw)"] -->|"BlockPackDescriptionFromPackageJsonRaw.parse()"| B["BlockPackDescriptionRaw"]
    B -->|"resolveBlockPackDescription(raw, root)"| C["BlockPackDescriptionAbsolute\n(ContentAbsoluteFile / ContentAbsoluteFolder)"]
    C -->|"consolidateBlockPackDescription(desc, dst)"| D["BlockPackDescriptionManifest\n(ContentRelative)"]
    D -->|"addRelativePathPrefix(manifest, prefix)"| E["BlockPackDescriptionManifest\n(ContentRelative, prefixed)"]
    D -->|"BlockPackManifest.parse()"| F["BlockPackManifest"]
    C2["BlockPackMetaDescription"] -->|"embedBlockPackMetaAbsoluteBase64()"| G["BlockPackMetaEmbeddedBase64"]
    C2 -->|"embedBlockPackMetaAbsoluteBytes()"| H["BlockPackMetaEmbeddedBytes"]
    C -->|".meta"| C2
    I["BlockPackMetaManifest\n(ContentRelative)"] -->|"embedBlockPackMetaBytes(manifest, reader)"| H
    D -->|".meta"| I
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `lib/model/middle-layer/src/block_meta/block_manifest.ts`, line 192-203 ([link](https://github.com/milaboratory/platforma/blob/07bf7e6af75e367974d064b805b7ec05ce44bc03/lib/model/middle-layer/src/block_meta/block_manifest.ts#L192-L203)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`.strict()` on workflow-v1 schema silently narrows `BlockPackManifest.parse`**

   The old `BlockComponents(ContentRelative, ContentRelative)` expanded to a `WorkflowV1` object without `.strict()`, so manifests written by older consolidators that happened to carry extra fields in the `{type:"workflow-v1", ...}` object would parse successfully. The new concrete schema rejects any such extra fields. If the registry holds manifests produced by a future-version consolidator that adds a field here, or if any hand-authored or externally-generated manifests include additional workflow fields, `BlockPackManifest.parse` will now throw where it previously succeeded. The PR's canary and block-repo tests cover currently-stored manifests, but this is a silent stricter-validation change that isn't reflected in the minor-bump changelog.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/middle-layer/src/block_meta/block_manifest.ts
   Line: 192-203

   Comment:
   **`.strict()` on workflow-v1 schema silently narrows `BlockPackManifest.parse`**

   The old `BlockComponents(ContentRelative, ContentRelative)` expanded to a `WorkflowV1` object without `.strict()`, so manifests written by older consolidators that happened to carry extra fields in the `{type:"workflow-v1", ...}` object would parse successfully. The new concrete schema rejects any such extra fields. If the registry holds manifests produced by a future-version consolidator that adds a field here, or if any hand-authored or externally-generated manifests include additional workflow fields, `BlockPackManifest.parse` will now throw where it previously succeeded. The PR's canary and block-repo tests cover currently-stored manifests, but this is a silent stricter-validation change that isn't reflected in the minor-bump changelog.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `tools/block-tools/src/v2/model/block_meta.ts`, line 1013-1033 ([link](https://github.com/milaboratory/platforma/blob/07bf7e6af75e367974d064b805b7ec05ce44bc03/tools/block-tools/src/v2/model/block_meta.ts#L1013-L1033)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`transformBlockPackMeta` return-type cast is load-bearing for four callers**

   All four public functions (`consolidateBlockPackMeta`, `embedBlockPackMetaAbsoluteBase64`, `embedBlockPackMetaAbsoluteBytes`, `embedBlockPackMetaBytes`) rely on `as Promise<BlockPackMetaManifest>` / `as Promise<BlockPackMetaEmbeddedBase64>` etc. to compile. The casts are correct at runtime because the mapper functions produce values that are subtypes of the declared target types (e.g. `ContentRelative ⊂ ContentRelativeText`), but TypeScript cannot verify this through the `transformBlockPackMeta` generic. If `transformBlockPackMeta` is ever changed to produce a wider type, or a new caller passes incompatible mappers, the casts will silently suppress the resulting type error. Adding an intermediate `satisfies` assertion or narrower overloads would let the compiler catch such regressions earlier.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tools/block-tools/src/v2/model/block_meta.ts
   Line: 1013-1033

   Comment:
   **`transformBlockPackMeta` return-type cast is load-bearing for four callers**

   All four public functions (`consolidateBlockPackMeta`, `embedBlockPackMetaAbsoluteBase64`, `embedBlockPackMetaAbsoluteBytes`, `embedBlockPackMetaBytes`) rely on `as Promise<BlockPackMetaManifest>` / `as Promise<BlockPackMetaEmbeddedBase64>` etc. to compile. The casts are correct at runtime because the mapper functions produce values that are subtypes of the declared target types (e.g. `ContentRelative ⊂ ContentRelativeText`), but TypeScript cannot verify this through the `transformBlockPackMeta` generic. If `transformBlockPackMeta` is ever changed to produce a wider type, or a new caller passes incompatible mappers, the casts will silently suppress the resulting type error. Adding an intermediate `satisfies` assertion or narrower overloads would let the compiler catch such regressions earlier.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/model/middle-layer/src/block_meta/block_manifest.ts:192-203
**`.strict()` on workflow-v1 schema silently narrows `BlockPackManifest.parse`**

The old `BlockComponents(ContentRelative, ContentRelative)` expanded to a `WorkflowV1` object without `.strict()`, so manifests written by older consolidators that happened to carry extra fields in the `{type:"workflow-v1", ...}` object would parse successfully. The new concrete schema rejects any such extra fields. If the registry holds manifests produced by a future-version consolidator that adds a field here, or if any hand-authored or externally-generated manifests include additional workflow fields, `BlockPackManifest.parse` will now throw where it previously succeeded. The PR's canary and block-repo tests cover currently-stored manifests, but this is a silent stricter-validation change that isn't reflected in the minor-bump changelog.

### Issue 2 of 2
tools/block-tools/src/v2/model/block_meta.ts:1013-1033
**`transformBlockPackMeta` return-type cast is load-bearing for four callers**

All four public functions (`consolidateBlockPackMeta`, `embedBlockPackMetaAbsoluteBase64`, `embedBlockPackMetaAbsoluteBytes`, `embedBlockPackMetaBytes`) rely on `as Promise<BlockPackMetaManifest>` / `as Promise<BlockPackMetaEmbeddedBase64>` etc. to compile. The casts are correct at runtime because the mapper functions produce values that are subtypes of the declared target types (e.g. `ContentRelative ⊂ ContentRelativeText`), but TypeScript cannot verify this through the `transformBlockPackMeta` generic. If `transformBlockPackMeta` is ever changed to produce a wider type, or a new caller passes incompatible mappers, the casts will silently suppress the resulting type error. Adding an intermediate `satisfies` assertion or narrower overloads would let the compiler catch such regressions earlier.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(block-tools/v2): address review..."](https://github.com/milaboratory/platforma/commit/07bf7e6af75e367974d064b805b7ec05ce44bc03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33486903)</sub>

<!-- /greptile_comment -->