### PR TITLE
fix: speedup Built-In mode startup by waiting only for GRPC to be ready

### DIFF
--- a/.changeset/cold-papayas-work.md
+++ b/.changeset/cold-papayas-work.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-deployments": patch
+---
+
+Speedup local pl connection by waiting only for GRPC to become ready.

--- a/lib/node/pl-deployments/src/local/pl.ts
+++ b/lib/node/pl-deployments/src/local/pl.ts
@@ -170,6 +170,7 @@ export class LocalPl {
         const status = await plHealthCheck({
           address: `127.0.0.1:${grpcPort}`,
           defaultRequestTimeout: requestTimeoutMs,
+          service: "GRPC",
         });
         if (status === ServingStatus.SERVING) return;
       } catch {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR speeds up Built-In mode startup by changing the gRPC health check in `LocalPl.isReady()` to poll a specific named service (`"GRPC"`) rather than the overall server health (empty string default), which becomes ready earlier during backend initialization.

- Adds `service: \"GRPC\"` to the single `plHealthCheck` call in `isReady()`, targeting the backend's named gRPC health entry so the readiness poll resolves as soon as the gRPC transport layer is up rather than waiting for all subsystems.
- Includes a corresponding patch-level changeset entry.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a single-field addition to a health check call with no structural impact on error handling or retry logic.

The change is minimal and intentional. The one concern worth noting is that "GRPC" is a magic string coupling this client to a specific backend service registration name — if that name ever drifts, isReady() silently loops to timeout with no diagnostic, but this is a pre-existing characteristic of the catch block rather than a new regression.

lib/node/pl-deployments/src/local/pl.ts — the hardcoded service name warrants a comment cross-referencing the backend registration.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-deployments/src/local/pl.ts | Adds `service: "GRPC"` to the `plHealthCheck` call in `isReady()` to target the backend's named "GRPC" health entry instead of overall server health, enabling faster startup detection. |
| .changeset/cold-papayas-work.md | Patch-level changeset entry describing the speedup to local pl connection readiness detection. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant isReady
    participant plHealthCheck
    participant Backend as pl-core (gRPC server)

    Caller->>isReady: isReady(opts)
    loop until SERVING or timeout
        isReady->>isReady: isProcessAlive(pid)
        isReady->>plHealthCheck: "{ address, service: "GRPC" }"
        plHealthCheck->>Backend: "grpc.health.v1.Health/Check { service: "GRPC" }"
        alt backend not yet up
            Backend-->>plHealthCheck: connection refused (throws)
            plHealthCheck-->>isReady: throws (caught, loop continues)
        else service name not registered
            Backend-->>plHealthCheck: NOT_FOUND (throws)
            plHealthCheck-->>isReady: throws (caught, loop continues silently)
        else GRPC service ready
            Backend-->>plHealthCheck: ServingStatus.SERVING
            plHealthCheck-->>isReady: SERVING
            isReady-->>Caller: return (ready)
        end
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pl-deployments/src/local/pl.ts`, line 170-178 ([link](https://github.com/milaboratory/platforma/blob/7175146f4e48a1dd0f6b3ac703d222b9a18951c2/lib/node/pl-deployments/src/local/pl.ts#L170-L178)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Undocumented magic string with silent failure mode**

   The string `"GRPC"` must match a service name explicitly registered in the backend's gRPC health server. If the backend doesn't register a service under that exact name (e.g. due to a case change or backend refactor), the health check call will throw a gRPC `NOT_FOUND` error on every iteration — silently swallowed by the `catch {}` — and `isReady()` will loop until the full timeout with no diagnostic output. A short comment referencing the corresponding backend registration (e.g. the Go `health.RegisterService` call) would make this coupling explicit and easier to maintain.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-deployments/src/local/pl.ts
   Line: 170-178

   Comment:
   **Undocumented magic string with silent failure mode**

   The string `"GRPC"` must match a service name explicitly registered in the backend's gRPC health server. If the backend doesn't register a service under that exact name (e.g. due to a case change or backend refactor), the health check call will throw a gRPC `NOT_FOUND` error on every iteration — silently swallowed by the `catch {}` — and `isReady()` will loop until the full timeout with no diagnostic output. A short comment referencing the corresponding backend registration (e.g. the Go `health.RegisterService` call) would make this coupling explicit and easier to maintain.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/node/pl-deployments/src/local/pl.ts:170-178
**Undocumented magic string with silent failure mode**

The string `"GRPC"` must match a service name explicitly registered in the backend's gRPC health server. If the backend doesn't register a service under that exact name (e.g. due to a case change or backend refactor), the health check call will throw a gRPC `NOT_FOUND` error on every iteration — silently swallowed by the `catch {}` — and `isReady()` will loop until the full timeout with no diagnostic output. A short comment referencing the corresponding backend registration (e.g. the Go `health.RegisterService` call) would make this coupling explicit and easier to maintain.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: speedup Built-In mode startup by wa..."](https://github.com/milaboratory/platforma/commit/7175146f4e48a1dd0f6b3ac703d222b9a18951c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33648797)</sub>

<!-- /greptile_comment -->