### PR TITLE
fix(uikit): render friendly label for missing dropdown values

### DIFF
--- a/.changeset/uikit-missing-value-label.md
+++ b/.changeset/uikit-missing-value-label.md
@@ -2,4 +2,4 @@
 "@milaboratories/uikit": patch
 ---
 
-Fix `PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, and `PlDropdownMultiRef`: selected values missing from the options list — typically `PlRef`s whose upstream block was deleted — now render an italic "Value not available" / "Upstream value removed" label instead of leaking raw JSON. Multi variants surface missing entries as closeable chips instead of dropping them. All four components accept a `missingValueLabel` prop for custom text.
+Fix `PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, and `PlDropdownMultiRef`: selected values missing from the options list — typically `PlRef`s whose upstream block was deleted — now render an italic "Value not available" / "Upstream value removed" label instead of leaking the raw value. Multi variants surface missing entries as closeable chips instead of dropping them. All four components accept a `missingValueLabel` prop for custom text.

--- a/.changeset/uikit-missing-value-label.md
+++ b/.changeset/uikit-missing-value-label.md
@@ -2,4 +2,4 @@
 "@milaboratories/uikit": patch
 ---
 
-Fix `PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, and `PlDropdownMultiRef` so that selected values not present in the options list — typically `PlRef`s whose upstream block was deleted — render a friendly italic "Value not available" / "Upstream value removed" label instead of leaking the raw JSON of the value. The multi variants now surface missing entries as styled, closeable chips rather than silently dropping them. New `missingValueLabel` prop on all four components lets callers customize the text.
+Fix `PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, and `PlDropdownMultiRef`: selected values missing from the options list — typically `PlRef`s whose upstream block was deleted — now render an italic "Value not available" / "Upstream value removed" label instead of leaking raw JSON. Multi variants surface missing entries as closeable chips instead of dropping them. All four components accept a `missingValueLabel` prop for custom text.

--- a/.changeset/uikit-missing-value-label.md
+++ b/.changeset/uikit-missing-value-label.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/uikit": patch
+---
+
+Fix `PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, and `PlDropdownMultiRef` so that selected values not present in the options list — typically `PlRef`s whose upstream block was deleted — render a friendly italic "Value not available" / "Upstream value removed" label instead of leaking the raw JSON of the value. The multi variants now surface missing entries as styled, closeable chips rather than silently dropping them. New `missingValueLabel` prop on all four components lets callers customize the text.

--- a/.changeset/uikit-missing-value-label.md
+++ b/.changeset/uikit-missing-value-label.md
@@ -1,5 +1,5 @@
 ---
-"@milaboratories/uikit": patch
+"@milaboratories/uikit": minor
 ---
 
 Fix `PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, and `PlDropdownMultiRef`: selected values missing from the options list — typically `PlRef`s whose upstream block was deleted — now render an italic "Value not available" / "Upstream value removed" label instead of leaking the raw value. Multi variants surface missing entries as closeable chips instead of dropping them. All four components accept a `missingValueLabel` prop for custom text.

--- a/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
+++ b/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
@@ -69,6 +69,12 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
+     * Text shown inside the field when `modelValue` is set but no option matches it
+     * (e.g. the upstream block that produced this value was deleted). Rendered
+     * italic + error color via the `input-value--missing` style.
+     */
+    missingValueLabel?: string;
+    /**
      * Enables a button to clear the selected value (default: false)
      */
     clearable?: boolean;
@@ -113,6 +119,7 @@ const props = withDefaults(
     error: undefined,
     showErrorMessage: true,
     placeholder: "...",
+    missingValueLabel: "Value not available",
     clearable: false,
     required: false,
     disabled: false,
@@ -168,6 +175,15 @@ const selectedIndex = computed(() => {
   return (props.options ?? []).findIndex((o) => deepEqual(o.value, props.modelValue));
 });
 
+const isMissing = computed(() => {
+  return (
+    props.modelValue !== undefined &&
+    props.modelValue !== null &&
+    selectedIndex.value === -1 &&
+    !isLoadingOptions.value
+  );
+});
+
 const computedError = computed(() => {
   if (isLoadingOptions.value) {
     return undefined;
@@ -177,10 +193,8 @@ const computedError = computed(() => {
     return getErrorMessage(props.error);
   }
 
-  if (props.modelValue !== undefined && selectedIndex.value === -1) {
-    return "The selected value is not one of the options";
-  }
-
+  // Missing state is communicated by the field itself (missingValueLabel),
+  // so don't duplicate it as a helper error.
   return undefined;
 });
 
@@ -195,10 +209,8 @@ const optionsRef = computed<LOption<M>[]>(() =>
 
 const textValue = computed(() => {
   const options = unref(optionsRef);
-
   const item: ListOption | undefined = options.find((o) => deepEqual(o.value, props.modelValue));
-
-  return item?.label || props.modelValue; // @todo show inner value?
+  return item?.label;
 });
 
 const computedPlaceholder = computed(() => {
@@ -206,7 +218,7 @@ const computedPlaceholder = computed(() => {
     return "";
   }
 
-  return props.modelValue ? String(textValue.value) : props.placeholder;
+  return textValue.value ? String(textValue.value) : props.placeholder;
 });
 
 const hasValue = computed(() => {
@@ -365,7 +377,12 @@ watchPostEffect(() => {
           />
 
           <div v-if="!data.open" class="input-value">
-            <LongText> {{ textValue }} </LongText>
+            <LongText v-if="isMissing" class="input-value--missing">
+              {{ missingValueLabel }}
+            </LongText>
+            <LongText v-else-if="textValue !== undefined">
+              {{ textValue }}
+            </LongText>
           </div>
 
           <div class="pl-dropdown__controls">

--- a/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
+++ b/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
@@ -175,13 +175,12 @@ const selectedIndex = computed(() => {
   return (props.options ?? []).findIndex((o) => deepEqual(o.value, props.modelValue));
 });
 
+const hasValue = computed(() => {
+  return props.modelValue !== undefined && props.modelValue !== null;
+});
+
 const isMissing = computed(() => {
-  return (
-    props.modelValue !== undefined &&
-    props.modelValue !== null &&
-    selectedIndex.value === -1 &&
-    !isLoadingOptions.value
-  );
+  return hasValue.value && selectedIndex.value === -1 && !isLoadingOptions.value;
 });
 
 const computedError = computed(() => {
@@ -214,15 +213,11 @@ const textValue = computed(() => {
 });
 
 const computedPlaceholder = computed(() => {
-  if (!data.open && props.modelValue !== undefined) {
+  if (!data.open && hasValue.value) {
     return "";
   }
 
   return textValue.value ? String(textValue.value) : props.placeholder;
-});
-
-const hasValue = computed(() => {
-  return props.modelValue !== undefined && props.modelValue !== null;
 });
 
 const filteredRef = computed(() => {

--- a/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
+++ b/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
@@ -69,9 +69,8 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
-     * Text shown inside the field when `modelValue` is set but no option matches it
-     * (e.g. the upstream block that produced this value was deleted). Rendered
-     * italic + error color via the `input-value--missing` style.
+     * Text shown in the field when `modelValue` has no matching option — e.g. its
+     * upstream block was deleted. Rendered italic in error color.
      */
     missingValueLabel?: string;
     /**
@@ -192,8 +191,8 @@ const computedError = computed(() => {
     return getErrorMessage(props.error);
   }
 
-  // Missing state is communicated by the field itself (missingValueLabel),
-  // so don't duplicate it as a helper error.
+  // The field renders the missing state via `missingValueLabel`; no need to
+  // duplicate it as a helper error.
   return undefined;
 });
 

--- a/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
@@ -52,7 +52,7 @@ describe("PlDropdown", () => {
     expect(wrapper.html()).not.toContain('"blockId"');
     expect(wrapper.html()).not.toContain('"__isRef"');
 
-    // Redundant generic error helper is suppressed.
+    // The redundant generic error helper no longer appears.
     const error = wrapper.find(".pl-dropdown__error");
     expect(error.exists() ? error.text() : "").not.toContain(
       "The selected value is not one of the options",
@@ -89,10 +89,9 @@ describe("PlDropdown", () => {
       },
     });
     await flushPromises();
-    // Wired-up CSS hooks: the SCSS disabled override (`color: var(--dis-01)`)
-    // depends on both `.disabled` on the root and `.input-value--missing` on the
-    // label being present simultaneously. jsdom does not resolve CSS specificity,
-    // so we only assert the selector hooks exist, not the computed color.
+    // The SCSS disabled override (`color: var(--dis-01)`) needs both `.disabled`
+    // on the root and `.input-value--missing` on the label. jsdom doesn't resolve
+    // CSS specificity, so we only assert the hooks exist — not the computed color.
     expect(wrapper.find(".pl-dropdown.disabled").exists()).toBe(true);
     expect(wrapper.find(".input-value--missing").exists()).toBe(true);
   });
@@ -106,9 +105,9 @@ describe("PlDropdown", () => {
       },
     });
     await flushPromises();
-    // null is "no value selected" — must render the placeholder, not a blank field.
+    // null means "no value selected" — must render the placeholder, not blank.
     expect(wrapper.find("input").attributes("placeholder")).toBe("Pick one");
-    // And must NOT trigger the missing-value branch.
+    // Must not trigger the missing-value branch.
     expect(wrapper.find(".input-value--missing").exists()).toBe(false);
   });
 

--- a/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
@@ -111,4 +111,42 @@ describe("PlDropdown", () => {
     // And must NOT trigger the missing-value branch.
     expect(wrapper.find(".input-value--missing").exists()).toBe(false);
   });
+
+  it("clears the missing-state label when options later contain the value", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: {
+        modelValue: 1,
+        options: [{ text: "Option 2", value: 2 }],
+      },
+    });
+    await flushPromises();
+    expect(wrapper.find(".input-value--missing").exists()).toBe(true);
+
+    // Simulates the upstream block coming back: options now contain the value.
+    await wrapper.setProps({
+      options: [
+        { text: "Option 1", value: 1 },
+        { text: "Option 2", value: 2 },
+      ],
+    });
+    await flushPromises();
+    expect(wrapper.find(".input-value--missing").exists()).toBe(false);
+  });
+
+  it("renders the clear button when clearable + missing, and clears the model on click", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: {
+        modelValue: 99,
+        clearable: true,
+        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        options: [{ text: "Option 1", value: 1 }],
+      },
+    });
+    await flushPromises();
+    const clearBtn = wrapper.find(".clear");
+    expect(clearBtn.exists()).toBe(true);
+    await clearBtn.trigger("click");
+    await flushPromises();
+    expect(wrapper.props("modelValue")).toBeUndefined();
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
@@ -79,4 +79,36 @@ describe("PlDropdown", () => {
     await flushPromises();
     expect(wrapper.find(".input-value--missing").exists()).toBe(false);
   });
+
+  it("renders missingValueLabel alongside .disabled root when disabled with missing value", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: {
+        modelValue: 99,
+        disabled: true,
+        options: [{ text: "Option 1", value: 1 }],
+      },
+    });
+    await flushPromises();
+    // Wired-up CSS hooks: the SCSS disabled override (`color: var(--dis-01)`)
+    // depends on both `.disabled` on the root and `.input-value--missing` on the
+    // label being present simultaneously. jsdom does not resolve CSS specificity,
+    // so we only assert the selector hooks exist, not the computed color.
+    expect(wrapper.find(".pl-dropdown.disabled").exists()).toBe(true);
+    expect(wrapper.find(".input-value--missing").exists()).toBe(true);
+  });
+
+  it("shows placeholder (not blank) when modelValue is null", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: {
+        modelValue: null,
+        placeholder: "Pick one",
+        options: [{ text: "Option 1", value: 1 }],
+      },
+    });
+    await flushPromises();
+    // null is "no value selected" — must render the placeholder, not a blank field.
+    expect(wrapper.find("input").attributes("placeholder")).toBe("Pick one");
+    // And must NOT trigger the missing-value branch.
+    expect(wrapper.find(".input-value--missing").exists()).toBe(false);
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
@@ -29,4 +29,46 @@ describe("PlDropdown", () => {
 
     expect(await wrapper.findAll(".dropdown-list-item").length).toBe(0); // options are closed after click
   });
+
+  it("renders missingValueLabel when modelValue is not in options", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: {
+        modelValue: { __isRef: true as const, blockId: "deleted", name: "out" },
+        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        options: [
+          { text: "Option 1", value: 1 },
+          { text: "Option 2", value: 2 },
+        ],
+      },
+    });
+
+    await flushPromises();
+
+    const missing = wrapper.find(".input-value--missing");
+    expect(missing.exists()).toBe(true);
+    expect(missing.text()).toBe("Value not available");
+
+    // Raw value (JSON-stringified object) must not leak into the DOM.
+    expect(wrapper.html()).not.toContain('"blockId"');
+    expect(wrapper.html()).not.toContain('"__isRef"');
+
+    // Redundant generic error helper is suppressed.
+    const error = wrapper.find(".pl-dropdown__error");
+    expect(error.exists() ? error.text() : "").not.toContain(
+      "The selected value is not one of the options",
+    );
+  });
+
+  it("uses custom missingValueLabel when provided", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: {
+        modelValue: 99,
+        missingValueLabel: "Gone, kaput",
+        options: [{ text: "Option 1", value: 1 }],
+      },
+    });
+
+    await flushPromises();
+    expect(wrapper.find(".input-value--missing").text()).toBe("Gone, kaput");
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts
@@ -71,4 +71,12 @@ describe("PlDropdown", () => {
     await flushPromises();
     expect(wrapper.find(".input-value--missing").text()).toBe("Gone, kaput");
   });
+
+  it("does not render missingValueLabel while options are loading (options undefined)", async () => {
+    const wrapper = mount(PlDropdown, {
+      props: { modelValue: 99, options: undefined },
+    });
+    await flushPromises();
+    expect(wrapper.find(".input-value--missing").exists()).toBe(false);
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdown/pl-dropdown.scss
+++ b/lib/ui/uikit/src/components/PlDropdown/pl-dropdown.scss
@@ -108,6 +108,11 @@
       cursor: inherit;
     }
 
+    .input-value--missing {
+      font-style: italic;
+      color: var(--txt-error);
+    }
+
     input {
       min-height: calc(var(--control-height) - 2px);
       line-height: 20px;

--- a/lib/ui/uikit/src/components/PlDropdown/pl-dropdown.scss
+++ b/lib/ui/uikit/src/components/PlDropdown/pl-dropdown.scss
@@ -239,5 +239,9 @@
     .input-value {
       color: var(--dis-01);
     }
+
+    .input-value--missing {
+      color: var(--dis-01);
+    }
   }
 }

--- a/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
@@ -68,8 +68,8 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
-     * Text shown in a chip when an entry in `modelValue` is missing from `options`.
-     * Use to communicate that an upstream source was deleted. Styled italic + error color.
+     * Text shown in a chip when a `modelValue` entry is missing from `options` —
+     * e.g. its upstream source was deleted. Rendered italic in error color.
      */
     missingValueLabel?: string;
     /**
@@ -133,8 +133,8 @@ const placeholderRef = computed(() => {
 const normalizedOptionsRef = computed(() => normalizeListOptions(props.options ?? []));
 
 const selectedOptionsRef = computed(() => {
-  // While options are loading (undefined), suppress all chips for unresolved values
-  // so the user doesn't briefly see "missing" chips that resolve once options arrive.
+  // While options load (`options === undefined`), hide chips for unresolved values
+  // to avoid a "missing" flash that resolves once options arrive.
   const optionsLoaded = props.options !== undefined;
   return selectedValuesRef.value
     .map((v) => {
@@ -147,7 +147,7 @@ const selectedOptionsRef = computed(() => {
       if (!optionsLoaded) {
         return undefined;
       }
-      // Empty `missingValueLabel` is honored verbatim — caller's explicit "render nothing".
+      // Honor empty `missingValueLabel` verbatim — caller's explicit "render nothing".
       return {
         value: v,
         label: props.missingValueLabel,

--- a/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
@@ -140,9 +140,10 @@ const selectedOptionsRef = computed(() => {
     .map((v) => {
       const opt = normalizedOptionsRef.value.find((o) => deepEqual(o.value, v));
       if (opt) {
-        // Found option with an empty label: fall back to the friendly label rather
-        // than rendering the raw value (which `toDisplayString` would JSON-stringify).
-        return { ...opt, label: opt.label || props.missingValueLabel, isMissing: false };
+        // Found: render the option's own (normalized) label verbatim — matches
+        // PlDropdown. `opt.label` is always a string (possibly ""), never an object,
+        // so there is no raw-value leak to guard against.
+        return { ...opt, isMissing: false };
       }
       if (!optionsLoaded) {
         return undefined;

--- a/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
@@ -320,7 +320,7 @@ watchPostEffect(() => {
               @click.stop="data.open = true"
               @close="unselectOption(opt.value)"
             >
-              {{ opt.label || opt.value }}
+              {{ opt.isMissing ? opt.label : opt.label || opt.value }}
             </PlChip>
           </div>
 
@@ -359,7 +359,7 @@ watchPostEffect(() => {
               small
               @close="unselectOption(opt.value)"
             >
-              {{ opt.label || opt.value }}
+              {{ opt.isMissing ? opt.label : opt.label || opt.value }}
             </PlChip>
           </div>
           <DropdownListItem

--- a/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
@@ -140,9 +140,9 @@ const selectedOptionsRef = computed(() => {
     .map((v) => {
       const opt = normalizedOptionsRef.value.find((o) => deepEqual(o.value, v));
       if (opt) {
-        // Coerce empty labels via String() so Vue's `toDisplayString` never gets
-        // to JSON-stringify the raw value (the original "broken hash" bug).
-        return { ...opt, label: opt.label || String(opt.value), isMissing: false };
+        // Found option with an empty label: fall back to the friendly label rather
+        // than rendering the raw value (which `toDisplayString` would JSON-stringify).
+        return { ...opt, label: opt.label || props.missingValueLabel, isMissing: false };
       }
       if (!optionsLoaded) {
         return undefined;

--- a/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
@@ -140,11 +140,14 @@ const selectedOptionsRef = computed(() => {
     .map((v) => {
       const opt = normalizedOptionsRef.value.find((o) => deepEqual(o.value, v));
       if (opt) {
-        return { ...opt, isMissing: false };
+        // Coerce empty labels via String() so Vue's `toDisplayString` never gets
+        // to JSON-stringify the raw value (the original "broken hash" bug).
+        return { ...opt, label: opt.label || String(opt.value), isMissing: false };
       }
       if (!optionsLoaded) {
         return undefined;
       }
+      // Empty `missingValueLabel` is honored verbatim — caller's explicit "render nothing".
       return {
         value: v,
         label: props.missingValueLabel,
@@ -320,7 +323,7 @@ watchPostEffect(() => {
               @click.stop="data.open = true"
               @close="unselectOption(opt.value)"
             >
-              {{ opt.isMissing ? opt.label : opt.label || opt.value }}
+              {{ opt.label }}
             </PlChip>
           </div>
 
@@ -359,7 +362,7 @@ watchPostEffect(() => {
               small
               @close="unselectOption(opt.value)"
             >
-              {{ opt.isMissing ? opt.label : opt.label || opt.value }}
+              {{ opt.label }}
             </PlChip>
           </div>
           <DropdownListItem

--- a/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue
@@ -68,6 +68,11 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
+     * Text shown in a chip when an entry in `modelValue` is missing from `options`.
+     * Use to communicate that an upstream source was deleted. Styled italic + error color.
+     */
+    missingValueLabel?: string;
+    /**
      * If `true`, the dropdown component is marked as required.
      */
     required?: boolean;
@@ -95,6 +100,7 @@ const props = withDefaults(
     helper: undefined,
     error: undefined,
     placeholder: "...",
+    missingValueLabel: "Value not available",
     required: false,
     disabled: false,
     options: undefined,
@@ -127,9 +133,25 @@ const placeholderRef = computed(() => {
 const normalizedOptionsRef = computed(() => normalizeListOptions(props.options ?? []));
 
 const selectedOptionsRef = computed(() => {
+  // While options are loading (undefined), suppress all chips for unresolved values
+  // so the user doesn't briefly see "missing" chips that resolve once options arrive.
+  const optionsLoaded = props.options !== undefined;
   return selectedValuesRef.value
-    .map((v) => normalizedOptionsRef.value.find((opt) => deepEqual(opt.value, v)))
-    .filter((v) => v !== undefined);
+    .map((v) => {
+      const opt = normalizedOptionsRef.value.find((o) => deepEqual(o.value, v));
+      if (opt) {
+        return { ...opt, isMissing: false };
+      }
+      if (!optionsLoaded) {
+        return undefined;
+      }
+      return {
+        value: v,
+        label: props.missingValueLabel,
+        isMissing: true,
+      };
+    })
+    .filter((v): v is NonNullable<typeof v> => v !== undefined);
 });
 
 const filteredOptionsRef = computed(() => {
@@ -292,6 +314,7 @@ watchPostEffect(() => {
             <PlChip
               v-for="(opt, i) in selectedOptionsRef"
               :key="i"
+              :class="{ 'pl-dropdown-multi__chip--missing': opt.isMissing }"
               closeable
               small
               @click.stop="data.open = true"
@@ -331,6 +354,7 @@ watchPostEffect(() => {
             <PlChip
               v-for="(opt, i) in selectedOptionsRef"
               :key="i"
+              :class="{ 'pl-dropdown-multi__chip--missing': opt.isMissing }"
               closeable
               small
               @close="unselectOption(opt.value)"

--- a/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
@@ -32,4 +32,54 @@ describe("PlDropdownMulti", () => {
 
     expect(getOptions().length).toBe(2); // options are not closed after click
   });
+
+  it("renders a missing chip for a modelValue not present in options", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [1, 999],
+        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        options: [
+          { text: "Option 1", value: 1 },
+          { text: "Option 2", value: 2 },
+        ],
+      },
+    });
+
+    await flushPromises();
+
+    const missingChips = wrapper.findAll(".pl-dropdown-multi__chip--missing");
+    expect(missingChips.length).toBe(1);
+    expect(missingChips[0].text()).toContain("Value not available");
+
+    // Total chip count: one for valid (1), one for missing (999).
+    expect(wrapper.findAll(".pl-chip").length).toBe(2);
+  });
+
+  it("emits update:modelValue without the missing value when its chip is closed", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [1, 999],
+        "onUpdate:modelValue": (e) => wrapper.setProps({ modelValue: e }),
+        options: [{ text: "Option 1", value: 1 }],
+      },
+    });
+
+    await flushPromises();
+
+    const missingChip = wrapper.find(".pl-dropdown-multi__chip--missing");
+    expect(missingChip.exists()).toBe(true);
+
+    await missingChip.find(".pl-chip__close").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.props("modelValue")).toEqual([1]);
+  });
+
+  it("does not render missing chips while options are loading (options undefined)", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: { modelValue: [99], options: undefined },
+    });
+    await flushPromises();
+    expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(false);
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
@@ -112,4 +112,42 @@ describe("PlDropdownMulti", () => {
     expect(wrapper.html()).not.toContain('"blockId"');
     expect(wrapper.html()).not.toContain('"__isRef"');
   });
+
+  it("does not leak raw JSON when a found option has an empty label", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [{ __isRef: true as const, blockId: "1", name: "Ref" }],
+        options: [{ label: "", value: { __isRef: true as const, blockId: "1", name: "Ref" } }],
+      },
+    });
+    await flushPromises();
+    // An option with empty `label` must not let `toDisplayString` JSON-stringify its value.
+    expect(wrapper.html()).not.toContain('"blockId"');
+    expect(wrapper.html()).not.toContain('"__isRef"');
+    // The chip is still rendered (not the missing branch — option is found).
+    expect(wrapper.find(".pl-chip").exists()).toBe(true);
+    expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(false);
+  });
+
+  it("replaces missing chips with normal chips when options later contain the values", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [1],
+        options: [{ text: "Option 2", value: 2 }],
+      },
+    });
+    await flushPromises();
+    expect(wrapper.findAll(".pl-dropdown-multi__chip--missing").length).toBe(1);
+
+    // Simulates the upstream block coming back: options now contain the value.
+    await wrapper.setProps({
+      options: [
+        { text: "Option 1", value: 1 },
+        { text: "Option 2", value: 2 },
+      ],
+    });
+    await flushPromises();
+    expect(wrapper.findAll(".pl-dropdown-multi__chip--missing").length).toBe(0);
+    expect(wrapper.findAll(".pl-chip").length).toBe(1);
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
@@ -92,9 +92,9 @@ describe("PlDropdownMulti", () => {
       },
     });
     await flushPromises();
-    // The SCSS rule `.pl-dropdown-multi.disabled .pl-dropdown-multi__chip--missing .pl-chip__text`
-    // depends on both selectors being applied. jsdom doesn't resolve specificity,
-    // so we only assert both hooks are wired up.
+    // The SCSS rule `.pl-dropdown-multi.disabled .pl-dropdown-multi__chip--missing
+    // .pl-chip__text` needs both selectors. jsdom doesn't resolve specificity, so
+    // we only assert the hooks exist.
     expect(wrapper.find(".pl-dropdown-multi.disabled").exists()).toBe(true);
     expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(true);
   });
@@ -121,10 +121,10 @@ describe("PlDropdownMulti", () => {
       },
     });
     await flushPromises();
-    // An option with empty `label` must not let `toDisplayString` JSON-stringify its value.
+    // An empty `label` must not produce JSON output via `toDisplayString`.
     expect(wrapper.html()).not.toContain('"blockId"');
     expect(wrapper.html()).not.toContain('"__isRef"');
-    // The chip is still rendered (not the missing branch — option is found).
+    // The chip still renders (not the missing branch — option is found).
     expect(wrapper.find(".pl-chip").exists()).toBe(true);
     expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(false);
   });

--- a/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
@@ -82,4 +82,34 @@ describe("PlDropdownMulti", () => {
     await flushPromises();
     expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(false);
   });
+
+  it("renders missing chip alongside .disabled root when disabled", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [999],
+        disabled: true,
+        options: [{ text: "Option 1", value: 1 }],
+      },
+    });
+    await flushPromises();
+    // The SCSS rule `.pl-dropdown-multi.disabled .pl-dropdown-multi__chip--missing .pl-chip__text`
+    // depends on both selectors being applied. jsdom doesn't resolve specificity,
+    // so we only assert both hooks are wired up.
+    expect(wrapper.find(".pl-dropdown-multi.disabled").exists()).toBe(true);
+    expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(true);
+  });
+
+  it("never renders raw object value in a chip even if missingValueLabel is empty string", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [{ __isRef: true as const, blockId: "deleted", name: "out" }],
+        missingValueLabel: "",
+        options: [],
+      },
+    });
+    await flushPromises();
+    // With empty label the chip must render empty text, not the raw PlRef JSON.
+    expect(wrapper.html()).not.toContain('"blockId"');
+    expect(wrapper.html()).not.toContain('"__isRef"');
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts
@@ -129,6 +129,23 @@ describe("PlDropdownMulti", () => {
     expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(false);
   });
 
+  it("renders a found option's empty label as empty, never the missing label", async () => {
+    const wrapper = mount(PlDropdownMulti, {
+      props: {
+        modelValue: [1],
+        // Distinctive text so a regression to the `|| missingValueLabel` fallback is obvious.
+        missingValueLabel: "SHOULD-NOT-APPEAR",
+        options: [{ label: "", value: 1 }],
+      },
+    });
+    await flushPromises();
+    // A found option renders its own (empty) label verbatim — matches PlDropdown. It must
+    // not borrow the missing-value text, which is reserved for values absent from options.
+    expect(wrapper.find(".pl-chip").exists()).toBe(true);
+    expect(wrapper.find(".pl-dropdown-multi__chip--missing").exists()).toBe(false);
+    expect(wrapper.html()).not.toContain("SHOULD-NOT-APPEAR");
+  });
+
   it("replaces missing chips with normal chips when options later contain the values", async () => {
     const wrapper = mount(PlDropdownMulti, {
       props: {

--- a/lib/ui/uikit/src/components/PlDropdownMulti/pl-dropdown-multi.scss
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/pl-dropdown-multi.scss
@@ -258,6 +258,10 @@
       animation: spin 2.5s linear infinite;
       --icon-color: var(--ic-accent);
     }
+
+    .pl-dropdown-multi__chip--missing .pl-chip__text {
+      color: var(--dis-01);
+    }
   }
 
   &__open-chips-container {

--- a/lib/ui/uikit/src/components/PlDropdownMulti/pl-dropdown-multi.scss
+++ b/lib/ui/uikit/src/components/PlDropdownMulti/pl-dropdown-multi.scss
@@ -269,3 +269,10 @@
     }
   }
 }
+
+.pl-dropdown-multi__chip--missing {
+  .pl-chip__text {
+    font-style: italic;
+    color: var(--txt-error);
+  }
+}

--- a/lib/ui/uikit/src/components/PlDropdownMultiRef/PlDropdownMultiRef.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMultiRef/PlDropdownMultiRef.vue
@@ -40,8 +40,8 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
-     * Text shown in a chip when a `modelValue` entry references an upstream block
-     * that no longer exists. Defaults to "Upstream value removed".
+     * Text shown in a chip when a `modelValue` entry's upstream block no longer
+     * exists. Defaults to "Upstream value removed".
      */
     missingValueLabel?: string;
     /**

--- a/lib/ui/uikit/src/components/PlDropdownMultiRef/PlDropdownMultiRef.vue
+++ b/lib/ui/uikit/src/components/PlDropdownMultiRef/PlDropdownMultiRef.vue
@@ -40,6 +40,11 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
+     * Text shown in a chip when a `modelValue` entry references an upstream block
+     * that no longer exists. Defaults to "Upstream value removed".
+     */
+    missingValueLabel?: string;
+    /**
      * If `true`, the dropdown component is marked as required.
      */
     required?: boolean;
@@ -54,6 +59,7 @@ const props = withDefaults(
     helper: undefined,
     error: undefined,
     placeholder: "...",
+    missingValueLabel: "Upstream value removed",
     required: false,
     disabled: false,
     options: undefined,

--- a/lib/ui/uikit/src/components/PlDropdownMultiRef/__tests__/PlDropdownMultiRef.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMultiRef/__tests__/PlDropdownMultiRef.spec.ts
@@ -63,4 +63,27 @@ describe("PlDropdownMultiRef", () => {
 
     expect(getOptions().length).toBe(2); // options are not closed after click
   });
+
+  it("renders the ref-specific missingValueLabel default for a stale ref", async () => {
+    const wrapper = mount(PlDropdownMultiRef, {
+      props: {
+        modelValue: [
+          { __isRef: true as const, blockId: "1", name: "Ref to block 1" },
+          { __isRef: true as const, blockId: "deleted", name: "Ref to deleted block" },
+        ],
+        options: [
+          {
+            label: "Ref 1",
+            ref: { __isRef: true as const, blockId: "1", name: "Ref to block 1" },
+          },
+        ],
+      },
+    });
+
+    await flushPromises();
+
+    const missing = wrapper.findAll(".pl-dropdown-multi__chip--missing");
+    expect(missing.length).toBe(1);
+    expect(missing[0].text()).toContain("Upstream value removed");
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdownMultiRef/__tests__/PlDropdownMultiRef.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownMultiRef/__tests__/PlDropdownMultiRef.spec.ts
@@ -86,4 +86,23 @@ describe("PlDropdownMultiRef", () => {
     expect(missing.length).toBe(1);
     expect(missing[0].text()).toContain("Upstream value removed");
   });
+
+  it("forwards a caller-supplied missingValueLabel that overrides the Ref default", async () => {
+    const wrapper = mount(PlDropdownMultiRef, {
+      props: {
+        modelValue: [{ __isRef: true as const, blockId: "deleted", name: "Ref to deleted block" }],
+        missingValueLabel: "Caller override",
+        options: [
+          {
+            label: "Ref 1",
+            ref: { __isRef: true as const, blockId: "1", name: "Ref to block 1" },
+          },
+        ],
+      },
+    });
+    await flushPromises();
+    const missing = wrapper.findAll(".pl-dropdown-multi__chip--missing");
+    expect(missing.length).toBe(1);
+    expect(missing[0].text()).toContain("Caller override");
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdownRef/PlDropdownRef.vue
+++ b/lib/ui/uikit/src/components/PlDropdownRef/PlDropdownRef.vue
@@ -53,8 +53,8 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
-     * Text shown inside the field when `modelValue` is set but the referenced upstream
-     * block / output no longer exists. Defaults to "Upstream value removed".
+     * Text shown in the field when the referenced upstream block / output no longer
+     * exists. Defaults to "Upstream value removed".
      */
     missingValueLabel?: string;
     /**

--- a/lib/ui/uikit/src/components/PlDropdownRef/PlDropdownRef.vue
+++ b/lib/ui/uikit/src/components/PlDropdownRef/PlDropdownRef.vue
@@ -53,6 +53,11 @@ const props = withDefaults(
      */
     placeholder?: string;
     /**
+     * Text shown inside the field when `modelValue` is set but the referenced upstream
+     * block / output no longer exists. Defaults to "Upstream value removed".
+     */
+    missingValueLabel?: string;
+    /**
      * Enables a button to clear the selected value (default: false)
      */
     clearable?: boolean;
@@ -75,6 +80,7 @@ const props = withDefaults(
     loadingOptionsHelper: undefined,
     error: undefined,
     placeholder: "...",
+    missingValueLabel: "Upstream value removed",
     clearable: false,
     required: false,
     disabled: false,

--- a/lib/ui/uikit/src/components/PlDropdownRef/__tests__/PlDropdownRef.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownRef/__tests__/PlDropdownRef.spec.ts
@@ -79,4 +79,29 @@ describe("PlDropdownRef", () => {
     expect(missing.exists()).toBe(true);
     expect(missing.text()).toBe("Upstream value removed");
   });
+
+  it("forwards a caller-supplied missingValueLabel that overrides the Ref default", async () => {
+    const wrapper = mount(PlDropdownRef, {
+      props: {
+        modelValue: {
+          __isRef: true as const,
+          blockId: "deleted-block",
+          name: "Ref to deleted block",
+        },
+        missingValueLabel: "Caller override",
+        options: [
+          {
+            label: "Ref 1",
+            ref: {
+              __isRef: true as const,
+              blockId: "1",
+              name: "Ref to block 1",
+            },
+          },
+        ],
+      },
+    });
+    await flushPromises();
+    expect(wrapper.find(".input-value--missing").text()).toBe("Caller override");
+  });
 });

--- a/lib/ui/uikit/src/components/PlDropdownRef/__tests__/PlDropdownRef.spec.ts
+++ b/lib/ui/uikit/src/components/PlDropdownRef/__tests__/PlDropdownRef.spec.ts
@@ -51,4 +51,32 @@ describe("PlDropdownRef", () => {
 
     expect(await wrapper.findAll(".dropdown-list-item").length).toBe(0); // options are closed after click
   });
+
+  it("renders the ref-specific missingValueLabel default when ref is not in options", async () => {
+    const wrapper = mount(PlDropdownRef, {
+      props: {
+        modelValue: {
+          __isRef: true as const,
+          blockId: "deleted-block",
+          name: "Ref to deleted block",
+        },
+        options: [
+          {
+            label: "Ref 1",
+            ref: {
+              __isRef: true as const,
+              blockId: "1",
+              name: "Ref to block 1",
+            },
+          },
+        ],
+      },
+    });
+
+    await flushPromises();
+
+    const missing = wrapper.find(".input-value--missing");
+    expect(missing.exists()).toBe(true);
+    expect(missing.text()).toBe("Upstream value removed");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the "broken hash" rendering in `@milaboratories/uikit` dropdowns when a selected value (typically a `PlRef` whose upstream block was deleted) is no longer present in the options list.

- **`PlDropdown`**: when `modelValue` is set but no option matches, the field renders a configurable `missingValueLabel` (italic, `--txt-error`) inside `.input-value--missing` instead of leaking the raw value through Vue's `toDisplayString`. The previous `"The selected value is not one of the options"` helper error is **removed entirely** — missing-value communication is now handled by the in-field label, avoiding the duplicate signal. Disabled dropdowns mute the missing tint to `--dis-01` for visual consistency.
- **`PlDropdownMulti`**: stops silently filtering out missing values in `selectedOptionsRef`. Missing entries now render as `.pl-dropdown-multi__chip--missing` chips (closeable, italic, `--txt-error`); closing one emits `update:modelValue` without that value so users can clear orphaned refs. Suppressed during options-load (`props.options === undefined`) and muted when disabled. Label normalization is centralized in `selectedOptionsRef` — both chip containers consume `{{ opt.label }}` directly; a found option with an empty label falls back to `missingValueLabel` rather than rendering its raw value.
- **`PlDropdownRef` / `PlDropdownMultiRef`**: declare the same `missingValueLabel` prop, defaulting to `"Upstream value removed"` (vs the neutral `"Value not available"` on the base components). Forwarded via the existing `v-bind="props"`.
- Loading-state suppression on both base components ensures no missing-state UI flashes while options resolve.
- New tests cover: missing-label render, custom-label override (on base components and Ref wrappers), loading-state suppression, raw-value DOM leak prevention on both the missing and found branches, disabled + missing state, `missing → resolved` transition when options arrive containing a stale value, clearable-button activation in the missing state, and (multi) chip close behavior.
- Changeset added: patch bump for `@milaboratories/uikit`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX bug across all four dropdown components (`PlDropdown`, `PlDropdownMulti`, `PlDropdownRef`, `PlDropdownMultiRef`) where a selected value absent from the options list (typically a stale `PlRef` after its upstream block is deleted) was either silently dropped or leaked its raw JSON representation into the DOM.

- **`PlDropdown`**: introduces `isMissing` computed and renders a configurable `missingValueLabel` in italic error color via `.input-value--missing`; removes the now-redundant helper error string; `null` correctly shows the placeholder instead of a blank field.
- **`PlDropdownMulti`**: rewrites `selectedOptionsRef` to retain missing values as closeable `isMissing` chips; loading-state suppression prevents a flash of false-missing state; empty `missingValueLabel=""` is honoured verbatim so raw object values can never leak through the `|| opt.value` fallback that existed before.
- **`PlDropdownRef` / `PlDropdownMultiRef`**: declare the same prop with a domain-specific default ("Upstream value removed") and forward it via the existing `v-bind="props"` spread.
- Test coverage is thorough: missing label, custom override, loading suppression, disabled+missing, missing→resolved transition, raw JSON leak prevention, and chip-close emission are all exercised.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All four components remain backwards-compatible: existing usages without `missingValueLabel` get sensible defaults, the old raw-value fallback is gone, and the loading-state guard prevents any flash of incorrect UI.

The logic changes are self-contained within each component's computed properties and template slots. CSS specificity for the disabled override is correct (0,3,0 beats 0,2,0). The test suite is comprehensive — it covers the primary happy path, the missing-value render, loading suppression, disabled state, the missing→resolved transition, and the chip-close emission. The only open question is the intended changeset bump level, which has no runtime impact.

`.changeset/uikit-missing-value-label.md` — the bump level (`minor` vs `patch`) should be confirmed against the team's versioning convention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue | Adds `missingValueLabel` prop and `isMissing` computed; replaces raw-value fallback with the labeled missing state; removes duplicate helper error; `null` now correctly shows placeholder instead of blank. |
| lib/ui/uikit/src/components/PlDropdownMulti/PlDropdownMulti.vue | Rewrites `selectedOptionsRef` to surface missing values as closeable chips with `isMissing: true`; loading-state suppression prevents flash; empty `missingValueLabel` is honoured verbatim so raw JSON cannot leak. |
| lib/ui/uikit/src/components/PlDropdownRef/PlDropdownRef.vue | Adds `missingValueLabel` prop defaulting to "Upstream value removed", forwarded via `v-bind="props"` to PlDropdown. |
| lib/ui/uikit/src/components/PlDropdownMultiRef/PlDropdownMultiRef.vue | Adds `missingValueLabel` prop defaulting to "Upstream value removed", forwarded via `v-bind="props"` to PlDropdownMulti. |
| lib/ui/uikit/src/components/PlDropdown/pl-dropdown.scss | Adds `.input-value--missing` with italic + `--txt-error`; disabled override uses 3-class specificity (0,3,0) to correctly trump the base 2-class rule (0,2,0) with `--dis-01`. |
| lib/ui/uikit/src/components/PlDropdownMulti/pl-dropdown-multi.scss | Adds global `.pl-dropdown-multi__chip--missing .pl-chip__text` rule (italic + `--txt-error`) and a disabled-context override with correct higher specificity to mute to `--dis-01`. |
| .changeset/uikit-missing-value-label.md | Changeset bump level is `minor`, but the PR description says "patch bump" — worth confirming intent since the correct bump type depends on whether adding new optional props is treated as a feature or a fix. |
| lib/ui/uikit/src/components/PlDropdown/__tests__/PlDropdown.spec.ts | Seven new test cases cover: default label, custom label, loading suppression, disabled+missing, null placeholder, missing→resolved transition, and clearable+missing behaviour. |
| lib/ui/uikit/src/components/PlDropdownMulti/__tests__/PlDropdownMulti.spec.ts | Seven new tests cover: missing chip render, chip-close emission, loading suppression, disabled+missing, raw-JSON leak prevention (empty label), found-option-empty-label, and missing→resolved transition. |
| lib/ui/uikit/src/components/PlDropdownRef/__tests__/PlDropdownRef.spec.ts | Two new tests verify the ref-specific default label and that a caller-supplied override is forwarded correctly. |
| lib/ui/uikit/src/components/PlDropdownMultiRef/__tests__/PlDropdownMultiRef.spec.ts | Two new tests mirror PlDropdownRef tests: default "Upstream value removed" label and caller override propagation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[modelValue set?] -->|No - null/undefined| B[Show placeholder]
    A -->|Yes| C{options loading?}
    C -->|options === undefined| D[Hide missing UI — wait for options]
    C -->|options defined| E{value in options?}
    E -->|Found| F[Render opt.label normally]
    E -->|Not found| G[isMissing = true]
    G --> H[PlDropdown: render LongText.input-value--missing with missingValueLabel]
    G --> I[PlDropdownMulti: render chip.pl-dropdown-multi__chip--missing with missingValueLabel]
    H --> J{disabled?}
    I --> J
    J -->|Yes| K[color: --dis-01]
    J -->|No| L[color: --txt-error, italic]
    I --> M[User closes chip → unselectOption → emit without that value]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/uikit-missing-value-label.md:2
**Changeset bump level disagrees with PR description**

The changeset file uses `minor`, but the PR description says "Changeset added: patch bump for `@milaboratories/uikit`." Since the PR adds a new optional `missingValueLabel` prop to four public component APIs, `minor` is the more correct semver classification. If the team intends this to land as a `patch` (e.g. because the new prop is purely additive / opt-in and the project's convention is to treat such fixes as patches), the changeset should be changed to `"@milaboratories/uikit": patch` to avoid an unintended minor version bump.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(uikit): stop substituting missingVal..."](https://github.com/milaboratory/platforma/commit/e1f17697eb9117a7755ac2f7c7eed0b80e3cf41a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33822923)</sub>

<!-- /greptile_comment -->