### PR TITLE
feat(ts-builder): dev-server sidecar for block-ui serve

### DIFF
--- a/tools/ts-builder/src/commands/serve.ts
+++ b/tools/ts-builder/src/commands/serve.ts
@@ -5,12 +5,10 @@ import {
   getConfigInfo,
   getGlobalOptions,
   getValidatedConfigPath,
-  installSidecarCleanup,
-  removeSidecar,
   requireTarget,
   resolveVite,
+  setupSidecarLifecycle,
   validateTargetForBrowser,
-  writeSidecar,
 } from "./utils/index";
 
 export const serveCommand = new Command("serve")
@@ -76,6 +74,14 @@ async function runBlockUiServe(opts: BlockUiServeOptions): Promise<void> {
     process.env.USE_SOURCES = "1";
   }
 
+  // Resolve sidecar path BEFORE starting Vite so lifecycle hooks register
+  // first — see `setupSidecarLifecycle` for the ordering rationale.
+  const sidecarDir = opts.sidecarOut
+    ? path.resolve(opts.sidecarOut)
+    : path.resolve(process.cwd(), "dist");
+  const sidecarPath = path.join(sidecarDir, ".dev-server");
+  const sidecar = setupSidecarLifecycle(sidecarPath);
+
   // Vite is a peer dep of ts-builder; resolve it from the consumer package
   // so we use the same version the project's config is written against.
   let vite: typeof import("vite");
@@ -104,20 +110,15 @@ async function runBlockUiServe(opts: BlockUiServeOptions): Promise<void> {
     return;
   }
 
-  const sidecarDir = opts.sidecarOut
-    ? path.resolve(opts.sidecarOut)
-    : path.resolve(process.cwd(), "dist");
-  const sidecarPath = path.join(sidecarDir, ".dev-server");
-
-  writeSidecar(sidecarPath, { schema: 1, url, pid: process.pid });
-  installSidecarCleanup(sidecarPath);
+  sidecar.publish({ schema: 1, url, pid: process.pid });
   console.log(`Wrote dev-server sidecar: ${sidecarPath}`);
 
   // Make Vite's own close path remove the sidecar too — covers programmatic
-  // shutdowns (e.g. test harnesses) where signal-based cleanup won't fire.
+  // shutdowns (e.g. test harnesses) and HMR-driven server restarts where
+  // signal-based cleanup wouldn't fire.
   const origClose = server.close.bind(server);
   server.close = async () => {
-    removeSidecar(sidecarPath);
+    sidecar.remove();
     return origClose();
   };
 }

--- a/tools/ts-builder/src/commands/serve.ts
+++ b/tools/ts-builder/src/commands/serve.ts
@@ -1,18 +1,26 @@
 import { Command } from "commander";
+import * as path from "node:path";
 import {
   executeCommand,
   getConfigInfo,
   getGlobalOptions,
   getValidatedConfigPath,
+  installSidecarCleanup,
+  removeSidecar,
   requireTarget,
   resolveVite,
   validateTargetForBrowser,
+  writeSidecar,
 } from "./utils/index";
 
 export const serveCommand = new Command("serve")
   .description("Start development server")
   .option("-p, --port <port>", "Port number")
   .option("--host <host>", "Host address")
+  .option(
+    "--sidecar-out <path>",
+    "Directory the dev-server sidecar is written into (default: ./dist for block-ui)",
+  )
   .action(async (options, command) => {
     const globalOpts = getGlobalOptions(command);
     const target = requireTarget(globalOpts);
@@ -25,17 +33,26 @@ export const serveCommand = new Command("serve")
       `Starting dev server for ${target} project${useSources ? " with sources condition" : ""}...`,
     );
 
+    const configInfo = getConfigInfo(target);
+    const configPath = getValidatedConfigPath(customServeConfig, configInfo!.filename);
+
+    if (target === "block-ui") {
+      await runBlockUiServe({
+        configPath,
+        port: options.port ? Number(options.port) : undefined,
+        host: options.host,
+        useSources,
+        sidecarOut: options.sidecarOut,
+      });
+      return;
+    }
+
+    // Other targets keep the existing CLI-spawn behavior — no sidecar is written.
     try {
       const viteCommand = resolveVite();
-      const viteArgs = ["dev"];
-      const configInfo = getConfigInfo(target);
-      const configPath = getValidatedConfigPath(customServeConfig, configInfo!.filename);
-
-      viteArgs.push("--config", configPath);
-
+      const viteArgs = ["dev", "--config", configPath];
       if (options.port) viteArgs.push("--port", options.port);
       if (options.host) viteArgs.push("--host", options.host);
-
       const env = useSources ? { USE_SOURCES: "1" } : undefined;
       await executeCommand(viteCommand, viteArgs, env);
     } catch (error) {
@@ -43,3 +60,64 @@ export const serveCommand = new Command("serve")
       process.exit(1);
     }
   });
+
+interface BlockUiServeOptions {
+  configPath: string;
+  port?: number;
+  host?: string;
+  useSources?: boolean;
+  sidecarOut?: string;
+}
+
+async function runBlockUiServe(opts: BlockUiServeOptions): Promise<void> {
+  // Vite's config file reads USE_SOURCES from process.env, so set it before
+  // we createServer.
+  if (opts.useSources) {
+    process.env.USE_SOURCES = "1";
+  }
+
+  // Vite is a peer dep of ts-builder; resolve it from the consumer package
+  // so we use the same version the project's config is written against.
+  let vite: typeof import("vite");
+  try {
+    vite = await import("vite");
+  } catch (error) {
+    console.error("Failed to load `vite`. Ensure it's installed as a dependency.", error);
+    process.exit(1);
+    return;
+  }
+
+  const server = await vite.createServer({
+    configFile: opts.configPath,
+    server: {
+      port: opts.port,
+      host: opts.host,
+    },
+  });
+
+  await server.listen();
+  server.printUrls();
+
+  const url = server.resolvedUrls?.local?.[0];
+  if (!url) {
+    console.warn("vite did not report a local URL; skipping dev-server sidecar.");
+    return;
+  }
+
+  const sidecarDir = opts.sidecarOut
+    ? path.resolve(opts.sidecarOut)
+    : path.resolve(process.cwd(), "dist");
+  const sidecarPath = path.join(sidecarDir, ".dev-server");
+
+  writeSidecar(sidecarPath, { schema: 1, url, pid: process.pid });
+  installSidecarCleanup(sidecarPath);
+  console.log(`Wrote dev-server sidecar: ${sidecarPath}`);
+
+  // Make Vite's own close path remove the sidecar too — covers programmatic
+  // shutdowns (e.g. test harnesses) where signal-based cleanup won't fire.
+  const origClose = server.close.bind(server);
+  server.close = async () => {
+    removeSidecar(sidecarPath);
+    return origClose();
+  };
+}

--- a/tools/ts-builder/src/commands/utils/dev-server-sidecar.ts
+++ b/tools/ts-builder/src/commands/utils/dev-server-sidecar.ts
@@ -1,0 +1,46 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface DevServerSidecar {
+  schema: 1;
+  url: string;
+  pid: number;
+}
+
+/**
+ * Atomically write the sidecar JSON file. The desktop app polls this file
+ * when loading a dev-v2 block; an atomic rename avoids the consumer reading
+ * a half-written file.
+ */
+export function writeSidecar(sidecarPath: string, payload: DevServerSidecar): void {
+  fs.mkdirSync(path.dirname(sidecarPath), { recursive: true });
+  const tmp = sidecarPath + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+  fs.renameSync(tmp, sidecarPath);
+}
+
+export function removeSidecar(sidecarPath: string): void {
+  try {
+    fs.unlinkSync(sidecarPath);
+  } catch {
+    // ignore — already gone
+  }
+}
+
+/**
+ * Install best-effort cleanup hooks. SIGINT/SIGTERM trigger an explicit
+ * unlink and then a clean process exit so any downstream `process.on("exit")`
+ * handlers also run.
+ */
+export function installSidecarCleanup(sidecarPath: string): void {
+  const cleanup = () => removeSidecar(sidecarPath);
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+}

--- a/tools/ts-builder/src/commands/utils/dev-server-sidecar.ts
+++ b/tools/ts-builder/src/commands/utils/dev-server-sidecar.ts
@@ -27,20 +27,57 @@ export function removeSidecar(sidecarPath: string): void {
   }
 }
 
+export interface SidecarLifecycle {
+  /** Write the sidecar and mark it as live for cleanup. */
+  publish(payload: DevServerSidecar): void;
+  /** Remove the sidecar explicitly (idempotent). */
+  remove(): void;
+}
+
 /**
- * Install best-effort cleanup hooks. SIGINT/SIGTERM trigger an explicit
- * unlink and then a clean process exit so any downstream `process.on("exit")`
- * handlers also run.
+ * Set up lifecycle hooks for a sidecar file BEFORE the server that owns it
+ * is started.
+ *
+ * Registration order matters. Node fires same-signal handlers in registration
+ * order. Vite's `createServer` / `listen` registers its own SIGINT/SIGHUP/etc.
+ * handlers that exit the process — if we wait until after `createServer` to
+ * register ours, Vite's may run first, exit synchronously, and our cleanup
+ * is missed. Install everything up-front, then `publish()` once the URL is
+ * known. `remove()` and the signal-triggered cleanup are idempotent.
  */
-export function installSidecarCleanup(sidecarPath: string): void {
-  const cleanup = () => removeSidecar(sidecarPath);
+export function setupSidecarLifecycle(sidecarPath: string): SidecarLifecycle {
+  let live = false;
+
+  const cleanup = () => {
+    if (!live) return;
+    live = false;
+    removeSidecar(sidecarPath);
+  };
+
+  const exitOn = (signal: NodeJS.Signals) => {
+    process.on(signal, () => {
+      cleanup();
+      // Re-raise the default behavior with a clean exit code so callers
+      // (shell, pnpm) see the expected termination.
+      process.exit(0);
+    });
+  };
+
+  exitOn("SIGINT");
+  exitOn("SIGTERM");
+  exitOn("SIGHUP");
   process.on("exit", cleanup);
-  process.on("SIGINT", () => {
+  process.on("uncaughtException", (err) => {
     cleanup();
-    process.exit(0);
+    console.error(err);
+    process.exit(1);
   });
-  process.on("SIGTERM", () => {
-    cleanup();
-    process.exit(0);
-  });
+
+  return {
+    publish(payload) {
+      writeSidecar(sidecarPath, payload);
+      live = true;
+    },
+    remove: cleanup,
+  };
 }

--- a/tools/ts-builder/src/commands/utils/index.ts
+++ b/tools/ts-builder/src/commands/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./command-runner";
 export * from "./common-options";
 export * from "./config-manager";
+export * from "./dev-server-sidecar";
 export * from "./executable-resolver";
 export * from "./path-utils";

--- a/tools/ts-builder/src/configs/utils/createViteDevConfig.ts
+++ b/tools/ts-builder/src/configs/utils/createViteDevConfig.ts
@@ -1,7 +1,111 @@
 import vue from "@vitejs/plugin-vue";
 import sourcemaps from "rollup-plugin-sourcemaps2";
-import type { ConfigEnv, UserConfig } from "vite";
+import type { ConfigEnv, Plugin, UserConfig } from "vite";
 import commonjs from "vite-plugin-commonjs";
+
+/*
+ * ───────────────────────────────────────────────────────────────────────────
+ *  TEMPORARY DEV-MODE SECURITY RELAXATIONS — TRACK AND REMOVE
+ * ───────────────────────────────────────────────────────────────────────────
+ *
+ * This file contains two `vite dev`-only hacks that weaken the security
+ * posture of the block UI runtime relative to production. They exist so the
+ * dev-server sidecar workflow (block author runs `ts-builder serve` and the
+ * desktop hot-loads the block from `http://localhost:<port>/`) functions at
+ * all. Both are documented at their respective sites below.
+ *
+ *   1. `relaxCspForDevWasm` — rewrites the block's CSP meta tag to add
+ *      `'wasm-unsafe-eval'` so in-page WebAssembly (PFrameSpec / SpecDriver)
+ *      can compile.
+ *   2. `define: { "process.env": "({})" }` — masks all `process.env.X`
+ *      references (including `NODE_ENV`) to `undefined` so transitive Node
+ *      imports don't blow up on `process is not defined`.
+ *
+ * Both are dev-only — production block UIs are served via the `block-ui://`
+ * custom protocol, registered with `bypassCSP: true`, so the CSP is
+ * effectively absent in production, and rolldown strips `process.env.X`
+ * references at build time.
+ *
+ * FOLLOW-UP — DO NOT LEAVE THIS AS THE STEADY STATE:
+ *   - Migrate the block template CSP (currently `script-src 'self' blob:`)
+ *     to a canonical policy that lists every source the runtime legitimately
+ *     uses (including `'wasm-unsafe-eval'`), so dev and prod share one CSP.
+ *   - Once block-ui:// no longer needs `bypassCSP: true`, drop the bypass on
+ *     the protocol registration in
+ *     `core/platforma-desktop-app/packages/main/src/protocols/block-ui.ts`.
+ *   - Re-enable strict CSP enforcement in dev by removing
+ *     `relaxCspForDevWasm`.
+ *   - Replace the blunt `process.env: ({})` substitution with a precise
+ *     allowlist of vars the SDK genuinely reads (or eliminate the references
+ *     entirely from browser-bound code paths — most are debug toggles like
+ *     `MI_LOG_PFRAMES` and can move to a constructor option or a
+ *     `globalThis` flag).
+ *   - Run a security review of the block-ui runtime end-to-end: CSP, preload
+ *     surface, IPC method allowlist, `webRequest` headers, WASM source set,
+ *     `webSecurity` / `nodeIntegration` / `contextIsolation` settings on
+ *     `webPreferencesForBlock`, and the dev-server sidecar trust gate
+ *     (currently dev-v2 only — confirm sufficient for prod hardening).
+ *
+ * Tracking ticket: TODO — create one in MILAB before this lands.
+ * ───────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Rewrite the block's index.html CSP meta tag during `vite dev` so WebAssembly
+ * modules (e.g. `@milaboratories/pframes-rs-wasm`) can compile in the browser.
+ *
+ * Why this is necessary, and why no smaller fix works:
+ *
+ *  - In production the block UI is served via the `block-ui://` custom
+ *    protocol, which Electron registers with `bypassCSP: true`. The strict
+ *    CSP in `index.html` (`script-src 'self' blob:`) never applies and the
+ *    in-page WASM driver (PFrameSpec / `pf-spec-driver`) loads fine.
+ *
+ *  - In `vite dev` the UI is served over `http://localhost:<port>`. We have
+ *    no equivalent privilege escape for `http:` — Electron honors the
+ *    standard browser CSP semantics for that scheme.
+ *
+ *  - The CSP that wins is the *intersection* of every source (meta tag +
+ *    response header). Adding a permissive `Content-Security-Policy`
+ *    response header via Vite middleware or
+ *    `session.webRequest.onHeadersReceived` does not loosen the meta — it
+ *    only tightens further. So a header-side fix cannot work.
+ *
+ *  - CSP is parse-time baked. DOM mutation of the meta tag after load is
+ *    ignored. Preload-side intervention runs after parse — too late.
+ *
+ *  - That leaves rewriting the served HTML. Vite's `transformIndexHtml` hook
+ *    is the canonical place. Scoped to `apply: "serve"` so production builds
+ *    are unaffected.
+ *
+ *  - WASM is in-page by deliberate architectural choice (see
+ *    `sdk/ui-vue/src/internal/service_factories.ts`: `PFrameSpec` is the
+ *    synchronous spec driver used inside Vue computed props; moving it to
+ *    IPC would break the sync reactive chain). So we cannot side-step the
+ *    CSP by relocating the WASM to preload/main.
+ *
+ * Narrowest fix: add `'wasm-unsafe-eval'` (WASM only, NOT JS `eval`). Do not
+ * use `'unsafe-eval'` here — that would also allow `eval()`. See the
+ * top-of-file follow-up block for the migration plan to remove this entirely.
+ */
+function relaxCspForDevWasm(): Plugin {
+  return {
+    name: "ts-builder:relax-csp-for-dev-wasm",
+    apply: "serve",
+    transformIndexHtml(html) {
+      const cspMetaRegex =
+        /<meta\s+http-equiv=["']Content-Security-Policy["']\s+content=["']([^"']*)["']\s*\/?>/i;
+      return html.replace(cspMetaRegex, (match, content: string) => {
+        if (content.includes("'wasm-unsafe-eval'")) return match;
+        const relaxed = content.replace(
+          /script-src([^;]*)/,
+          (m, srcs: string) => `script-src${srcs} 'wasm-unsafe-eval'`,
+        );
+        return `<meta http-equiv="Content-Security-Policy" content="${relaxed}" />`;
+      });
+    },
+  };
+}
 
 export function createViteDevConfig({ mode, command }: ConfigEnv): UserConfig {
   const isProd = mode === "production";
@@ -17,6 +121,7 @@ export function createViteDevConfig({ mode, command }: ConfigEnv): UserConfig {
     plugins: [
       vue(),
       ...(isServe ? [commonjs({ filter: (id) => id.includes("node_modules") })] : []),
+      relaxCspForDevWasm(),
     ],
     build: {
       target: ["chrome140"],
@@ -32,6 +137,18 @@ export function createViteDevConfig({ mode, command }: ConfigEnv): UserConfig {
     },
     define: {
       "import.meta.vitest": "undefined",
+      // `vite dev` does not strip `process.env.X` references the way the
+      // production rolldown build does. Transitive imports (e.g.
+      // `pf-spec-driver/logging.ts`, `pf-driver/logging.ts`) hit top-level
+      // `process.env.MI_LOG_PFRAMES` lookups and throw
+      // `ReferenceError: process is not defined` in the browser at module
+      // load, leaving the block view white.
+      //
+      // Inlining an empty object makes every `process.env.X` resolve to
+      // `undefined`. Side effect: `process.env.NODE_ENV` is also `undefined`
+      // in dev — fine for our current consumers, but flagged in the
+      // top-of-file follow-up block as a thing to tighten later.
+      "process.env": "({})",
     },
   };
 }

--- a/tools/ts-builder/src/configs/utils/createViteDevConfig.ts
+++ b/tools/ts-builder/src/configs/utils/createViteDevConfig.ts
@@ -93,8 +93,11 @@ function relaxCspForDevWasm(): Plugin {
     name: "ts-builder:relax-csp-for-dev-wasm",
     apply: "serve",
     transformIndexHtml(html) {
+      // CSP source keywords (`'self'`, `'wasm-unsafe-eval'`, ...) are
+      // single-quoted inside the double-quoted content attribute, so the
+      // content character class must exclude only the delimiter.
       const cspMetaRegex =
-        /<meta\s+http-equiv=["']Content-Security-Policy["']\s+content=["']([^"']*)["']\s*\/?>/i;
+        /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]*)"\s*\/?>/i;
       return html.replace(cspMetaRegex, (match, content: string) => {
         if (content.includes("'wasm-unsafe-eval'")) return match;
         const relaxed = content.replace(


### PR DESCRIPTION
## Summary

Adds dev-server sidecar mechanism: when block authors run `ts-builder serve --target block-ui`, ts-builder writes `<ui>/dist/.dev-server` (atomic JSON: `schema`, `url`, `pid`) signalling the URL where the live Vite dev server is reachable. The desktop app reads this file and routes the block view to Vite instead of the `block-ui://` folder protocol, enabling HMR. File is removed on clean shutdown; the desktop app HEAD-probes the URL before using it, so a stale sidecar safely falls back to folder mode.

- `serve --target block-ui` switches from spawning Vite to using its programmatic API so we can write the sidecar with the actually-bound URL (port may differ from 5173).
- `setupSidecarLifecycle()` registers `SIGINT`/`SIGTERM`/`SIGHUP`/`exit`/`uncaughtException` cleanup hooks *before* `createServer()` to win the race against Vite's own signal handlers.
- Dev-only Vite plugin (`apply: "serve"`) injects `'wasm-unsafe-eval'` into the index.html CSP meta tag so in-page WASM (used by `SpecDriver`) loads under dev. Production loads via `block-ui://` with `bypassCSP: true` and is unchanged. A `FOLLOW-UP` block at the top of `createViteDevConfig.ts` flags the migration debt (drop bypassCSP everywhere + security review).
- `define: { "process.env": "({})" }` so browser-side packages that runtime-reference `process.env.*` (e.g. `pf-spec-driver/logging.ts`) don't crash on load.

Consumer side (desktop app) lives in milaboratory/platforma-desktop-app#<TBD> on branch `feat/dev-server-sidecar`.

## Test plan

- [x] `pnpm build` clean
- [x] End-to-end smoke with `enter-numbers-v3` block: serve → desktop loads via Vite, label edit hot-reloads
- [x] Sidecar removed on Ctrl-C / process exit
- [x] Stale sidecar (process SIGKILL'd) → desktop HEAD probe fails → folder fallback
- [x] Port collision (5173 taken by renderer) → Vite picks 5174 → sidecar carries 5174 → desktop loads correct URL

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a dev-server sidecar mechanism for `ts-builder serve --target block-ui`: rather than spawning Vite as a child process, it uses Vite's programmatic API to discover the actual bound URL and atomically writes a `.dev-server` JSON file that the desktop app reads to enable HMR. It also adds a dev-only Vite plugin to relax the `script-src` CSP for WASM and a `process.env` shim to silence transitive Node references in the browser.

- **Sidecar lifecycle** (`dev-server-sidecar.ts`): registers SIGINT/SIGTERM/SIGHUP/`exit`/`uncaughtException` hooks before `vite.createServer()` to win the race against Vite's own signal handlers; atomic rename prevents half-written reads; `server.close()` is monkey-patched to cover programmatic/HMR restart paths.
- **CSP plugin** (`createViteDevConfig.ts`): `apply: \"serve\"` scoped plugin rewrites the `index.html` CSP meta tag to add `'wasm-unsafe-eval'`; accompanied by a detailed follow-up block listing migration debt.
- **`process.env` define**: not guarded by `isServe`, which may affect production `vite build` runs; the CSP regex also requires a specific attribute order that could silently miss non-canonical `<meta>` tags.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe to merge for dev-only use, but the unconditional process.env define warrants a check before landing.

The core sidecar mechanism is well-designed and the signal-ordering rationale is sound. The main concern is the process.env define being applied without an isServe guard — if createViteDevConfig is used for production builds, process.env.NODE_ENV will be undefined in bundles, potentially disabling dead-code elimination and leaving Vue dev warnings active in shipped builds. The CSP regex silently failing on non-canonical attribute order is a secondary concern.

tools/ts-builder/src/configs/utils/createViteDevConfig.ts — the unconditional process.env define and attribute-order-sensitive CSP regex both live here.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/ts-builder/src/configs/utils/createViteDevConfig.ts | Adds CSP-relaxation plugin and process.env shim; process.env define is not guarded by isServe, potentially affecting production builds |
| tools/ts-builder/src/commands/utils/dev-server-sidecar.ts | New sidecar lifecycle module — signal cleanup logic and exit codes need attention |
| tools/ts-builder/src/commands/serve.ts | Block-UI serve path refactored to programmatic Vite API with sidecar publishing; generally sound |
| tools/ts-builder/src/commands/utils/index.ts | Re-exports new dev-server-sidecar module; trivial barrel change |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Author as Block Author (CLI)
    participant TS as ts-builder serve
    participant SC as SidecarLifecycle
    participant Vite as Vite Dev Server
    participant FS as dist/.dev-server
    participant Desktop as Desktop App

    Author->>TS: ts-builder serve --target block-ui
    TS->>SC: setupSidecarLifecycle(sidecarPath)
    Note over SC: registers SIGINT/SIGTERM/SIGHUP/exit/uncaughtException
    TS->>Vite: vite.createServer(configFile, port, host)
    Vite-->>TS: server instance
    TS->>Vite: server.listen()
    Vite-->>TS: resolvedUrls.local[0]
    TS->>SC: "sidecar.publish({schema:1, url, pid})"
    SC->>FS: atomic write (tmp then rename)
    TS->>Vite: patch server.close() to call sidecar.remove()

    Desktop->>FS: read .dev-server JSON
    Desktop->>Vite: HEAD probe URL
    Vite-->>Desktop: 200 OK
    Desktop->>Vite: load block UI (HMR enabled)

    Author->>TS: Ctrl-C (SIGINT)
    TS->>SC: cleanup()
    SC->>FS: fs.unlink(.dev-server)
    TS->>TS: process.exit(0)

    Note over Desktop,FS: Stale sidecar (SIGKILL path): HEAD probe fails, fallback to block-ui:// folder protocol
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
tools/ts-builder/src/configs/utils/createViteDevConfig.ts:141-155
The `"process.env": "({})"` define is applied unconditionally — including when `command === "build"` and `mode === "production"`. In a production build, Vite internally sets `"process.env.NODE_ENV"` to `JSON.stringify(mode)`, but the broader `"process.env"` substitution replaces the entire object with `({})` before more-specific keys can win, making `process.env.NODE_ENV` resolve to `undefined`. Libraries like Vue use `process.env.NODE_ENV === "production"` for dead-code elimination; leaving it `undefined` can produce larger, non-optimised production bundles with dev warnings active. Guard this define with `isServe` so it only fires during `vite dev`.

```suggestion
    define: {
      "import.meta.vitest": "undefined",
      // `vite dev` does not strip `process.env.X` references the way the
      // production rolldown build does. Transitive imports (e.g.
      // `pf-spec-driver/logging.ts`, `pf-driver/logging.ts`) hit top-level
      // `process.env.MI_LOG_PFRAMES` lookups and throw
      // `ReferenceError: process is not defined` in the browser at module
      // load, leaving the block view white.
      //
      // Inlining an empty object makes every `process.env.X` resolve to
      // `undefined`. Side effect: `process.env.NODE_ENV` is also `undefined`
      // in dev — fine for our current consumers, but flagged in the
      // top-of-file follow-up block as a thing to tighten later.
      ...(isServe ? { "process.env": "({})" } : {}),
    },
```

### Issue 2 of 4
tools/ts-builder/src/commands/utils/dev-server-sidecar.ts:57-64
The signal handlers always call `process.exit(0)`, making SIGINT/SIGTERM look like a clean success to any parent process or shell. The conventional exit codes are 130 for SIGINT, 143 for SIGTERM, and 129 for SIGHUP (128 + signal number). pnpm scripts, CI systems, and process supervisors that inspect `$?` may mis-classify the termination. The idiomatic fix is to remove the handler and re-kill the process with the original signal, letting the kernel apply the default disposition.

```suggestion
  const exitOn = (signal: NodeJS.Signals) => {
    const handler = () => {
      cleanup();
      // Re-raise the signal with the kernel's default disposition so the
      // shell / pnpm sees the conventional exit status (130 for SIGINT,
      // 143 for SIGTERM, 129 for SIGHUP).
      process.removeListener(signal, handler);
      process.kill(process.pid, signal);
    };
    process.on(signal, handler);
  };
```

### Issue 3 of 4
tools/ts-builder/src/configs/utils/createViteDevConfig.ts:99-100
The CSP regex matches only when `http-equiv` appears before `content`. HTML attributes can appear in any order; if a block's `index.html` writes `<meta content="…" http-equiv="Content-Security-Policy">`, the regex silently misses the tag and WASM fails to load in dev without any warning.

```suggestion
      // Match regardless of attribute order (http-equiv before or after content).
      const cspMetaRegex =
        /<meta\b[^>]*\bhttp-equiv="Content-Security-Policy"[^>]*\bcontent="([^"]*)"[^>]*\/?>/i;
```

### Issue 4 of 4
tools/ts-builder/src/commands/serve.ts:108-111
**Server left running without sidecar on missing URL**

When `server.resolvedUrls?.local?.[0]` is undefined, the function returns early but the Vite server remains listening. The patched `server.close` that removes the sidecar is never installed, so if a test harness calls `server.close()` directly the server shuts down but cleanup wiring is absent. Consider closing the server explicitly and exiting with an error when no URL is reported.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ts-builder): register sidecar cleanu..."](https://github.com/milaboratory/platforma/commit/b17e5bdd34a7ce139cd78270758c6c6985fc22c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33901446)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->