### PR TITLE
feat(pf-driver): prepare for next pframes-rs-node addon revision

### DIFF
--- a/.changeset/pframes-prepare.md
+++ b/.changeset/pframes-prepare.md
@@ -1,0 +1,30 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+"@milaboratories/pf-driver": patch
+---
+
+Prepare pf-driver for the next pframes-rs-node addon revision.
+
+- Declare V5 addon interfaces (`PFrameFactoryAPIV5`, `PTableV9`,
+  `PFrameReadAPIV12`, `PFrameV14`, `PFrameFactoryV5`) alongside the V4
+  ones so the next addon publish has a concrete TS contract to
+  implement. The current V4 surface is unchanged.
+- Cache the WASM-spec frame on `PFrameHolder` and route
+  `driver.findColumns`, `getColumnSpec`, `listColumns` through it
+  instead of round-tripping through the addon. `getColumnSpec` and
+  `listColumns` now return only value-typed columns — the queryable
+  subset that exec can plan against.
+- Lower V1 `createPTable` inputs via WASM-spec at construction time
+  and unify the def shape: `FullPTableDef` is now flat
+  `{ pFrameHandle, tableSpec, dataQuery }` for both V1 and V2 entry
+  points. The recursive sort/filter peeling in `createNewResourceV1`
+  is dropped; the existing `createTableV2` path materialises the
+  lowered query end-to-end.
+- Switch the `driver.getSpec` PTable read to a JS-side lookup from the
+  cached def — no addon roundtrip.
+
+After this PR every existing V4 addon call still works; pf-driver
+just stops needing several of them. The remaining cutover (drop V4
+interface declarations, switch to V5 addon calls, send pre-resolved
+indices for `getUniqueValues`, bulk `addColumns`) lands in a follow-up
+once the addon publishes V5.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
@@ -1,6 +1,8 @@
 import type {
+  AxisValueType,
   BinaryPartitionedDataInfo,
   Branded,
+  ColumnValueType,
   JsonDataInfo,
   JsonPartitionedDataInfo,
   ParquetChunk,
@@ -70,6 +72,48 @@ export interface PFrameFactoryAPIV4 extends Disposable {
   setColumnData(
     columnId: PObjectId,
     dataInfo: DataInfo<PFrameBlobId>,
+    options?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<void>;
+
+  /** Releases all the data previously added to PFrame using methods above,
+   * any interactions with disposed PFrame will result in exception */
+  dispose(): void;
+}
+
+/**
+ * Structural type information needed by the data side: axis value
+ * types and column value types, in their canonical order. Mirrors
+ * the bridge-side `TypeSpec`.
+ */
+export interface PColumnTypeSpec {
+  readonly axes: AxisValueType[];
+  readonly columns: ColumnValueType[];
+}
+
+/** Single column entry for {@link PFrameFactoryAPIV5.addColumns}. */
+export interface AddColumnEntry {
+  /** Unique column identifier within the PFrame. */
+  readonly id: PObjectId;
+  /** Structural type info (axes / column value types). */
+  readonly typeSpec: PColumnTypeSpec;
+  /** Data info for the column. */
+  readonly data: DataInfo<PFrameBlobId>;
+}
+
+/** API for populating a PFrame with columns and a data source. */
+export interface PFrameFactoryAPIV5 extends Disposable {
+  /** Associates data source with this PFrame. */
+  setDataSource(dataSource: PFrameDataSourceV2): void;
+
+  /**
+   * Registers all PColumns at once: specs are recorded and data info
+   * is attached atomically. For parquet data info, schema resolution
+   * via network is performed during this call.
+   */
+  addColumns(
+    columns: AddColumnEntry[],
     options?: {
       signal?: AbortSignal;
     },

--- a/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
@@ -87,7 +87,7 @@ export interface PFrameFactoryAPIV4 extends Disposable {
  * types and column value types, in their canonical order. Mirrors
  * the bridge-side `TypeSpec`.
  */
-export interface PColumnTypeSpec {
+export interface PColumnValueTypeSpec {
   readonly axes: AxisValueType[];
   readonly columns: ColumnValueType[];
 }
@@ -97,7 +97,7 @@ export interface AddColumnEntry {
   /** Unique column identifier within the PFrame. */
   readonly id: PObjectId;
   /** Structural type info (axes / column value types). */
-  readonly typeSpec: PColumnTypeSpec;
+  readonly typeSpec: PColumnValueTypeSpec;
   /** Data info for the column. */
   readonly data: DataInfo<PFrameBlobId>;
 }

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -10,10 +10,11 @@ import type {
   UniqueValuesRequest,
   UniqueValuesResponse,
   DataQuery,
+  DataQueryBooleanExpression,
   PTableColumnSpec,
 } from "@milaboratories/pl-model-common";
 import type { CreateTableRequestV4 } from "./create_table";
-import type { PTableV8 } from "./table";
+import type { PTableV8, PTableV9 } from "./table";
 import type { PTableId } from "./common";
 
 /** Read interface exposed by PFrames library */
@@ -55,6 +56,52 @@ export interface PFrameReadAPIV11 {
   /** Calculate set of unique values for a specific axis for the filtered set of records */
   getUniqueValues(
     request: UniqueValuesRequest,
+    ops?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<UniqueValuesResponse>;
+}
+
+/**
+ * V2 unique-values request. Axis and filter references are
+ * pre-resolved to numeric indices; no selector ids cross the API
+ * boundary. Each filter is a boolean predicate that must evaluate to
+ * true for the row to be included.
+ */
+export interface UniqueValuesRequestV2 {
+  /** Target column. */
+  readonly columnId: PObjectId;
+
+  /**
+   * Target axis (pre-resolved index into the column's axes).
+   * When omitted, unique values are collected from the column itself.
+   */
+  readonly axisIndex?: number;
+
+  /** Pre-resolved boolean predicates applied before collecting values. */
+  readonly filters: DataQueryBooleanExpression[];
+
+  /** Max number of values to return. Overflow is reported in the response. */
+  readonly limit: number;
+}
+
+/**
+ * Read interface exposed by PFrames library.
+ *
+ * Spec-side operations (finding columns, listing columns, retrieving
+ * column specs, computing axis integrations) are not part of this
+ * surface — callers cache column specs themselves or route through
+ * WASM-spec. The data-side `createTableV2` accepts a pre-lowered
+ * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
+ * {@link UniqueValuesRequestV2}.
+ */
+export interface PFrameReadAPIV12 {
+  /** Creates table from a pre-lowered data query. */
+  createTableV2(tableId: PTableId, dataQuery: DataQuery): PTableV9;
+
+  /** Calculate set of unique values for a specific axis for the filtered set of records. */
+  getUniqueValues(
+    request: UniqueValuesRequestV2,
     ops?: {
       signal?: AbortSignal;
     },

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,9 +1,12 @@
-import type { PFrameFactoryAPIV4 } from "./api_factory";
-import type { PFrameReadAPIV11 } from "./api_read";
+import type { PFrameFactoryAPIV4, PFrameFactoryAPIV5 } from "./api_factory";
+import type { PFrameReadAPIV11, PFrameReadAPIV12 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
 export interface PFrameV13 extends PFrameFactoryAPIV4, PFrameReadAPIV11 {}
+
+/** Full PFrame surface — factory operations plus data-side reads. */
+export interface PFrameV14 extends PFrameFactoryAPIV5, PFrameReadAPIV12 {}
 
 export type PFrameOptionsV2 = {
   /** PFrame ID for logging purposes */
@@ -21,6 +24,24 @@ export interface PFrameFactoryV4 {
    * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
    */
   createPFrame(options: PFrameOptionsV2): PFrameV13;
+
+  /**
+   * Dump active allocations from all PFrames instances in pprof format.
+   * The result of this function should be saved as `profile.pb.gz`.
+   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
+   * to view the allocation flamechart.
+   * @warning This method will always reject on Windows!
+   */
+  pprofDump: () => Promise<Uint8Array>;
+}
+
+/** PFrame management functions exposed by the PFrame module. */
+export interface PFrameFactoryV5 {
+  /**
+   * Create a new PFrame instance.
+   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
+   */
+  createPFrame(options: PFrameOptionsV2): PFrameV14;
 
   /**
    * Dump active allocations from all PFrames instances in pprof format.

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -68,3 +68,57 @@ export interface PTableV8 extends Disposable {
   /** Deallocates all underlying resources */
   dispose(): void;
 }
+
+/**
+ * Table view returned by `createTableV2`, `filter`, and `sort`.
+ *
+ * PTable can be thought as having a composite primary key, consisting
+ * of axes, and a set of data columns derived from PColumn values.
+ * The table's column spec is owned by the caller — selector → index
+ * resolution runs on the caller side via WASM-spec.
+ */
+export interface PTableV9 extends Disposable {
+  /**
+   * Get PTable disk footprint in bytes.
+   *
+   * @param ops.withPredecessors When true, the footprint includes
+   *   every registered predecessor table reachable through the
+   *   query lineage. When false or omitted, only this table's own
+   *   materialised data is counted.
+   *
+   * Warning: This call materializes the join.
+   */
+  getFootprint(ops?: { withPredecessors?: boolean; signal?: AbortSignal }): Promise<number>;
+
+  /**
+   * Unified table shape
+   * Warning: This call materializes the join.
+   */
+  getShape(ops?: { signal?: AbortSignal }): Promise<PTableShape>;
+
+  /**
+   * Retrieve the data from the table. To retrieve only data required, it can be
+   * sliced both horizontally ({@link columnIndices}) and vertically
+   * ({@link range}).
+   * This call materializes the join.
+   *
+   * @param columnIndices unified indices of columns to be retrieved
+   * @param range optionally limit the range of records to retrieve
+   * */
+  getData(
+    columnIndices: number[],
+    ops?: {
+      range?: TableRange;
+      signal?: AbortSignal;
+    },
+  ): Promise<PTableVector[]>;
+
+  /** Filters the table and returns new PTable instance */
+  filter(tableId: PTableId, request: PTableRecordFilter[]): PTableV9;
+
+  /** Sorts the table and returns new PTable instance. */
+  sort(tableId: PTableId, request: PTableSorting[]): PTableV9;
+
+  /** Deallocates all underlying resources */
+  dispose(): void;
+}

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -71,7 +71,6 @@ import {
   PTableCachePlainOpsDefaults,
   type PTableCachePlainOps,
 } from "./ptable_cache_plain";
-import { createPFrame as createSpecFrame } from "@milaboratories/pframes-rs-wasm";
 
 export interface LocalBlobProvider<TreeEntry extends JsonSerializable>
   extends PoolLocalBlobProvider<TreeEntry>, AsyncDisposable {}
@@ -194,26 +193,31 @@ export class AbstractPFrameDriver<
   }
 
   public createPTable(rawDef: PTableDef<PColumn<PColumnData>>): PoolEntry<PTableHandle> {
-    using pFrameGuard = new PoolEntryGuard(this.createPFrame(extractAllColumns(rawDef.src)));
+    const columns = uniqueBy(extractAllColumns(rawDef.src), (c) => c.id);
+    using pFrameGuard = new PoolEntryGuard(this.createPFrame(columns));
     const sortedDef = sortPTableDef(
       migrateTableFilter(
         mapPTableDef(rawDef, (c) => c.id),
         this.logger,
       ),
     );
-    const pTableEntry = this.pTableDefs.acquire({
-      type: "v1",
-      def: sortedDef,
-      pFrameHandle: pFrameGuard.key,
-    });
+    const pFrameSpec = this.pFrames.getByKey(pFrameGuard.key).pFrameSpec;
+    using pTableGuard = new PoolEntryGuard(
+      this.pTableDefs.acquireFromLegacy({
+        pFrameHandle: pFrameGuard.key,
+        def: sortedDef,
+        pFrameSpec,
+      }).entry,
+    );
     if (logPFrames()) {
       this.logger(
         "info",
-        `Create PTable call (pFrameHandle = ${pFrameGuard.key}; pTableHandle = ${pTableEntry.key})`,
+        `Create PTable call (pFrameHandle = ${pFrameGuard.key}; pTableHandle = ${pTableGuard.key})`,
       );
     }
 
     const pFrameEntry = pFrameGuard.keep();
+    const pTableEntry = pTableGuard.keep();
     const unref = () => {
       pTableEntry.unref();
       pFrameEntry.unref();
@@ -228,38 +232,27 @@ export class AbstractPFrameDriver<
 
   public createPTableV2(def: PTableDefV2<PColumn<PColumnData>>): PoolEntry<PTableHandle> {
     const columns = uniqueBy(collectSpecQueryColumns(def.query), (c) => c.id);
-    const columnsMap = columns.reduce(
-      (acc, col) => ((acc[col.id] = col.spec), acc),
-      {} as Record<string, PColumnSpec>,
-    );
-
     using pFrameGuard = new PoolEntryGuard(this.createPFrame(columns));
-    const ValueTypes = new Set(Object.values(ValueType));
-    const specColumnsMap = Object.fromEntries(
-      Object.entries(columnsMap)
-        .filter(([, spec]) => ValueTypes.has(spec.valueType))
-        .map(([id, spec]) => [id, resolveAnnotationParents(spec)]),
-    );
-    const specFrame = createSpecFrame(specColumnsMap);
+    const pFrameSpec = this.pFrames.getByKey(pFrameGuard.key).pFrameSpec;
     const sortedQuery = sortSpecQuery(mapSpecQueryColumns(def.query, (c) => c.id));
-    const { tableSpec, dataQuery } = specFrame.evaluateQuery(sortedQuery);
+    const { tableSpec, dataQuery } = pFrameSpec.evaluateQuery(sortedQuery);
 
-    const pTableEntry = this.pTableDefs.acquire({
-      type: "v2",
-      pFrameHandle: pFrameGuard.key,
-      def: {
+    using pTableGuard = new PoolEntryGuard(
+      this.pTableDefs.acquire({
+        pFrameHandle: pFrameGuard.key,
         tableSpec,
         dataQuery,
-      },
-    });
+      }),
+    );
     if (logPFrames()) {
       this.logger(
         "info",
-        `Create PTable call (pFrameHandle = ${pFrameGuard.key}; pTableHandle = ${pTableEntry.key})`,
+        `Create PTable call (pFrameHandle = ${pFrameGuard.key}; pTableHandle = ${pTableGuard.key})`,
       );
     }
 
     const pFrameEntry = pFrameGuard.keep();
+    const pTableEntry = pTableGuard.keep();
     const unref = () => {
       pTableEntry.unref();
       pFrameEntry.unref();
@@ -293,7 +286,7 @@ export class AbstractPFrameDriver<
     return await this.tableConcurrencyLimiter.run(async () => {
       const shape = await pTable.getShape({ signal: combinedSignal });
       const clippedRange = clipRange(options.range, shape);
-      const specs = pTable.getSpec();
+      const specs = def.tableSpec;
       const separator = options.format === "tsv" ? "\t" : ",";
 
       const iterable = streamPTableRows({
@@ -371,10 +364,8 @@ export class AbstractPFrameDriver<
           : [],
     };
 
-    const { pFramePromise } = this.pFrames.getByKey(handle);
-    const pFrame = await pFramePromise;
-
-    const response = await pFrame.findColumns(iRequest);
+    const { pFrameSpec } = this.pFrames.getByKey(handle);
+    const response = pFrameSpec.findColumns(iRequest);
     return {
       hits: response.hits
         .filter(
@@ -395,15 +386,14 @@ export class AbstractPFrameDriver<
     handle: PFrameHandle,
     columnId: PObjectId,
   ): Promise<PColumnSpec | null> {
-    const { pFramePromise } = this.pFrames.getByKey(handle);
-    const pFrame = await pFramePromise;
-    return await pFrame.getColumnSpec(columnId);
+    const { pFrameSpec } = this.pFrames.getByKey(handle);
+    const info = pFrameSpec.listColumns().find((c) => c.columnId === columnId);
+    return info?.spec ?? null;
   }
 
   public async listColumns(handle: PFrameHandle): Promise<PColumnIdAndSpec[]> {
-    const { pFramePromise } = this.pFrames.getByKey(handle);
-    const pFrame = await pFramePromise;
-    return await pFrame.listColumns();
+    const { pFrameSpec } = this.pFrames.getByKey(handle);
+    return pFrameSpec.listColumns().map(({ columnId, spec }) => ({ columnId, spec }));
   }
 
   public async calculateTableData(
@@ -419,13 +409,15 @@ export class AbstractPFrameDriver<
       );
     }
 
-    using tableGuard = new PoolEntryGuard(
-      this.pTables.acquire({
-        type: "v1",
-        pFrameHandle: handle,
-        def: sortPTableDef(migrateTableFilter(request, this.logger)),
-      }),
-    );
+    const { pFrameSpec } = this.pFrames.getByKey(handle);
+    const sortedDef = sortPTableDef(migrateTableFilter(request, this.logger));
+    const { def, entry } = this.pTables.acquireFromLegacy({
+      pFrameHandle: handle,
+      def: sortedDef,
+      pFrameSpec,
+    });
+    using tableGuard = new PoolEntryGuard(entry);
+    const tableSpec = def.tableSpec;
     const { pTablePromise, disposeSignal } = tableGuard.resource;
     const pTable = await pTablePromise;
 
@@ -434,8 +426,7 @@ export class AbstractPFrameDriver<
       // TODO: throw error when more then 150k rows is requested
       // after pf-plots migration to stream API
 
-      const spec = pTable.getSpec();
-      const data = await pTable.getData([...spec.keys()], {
+      const data = await pTable.getData([...tableSpec.keys()], {
         range,
         signal: combinedSignal,
       });
@@ -445,7 +436,7 @@ export class AbstractPFrameDriver<
       });
       this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
 
-      return spec.map((spec, i) => ({
+      return tableSpec.map((spec, i) => ({
         spec: spec,
         data: data[i],
       }));
@@ -464,12 +455,12 @@ export class AbstractPFrameDriver<
       );
     }
 
-    const { pFramePromise, disposeSignal } = this.pFrames.getByKey(handle);
-    const pFrame = await pFramePromise;
+    const { pFrameDataPromise, disposeSignal } = this.pFrames.getByKey(handle);
+    const pFrameData = await pFrameDataPromise;
 
     const combinedSignal = AbortSignal.any([signal, disposeSignal].filter((s) => !!s));
     return await this.frameConcurrencyLimiter.run(async () => {
-      return await pFrame.getUniqueValues(
+      return await pFrameData.getUniqueValues(
         {
           ...request,
           filters: migrateFilters(request.filters, this.logger),
@@ -487,12 +478,7 @@ export class AbstractPFrameDriver<
 
   public async getSpec(handle: PTableHandle): Promise<PTableColumnSpec[]> {
     const { def } = this.pTableDefs.getByKey(handle);
-    using table = this.pTables.acquire(def);
-
-    const { pTablePromise } = table.resource;
-    const pTable = await pTablePromise;
-
-    return pTable.getSpec();
+    return def.tableSpec;
   }
 
   public async getShape(handle: PTableHandle, signal?: AbortSignal): Promise<PTableShape> {

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -59,88 +59,105 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
     }
     this.pFrameSpec = createPFrameSpec(specColumnsMap);
 
-    const makeLocalBlobId = (blob: TreeEntry): PFrameInternal.PFrameBlobId => {
-      const localBlob = this.localBlobProvider.acquire(blob);
-      this.localBlobs.push(localBlob);
-      return localBlob.key;
-    };
-
-    const makeRemoteBlobId = (blob: TreeEntry): PFrameInternal.PFrameBlobId => {
-      const remoteBlob = this.remoteBlobProvider.acquire(blob);
-      this.remoteBlobs.push(remoteBlob);
-      return `${remoteBlob.key}${PFrameInternal.ParquetExtension}` as PFrameInternal.PFrameBlobId;
-    };
-
-    const mapColumnData = (
-      data: PFrameInternal.DataInfo<TreeEntry>,
-    ): PFrameInternal.DataInfo<PFrameInternal.PFrameBlobId> => {
-      switch (data.type) {
-        case "Json":
-          return { ...data };
-        case "JsonPartitioned":
-          return {
-            ...data,
-            parts: mapValues(data.parts, makeLocalBlobId),
-          };
-        case "BinaryPartitioned":
-          return {
-            ...data,
-            parts: mapValues(data.parts, (v) => ({
-              index: makeLocalBlobId(v.index),
-              values: makeLocalBlobId(v.values),
-            })),
-          };
-        case "ParquetPartitioned":
-          return {
-            ...data,
-            parts: mapValues(data.parts, (v) => ({
-              ...v,
-              data: makeRemoteBlobId(v.data),
-            })),
-          };
-        default:
-          assertNever(data);
-      }
-    };
-
-    const jsonifiedColumns = columns.map((column) => ({
-      ...column,
-      data: mapColumnData(column.data),
-    }));
-
     try {
+      const makeLocalBlobId = (blob: TreeEntry): PFrameInternal.PFrameBlobId => {
+        const localBlob = this.localBlobProvider.acquire(blob);
+        this.localBlobs.push(localBlob);
+        return localBlob.key;
+      };
+
+      const makeRemoteBlobId = (blob: TreeEntry): PFrameInternal.PFrameBlobId => {
+        const remoteBlob = this.remoteBlobProvider.acquire(blob);
+        this.remoteBlobs.push(remoteBlob);
+        return `${remoteBlob.key}${PFrameInternal.ParquetExtension}` as PFrameInternal.PFrameBlobId;
+      };
+
+      const mapColumnData = (
+        data: PFrameInternal.DataInfo<TreeEntry>,
+      ): PFrameInternal.DataInfo<PFrameInternal.PFrameBlobId> => {
+        switch (data.type) {
+          case "Json":
+            return { ...data };
+          case "JsonPartitioned":
+            return {
+              ...data,
+              parts: mapValues(data.parts, makeLocalBlobId),
+            };
+          case "BinaryPartitioned":
+            return {
+              ...data,
+              parts: mapValues(data.parts, (v) => ({
+                index: makeLocalBlobId(v.index),
+                values: makeLocalBlobId(v.values),
+              })),
+            };
+          case "ParquetPartitioned":
+            return {
+              ...data,
+              parts: mapValues(data.parts, (v) => ({
+                ...v,
+                data: makeRemoteBlobId(v.data),
+              })),
+            };
+          default:
+            assertNever(data);
+        }
+      };
+
+      const jsonifiedColumns = columns.map((column) => ({
+        ...column,
+        data: mapColumnData(column.data),
+      }));
+
       const pFrameData = PFrameFactory.createPFrame({ frameId, spillPath: this.spillPath, logger });
-      pFrameData.setDataSource({
-        ...this.localBlobProvider.makeDataSource(this.disposeSignal),
-        parquetServer: this.remoteBlobProvider.httpServerInfo(),
-      });
-
       const promises: Promise<void>[] = [];
-      for (const column of jsonifiedColumns) {
-        pFrameData.addColumnSpec(column.id, column.spec);
-        promises.push(
-          pFrameData.setColumnData(column.id, column.data, { signal: this.disposeSignal }),
-        );
-      }
-
-      this.pFrameDataPromise = Promise.all(promises)
-        .then(() => pFrameData)
-        .catch((err) => {
-          this.dispose();
-          pFrameData.dispose();
-          const error = new PFrameDriverError("PFrame creation failed asynchronously");
-          error.cause = new Error(
-            `PFrame cannot be created from columns: ${JSON.stringify(jsonifiedColumns)}`,
-            { cause: ensureError(err) },
-          );
-          throw error;
+      try {
+        pFrameData.setDataSource({
+          ...this.localBlobProvider.makeDataSource(this.disposeSignal),
+          parquetServer: this.remoteBlobProvider.httpServerInfo(),
         });
+
+        for (const column of jsonifiedColumns) {
+          pFrameData.addColumnSpec(column.id, column.spec);
+          promises.push(
+            pFrameData.setColumnData(column.id, column.data, { signal: this.disposeSignal }),
+          );
+        }
+
+        this.pFrameDataPromise = Promise.all(promises)
+          .then(() => pFrameData)
+          .catch((err) => {
+            this.dispose();
+            pFrameData.dispose();
+            const error = new PFrameDriverError("PFrame creation failed asynchronously");
+            error.cause = new Error(
+              `PFrame cannot be created from columns: ${JSON.stringify(jsonifiedColumns)}`,
+              { cause: ensureError(err) },
+            );
+            throw error;
+          });
+      } catch (err: unknown) {
+        // setDataSource / addColumnSpec / setColumnData threw synchronously
+        // before pFrameDataPromise was assigned — dispose the addon's
+        // pFrameData explicitly (the dispose() path can't reach it yet).
+        // `allSettled` attaches handlers to any in-flight setColumnData
+        // promises so they don't trigger unhandled-rejection warnings
+        // when the dispose below rejects them.
+        void Promise.allSettled(promises);
+        pFrameData.dispose();
+        throw err;
+      }
     } catch (err: unknown) {
+      // Release everything allocated so far in this constructor:
+      // acquired blobs, the WASM spec frame, and the abort signal.
+      this.abortController.abort();
+      this.localBlobs.forEach((entry) => entry.unref());
+      this.remoteBlobs.forEach((entry) => entry.unref());
+      this.pFrameSpec[Symbol.dispose]();
       const error = new PFrameDriverError("PFrame creation failed synchronously");
-      error.cause = new Error(
-        `PFrame cannot be created from columns: ${JSON.stringify(jsonifiedColumns)}`,
-        { cause: ensureError(err) },
-      );
+      error.cause = new Error(`PFrame cannot be created from columns: ${JSON.stringify(columns)}`, {
+        cause: ensureError(err),
+      });
       throw error;
     }
   }

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -5,13 +5,17 @@ import {
   ensureError,
   mapPObjectData,
   PFrameDriverError,
+  ValueType,
+  resolveAnnotationParents,
   type JsonSerializable,
   type PColumn,
+  type PColumnSpec,
   type PFrameHandle,
 } from "@milaboratories/pl-model-common";
 import { hashJson, PFrameInternal } from "@milaboratories/pl-model-middle-layer";
 import { RefCountPoolBase, type PoolEntry } from "@milaboratories/helpers";
 import { PFrameFactory } from "@milaboratories/pframes-rs-node";
+import { createPFrame as createPFrameSpec } from "@milaboratories/pframes-rs-wasm";
 import { mapValues } from "es-toolkit";
 import { logPFrames } from "./logging";
 
@@ -26,7 +30,13 @@ export interface RemoteBlobProvider<TreeEntry extends JsonSerializable> {
 }
 
 export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposable {
-  public readonly pFramePromise: Promise<PFrameInternal.PFrameV13>;
+  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV13>;
+  /**
+   * WASM-spec frame built from this PFrame's columns. Source of truth
+   * for spec-side operations: column discovery, selector resolution,
+   * legacy-query lowering.
+   */
+  public readonly pFrameSpec: PFrameInternal.PFrameWasmV3;
   private readonly abortController = new AbortController();
 
   private readonly localBlobs: PoolEntry<PFrameInternal.PFrameBlobId>[] = [];
@@ -40,6 +50,15 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
     private readonly spillPath: string,
     columns: PColumn<PFrameInternal.DataInfo<TreeEntry>>[],
   ) {
+    const ValueTypes = new Set(Object.values(ValueType));
+    const specColumnsMap: Record<string, PColumnSpec> = {};
+    for (const c of columns) {
+      if (ValueTypes.has(c.spec.valueType)) {
+        specColumnsMap[c.id] = resolveAnnotationParents(c.spec);
+      }
+    }
+    this.pFrameSpec = createPFrameSpec(specColumnsMap);
+
     const makeLocalBlobId = (blob: TreeEntry): PFrameInternal.PFrameBlobId => {
       const localBlob = this.localBlobProvider.acquire(blob);
       this.localBlobs.push(localBlob);
@@ -90,23 +109,25 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
     }));
 
     try {
-      const pFrame = PFrameFactory.createPFrame({ frameId, spillPath: this.spillPath, logger });
-      pFrame.setDataSource({
+      const pFrameData = PFrameFactory.createPFrame({ frameId, spillPath: this.spillPath, logger });
+      pFrameData.setDataSource({
         ...this.localBlobProvider.makeDataSource(this.disposeSignal),
         parquetServer: this.remoteBlobProvider.httpServerInfo(),
       });
 
       const promises: Promise<void>[] = [];
       for (const column of jsonifiedColumns) {
-        pFrame.addColumnSpec(column.id, column.spec);
-        promises.push(pFrame.setColumnData(column.id, column.data, { signal: this.disposeSignal }));
+        pFrameData.addColumnSpec(column.id, column.spec);
+        promises.push(
+          pFrameData.setColumnData(column.id, column.data, { signal: this.disposeSignal }),
+        );
       }
 
-      this.pFramePromise = Promise.all(promises)
-        .then(() => pFrame)
+      this.pFrameDataPromise = Promise.all(promises)
+        .then(() => pFrameData)
         .catch((err) => {
           this.dispose();
-          pFrame.dispose();
+          pFrameData.dispose();
           const error = new PFrameDriverError("PFrame creation failed asynchronously");
           error.cause = new Error(
             `PFrame cannot be created from columns: ${JSON.stringify(jsonifiedColumns)}`,
@@ -132,15 +153,16 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
     this.abortController.abort();
     this.localBlobs.forEach((entry) => entry.unref());
     this.remoteBlobs.forEach((entry) => entry.unref());
+    this.pFrameSpec[Symbol.dispose]();
+    void this.pFrameDataPromise
+      .then((pFrameData) => pFrameData.dispose())
+      .catch(() => {
+        /* mute error */
+      });
   }
 
   [Symbol.dispose](): void {
     this.dispose();
-    void this.pFramePromise
-      .then((pFrame) => pFrame.dispose())
-      .catch(() => {
-        /* mute error */
-      });
   }
 }
 

--- a/lib/node/pf-driver/src/ptable_def_pool.ts
+++ b/lib/node/pf-driver/src/ptable_def_pool.ts
@@ -1,9 +1,15 @@
-import { PFrameDriverError, type PTableHandle } from "@milaboratories/pl-model-common";
+import {
+  PFrameDriverError,
+  type PFrameHandle,
+  type PObjectId,
+  type PTableDef,
+  type PTableHandle,
+} from "@milaboratories/pl-model-common";
 import type { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
-import { RefCountPoolBase } from "@milaboratories/helpers";
+import { RefCountPoolBase, type PoolEntry } from "@milaboratories/helpers";
 import { logPFrames } from "./logging";
 import type { FullPTableDef } from "./ptable_shared";
-import { stableKeyFromFullPTableDef } from "./ptable_shared";
+import { buildFullPTableDefFromLegacy, stableKeyFromFullPTableDef } from "./ptable_shared";
 
 export class PTableDefHolder implements Disposable {
   private readonly abortController = new AbortController();
@@ -51,5 +57,22 @@ export class PTableDefPool extends RefCountPoolBase<FullPTableDef, PTableHandle,
       throw error;
     }
     return resource;
+  }
+
+  /**
+   * Acquire a def from a legacy `PTableDef` + column specs map.
+   * Lowers the input via WASM-spec and stores the resulting
+   * `{ tableSpec, dataQuery }` shape. Returns the lowered def
+   * alongside the pool entry — callers that need `tableSpec`
+   * (e.g. `calculateTableData`) read it from `def.tableSpec`
+   * without re-deriving.
+   */
+  public acquireFromLegacy(opts: {
+    pFrameHandle: PFrameHandle;
+    def: PTableDef<PObjectId>;
+    pFrameSpec: PFrameInternal.PFrameWasmV3;
+  }): { def: FullPTableDef; entry: PoolEntry<PTableHandle> } {
+    const def = buildFullPTableDefFromLegacy(opts);
+    return { def, entry: this.acquire(def) };
   }
 }

--- a/lib/node/pf-driver/src/ptable_pool.ts
+++ b/lib/node/pf-driver/src/ptable_pool.ts
@@ -1,12 +1,10 @@
 import {
-  assertNever,
   bigintReplacer,
   PFrameDriverError,
   type PFrameHandle,
+  type PTableDef,
   type PTableHandle,
-  type JoinEntry,
   type JsonSerializable,
-  type PColumnValue,
   type PObjectId,
 } from "@milaboratories/pl-model-common";
 import type { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
@@ -14,8 +12,7 @@ import { RefCountPoolBase, type PoolEntry } from "@milaboratories/helpers";
 import { logPFrames } from "./logging";
 import type { PFramePool } from "./pframe_pool";
 import {
-  FullPTableDefV1,
-  FullPTableDefV2,
+  buildFullPTableDefFromLegacy,
   stableKeyFromFullPTableDef,
   type FullPTableDef,
 } from "./ptable_shared";
@@ -77,75 +74,16 @@ export class PTablePool<TreeEntry extends JsonSerializable> extends RefCountPool
       );
     }
 
-    switch (params.type) {
-      case "v1":
-        return this.createNewResourceV1(params, key);
-      case "v2":
-        return this.createNewResourceV2(params, key);
-      default:
-        // @ts-expect-error `params.type` is a string, but we want to make sure all cases are handled
-        throw new PFrameDriverError(`Unsupported FullPTableDef type: ${params.type}`);
-    }
-  }
-
-  protected createNewResourceV1(params: FullPTableDefV1, key: PTableHandle): PTableHolder {
-    const { def, pFrameHandle } = params;
-    const { pFramePromise, disposeSignal } = this.pFrames.getByKey(pFrameHandle);
-
-    const defDisposeSignal = this.pTableDefs.tryGetByKey(key)?.disposeSignal;
-    const combinedSignal = AbortSignal.any([disposeSignal, defDisposeSignal].filter((s) => !!s));
-
-    // 3. Sort
-    if (def.sorting.length > 0) {
-      const predecessor = this.acquire({
-        ...params,
-        def: {
-          ...def,
-          sorting: [],
-        },
-      });
-      const {
-        resource: { pTablePromise },
-      } = predecessor;
-      const sortedTable = pTablePromise.then((pTable) => pTable.sort(key, def.sorting));
-      return new PTableHolder(pFrameHandle, combinedSignal, sortedTable, predecessor);
-    }
-
-    // 2. Filter (except the case with artificial columns where cartesian creates too many rows)
-    if (!hasArtificialColumns(def.src) && def.filters.length > 0) {
-      const predecessor = this.acquire({
-        ...params,
-        def: {
-          ...def,
-          filters: [],
-        },
-      });
-      const {
-        resource: { pTablePromise },
-      } = predecessor;
-      const filteredTable = pTablePromise.then((pTable) => pTable.filter(key, def.filters));
-      return new PTableHolder(pFrameHandle, combinedSignal, filteredTable, predecessor);
-    }
-
-    // 1. Join
-    const table = pFramePromise.then((pFrame) =>
-      pFrame.createTable(key, {
-        src: joinEntryToInternal(def.src),
-        // `def.filters` would be non-empty only when join has artificial columns
-        filters: [...def.partitionFilters, ...def.filters],
-      }),
-    );
-    return new PTableHolder(pFrameHandle, combinedSignal, table);
-  }
-
-  protected createNewResourceV2(params: FullPTableDefV2, key: PTableHandle): PTableHolder {
     const { pFrameHandle } = params;
-    const { pFramePromise, disposeSignal } = this.pFrames.getByKey(pFrameHandle);
+    const { pFrameDataPromise: pFramePromise, disposeSignal } = this.pFrames.getByKey(pFrameHandle);
 
     const defDisposeSignal = this.pTableDefs.tryGetByKey(key)?.disposeSignal;
     const combinedSignal = AbortSignal.any([disposeSignal, defDisposeSignal].filter((s) => !!s));
 
-    const table = pFramePromise.then((pFrame) => pFrame.createTableV2(key, params.def));
+    const { tableSpec, dataQuery } = params;
+    const table = pFramePromise.then((pFrame) =>
+      pFrame.createTableV2(key, { tableSpec, dataQuery }),
+    );
     return new PTableHolder(pFrameHandle, combinedSignal, table);
   }
 
@@ -158,78 +96,19 @@ export class PTablePool<TreeEntry extends JsonSerializable> extends RefCountPool
     }
     return resource;
   }
-}
 
-function hasArtificialColumns<T>(entry: JoinEntry<T>): boolean {
-  switch (entry.type) {
-    case "column":
-    case "slicedColumn":
-    case "inlineColumn":
-      return false;
-    case "artificialColumn":
-      return true;
-    case "full":
-    case "inner":
-      return entry.entries.some(hasArtificialColumns);
-    case "outer":
-      return hasArtificialColumns(entry.primary) || entry.secondary.some(hasArtificialColumns);
-    default:
-      assertNever(entry);
-  }
-}
-
-function joinEntryToInternal(entry: JoinEntry<PObjectId>): PFrameInternal.JoinEntryV4 {
-  const type = entry.type;
-  switch (type) {
-    case "column":
-      return {
-        type: "column",
-        columnId: entry.column,
-      };
-    case "slicedColumn":
-      return {
-        type: "slicedColumn",
-        columnId: entry.column,
-        newId: entry.newId,
-        axisFilters: entry.axisFilters,
-      };
-    case "artificialColumn":
-      return {
-        type: "artificialColumn",
-        columnId: entry.column,
-        newId: entry.newId,
-        axesIndices: entry.axesIndices,
-      };
-    case "inlineColumn":
-      return {
-        type: "inlineColumn",
-        newId: entry.column.id,
-        spec: entry.column.spec,
-        dataInfo: {
-          type: "Json",
-          keyLength: entry.column.spec.axesSpec.length,
-          data: entry.column.data.reduce(
-            (acc, row) => {
-              acc[JSON.stringify(row.key)] = row.val;
-              return acc;
-            },
-            {} as Record<string, PColumnValue>,
-          ),
-        },
-      };
-    case "inner":
-    case "full":
-      return {
-        type: entry.type,
-        entries: entry.entries.map((col) => joinEntryToInternal(col)),
-      };
-    case "outer":
-      return {
-        type: "outer",
-        primary: joinEntryToInternal(entry.primary),
-        secondary: entry.secondary.map((col) => joinEntryToInternal(col)),
-      };
-    default:
-      throw new PFrameDriverError(`unsupported PFrame join entry type: ${type satisfies never}`);
+  /**
+   * Acquire a PTable from a legacy `PTableDef` + column specs map.
+   * Lowers the input via WASM-spec and stores the resulting
+   * `{ tableSpec, dataQuery }` shape. Returns the lowered def
+   * alongside the pool entry.
+   */
+  public acquireFromLegacy(opts: {
+    pFrameHandle: PFrameHandle;
+    def: PTableDef<PObjectId>;
+    pFrameSpec: PFrameInternal.PFrameWasmV3;
+  }): { def: FullPTableDef; entry: PoolEntry<PTableHandle, PTableHolder> } {
+    const def = buildFullPTableDefFromLegacy(opts);
+    return { def, entry: this.acquire(def) };
   }
 }

--- a/lib/node/pf-driver/src/ptable_shared.ts
+++ b/lib/node/pf-driver/src/ptable_shared.ts
@@ -1,30 +1,59 @@
 import type {
-  PObjectId,
+  DataQuery,
   PFrameHandle,
+  PObjectId,
+  PTableColumnSpec,
   PTableDef,
   PTableHandle,
-  DataQuery,
-  PTableColumnSpec,
 } from "@milaboratories/pl-model-common";
-import { hashJson } from "@milaboratories/pl-model-middle-layer";
+import { hashJson, PFrameInternal } from "@milaboratories/pl-model-middle-layer";
 
-export type FullPTableDefV1 = {
-  type: "v1";
+/**
+ * PTable definition stored in the def / table pools. Always
+ * carries a pre-lowered data query plus the corresponding output
+ * `tableSpec`. Legacy `PTableDef<PObjectId>` inputs are lowered to
+ * this shape via WASM-spec at acquire time.
+ */
+export type FullPTableDef = {
   pFrameHandle: PFrameHandle;
-  def: PTableDef<PObjectId>;
+  tableSpec: PTableColumnSpec[];
+  dataQuery: DataQuery;
 };
-
-export type FullPTableDefV2 = {
-  type: "v2";
-  pFrameHandle: PFrameHandle;
-  def: {
-    tableSpec: PTableColumnSpec[];
-    dataQuery: DataQuery;
-  };
-};
-
-export type FullPTableDef = FullPTableDefV1 | FullPTableDefV2;
 
 export function stableKeyFromFullPTableDef(data: FullPTableDef): PTableHandle {
   return hashJson(data) as string as PTableHandle;
+}
+
+/**
+ * Lower a legacy `PTableDef<PObjectId>` to the data layer. Returns
+ * the output `tableSpec` and the lowered `dataQuery`. Routes through
+ * `rewriteLegacyQuery` + `evaluateQuery` on the caller-supplied
+ * WASM-spec frame.
+ */
+export function lowerLegacyPTableDef(
+  pFrameSpec: PFrameInternal.PFrameWasmV3,
+  legacyDef: PTableDef<PObjectId>,
+): { tableSpec: PTableColumnSpec[]; dataQuery: DataQuery } {
+  const legacy: PFrameInternal.LegacyQuery = {
+    src: legacyDef.src,
+    filters: [...legacyDef.partitionFilters, ...legacyDef.filters],
+    sorting: legacyDef.sorting,
+  };
+  return pFrameSpec.evaluateQuery(pFrameSpec.rewriteLegacyQuery(legacy));
+}
+
+/**
+ * Build a `FullPTableDef` from a legacy `PTableDef` plus the
+ * PFrame's WASM-spec frame. Used by pool `acquireFromLegacy` methods
+ * to keep lowering off the call site.
+ */
+export function buildFullPTableDefFromLegacy(opts: {
+  pFrameHandle: PFrameHandle;
+  def: PTableDef<PObjectId>;
+  pFrameSpec: PFrameInternal.PFrameWasmV3;
+}): FullPTableDef {
+  return {
+    pFrameHandle: opts.pFrameHandle,
+    ...lowerLegacyPTableDef(opts.pFrameSpec, opts.def),
+  };
 }


### PR DESCRIPTION
## Summary

Preparation PR for the next `@milaboratories/pframes-rs-node` addon
revision. After this PR the existing V4 addon still works; pf-driver
just stops needing several of its methods.

- **Declare V5 addon interfaces** (`PFrameFactoryAPIV5`, `PTableV9`,
  `PFrameReadAPIV12`, `PFrameV14`, `PFrameFactoryV5`) alongside V4 so
  the next addon publish has a concrete TS contract.
- **Cache the WASM-spec frame on `PFrameHolder`** and route
  `driver.findColumns` / `getColumnSpec` / `listColumns` through it
  instead of the addon. `getColumnSpec` / `listColumns` now return
  only value-typed columns (the queryable subset).
- **Lower V1 `createPTable` inputs JS-side** via WASM-spec at
  construction time and unify the def shape: `FullPTableDef` is a
  flat `{ pFrameHandle, tableSpec, dataQuery }` for both V1 and V2
  entry points. The recursive sort/filter peeling in
  `createNewResourceV1` is dropped — `createTableV2` materialises the
  lowered query end-to-end.
- **`driver.getSpec` reads from the JS-side cache** — no addon
  roundtrip.
- Pool `acquireFromLegacy(pFrameHandle, def, pFrameSpec)` builds the
  unified def via `lowerLegacyPTableDef` so call sites pass raw
  inputs.

The remaining cutover (drop V4 interface declarations, switch to V5
addon calls, send pre-resolved indices for `getUniqueValues`, bulk
`addColumns`) lands in a follow-up once the addon publishes V5.

## Test plan

- [x] `pnpm types:check` clean on `lib/model/middle-layer` and
  `lib/node/pf-driver`
- [x] `pnpm test` in `lib/node/pf-driver` — 44/44 passing
- [ ] Manual smoke: `writePTableToFs` against a real PFrame — CSV
  output byte-identical to pre-migration baseline
- [ ] After ship, verify the V4 addon methods `pTable.getSpec`,
  `pFrame.getColumnSpec`, `listColumns`, `findColumns` are no longer
  called from pf-driver (observability)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prepares `pf-driver` for the next `pframes-rs-node` V5 addon by caching WASM-spec frames on `PFrameHolder` and routing spec-side operations (`findColumns`, `getColumnSpec`, `listColumns`, `getSpec`) through them instead of round-tripping through the native addon. It also flattens `FullPTableDef` to a unified `{ pFrameHandle, tableSpec, dataQuery }` shape and lowers legacy `PTableDef` inputs via WASM-spec at construction time, eliminating the old recursive sort/filter/join peeling in `createNewResourceV1`.

- **New V5 interface declarations** (`PFrameFactoryAPIV5`, `PTableV9`, `PFrameReadAPIV12`, `PFrameV14`, `PFrameFactoryV5`) are added in `middle-layer` as a forward-compatible TS contract; the V4 surface is untouched.
- **`PFrameHolder` now owns a `pFrameSpec: PFrameWasmV3`** built synchronously at construction, and exposes `pFrameDataPromise` (renamed from `pFramePromise`) for data-side operations only.
- **`FullPTableDef`** is flattened and all legacy entry points lower through `lowerLegacyPTableDef` → `rewriteLegacyQuery` + `evaluateQuery`; `PTablePool.createNewResource` has a single branch calling `pFrame.createTableV2`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the pFrameSpec disposal gap addressed; the V4 addon path is fully preserved and tests pass 44/44.

The core migration is well-structured and test-covered. The one gap is that `pFrameSpec` — a WASM heap object — is created before the `try` block in the `PFrameHolder` constructor and has no disposal path when `PFrameFactory.createPFrame` throws synchronously. Every synchronous native-addon creation failure from this point forward silently leaks a WASM allocation.

lib/node/pf-driver/src/pframe_pool.ts — the constructor's error path needs to dispose pFrameSpec on throw.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pf-driver/src/pframe_pool.ts | Renamed pFramePromise→pFrameDataPromise; added pFrameSpec (WASM spec frame) built at construction time; pFrameSpec is not disposed in the synchronous-error catch path of the constructor |
| lib/node/pf-driver/src/driver_impl.ts | Routes findColumns/getColumnSpec/listColumns through cached pFrameSpec (WASM) instead of the native addon; switches createPTable, createPTableV2, calculateTableData, and getSpec to use pre-lowered FullPTableDef; minor redundant uniqueBy in createPTable |
| lib/node/pf-driver/src/ptable_shared.ts | FullPTableDef flattened to {pFrameHandle, tableSpec, dataQuery}; adds lowerLegacyPTableDef and buildFullPTableDefFromLegacy helpers for WASM-spec lowering of legacy PTableDef inputs |
| lib/node/pf-driver/src/ptable_pool.ts | Collapsed V1/V2 createNewResource branches into a single path that calls pFrame.createTableV2; removes hasArtificialColumns, joinEntryToInternal, and the recursive sort/filter peeling logic; adds acquireFromLegacy helper |
| lib/node/pf-driver/src/ptable_def_pool.ts | Adds acquireFromLegacy method that lowers a legacy PTableDef through WASM-spec and returns both the lowered FullPTableDef and the pool entry |
| lib/model/middle-layer/src/pframe/internal_api/api_factory.ts | Declares V5 addon interfaces: PColumnTypeSpec, AddColumnEntry, and PFrameFactoryAPIV5 with bulk addColumns; V4 surface unchanged |
| lib/model/middle-layer/src/pframe/internal_api/api_read.ts | Declares UniqueValuesRequestV2 with pre-resolved index fields and PFrameReadAPIV12 using createTableV2+getUniqueValues, alongside unchanged V11 |
| lib/model/middle-layer/src/pframe/internal_api/pframe.ts | Adds PFrameV14 (PFrameFactoryAPIV5 + PFrameReadAPIV12) and PFrameFactoryV5 alongside existing V13/V4 interfaces |
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Adds PTableV9 alongside PTableV8; removes getSpec (replaced by caller-side tableSpec cache); filter/sort return PTableV9 instead of PTableV8 |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createPTable / createPTableV2 / calculateTableData] --> B[createPFrame to PFrameHolder]
    B --> C[createPFrameSpec WASM - pFrameSpec PFrameWasmV3]
    B --> D[PFrameFactory.createPFrame native - pFrameDataPromise PFrameV13]
    A --> E[acquireFromLegacy or direct acquire]
    E --> F[lowerLegacyPTableDef - rewriteLegacyQuery plus evaluateQuery]
    F --> G[FullPTableDef - pFrameHandle tableSpec dataQuery]
    G --> H[PTableDefPool]
    G --> I[PTablePool - pFrame.createTableV2]
    J[findColumns / getColumnSpec / listColumns / getSpec] --> C
    K[getUniqueValues] --> D
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pf-driver/src/pframe_pool.ts`, line 53-145 ([link](https://github.com/milaboratory/platforma/blob/b9b9169f488a8f50246d4e52adb7da4652268d7e/lib/node/pf-driver/src/pframe_pool.ts#L53-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`pFrameSpec` leaks when the native-addon constructor path throws**

   `this.pFrameSpec` is assigned synchronously before the `try` block (line 60). If `PFrameFactory.createPFrame`, `pFrameData.setDataSource`, or any `pFrameData.addColumnSpec` call throws synchronously, the constructor re-throws at the catch but never calls `this.pFrameSpec[Symbol.dispose]()`. Because `PFrameWasmV3 extends Disposable` it owns a WASM-heap allocation, so this is a real resource leak on every synchronous PFrame-creation failure.

   A minimal fix is to add `this.pFrameSpec[Symbol.dispose]()` inside the catch block (and to widen the catch to also cover the blob-mapping that precedes the try).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pf-driver/src/pframe_pool.ts
   Line: 53-145

   Comment:
   **`pFrameSpec` leaks when the native-addon constructor path throws**

   `this.pFrameSpec` is assigned synchronously before the `try` block (line 60). If `PFrameFactory.createPFrame`, `pFrameData.setDataSource`, or any `pFrameData.addColumnSpec` call throws synchronously, the constructor re-throws at the catch but never calls `this.pFrameSpec[Symbol.dispose]()`. Because `PFrameWasmV3 extends Disposable` it owns a WASM-heap allocation, so this is a real resource leak on every synchronous PFrame-creation failure.

   A minimal fix is to add `this.pFrameSpec[Symbol.dispose]()` inside the catch block (and to widen the catch to also cover the blob-mapping that precedes the try).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pf-driver/src/pframe_pool.ts:53-145
**`pFrameSpec` leaks when the native-addon constructor path throws**

`this.pFrameSpec` is assigned synchronously before the `try` block (line 60). If `PFrameFactory.createPFrame`, `pFrameData.setDataSource`, or any `pFrameData.addColumnSpec` call throws synchronously, the constructor re-throws at the catch but never calls `this.pFrameSpec[Symbol.dispose]()`. Because `PFrameWasmV3 extends Disposable` it owns a WASM-heap allocation, so this is a real resource leak on every synchronous PFrame-creation failure.

A minimal fix is to add `this.pFrameSpec[Symbol.dispose]()` inside the catch block (and to widen the catch to also cover the blob-mapping that precedes the try).

### Issue 2 of 2
lib/node/pf-driver/src/driver_impl.ts:196-197
`createPTable` pre-deduplicates with `uniqueBy` before handing the full column list to `createPFrame`, which internally filters to value types and calls `uniqueBy` a second time. The outer `uniqueBy` is harmless but does work on a superset (all extracted columns including axis types) that is then silently reduced inside `createPFrame`. Consider dropping the outer deduplication and letting `createPFrame` own it, or document why a preliminary pass is intentional here.

```suggestion
    using pFrameGuard = new PoolEntryGuard(this.createPFrame(extractAllColumns(rawDef.src)));
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Prepare pf-driver for the next pframes-r..."](https://github.com/milaboratory/platforma/commit/b9b9169f488a8f50246d4e52adb7da4652268d7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33927661)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->