### PR TITLE
fix(pl-client): invalidate cached test JWT when backend instanceId rotates

### DIFF
--- a/.changeset/test-auth-cache-instance-id.md
+++ b/.changeset/test-auth-cache-instance-id.md
@@ -1,0 +1,15 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Fix stale-JWT flake in test helper. `TestHelpers.getTestClient` cached the
+backend's JWT for 24h keyed on address/user/password, but ignored
+`MaintenanceAPI.Ping.Response.instanceId`. A backend restart that rotated
+`instanceId` invalidated every previously-issued JWT (the validator
+rejects tokens whose `iss` claim doesn't match the live instance) while
+leaving the cache file's other validity checks satisfied. Concurrent test
+files loaded the dead JWT and failed the first authenticated call with
+`failed to authenticate request using any of available methods` before
+`onAuthError` cleared the cache for the next attempt. The cache now
+captures `instanceId` at issue time and compares it against the live
+ping response on load.

--- a/lib/node/pl-client/src/test/test_config.ts
+++ b/lib/node/pl-client/src/test/test_config.ts
@@ -65,11 +65,20 @@ export function plAddressToTestConfig(address: string): PlClientConfig {
 interface AuthCache {
   /** To check if config changed */
   conf: TestConfig;
+  /** Backend's instance ID at the moment the JWT was issued. Restarts that
+   * reset state rotate this; the JWT's `iss` claim is bound to it and the
+   * backend rejects tokens minted by a different instance. Without this
+   * check, a cached JWT from a previous backend run would silently fail
+   * the first authenticated call after restart. */
+  instanceId: string;
   expiration: number;
   authInformation: AuthInformation;
 }
 
-function saveAuthInfoCallback(tConf: TestConfig): (authInformation: AuthInformation) => void {
+function saveAuthInfoCallback(
+  tConf: TestConfig,
+  instanceId: string,
+): (authInformation: AuthInformation) => void {
   return (authInformation) => {
     const dst = getFullAuthDataFilePath();
     const tmpDst = getFullAuthDataFilePath() + randomUUID();
@@ -78,6 +87,7 @@ function saveAuthInfoCallback(tConf: TestConfig): (authInformation: AuthInformat
       Buffer.from(
         JSON.stringify({
           conf: tConf,
+          instanceId,
           authInformation,
           expiration: inferAuthRefreshTime(authInformation, 24 * 60 * 60),
         } as AuthCache),
@@ -99,9 +109,19 @@ const cleanAuthInfoCallback = () => {
 export async function getTestClientConf(): Promise<{ conf: PlClientConfig; auth: AuthOps }> {
   const tConf = getTestConfig();
 
+  const plConf = plAddressToTestConfig(tConf.address);
+  const uClient = await UnauthenticatedPlClient.build(plConf);
+  // ll.serverInfo is populated by build()'s ping; instanceId rotates on a
+  // backend restart that drops the persisted state.
+  const instanceId = uClient.ll.serverInfo.instanceId;
+
   let authInformation: AuthInformation | undefined = undefined;
 
-  // try recover from cache
+  // Try recover from cache. The cache is keyed by config AND backend
+  // instanceId — a backend restart that rotates instanceId invalidates the
+  // cached JWT (the token's `iss` claim no longer matches the live
+  // instance), so we re-login instead of carrying the dead token through
+  // to the first authenticated call.
   if (fs.existsSync(getFullAuthDataFilePath())) {
     try {
       const cache: AuthCache = JSON.parse(
@@ -111,7 +131,8 @@ export async function getTestClientConf(): Promise<{ conf: PlClientConfig; auth:
         cache.conf.address === tConf.address &&
         cache.conf.test_user === tConf.test_user &&
         cache.conf.test_password === tConf.test_password &&
-        cache.expiration > Date.now()
+        cache.expiration > Date.now() &&
+        cache.instanceId === instanceId
       )
         authInformation = cache.authInformation;
     } catch {
@@ -119,9 +140,6 @@ export async function getTestClientConf(): Promise<{ conf: PlClientConfig; auth:
       fs.rmSync(getFullAuthDataFilePath());
     }
   }
-
-  const plConf = plAddressToTestConfig(tConf.address);
-  const uClient = await UnauthenticatedPlClient.build(plConf);
 
   const requireAuth = await uClient.requireAuth();
 
@@ -141,14 +159,14 @@ export async function getTestClientConf(): Promise<{ conf: PlClientConfig; auth:
     else authInformation = {};
 
     // saving cache
-    saveAuthInfoCallback(tConf)(authInformation);
+    saveAuthInfoCallback(tConf, instanceId)(authInformation);
   }
 
   return {
     conf: plConf,
     auth: {
       authInformation,
-      onUpdate: saveAuthInfoCallback(tConf),
+      onUpdate: saveAuthInfoCallback(tConf, instanceId),
       onAuthError: cleanAuthInfoCallback,
       onUpdateError: cleanAuthInfoCallback,
     },


### PR DESCRIPTION
## Summary

`TestHelpers.getTestClient` caches the JWT in `.test_auth.json` for 24h keyed on `address` + `test_user` + `test_password` + `expiration`. The backend's JWT validator binds tokens to the live `instanceID` via the `iss` claim and rejects everything else ([`platform/auth/jwt.go:168`](https://github.com/milaboratory/pl/blob/main/platform/auth/jwt.go) — `jwt.WithIssuer(j.settings.instanceID)`). A backend restart that resets persisted state rotates `instanceID`, **instantly invalidating every cached token while the on-disk file's other validity checks still pass**.

The result is a post-restart test flake: vitest spreads test files across worker processes, each reading the shared cache; whichever worker(s) ran first against the new instance hit

```
RpcError: failed to authenticate request using any of available methods
```

before the `onAuthError` handler had a chance to delete the cache file for later workers. The flake clears itself after one full retry, which is why it presented as intermittent.

## Change

- `AuthCache` carries `instanceId: string` alongside `conf` / `expiration` / `authInformation`.
- `getTestClientConf` builds the `UnauthenticatedPlClient` **before** consulting the cache (`build()` already pings, populating `ll.serverInfo.instanceId`), then compares `cache.instanceId === instanceId` as part of validity.
- `saveAuthInfoCallback` takes the live `instanceId` and writes it into every saved entry, including the `onUpdate` (token-refresh) path.

Existing cache files without the new `instanceId` field self-heal: the comparison `undefined === <non-empty>` is false, so the next test run re-logs in and rewrites the cache.

## Test plan

- [x] Tampered `.test_auth.json` to a fake `instanceId` simulating a post-restart state; full `src/wasm/` integration suite (12 files, 14 tests) passes; cache rewritten with live `instanceId` afterwards.
- [x] 4 consecutive clean runs of the same suite to confirm no residual flake.
- [ ] CI verifies on the pl-client's own unit tests.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes an intermittent test flake where concurrent vitest workers loaded a cached JWT that had been invalidated by a backend restart (which rotates `instanceId` and thereby breaks the `iss` claim in existing tokens). The fix embeds the live `instanceId` from `UnauthenticatedPlClient.build()`'s ping into every saved `AuthCache` entry and compares it against the freshly-pinged `instanceId` before trusting a cached token.

- **`AuthCache` extended with `instanceId: string`**: The cache now captures the backend's instance ID at JWT-issue time; a backend restart that rotates the ID causes the cache comparison (`cache.instanceId === instanceId`) to fail and triggers a fresh login.
- **Build-before-cache ordering**: `UnauthenticatedPlClient.build()` is moved before the cache check so the live `instanceId` is available for validation — total network round-trips are unchanged since `build()` was already unconditionally called.
- **Self-healing**: Old cache files without `instanceId` return `undefined` for the field, so `undefined === \"<live-id>\"` is always `false` and stale entries are automatically discarded on the first run after the upgrade.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped to the test helper cache layer and does not touch any production code paths.

The fix is mechanically straightforward: instanceId comes from the protobuf-generated MaintenanceAPI_Ping_Response.instanceId field (typed string, always populated by build()'s ping). The cache comparison is correct, old entries without the field self-heal via undefined !== live-id, and the atomic tmp-then-rename write keeps concurrent workers safe.

No files require special attention; both changed files are test/changeset infrastructure only.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/test/test_config.ts | Core fix: adds instanceId to AuthCache and validates it against the live ping response before trusting cached JWTs; build/cache ordering resequenced correctly with no change in total network round-trips. |
| .changeset/test-auth-cache-instance-id.md | Changeset entry accurately describes the bug and the fix; classified correctly as a patch. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Test Worker
    participant FS as .test_auth.json
    participant B as Backend

    W->>B: UnauthenticatedPlClient.build() Ping
    B-->>W: instanceId (live)
    W->>FS: Read cache if exists
    FS-->>W: conf, instanceId, expiration, authInformation
    alt cache valid: conf match AND expiration valid AND instanceId matches live
        W->>W: Use cached authInformation
    else cache miss or instanceId mismatch or expired
        W->>B: login(user, password)
        B-->>W: JWT bound to live instanceId
        W->>FS: Atomic write cache with live instanceId
    end
    W->>B: Authenticated gRPC calls
    note over W,FS: onAuthError deletes cache on auth failure
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pl-client): invalidate cached JWT wh..."](https://github.com/milaboratory/platforma/commit/a0a909c76668e591e15e38227b64fde0fc2835e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33995114)</sub>

<!-- /greptile_comment -->