### PR TITLE
MILAB-6365: allow casting strings to SignedResourceId with no signature

### DIFF
--- a/.changeset/red-toys-play.md
+++ b/.changeset/red-toys-play.md
@@ -1,0 +1,11 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Support backends before security layer implementation.
+
+Before the update, pl client required resource signatures to be not empty in any conversion
+from string to SignedResourceId.
+
+This is impossible to meet when connected to older backend (i.e. 1.45.3) that have no code
+of our modern security layer.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -341,7 +341,7 @@ export class PlClient {
 
         // Auto-set default color proof from the client root's signature.
         // Skip when backend doesn't implement the `set_default_color` TX request.
-        if (this.ll.supportsSetDefaultColor && !isNullSignedResourceId(clientRoot) && writable) {
+        if (this.ll.supportsResourceSignatures && !isNullSignedResourceId(clientRoot) && writable) {
           const parsed = parseSignedResourceId(clientRoot);
           if (parsed.signature) {
             tx.setDefaultColor(parsed.signature as ColorProof);

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -17,6 +17,7 @@ import { plAddressToConfig, type wireProtocol, SUPPORTED_WIRE_PROTOCOLS } from "
 import type { GrpcOptions } from "@protobuf-ts/grpc-transport";
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
 import { LLPlTransaction } from "./ll_transaction";
+import { setResourceSignaturesRequired } from "./types";
 import { parsePlJwt } from "../util/pl";
 import { type Dispatcher, interceptors } from "undici";
 import type { Middleware } from "openapi-fetch";
@@ -158,6 +159,9 @@ export class LLPlClient implements WireClientProviderFactory {
     // In the autodetect path the loop's last successful ping already populated _serverInfo via the
     // side-effect in ping(); this fallback covers the path where autodetect is disabled.
     if (!pl._serverInfo) await pl.ping();
+
+    // Install the process-global signature-strictness flag based on backend version.
+    setResourceSignaturesRequired(pl.supportsResourceSignatures);
 
     // Guarantee authMethods happened so client can make weighted decision on which auth method to use.
     if (!pl._authMethodsSync) await pl.authMethods();
@@ -679,8 +683,10 @@ export class LLPlClient implements WireClientProviderFactory {
     return hasCapability(this.serverInfo.capabilities, capability);
   }
 
-  /** True if the backend implements the setDefaultColor TX request. */
-  public get supportsSetDefaultColor(): boolean {
+  /** True if the backend produces signed resource ids (and accepts the
+   * setDefaultColor TX request). Tagged at 3.3.0 — backends older than this
+   * return resources without signatures and reject color-proof requests. */
+  public get supportsResourceSignatures(): boolean {
     return isVersionAtLeast(this.serverInfo.coreVersion, [3, 3, 0]);
   }
 

--- a/lib/node/pl-client/src/core/ll_transaction.test.ts
+++ b/lib/node/pl-client/src/core/ll_transaction.test.ts
@@ -115,7 +115,7 @@ test("check timeout error type (active)", async () => {
 
     // Set default color so resource creation succeeds in strict mode.
     // Skip on older backends that don't implement the setDefaultColor TX request.
-    if (client.supportsSetDefaultColor) {
+    if (client.supportsResourceSignatures) {
       await tx.send(
         { oneofKind: "setDefaultColor", setDefaultColor: { colorProof: rootSig } },
         false,
@@ -189,7 +189,7 @@ test("check is abort error (active)", async () => {
 
     // Set default color so resource creation succeeds in strict mode
     // Skip on older backends that don't implement the setDefaultColor TX request.
-    if (client.supportsSetDefaultColor) {
+    if (client.supportsResourceSignatures) {
       await tx.send(
         { oneofKind: "setDefaultColor", setDefaultColor: { colorProof: rootSig } },
         false,

--- a/lib/node/pl-client/src/core/types.ts
+++ b/lib/node/pl-client/src/core/types.ts
@@ -298,13 +298,26 @@ export function isSignedResourceId(resourceId: bigint | string): resourceId is S
   return typeof resourceId === "string" && resourceId.includes("|");
 }
 
+// Process-global switch. Set to false by LLPlClient.build() when the connected
+// backend predates resource signatures (~< 3.3.0). When false, asSignedResourceId
+// accepts ids minted with an empty signature. Single-backend-per-process only:
+// a Node process talking to mixed signed/unsigned backends will share last-wins
+// state. Desktop App is single-backend-per-process, so this is acceptable.
+let resourceSignaturesRequired = true;
+
+export function setResourceSignaturesRequired(required: boolean): void {
+  resourceSignaturesRequired = required;
+}
+
 /** Validate a string as a SignedResourceId and return it with the branded type.
- *  Requires the format "<globalId>|<signatureHex>" with a non-empty signature. */
+ *  Requires the format "<globalId>|<signatureHex>". A non-empty signature is
+ *  required only when {@link areResourceSignaturesRequired} is true. */
 export function asSignedResourceId(str: string): SignedResourceId {
   const pipeIdx = str.indexOf("|");
   if (pipeIdx < 0) throw new Error(`Not a signed resource id (no '|' separator): ${str}`);
   if (pipeIdx === 0) throw new Error(`Signed resource id has empty globalId: ${str}`);
-  if (pipeIdx === str.length - 1) throw new Error(`Signed resource id has empty signature: ${str}`);
+  if (resourceSignaturesRequired && pipeIdx === str.length - 1)
+    throw new Error(`Signed resource id has empty signature: ${str}`);
   return str as SignedResourceId;
 }
 


### PR DESCRIPTION
When connected to old backends (i.e. 1.45.3), there is no signatures coming from server and there is nothing to encode/decode when serializing these IDs into some other structures.

In this case, when we know for sure no signatures exist in the system at all, we should not throw an error for type conversions

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds backward compatibility for pre-3.3.0 backends that don't produce signed resource IDs, by introducing a process-global flag (`resourceSignaturesRequired`) that relaxes the non-empty-signature requirement in `asSignedResourceId` when connected to an older backend.

- `LLPlClient.build()` now calls `setResourceSignaturesRequired(pl.supportsResourceSignatures)` immediately after `ping()`, setting the flag to `false` for backends older than 3.3.0 and `true` for newer ones.
- `supportsSetDefaultColor` is renamed to `supportsResourceSignatures` — same version gate (>= 3.3.0) — and all call sites are updated consistently.
- The global-state design is intentional and well-documented in comments; the limitation (last-writer-wins in multi-backend processes) is acknowledged and acceptable for the stated single-backend-per-process use case.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the single-backend-per-process Desktop App target; the one concern is the public re-export of the internal flag-control functions.

The change is narrow and well-reasoned. The flag defaults to true (strict), is set unconditionally on every successful build(), and ping() — which runs before the flag is written — doesn't process any signed resource IDs, so there is no ordering hazard. The only open question is whether setResourceSignaturesRequired and areResourceSignaturesRequired should remain part of the public package API via the export * barrel in index.ts; external callers can currently disable signature enforcement for the entire process with a single call.

lib/node/pl-client/src/core/types.ts — the two new exported functions are visible as public API through src/index.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/types.ts | Adds process-global `resourceSignaturesRequired` flag (default `true`) and exposes getter/setter. `asSignedResourceId` now skips the non-empty-signature check when the flag is `false`. Both new functions are re-exported through the public package index. |
| lib/node/pl-client/src/core/ll_client.ts | Renames `supportsSetDefaultColor` to `supportsResourceSignatures` (same version gate: >= 3.3.0) and calls `setResourceSignaturesRequired` in `build()` right after the guaranteed `ping()`. Ordering is correct. |
| lib/node/pl-client/src/core/client.ts | Trivial rename of `supportsSetDefaultColor` → `supportsResourceSignatures` at the `setDefaultColor` call site. No logic change. |
| lib/node/pl-client/src/core/ll_transaction.test.ts | Two test guards updated from `supportsSetDefaultColor` to `supportsResourceSignatures` to match the renamed getter. No behavioral change. |
| .changeset/red-toys-play.md | Patch-level changeset for `@milaboratories/pl-client` documenting backward-compat support for pre-3.3.0 backends. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant LLPlClient
    participant types_module as types module
    participant Backend

    App->>LLPlClient: build(config)
    LLPlClient->>Backend: ping()
    Backend-->>LLPlClient: serverInfo (coreVersion)
    LLPlClient->>LLPlClient: "supportsResourceSignatures = coreVersion >= 3.3.0"
    LLPlClient->>types_module: setResourceSignaturesRequired(supportsResourceSignatures)
    Note over types_module: resourceSignaturesRequired = true/false
    LLPlClient->>Backend: authMethods()
    Backend-->>LLPlClient: methods
    LLPlClient-->>App: LLPlClient instance

    App->>LLPlClient: openClientRoot(...)
    alt "supportsResourceSignatures == true"
        LLPlClient->>types_module: asSignedResourceId(str) — signature required
        LLPlClient->>Backend: setDefaultColor(colorProof)
    else "supportsResourceSignatures == false"
        Note over LLPlClient: skip setDefaultColor block
        LLPlClient->>types_module: asSignedResourceId(str) — empty sig allowed
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/node/pl-client/src/core/types.ts:308-313
**Public API exposes internal flag control**

`setResourceSignaturesRequired` and `areResourceSignaturesRequired` are re-exported through `src/index.ts` via `export * from "./core/types"`, making them part of the package's public API. Any downstream consumer of `@milaboratories/pl-client` can call `setResourceSignaturesRequired(false)` and silently disable signature enforcement for the entire process — even if the client is connected to a new backend that requires signatures. If these functions are meant to be internal to `LLPlClient.build()`, consider omitting them from the public barrel export or prefixing them with an `_` convention to signal their internal nature.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6365: allow casting strings to Sig..."](https://github.com/milaboratory/platforma/commit/89eb2ec70346b2ec54b418e550db41ac68093f57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34138715)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->