### PR TITLE
Drop filter/sort from PFrameInternal.PTableV9

### DIFF
--- a/.changeset/pframes-ptable-v9-drop-filter-sort.md
+++ b/.changeset/pframes-ptable-v9-drop-filter-sort.md
@@ -1,0 +1,22 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+---
+
+PFrames PTableV9: remove `filter` / `sort` methods from the interface.
+
+`PTableV9` previously declared `filter(tableId, request: PTableRecordFilter[])`
+and `sort(tableId, request: PTableSorting[])`, both taking spec-based
+selectors. Implementing those would force `pframes-rs-node` to either keep
+a JS-side spec→data adapter or retain `pframes_rs_spec` in its exec crate
+purely to translate filter / sort selectors — defeating the broader effort
+to push selector resolution to the caller side via WASM-spec.
+
+The cleaner cut, made now while `V9` is still pre-adoption: drop the two
+methods. Callers compose filtering and sorting into the input `DataQuery`
+of the next `createTableV2` call (via `QueryData::Filter` / `Sort` over a
+`QueryData::Table` leaf) — exactly the same vocabulary already used by
+`getUniqueValues` V2.
+
+No production caller depends on `V9.filter` / `.sort` yet (the interface
+shipped with PR #1658 but hasn't been adopted). `PTableV8` retains both
+methods unchanged.

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -70,7 +70,7 @@ export interface PTableV8 extends Disposable {
 }
 
 /**
- * Table view returned by `createTableV2`, `filter`, and `sort`.
+ * Table view returned by `createTableV2`.
  *
  * PTable can be thought as having a composite primary key, consisting
  * of axes, and a set of data columns derived from PColumn values.
@@ -112,12 +112,6 @@ export interface PTableV9 extends Disposable {
       signal?: AbortSignal;
     },
   ): Promise<PTableVector[]>;
-
-  /** Filters the table and returns new PTable instance */
-  filter(tableId: PTableId, request: PTableRecordFilter[]): PTableV9;
-
-  /** Sorts the table and returns new PTable instance. */
-  sort(tableId: PTableId, request: PTableSorting[]): PTableV9;
 
   /** Deallocates all underlying resources */
   dispose(): void;


### PR DESCRIPTION
## Summary

- Remove the spec-based `filter` / `sort` methods from `PTableV9` (introduced in #1658 but not yet adopted).
- Update the V9 doc-block to explain how callers compose filter/sort going forward (via the input `DataQuery` of `createTableV2`).
- Adds a changeset (`@milaboratories/pl-model-middle-layer` minor).

## Motivation

Implementing `V9.filter` / `.sort` in `pframes-rs-node` would force the addon to either ship a JS-side spec→data adapter or keep `pframes_rs_spec` in its exec crate — both contradict the broader push to handle selector resolution caller-side via WASM-spec.

The cleaner cut, while `V9` is still pre-adoption: drop the two methods. Callers compose filtering and sorting into the input `DataQuery` of the next `createTableV2` call (`QueryData::Filter` / `Sort` over a `QueryData::Table` leaf) — exactly the same vocabulary already used by `getUniqueValues` V2.

`PTableV8` retains both methods unchanged.

## Companion work

- pframes-rs branch `feat/table_join` (PLAN.md commit `7f7c2e1`) updates the implementation plan to delete `pTableFilter` / `pTableSort` from the addon surface in C8, rather than rewiring them.

## Test plan

- [x] `pnpm --filter @milaboratories/pl-model-middle-layer build` is green.
- [ ] CI confirms no downstream consumer references `PTableV9.filter` / `.sort`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Drops `filter` and `sort` from the `PTableV9` interface (introduced in #1658 but never adopted), removing the need for `pframes-rs-node` to ship a spec→data adapter or retain `pframes_rs_spec` in its exec crate. All existing imports remain valid because `PTableV8` still uses them.

- `PTableV9` now exposes only `getFootprint`, `getShape`, `getData`, and `dispose`; callers compose filtering and sorting into the `DataQuery` passed to `PFrameReadAPIV12.createTableV2`.
- A minor changeset is added for `@milaboratories/pl-model-middle-layer` with a clear migration note.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes two pre-adoption methods from a never-consumed interface, leaves all other V8 and V9 surface intact, and carries no risk of breaking existing callers.

The change is a clean interface trim on a freshly-shipped, unadopted API. No callers in the repo reference `PTableV9.filter` or `PTableV9.sort`, all remaining imports in `table.ts` are still needed by `PTableV8`, and the minor changeset bump correctly signals the removal to downstream packages.

No files require special attention. The only observation is that the `PTableV9` doc-block could be more explicit about the `DataQuery` composition pattern promised in the PR description.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Removes `filter` and `sort` methods from `PTableV9`; all remaining imports (`PTableRecordFilter`, `PTableSorting`, `PTableId`) are still consumed by `PTableV8`. The trimmed doc-block first line is correct. Minor gap: no in-source guidance added for callers on how to compose filtering/sorting via `DataQuery`. |
| .changeset/pframes-ptable-v9-drop-filter-sort.md | Adds a well-written minor changeset entry explaining the rationale for dropping `filter`/`sort` from `PTableV9` and pointing callers to the `DataQuery` composition pattern. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    caller["Caller (WASM-spec side)"]
    dq["DataQuery\n(QueryData::Filter / Sort\nover QueryData::Table leaf)"]
    ctv2["PFrameReadAPIV12.createTableV2(id, dataQuery)"]
    v9["PTableV9\ngetFootprint / getShape / getData / dispose"]

    caller -->|"compose filter+sort into"| dq
    dq -->|"pass as input"| ctv2
    ctv2 -->|"returns"| v9

    note1["❌ V9.filter removed\n❌ V9.sort removed"]
    style note1 fill:#fdd,stroke:#c00
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/model/middle-layer/src/pframe/internal_api/table.ts`, line 72-79 ([link](https://github.com/milaboratory/platforma/blob/a5bc059a9a143887ba48f436d9b10ff0d17a50a6/lib/model/middle-layer/src/pframe/internal_api/table.ts#L72-L79)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Doc-block missing promised filter/sort guidance**

   The PR description says this update "explains how callers compose filter/sort going forward (via the input `DataQuery` of `createTableV2`)," but the actual doc-block only removes the old references without adding the replacement guidance. A future caller who previously used `V9.filter` / `.sort` has no in-source pointer to the `QueryData::Filter` / `Sort` over a `QueryData::Table` leaf pattern. The changeset notes explain the design well — it would be worth surfacing a brief `@remarks` or inline sentence here so the interface is self-documenting.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/middle-layer/src/pframe/internal_api/table.ts
   Line: 72-79

   Comment:
   **Doc-block missing promised filter/sort guidance**

   The PR description says this update "explains how callers compose filter/sort going forward (via the input `DataQuery` of `createTableV2`)," but the actual doc-block only removes the old references without adding the replacement guidance. A future caller who previously used `V9.filter` / `.sort` has no in-source pointer to the `QueryData::Filter` / `Sort` over a `QueryData::Table` leaf pattern. The changeset notes explain the design well — it would be worth surfacing a brief `@remarks` or inline sentence here so the interface is self-documenting.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/middle-layer/src/pframe/internal_api/table.ts:72-79
**Doc-block missing promised filter/sort guidance**

The PR description says this update "explains how callers compose filter/sort going forward (via the input `DataQuery` of `createTableV2`)," but the actual doc-block only removes the old references without adding the replacement guidance. A future caller who previously used `V9.filter` / `.sort` has no in-source pointer to the `QueryData::Filter` / `Sort` over a `QueryData::Table` leaf pattern. The changeset notes explain the design well — it would be worth surfacing a brief `@remarks` or inline sentence here so the interface is self-documenting.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Drop filter/sort from PTableV9"](https://github.com/milaboratory/platforma/commit/a5bc059a9a143887ba48f436d9b10ff0d17a50a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34369061)</sub>

<!-- /greptile_comment -->