### PR TITLE
uikit: center PlAlert close button vertically

### DIFF
--- a/.changeset/pl-alert-close-btn-centering.md
+++ b/.changeset/pl-alert-close-btn-centering.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/uikit": patch
+---
+
+`PlAlert`: vertically center the `closeable` close button instead of pinning it near the top. The X now aligns with the alert text on both single-line and multi-line alerts.

--- a/.changeset/pl-alert-close-btn-centering.md
+++ b/.changeset/pl-alert-close-btn-centering.md
@@ -2,4 +2,4 @@
 "@milaboratories/uikit": patch
 ---
 
-`PlAlert`: vertically center the `closeable` close button instead of pinning it near the top. The X now aligns with the alert text on both single-line and multi-line alerts.
+`PlAlert`: center the `closeable` close button on the first line of text. The X was pinned ~6px too low on single-line alerts; it now aligns with the text on both single-line and multi-line alerts.

--- a/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
+++ b/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
@@ -70,13 +70,9 @@
 
   &__close-btn {
     position: absolute;
-    // 24px is a single-line alert's vertical centre (12px padding + half the
-    // 24px content row). Hard-coding it instead of `top: 50%` keeps the X on
-    // the first line — not the middle — once the text wraps.
-    top: 24px;
+    // Centre the 40px button on the first content row. The row's centre sits at
+    // 24px (12px padding + half the 24px row); top = 24 − 20 (half the button).
+    top: 4px;
     right: 12px;
-    // Centres the button on that line via its own height — stays centred if the
-    // button is ever resized, unlike a hard-coded `top: 4px` (= 24 − 40/2).
-    transform: translateY(-50%);
   }
 }

--- a/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
+++ b/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
@@ -70,7 +70,9 @@
 
   &__close-btn {
     position: absolute;
-    top: 10px;
+    // center vertically regardless of alert height (single- or multi-line)
+    top: 50%;
     right: 12px;
+    transform: translateY(-50%);
   }
 }

--- a/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
+++ b/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
@@ -70,8 +70,10 @@
 
   &__close-btn {
     position: absolute;
-    // center vertically regardless of alert height (single- or multi-line)
-    top: 50%;
+    // 24px is a single-line alert's vertical centre (12px padding + half the
+    // 24px content row). Hard-coding it instead of `top: 50%` keeps the X on
+    // the first line — not the middle — once the text wraps.
+    top: 24px;
     right: 12px;
     transform: translateY(-50%);
   }

--- a/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
+++ b/lib/ui/uikit/src/components/PlAlert/pl-alert.scss
@@ -75,6 +75,8 @@
     // the first line — not the middle — once the text wraps.
     top: 24px;
     right: 12px;
+    // Centres the button on that line via its own height — stays centred if the
+    // button is ever resized, unlike a hard-coded `top: 4px` (= 24 − 40/2).
     transform: translateY(-50%);
   }
 }


### PR DESCRIPTION
## What
`PlAlert`'s `closeable` close button was pinned at `top: 10px`. That put the 40px button's *center* at 30px — ~6px below the center of a single-line (~48px) alert, drifting further as the alert grew.

Center the button on the first line of text instead:

```scss
&__close-btn {
  position: absolute;
  top: 4px;     // 24px row centre − 20px (half the 40px button)
  right: 12px;
}
```

The first content row's center sits at 24px (12px padding + half the 24px row). Placing the 40px button's top edge at `24 − 20 = 4px` puts its center on that row.

A fixed `top` — not `top: 50%` — anchors the X to the first line. On a tall multi-line alert the X stays top-right rather than floating to the vertical middle. (An earlier revision used `top: 50%`; review feedback asked to keep the multi-line X top-right, hence the first-line anchor.)

`top: 4px` also matches the existing house pattern: `PlDialogModal` already pins the same `PlCloseModalBtn` with `top: 4px`.

## Why
The off-center X showed on every `closeable` PlAlert. Surfaced on the sequence-properties block (MILAB-6368).

## Blast radius
The change touches only `.pl-alert__close-btn`, which renders only when `closeable`. Across blocks + core there are 157 `PlAlert` usages; 2 are closeable — `sequence-properties` and `clonotype-enrichment` — and both improve. Non-closeable `PlAlert`s and the separate `PlNotificationAlert` (its own `closable`/CSS) stay untouched.

## Verification
Built `@milaboratories/uikit` and previewed live in the sequence-properties dev block. The X-center sits ~24px from the alert top regardless of height:

| Alert | X vs block center |
|---|---|
| 1 line | centered (delta 0) |
| 2 lines | 8px above middle (on line 1) |
| 8 lines | 68px above middle (on line 1) |

Changeset: `@milaboratories/uikit: patch` — auto-propagates a `@platforma-sdk/ui-vue` patch (`workspace:*` + `updateInternalDependencies: patch`), so blocks pick up the fix on their next ui-vue bump.
