### PR TITLE
Add PFrameWasmAPIV4.rewriteLegacyFilters; rename createTableV2 to createTable

### DIFF
--- a/.changeset/pframes-wasm-rewrite-legacy-filters.md
+++ b/.changeset/pframes-wasm-rewrite-legacy-filters.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+---
+
+PFrame internal API: add `PFrameWasmAPIV4` — a self-contained WASM-spec factory that adds a stateless `rewriteLegacyFilters`, which upgrades selector-based legacy record filters into index-based data-layer boolean expressions for a given unified table spec (usable both for `getUniqueValues` and for composing a `filter` over a `table` query node). Also drop the `V2` suffix from the data-side create method on the (unreleased) `PFrameReadAPIV12`: `createTableV2` → `createTable`.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -91,13 +91,13 @@ export interface UniqueValuesRequestV2 {
  * Spec-side operations (finding columns, listing columns, retrieving
  * column specs, computing axis integrations) are not part of this
  * surface — callers cache column specs themselves or route through
- * WASM-spec. The data-side `createTableV2` accepts a pre-lowered
+ * WASM-spec. The data-side `createTable` accepts a pre-lowered
  * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
  * {@link UniqueValuesRequestV2}.
  */
 export interface PFrameReadAPIV12 {
   /** Creates table from a pre-lowered data query. */
-  createTableV2(tableId: PTableId, dataQuery: DataQuery): PTableV9;
+  createTable(tableId: PTableId, dataQuery: DataQuery): PTableV9;
 
   /** Calculate set of unique values for a specific axis for the filtered set of records. */
   getUniqueValues(

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -11,6 +11,7 @@ import type {
   PTableRecordFilter,
   PTableSorting,
   DataQuery,
+  DataQueryBooleanExpression,
   SpecQuery,
   SpecQueryJoinEntry,
   SingleAxisSelector,
@@ -21,6 +22,67 @@ import type {
 } from "./delete_column";
 import type { DiscoverColumnsRequestV2, DiscoverColumnsResponse } from "./discover_columns";
 import type { FindColumnsRequest, FindColumnsResponse } from "./find_columns";
+
+/**
+ * V4 PFrame API factory — pure spec-layer operations plus frame construction.
+ *
+ * Self-contained (does not extend {@link PFrameWasmAPIV3}, which is dropped
+ * once V4 is adopted). Same surface as V3 plus
+ * {@link PFrameWasmAPIV4.rewriteLegacyFilters}. The per-frame interface is
+ * unchanged, so {@link PFrameWasmAPIV4.createPFrame} still returns a
+ * {@link PFrameWasmV3}.
+ */
+export interface PFrameWasmAPIV4 {
+  /**
+   * Creates a new PFrame from a map of column IDs to column specifications.
+   */
+  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV3;
+
+  /**
+   * Expands an {@link AxesSpec} into {@link AxesId}s with parent information
+   * resolved.
+   */
+  expandAxes(spec: AxesSpec): AxesId;
+
+  /**
+   * Collapses {@link AxesId} into {@link AxesSpec}.
+   */
+  collapseAxes(ids: AxesId): AxesSpec;
+
+  /**
+   * Finds the index of an axis matching the given selector.
+   * Returns -1 if no matching axis is found.
+   */
+  findAxis(spec: AxesSpec, selector: SingleAxisSelector): number;
+
+  /**
+   * Finds the flat index of a table column matching the given
+   * selector within a table spec. Returns -1 if not found.
+   */
+  findTableColumn(tableSpec: PTableColumnSpec[], selector: PTableColumnId): number;
+
+  /**
+   * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
+   * ordered path of wrapping steps (linker hops, filter joins). See
+   * {@link PFrameWasmAPIV3.buildQuery} for the folding semantics.
+   */
+  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
+
+  /**
+   * Upgrades selector-based legacy record filters into index-based data-layer
+   * boolean expressions, resolved against the provided unified table spec
+   * (axes first, then columns).
+   *
+   * Stateless (no frame needed): filtering does not change a table's spec, so
+   * the resulting predicates are valid both for the V2 unique-values request
+   * (over the source column's single-column table) and for composing a
+   * `filter` over a `table` query node of that table.
+   */
+  rewriteLegacyFilters(request: {
+    tableSpec: PTableColumnSpec[];
+    filters: PTableRecordFilter[];
+  }): DataQueryBooleanExpression[];
+}
 
 /**
  * V3 PFrame interface — per-frame instance operations.
@@ -68,6 +130,9 @@ export interface PFrameWasmV3 extends Disposable {
 /**
  * V3 PFrame API factory — pure spec-layer operations plus frame construction.
  * Everything here is stateless and does not require a frame instance.
+ *
+ * Superseded by {@link PFrameWasmAPIV4} (adds `rewriteLegacyFilters`); will be
+ * removed in a future PFrames update.
  */
 export interface PFrameWasmAPIV3 {
   /**

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -63,8 +63,17 @@ export interface PFrameWasmAPIV4 {
 
   /**
    * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
-   * ordered path of wrapping steps (linker hops, filter joins). See
-   * {@link PFrameWasmAPIV3.buildQuery} for the folding semantics.
+   * ordered path of wrapping steps (linker hops, filter joins).
+   *
+   * Right-fold over `path` starting from `Column(column)`: each `linker` step
+   * wraps the current subquery as `linkerJoin`, each `filter` step as
+   * `innerJoin` with the filter column. `qualifications` annotate the
+   * outermost entry only.
+   *
+   * Pure over its input — no frame needed. Column ids are resolved later at
+   * {@link PFrameWasmV3.evaluateQuery} against the registered specs. Throws
+   * only on malformed input: shape violations and unknown step tags (so v1
+   * callers are shielded from step variants added in later versions).
    */
   buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
 

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -70,7 +70,7 @@ export interface PTableV8 extends Disposable {
 }
 
 /**
- * Table view returned by `createTableV2`.
+ * Table view returned by `createTable`.
  *
  * PTable can be thought as having a composite primary key, consisting
  * of axes, and a set of data columns derived from PColumn values.


### PR DESCRIPTION
## What

PFrame internal-API (`@milaboratories/pl-model-middle-layer`) changes that unblock the `pframes-rs` C7/C14 migration and the `pf-driver` follow-up.

### `rewriteLegacyFilters` (WASM-spec)
- Adds **`PFrameWasmAPIV4`** — a self-contained WASM-spec factory (does not extend `PFrameWasmAPIV3`, so the old one can be dropped once adopted) that adds a stateless **`rewriteLegacyFilters`**.
- `rewriteLegacyFilters({ tableSpec, filters })` upgrades selector-based legacy record filters into index-based **data-layer boolean expressions** for a given unified table spec. It lives on the factory (not the per-frame interface) because it's stateless — filtering never changes a table's spec, so the result is valid both for the V2 unique-values request (over the source column's single-column table) and for composing a `filter` over a `table` query node of that table.
- The per-frame `PFrameWasmV3` interface is **unchanged**; `PFrameWasmAPIV4.createPFrame` still returns `PFrameWasmV3`. `PFrameWasmAPIV3` is marked superseded.

### Drop the `V2` suffix on the data-side create method
- `PFrameReadAPIV12.createTableV2` → **`createTable`** (now that the legacy V1 `createTable` is gone). Altered in place since `PFrameReadAPIV12` / `PFrameV14` are the not-yet-released Vx+1 interfaces. The released `PFrameReadAPIV11.createTableV2` (`{ tableSpec, dataQuery }` → `PTableV8`) is untouched.

## Verification
- `pl-model-middle-layer` `check` (tsc + oxlint + format) passes.
- `pf-driver` `check` passes (it consumes the untouched V11 `createTableV2`); no implementers of `PFrameReadAPIV12`/`PFrameV14` exist in the repo yet, so the rename breaks nothing.

## Follow-up
Once released, `pframes-rs` bumps `pl-model-middle-layer` and switches its wrappers off the transitional shims — the wasm `PFrame` exposes `rewriteLegacyFilters` via `PFrameWasmAPIV4`, and the node `PFrame` uses `createTable` (PFrameV14).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the `@milaboratories/pl-model-middle-layer` WASM-spec surface with two changes to unblock the `pframes-rs` migration. Both changes are interface-only (TypeScript types) with no runtime logic.

- Adds **`PFrameWasmAPIV4`** — a self-contained factory that duplicates all `PFrameWasmAPIV3` methods and adds the new stateless `rewriteLegacyFilters`, which upgrades selector-based legacy record filters into index-based `DataQueryBooleanExpression[]` for a given unified table spec. `PFrameWasmAPIV3` is marked superseded.
- Renames `createTableV2` → `createTable` on the unreleased **`PFrameReadAPIV12`** interface (and updates its JSDoc and the `PTableV9` comment); the released `PFrameReadAPIV11.createTableV2` is untouched.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are TypeScript interface declarations with no runtime logic; the released V11 surface is untouched and the V12 rename affects only an unreleased interface.

The changes are purely additive interface definitions. The one thing worth a second look before V3 is deleted is the buildQuery JSDoc in PFrameWasmAPIV4, which defers to PFrameWasmAPIV3.buildQuery for its full semantics description — that cross-reference will dangle once V3 is removed.

lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts — specifically the buildQuery JSDoc in PFrameWasmAPIV4 before V3 is eventually dropped.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts | Adds PFrameWasmAPIV4 — a self-contained factory with all PFrameWasmAPIV3 methods plus rewriteLegacyFilters; marks V3 as superseded. One JSDoc cross-reference in buildQuery points back to V3 and will dangle when V3 is removed. |
| lib/model/middle-layer/src/pframe/internal_api/api_read.ts | Renames createTableV2 → createTable on the unreleased PFrameReadAPIV12 interface and updates the surrounding JSDoc comment; no logic changes. |
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Doc-comment update only: adjusts the PTableV9 JSDoc to say 'createTable' instead of 'createTableV2' to match the rename in PFrameReadAPIV12. |
| .changeset/pframes-wasm-rewrite-legacy-filters.md | Changeset file marking pl-model-middle-layer as a minor bump; description accurately covers both the new PFrameWasmAPIV4 and the createTableV2 rename. |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PFrameWasmAPIV4 {
        +createPFrame(spec) PFrameWasmV3
        +expandAxes(spec) AxesId
        +collapseAxes(ids) AxesSpec
        +findAxis(spec, selector) number
        +findTableColumn(tableSpec, selector) number
        +buildQuery(input) SpecQueryJoinEntry
        +rewriteLegacyFilters(request) DataQueryBooleanExpression[]
    }
    class PFrameWasmAPIV3 {
        +createPFrame(spec) PFrameWasmV3
        +expandAxes(spec) AxesId
        +collapseAxes(ids) AxesSpec
        +findAxis(spec, selector) number
        +findTableColumn(tableSpec, selector) number
        +buildQuery(input) SpecQueryJoinEntry
    }
    class PFrameWasmV3 {
        +deleteColumns(request)
        +listColumns()
        +discoverColumns(request)
        +findColumns(request)
        +evaluateQuery(request)
        +rewriteLegacyQuery(request)
        +dispose()
    }
    class PFrameReadAPIV12 {
        +createTable(tableId, dataQuery) PTableV9
        +getUniqueValues(request)
    }
    PFrameWasmAPIV4 ..> PFrameWasmV3 : creates
    PFrameWasmAPIV3 ..> PFrameWasmV3 : creates
    PFrameWasmAPIV3 <|.. PFrameWasmAPIV4 : supersedes
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts:64-69
**Dangling cross-reference to a superseded interface**

`PFrameWasmAPIV4.buildQuery`'s JSDoc says "See `{@link PFrameWasmAPIV3.buildQuery}` for the folding semantics", but `PFrameWasmAPIV3` is marked superseded and will be removed once V4 is adopted. When V3 is deleted, this link becomes a broken TypeDoc reference. Since V4 is intentionally self-contained, it should carry the full folding-semantics paragraph from V3's `buildQuery` JSDoc directly rather than forwarding to the interface it replaces.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add PFrameWasmAPIV4.rewriteLegacyFilters..."](https://github.com/milaboratory/platforma/commit/7a8aeea7f07b792ccc7c57c5068621a3db62f091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34550014)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->