### PR TITLE
MILAB-6145: per-call memoryLimit override for assets.importWasm

### DIFF
--- a/.changeset/milab-6145-wasm-memory-cap.md
+++ b/.changeset/milab-6145-wasm-memory-cap.md
@@ -1,0 +1,26 @@
+---
+"@platforma-sdk/tengo-builder": patch
+"@platforma-sdk/workflow-tengo": minor
+---
+
+MILAB-6145: per-call memory-cap override on `assets.importWasm`.
+
+- `assets.importWasm(name, opts?)` — new optional `opts` argument. Today
+  `opts.memoryLimit` (bytes) overrides the install-time per-instance
+  memory cap for just this sandbox; backend silently clamps to
+  `[16 MiB, 64 MiB]`. Omit `opts` (or omit the option) to keep the
+  install-time default (32 MiB unless the WasmV1 resource was created
+  with a different value).
+- `pl-tengo` regex/substitution now passes multi-arg `import*` calls
+  through untouched. Previously the substitution rewrote
+  `assets.importWasm("name", opts)` into `assets.importWasm("normalized") opts)`
+  — a syntax error. Single-arg call sites are unchanged.
+
+Tengo parser quirk worth knowing: `assets.importWasm("name", { ... })`
+inline trips a parse error around `{`. Hoist the opts map into a local
+first:
+
+```go
+opts := { memoryLimit: 50 * 1024 * 1024 }
+api := assets.importWasm("name", opts)["iface"]
+```

--- a/sdk/workflow-tengo/src/assets/wasm.lib.tengo
+++ b/sdk/workflow-tengo/src/assets/wasm.lib.tengo
@@ -4,6 +4,7 @@
 
 plapi := import("plapi")
 ll := import(":ll")
+maps := import(":maps")
 
 /**
  * Imports a WebAssembly component. Bundles its bytes into the template pack
@@ -30,10 +31,10 @@ ll := import(":ll")
  *   - Per-render sandbox count: 64. The 65th `assets.importWasm(...)` in
  *     one render aborts the script.
  *
- *   - Per-instance memory cap: 32 MiB by default. A block can request an
- *     override on its WasmV1 dependency, clamped to the range
- *     [16 MiB, 64 MiB]. Allocations past the live cap trap inside the
- *     guest, which aborts the script.
+ *   - Per-instance memory cap: 32 MiB by default. The caller can override
+ *     per-import via `opts.memoryLimit` (bytes); the backend silently
+ *     clamps to the range [16 MiB, 64 MiB]. Allocations past the live
+ *     cap trap inside the guest, which aborts the script.
  *
  *   - Per-call wall-clock budget: 1 minute. A guest call that runs
  *     longer trips the engine's epoch deadline and traps, aborting the
@@ -56,14 +57,31 @@ ll := import(":ll")
  *                           including the namespace (NPM package name),
  *                           e.g. "@milaboratories/pframes-rs-wasip2:main".
  *
+ * @param opts: map (optional) - per-import options:
+ *     - memoryLimit: int (bytes) — override the per-instance memory cap
+ *       just for this sandbox. Clamped to [16 MiB, 64 MiB] by the
+ *       backend; zero or omitted means "use the install-time default
+ *       (32 MiB unless the WasmV1 resource was created with a different
+ *       value)". Omit the option (or pass an empty map) for the default.
+ *
  * @return wasm: a tengo.Map keyed by WIT interface name —
  *               `wasm[<iface>][<resource>][<friendlyMethodName>]`
  *               where method names are camelCased from the WIT kebab-case
  *               (so WIT `from-json` → `fromJson`). Bare top-level funcs
  *               live at `wasm[<friendlyFuncName>]`.
  */
-importWasm := func(wasmName) {
-	return plapi.loadWasm(wasmName)
+importWasm := func(wasmName, ...rest) {
+	ll.assert(len(rest) <= 1, "assets.importWasm: too many arguments (want 1 or 2, got %d)", 1+len(rest))
+	if len(rest) == 0 {
+		return plapi.loadWasm(wasmName)
+	}
+	opts := rest[0]
+	ll.assert(ll.isMap(opts), "assets.importWasm: opts must be a map, got %v", opts)
+	memLimit := 0
+	if maps.containsKey(opts, "memoryLimit") {
+		memLimit = opts.memoryLimit
+	}
+	return plapi.loadWasm(wasmName, memLimit)
 }
 
 export ll.toStrict({

--- a/sdk/workflow-tengo/src/assets/wasm.lib.tengo
+++ b/sdk/workflow-tengo/src/assets/wasm.lib.tengo
@@ -32,9 +32,10 @@ maps := import(":maps")
  *     one render aborts the script.
  *
  *   - Per-instance memory cap: 32 MiB by default. The caller can override
- *     per-import via `opts.memoryLimit` (bytes); the backend silently
- *     clamps to the range [16 MiB, 64 MiB]. Allocations past the live
- *     cap trap inside the guest, which aborts the script.
+ *     per-import via `opts.memoryLimit` (int bytes or size-suffixed
+ *     string, e.g. `"50MiB"`); the backend silently clamps to the range
+ *     [16 MiB, 64 MiB]. Allocations past the live cap trap inside the
+ *     guest, which aborts the script.
  *
  *   - Per-call wall-clock budget: 1 minute. A guest call that runs
  *     longer trips the engine's epoch deadline and traps, aborting the
@@ -57,12 +58,16 @@ maps := import(":maps")
  *                           including the namespace (NPM package name),
  *                           e.g. "@milaboratories/pframes-rs-wasip2:main".
  *
- * @param opts: map (optional) - per-import options:
- *     - memoryLimit: int (bytes) — override the per-instance memory cap
- *       just for this sandbox. Clamped to [16 MiB, 64 MiB] by the
- *       backend; zero or omitted means "use the install-time default
- *       (32 MiB unless the WasmV1 resource was created with a different
- *       value)". Omit the option (or pass an empty map) for the default.
+ * @param opts: map (optional) - per-import options. Unknown keys are
+ *               rejected (typo guard — a misspelled `memorylimit` would
+ *               otherwise silently leave the default cap in place).
+ *     - memoryLimit: int (bytes) or string (size-suffixed, e.g.
+ *       "50MiB" — same form pt.mem(...) accepts; KiB/MiB/GiB for
+ *       base-2 or KB/MB/GB for decimal). Overrides the per-instance
+ *       memory cap just for this sandbox. Clamped to [16 MiB, 64 MiB]
+ *       by the backend; zero / "" / omitted means "use the install-time
+ *       default (32 MiB unless the WasmV1 resource was created with a
+ *       different value)".
  *
  * @return wasm: a tengo.Map keyed by WIT interface name —
  *               `wasm[<iface>][<resource>][<friendlyMethodName>]`
@@ -71,17 +76,36 @@ maps := import(":maps")
  *               live at `wasm[<friendlyFuncName>]`.
  */
 importWasm := func(wasmName, ...rest) {
-	ll.assert(len(rest) <= 1, "assets.importWasm: too many arguments (want 1 or 2, got %d)", 1+len(rest))
+	ll.assert(
+		len(rest) <= 1,
+		"assets.importWasm: too many arguments (want 1 or 2, got %d)",
+		1 + len(rest)
+	)
 	if len(rest) == 0 {
 		return plapi.loadWasm(wasmName)
 	}
 	opts := rest[0]
 	ll.assert(ll.isMap(opts), "assets.importWasm: opts must be a map, got %v", opts)
-	memLimit := 0
-	if maps.containsKey(opts, "memoryLimit") {
-		memLimit = opts.memoryLimit
+	// Typo guard: a caller who writes `memorylimit` or `memory_limit` (or
+	// expects some other key we don't recognise yet) should hear about it
+	// at the first call rather than silently get the default cap.
+	for k, _ in opts {
+		ll.assert(
+			k == "memoryLimit",
+			"assets.importWasm: unknown opts key %q (recognised: \"memoryLimit\")",
+			k
+		)
 	}
-	return plapi.loadWasm(wasmName, memLimit)
+	if !maps.containsKey(opts, "memoryLimit") {
+		return plapi.loadWasm(wasmName)
+	}
+	limit := opts.memoryLimit
+	ll.assert(
+		is_int(limit) || is_string(limit),
+		"assets.importWasm: opts.memoryLimit must be int (bytes) or string (e.g. \"50MiB\"), got %v",
+		limit
+	)
+	return plapi.loadWasm(wasmName, limit)
 }
 
 export ll.toStrict({

--- a/tests/workflow-tengo/src/wasm/memory-cap-override.tpl.tengo
+++ b/tests/workflow-tengo/src/wasm/memory-cap-override.tpl.tengo
@@ -1,0 +1,23 @@
+// Per-import memory-cap override. The default cap is 32 MiB, so a 40 MiB
+// allocation traps (cf. memory-cap-overflow-near.tpl.tengo). Here we
+// raise the cap to 50 MiB via the `memoryLimit` option on
+// assets.importWasm; the same 40 MiB allocation now succeeds.
+//
+// 50 MiB is comfortably inside the backend's clamp range
+// [16 MiB, 64 MiB], so the live cap on this Store is exactly 50 MiB.
+
+self   := import("@platforma-sdk/workflow-tengo:tpl")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+
+self.defineOutputs(["ack"])
+
+self.body(func(_inputs) {
+	// Literal must be on the same line as importWasm( — tengo-builder's
+	// build-time regex is line-by-line. The opts map is hoisted into a
+	// local because Tengo's parser doesn't accept `{...}` as a second
+	// positional arg inline.
+	opts := { memoryLimit: 50 * 1024 * 1024 }
+	api := assets.importWasm("@platforma-tests/wasm-table-fixture:main", opts)["demo:tables/api"]
+	// 40 MiB > default 32 MiB; with the 50 MiB override this fits.
+	return { ack: string(api.table.consumeMemory(string(40 * 1024 * 1024))) }
+})

--- a/tests/workflow-tengo/src/wasm/memory-cap.test.ts
+++ b/tests/workflow-tengo/src/wasm/memory-cap.test.ts
@@ -75,3 +75,26 @@ tplTest.concurrent(
     ).rejects.toThrow(/wasm trap|memory|allocation|consume-memory/);
   },
 );
+
+// Per-import override raises the live cap. The fixture's consumeMemory is
+// asked for 40 MiB — over the 32 MiB default, but within the 50 MiB
+// override — so the allocation must succeed where it would otherwise trap
+// (see memory-cap-overflow-near.tpl.tengo for the same payload at the
+// default cap).
+tplTest.concurrent(
+  "assets.importWasm — opts.memoryLimit raises the live cap above the default",
+  async ({ pl, helper, expect, skip }) => {
+    if (!pl.hasCapability("wasm:v1")) {
+      skip();
+      return;
+    }
+    const result = await helper.renderTemplate(
+      false,
+      "wasm.memory-cap-override",
+      ["ack"],
+      () => ({}),
+    );
+    const ack = await result.computeOutput("ack", (a) => a?.getDataAsJson()).awaitStableValue();
+    expect(ack as string).toMatch(/consumed/);
+  },
+);

--- a/tools/tengo-builder/src/compiler/source.test.ts
+++ b/tools/tengo-builder/src/compiler/source.test.ts
@@ -156,6 +156,36 @@ describe("import statements", () => {
       "variables are not allowed",
     );
   });
+
+  test("assets.importWasm with extra positional args keeps trailing args intact", () => {
+    // MILAB-6145: importWasm gained an optional 2nd opts arg
+    // (e.g. assets.importWasm("name", { memoryLimit: ... })). The build-
+    // time rewrite must preserve the trailing args — previously the
+    // substitution wrote its own `)` and corrupted multi-arg calls into
+    // syntactically broken output like `importWasm("normalized") opts)`.
+    const logger = createLogger("error");
+    const wasmImportWithOpts = `
+      assets := import("@platforma-sdk/workflow-tengo:assets")
+      opts := { memoryLimit: 50 * 1024 * 1024 }
+      wasm := assets.importWasm("@milaboratories/pframes-rs-wasip2:main", opts)
+    `;
+
+    const parsed = parseSource(logger, "dist", wasmImportWithOpts, stubTplName, true);
+
+    // The dependency is still discovered from the literal.
+    expect(parsed.dependencies).toContainEqual({
+      type: "wasm",
+      pkg: "@milaboratories/pframes-rs-wasip2",
+      id: "main",
+    });
+
+    // The rewritten source still calls importWasm with two args; the
+    // `, opts)` tail survives the rewrite. The normalized form replaces
+    // the package literal in place but leaves the closing tokens alone.
+    expect(parsed.src).toContain(`importWasm("@milaboratories/pframes-rs-wasip2:main", opts)`);
+    // No stray `) opts)` from the old broken substitution.
+    expect(parsed.src).not.toMatch(/\)\s*opts\)/);
+  });
 });
 
 describe("parseSingleSourceLine", () => {

--- a/tools/tengo-builder/src/compiler/source.ts
+++ b/tools/tengo-builder/src/compiler/source.ts
@@ -16,10 +16,16 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
 const namePattern = "[_a-zA-Z][_a-zA-Z0-9]*";
 
 const functionCallRE = (moduleName: string, fnName: string) => {
+  // `fnCall` captures from the function name through the first string
+  // argument (including the closing quote and any trailing whitespace);
+  // the closing-paren-or-comma check is a non-consuming lookahead, so
+  // any extra args (`assets.importWasm("name", { memoryLimit: ... })`)
+  // survive the rewrite in `compiler.ts` — only the literal is
+  // build-time material, anything past it is runtime config.
   return new RegExp(
     `\\b${moduleName}\\.(?<fnCall>(?<fnName>` +
       fnName +
-      `)\\s*\\(\\s*"(?<templateName>[^"]+)"\\s*\\))`,
+      `)\\s*\\(\\s*"(?<templateName>[^"]+)"\\s*)(?=[,)])`,
     "g",
   );
 };
@@ -454,10 +460,14 @@ function processAssetImport(
           artifacts.push(artifact);
 
           if (globalizeImports) {
-            // Replace all occurrences of this fnCall in originalLine
+            // Replace all occurrences of this fnCall in originalLine.
+            // fnCall ends right after the literal's closing quote + ws;
+            // the trailing `)` or `,` is preserved from the original
+            // line, so multi-arg calls (`fn("name", opts)`) keep their
+            // remaining args intact.
             originalLine = originalLine.replaceAll(
               fnCall,
-              `${fnName}("${artifact.pkg}:${artifact.id}")`,
+              `${fnName}("${artifact.pkg}:${artifact.id}"`,
             );
           }
         }


### PR DESCRIPTION
## Summary

`assets.importWasm` gains an optional second argument — an opts map. Today the only recognised option is `opts.memoryLimit` (bytes), which overrides the install-time per-instance memory cap for one sandboxed Store. Omitting the second argument (or omitting the option) keeps the existing behaviour.

```go
opts := { memoryLimit: 50 * 1024 * 1024 }
api := assets.importWasm("@my/wasm:main", opts)["iface"]
```

Backend silently clamps to `[16 MiB, 64 MiB]` (unchanged contract).

Paired with backend PR: https://github.com/milaboratory/pl/pull/1906.

## What changed

1. **`sdk/workflow-tengo/src/assets/wasm.lib.tengo`** — `importWasm` becomes variadic (`func(wasmName, ...rest)`). Asserts `rest` has at most one element, that element is a map, and only the recognised `memoryLimit` key is forwarded to `plapi.loadWasm(name, limit)`. JSDoc updated.

2. **`tools/tengo-builder/src/compiler/source.ts`** — regex + substitution updated so multi-arg `assets.importWasm("name", opts)` calls survive the build-time rewrite. The old regex consumed the closing `)`, then the substitution wrote its own `)` — fine for single-arg, but multi-arg calls came out corrupted (e.g. `importWasm("normalized") opts)`). Now:
   - The capture's closing token is a non-consuming lookahead for `[,)]` so trailing args survive untouched.
   - The replacement no longer adds a closing `)` — the original line's `)` (single-arg) or `,` (multi-arg) provides it.
   - All 23 existing `source.test.ts` import-regex tests still pass.

3. **Integration test** — new `memory-cap-override.tpl.tengo`: a 40 MiB allocation against a 50 MiB override succeeds. Same payload (40 MiB) traps at the default 32 MiB cap in `memory-cap-overflow-near.tpl.tengo`.

## Tengo parser quirk

`assets.importWasm("name", { memoryLimit: ... })` inline trips Tengo's parser around the `{`. Hoist the opts map into a local first — the template comment in the new test calls this out.

## Test plan

- [x] tengo-builder unit tests: 50/51 pass (1 pre-existing skip).
- [x] workflow-tengo integration suite: 11 files / 20 passed / 1 skipped (`memory-cap.test.ts` 3 → 4 tests; rest unchanged).
- [x] Build: full `pnpm build` clean.

## Changeset

`@platforma-sdk/workflow-tengo` minor, `@platforma-sdk/tengo-builder` patch.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `opts` second argument to `assets.importWasm`, with `opts.memoryLimit` (bytes) allowing per-call override of the wasm sandbox memory cap (backend clamps to [16 MiB, 64 MiB]). The build-time regex in `tengo-builder` is also fixed so multi-arg `importWasm(\"name\", opts)` calls survive the source rewrite intact.

- `wasm.lib.tengo` becomes variadic, dispatching to `plapi.loadWasm(name, 0)` or `plapi.loadWasm(name, limit)` depending on whether `opts.memoryLimit` is present.
- `source.ts` regex now uses a non-consuming lookahead `(?=[,)])` and the replacement drops the trailing `)` so extra arguments are preserved verbatim after the rewrite.
- Integration test added: 40 MiB allocation succeeds under a 50 MiB override (and traps at the default 32 MiB cap in the companion template).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the regex fix is correct and the new opt-in argument cannot break existing call sites.

The regex change is mechanically sound and all existing tests pass. The two gaps are the absence of a source.test.ts unit test for the multi-arg rewrite and the silent discard of unknown opts keys. Neither is a present defect in the shipped code.

tools/tengo-builder/src/compiler/source.ts — the new regex path has no dedicated unit test; sdk/workflow-tengo/src/assets/wasm.lib.tengo — opts key validation is absent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/tengo-builder/src/compiler/source.ts | Regex updated to use a non-consuming lookahead `(?=[,)])` and the replacement omits the closing `)` so multi-arg calls survive the build-time rewrite intact. Logic is correct; no unit test covers the new multi-arg rewrite path. |
| sdk/workflow-tengo/src/assets/wasm.lib.tengo | Variadic `importWasm` correctly dispatches to the no-limit or limit-carrying `plapi.loadWasm` overload. Unknown keys in `opts` are silently ignored, which could mask typos. |
| tests/workflow-tengo/src/wasm/memory-cap-override.tpl.tengo | New integration template that exercises the 50 MiB override for a 40 MiB allocation; correctly hoists the opts map to avoid the Tengo inline-brace parser quirk. |
| tests/workflow-tengo/src/wasm/memory-cap.test.ts | New test case correctly skips when wasm:v1 capability is absent and asserts the override template returns a consumed response string. |
| .changeset/milab-6145-wasm-memory-cap.md | Changeset correctly marks workflow-tengo as minor (new optional API) and tengo-builder as patch (bug fix). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Src as Tengo source
    participant TB as tengo-builder (source.ts)
    participant Wasm as wasm.lib.tengo
    participant PL as plapi.loadWasm

    Note over Src,TB: Build time
    Src->>TB: assets.importWasm("pkg:id", opts)
    TB->>TB: regex matches fnCall up to closing quote + ws
    TB->>Src: rewrite to assets.importWasm("normalized:id", opts)

    Note over Wasm,PL: Runtime
    Src->>Wasm: importWasm("normalized:id", opts)
    Wasm->>Wasm: extract opts.memoryLimit (0 if absent)
    alt "memLimit == 0"
        Wasm->>PL: loadWasm(name)
    else "memLimit > 0"
        Wasm->>PL: loadWasm(name, memLimit)
    end
    PL-->>Wasm: sandboxed wasm handle
    Wasm-->>Src: handle keyed by WIT interface
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tools/tengo-builder/src/compiler/source.ts:25-30
**No unit test for the multi-arg regex rewrite**

The PR fixes the build-time regex so `importWasm("name", opts)` is rewritten correctly to `importWasm("normalized", opts)` rather than the corrupted `importWasm("normalized") opts)`. That exact transform is not covered in `source.test.ts` — the two existing `importWasm` tests only exercise the single-arg form and the variable-id rejection. A dedicated unit test in `source.test.ts` (checking that `fnCall` is extracted correctly and `replaceAll` leaves the trailing `, opts)` untouched) would lock in the fix and catch any future regex regression immediately, since the integration suite is slower and has infrastructure dependencies.

### Issue 2 of 2
sdk/workflow-tengo/src/assets/wasm.lib.tengo:79-84
**Unknown `opts` keys silently ignored — typos have no effect**

Only `memoryLimit` is extracted from `opts`; any other key (e.g. `memorylimit`, `memoryLimitBytes`, `memory_limit`) is silently discarded and the call falls back to the default 32 MiB cap. A caller who typos the key will see no error and will not get the override they expected. Consider iterating over `opts` and asserting that every key is in a known-good set, or at least documenting the silent-ignore behaviour clearly at the call site so callers know to double-check spelling.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6145: changeset for per-call memor..."](https://github.com/milaboratory/platforma/commit/c179f25c85f633912996aac3a675b64af3229ae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34565658)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->