### PR TITLE
fix: make blocks work in setups without separate UI-tasks processor

### DIFF
--- a/.changeset/heavy-jars-drum.md
+++ b/.changeset/heavy-jars-drum.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Make UI-tasks work in google batch-only setups

--- a/sdk/workflow-tengo/src/exec/limits.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/limits.lib.tengo
@@ -29,7 +29,7 @@ getResourceTypes := func(queueName) {
 		return result
 	}
 
-  //
+	//
 	// Fallback: existing logic for backward compatibility with older backends
 	//
 	runnerType := constants.RUNNER_EXECUTOR

--- a/sdk/workflow-tengo/src/exec/limits.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/limits.lib.tengo
@@ -29,9 +29,13 @@ getResourceTypes := func(queueName) {
 		return result
 	}
 
+  //
 	// Fallback: existing logic for backward compatibility with older backends
+	//
 	runnerType := constants.RUNNER_EXECUTOR
-	if feats.hasBatch && queueName != constants.UI_TASKS_QUEUE {
+
+	// Special case for old deployments with google batch integration enabled.
+	if feats.hasBatch {
 		runnerType = constants.RUNNER_BATCH
 	}
 	return {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This patch fixes UI-task blocks crashing in Google Batch-only deployments where no separate executor runner exists. The fix drops the `UI_TASKS_QUEUE` exception from the legacy runner-selection fallback so that all queues — including `ui-tasks` — use the batch runner when `feats.hasBatch` is true.

- **`limits.lib.tengo`**: `getResourceTypes` fallback no longer carves out the `ui-tasks` queue; all queues now fall through to `RUNNER_BATCH` when batch is available, resolving the crash in executor-less setups.
- **`.changeset/heavy-jars-drum.md`**: Adds a patch-level changeset entry for `@platforma-sdk/workflow-tengo`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change fixes batch-only setups but removes a targeted guard without checking whether an executor is actually absent, which may silently reroute UI tasks to the batch runner in older deployments that have both runners.

The fallback condition now routes all queues — including ui-tasks — to the batch runner whenever batch is available, fixing batch-only deployments but potentially changing behaviour for older deployments that expose both runners and rely on the fallback path.

sdk/workflow-tengo/src/exec/limits.lib.tengo — the updated fallback condition warrants a second look to confirm the removal of the UI_TASKS_QUEUE exception is safe for all deployment topologies.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/exec/limits.lib.tengo | Removes the UI_TASKS_QUEUE exception from the batch-runner fallback, routing all queues to BATCH when hasBatch is true; this fixes batch-only setups but may silently reroute UI tasks away from the executor in deployments that have both runners. |
| .changeset/heavy-jars-drum.md | Standard changeset entry marking a patch release for the workflow-tengo SDK package. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getResourceTypes called with queueName] --> B{feats.getResourceTypes returns result?}
    B -- yes --> C[Return backend-provided resource types]
    B -- no --> D[Fallback: legacy logic]
    D --> E{feats.hasBatch?}
    E -- no --> F[runnerType = RUNNER_EXECUTOR]
    E -- yes --> G["runnerType = RUNNER_BATCH (ALL queues, including ui-tasks)"]
    F --> H[Return RunCommand/executor + ComputeRequest/executor]
    G --> H2[Return RunCommand/batch + ComputeRequest/batch]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
sdk/workflow-tengo/src/exec/limits.lib.tengo:37-38
**Overly broad fix may regress batch + executor deployments**

The old guard `queueName != constants.UI_TASKS_QUEUE` was removed without checking whether an executor is actually present. For old backends that expose **both** runners (`feats.hasBatch && feats.hasExec`), the fallback now routes UI-task-queue work to the batch runner instead of the executor — the opposite of the original intent. Only when `!feats.hasExec` is the executor unavailable; in that case the batch runner is the correct fallback. Consider tightening the condition so the existing behaviour is preserved when the executor is present.

```suggestion
	// Special case for old deployments with google batch integration enabled.
	if feats.hasBatch && (queueName != constants.UI_TASKS_QUEUE || !feats.hasExec) {
```

### Issue 2 of 2
sdk/workflow-tengo/src/exec/limits.lib.tengo:32-34
Mixed indentation: the opening `//` line uses 2-space indentation while the surrounding lines use tabs. Consistent tab indentation would match the rest of the file.

```suggestion
	//
	// Fallback: existing logic for backward compatibility with older backends
	//
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make blocks work in setups without ..."](https://github.com/milaboratory/platforma/commit/89f248cfd46a526d16639b5000be650ca54959cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34887428)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->