### PR TITLE
MILAB-6324: gzip WASM artefacts

### DIFF
--- a/.changeset/milab-6145-wasm-memory-cap.md
+++ b/.changeset/milab-6145-wasm-memory-cap.md
@@ -1,0 +1,26 @@
+---
+"@platforma-sdk/tengo-builder": patch
+"@platforma-sdk/workflow-tengo": minor
+---
+
+MILAB-6145: per-call memory-cap override on `assets.importWasm`.
+
+- `assets.importWasm(name, opts?)` — new optional `opts` argument. Today
+  `opts.memoryLimit` (bytes) overrides the install-time per-instance
+  memory cap for just this sandbox; backend silently clamps to
+  `[16 MiB, 64 MiB]`. Omit `opts` (or omit the option) to keep the
+  install-time default (32 MiB unless the WasmV1 resource was created
+  with a different value).
+- `pl-tengo` regex/substitution now passes multi-arg `import*` calls
+  through untouched. Previously the substitution rewrote
+  `assets.importWasm("name", opts)` into `assets.importWasm("normalized") opts)`
+  — a syntax error. Single-arg call sites are unchanged.
+
+Tengo parser quirk worth knowing: `assets.importWasm("name", { ... })`
+inline trips a parse error around `{`. Hoist the opts map into a local
+first:
+
+```go
+opts := { memoryLimit: 50 * 1024 * 1024 }
+api := assets.importWasm("name", opts)["iface"]
+```

--- a/.changeset/milab-6324-wasm-gzip.md
+++ b/.changeset/milab-6324-wasm-gzip.md
@@ -1,0 +1,21 @@
+---
+"@platforma-sdk/tengo-builder": patch
+---
+
+MILAB-6324: gzip WASM artefacts in the template pack.
+
+- `pl-tengo` now gzips every `.wasm` file (level 9) before base64-encoding it
+  into the pack's `hashToSource`. Real wasm components compress to ~30-40 % of
+  their raw size, so a `pframes-rs` build that was approaching the 2 MiB raw
+  ceiling now uses a fraction of the per-WASM resource cap and the on-wire
+  pack stays correspondingly smaller.
+- The `MAX_WASM_FILE_BYTES` guard now applies to the gzipped payload. The
+  numeric cap is unchanged (2 MiB), so the check stays in sync with the
+  backend's 3 MiB value-resource limit; in practice each `.wasm` file can
+  now be several MiB raw before hitting it.
+- Requires a backend built from `MILAB-6324-wasm-gzip` (or later): the
+  workflow controller sniffs the gzip header at precompile time and gunzips
+  before handing bytes to wasmtime. Older WASM-aware backends would reject
+  the gzip header as "not a valid wasm component" — there are no
+  WASM-using installations in the wild yet, so no compatibility window is
+  needed.

--- a/sdk/workflow-tengo/src/assets/wasm.lib.tengo
+++ b/sdk/workflow-tengo/src/assets/wasm.lib.tengo
@@ -4,6 +4,7 @@
 
 plapi := import("plapi")
 ll := import(":ll")
+maps := import(":maps")
 
 /**
  * Imports a WebAssembly component. Bundles its bytes into the template pack
@@ -30,10 +31,10 @@ ll := import(":ll")
  *   - Per-render sandbox count: 64. The 65th `assets.importWasm(...)` in
  *     one render aborts the script.
  *
- *   - Per-instance memory cap: 32 MiB by default. A block can request an
- *     override on its WasmV1 dependency, clamped to the range
- *     [16 MiB, 64 MiB]. Allocations past the live cap trap inside the
- *     guest, which aborts the script.
+ *   - Per-instance memory cap: 32 MiB by default. The caller can override
+ *     per-import via `opts.memoryLimit` (bytes); the backend silently
+ *     clamps to the range [16 MiB, 64 MiB]. Allocations past the live
+ *     cap trap inside the guest, which aborts the script.
  *
  *   - Per-call wall-clock budget: 1 minute. A guest call that runs
  *     longer trips the engine's epoch deadline and traps, aborting the
@@ -56,14 +57,31 @@ ll := import(":ll")
  *                           including the namespace (NPM package name),
  *                           e.g. "@milaboratories/pframes-rs-wasip2:main".
  *
+ * @param opts: map (optional) - per-import options:
+ *     - memoryLimit: int (bytes) — override the per-instance memory cap
+ *       just for this sandbox. Clamped to [16 MiB, 64 MiB] by the
+ *       backend; zero or omitted means "use the install-time default
+ *       (32 MiB unless the WasmV1 resource was created with a different
+ *       value)". Omit the option (or pass an empty map) for the default.
+ *
  * @return wasm: a tengo.Map keyed by WIT interface name —
  *               `wasm[<iface>][<resource>][<friendlyMethodName>]`
  *               where method names are camelCased from the WIT kebab-case
  *               (so WIT `from-json` → `fromJson`). Bare top-level funcs
  *               live at `wasm[<friendlyFuncName>]`.
  */
-importWasm := func(wasmName) {
-	return plapi.loadWasm(wasmName)
+importWasm := func(wasmName, ...rest) {
+	ll.assert(len(rest) <= 1, "assets.importWasm: too many arguments (want 1 or 2, got %d)", 1+len(rest))
+	if len(rest) == 0 {
+		return plapi.loadWasm(wasmName)
+	}
+	opts := rest[0]
+	ll.assert(ll.isMap(opts), "assets.importWasm: opts must be a map, got %v", opts)
+	memLimit := 0
+	if maps.containsKey(opts, "memoryLimit") {
+		memLimit = opts.memoryLimit
+	}
+	return plapi.loadWasm(wasmName, memLimit)
 }
 
 export ll.toStrict({

--- a/sdk/workflow-tengo/src/assets/wasm.lib.tengo
+++ b/sdk/workflow-tengo/src/assets/wasm.lib.tengo
@@ -32,9 +32,10 @@ maps := import(":maps")
  *     one render aborts the script.
  *
  *   - Per-instance memory cap: 32 MiB by default. The caller can override
- *     per-import via `opts.memoryLimit` (bytes); the backend silently
- *     clamps to the range [16 MiB, 64 MiB]. Allocations past the live
- *     cap trap inside the guest, which aborts the script.
+ *     per-import via `opts.memoryLimit` (int bytes or size-suffixed
+ *     string, e.g. `"50MiB"`); the backend silently clamps to the range
+ *     [16 MiB, 64 MiB]. Allocations past the live cap trap inside the
+ *     guest, which aborts the script.
  *
  *   - Per-call wall-clock budget: 1 minute. A guest call that runs
  *     longer trips the engine's epoch deadline and traps, aborting the
@@ -57,12 +58,16 @@ maps := import(":maps")
  *                           including the namespace (NPM package name),
  *                           e.g. "@milaboratories/pframes-rs-wasip2:main".
  *
- * @param opts: map (optional) - per-import options:
- *     - memoryLimit: int (bytes) — override the per-instance memory cap
- *       just for this sandbox. Clamped to [16 MiB, 64 MiB] by the
- *       backend; zero or omitted means "use the install-time default
- *       (32 MiB unless the WasmV1 resource was created with a different
- *       value)". Omit the option (or pass an empty map) for the default.
+ * @param opts: map (optional) - per-import options. Unknown keys are
+ *               rejected (typo guard — a misspelled `memorylimit` would
+ *               otherwise silently leave the default cap in place).
+ *     - memoryLimit: int (bytes) or string (size-suffixed, e.g.
+ *       "50MiB" — same form pt.mem(...) accepts; KiB/MiB/GiB for
+ *       base-2 or KB/MB/GB for decimal). Overrides the per-instance
+ *       memory cap just for this sandbox. Clamped to [16 MiB, 64 MiB]
+ *       by the backend; zero / "" / omitted means "use the install-time
+ *       default (32 MiB unless the WasmV1 resource was created with a
+ *       different value)".
  *
  * @return wasm: a tengo.Map keyed by WIT interface name —
  *               `wasm[<iface>][<resource>][<friendlyMethodName>]`
@@ -71,17 +76,36 @@ maps := import(":maps")
  *               live at `wasm[<friendlyFuncName>]`.
  */
 importWasm := func(wasmName, ...rest) {
-	ll.assert(len(rest) <= 1, "assets.importWasm: too many arguments (want 1 or 2, got %d)", 1+len(rest))
+	ll.assert(
+		len(rest) <= 1,
+		"assets.importWasm: too many arguments (want 1 or 2, got %d)",
+		1 + len(rest)
+	)
 	if len(rest) == 0 {
 		return plapi.loadWasm(wasmName)
 	}
 	opts := rest[0]
 	ll.assert(ll.isMap(opts), "assets.importWasm: opts must be a map, got %v", opts)
-	memLimit := 0
-	if maps.containsKey(opts, "memoryLimit") {
-		memLimit = opts.memoryLimit
+	// Typo guard: a caller who writes `memorylimit` or `memory_limit` (or
+	// expects some other key we don't recognise yet) should hear about it
+	// at the first call rather than silently get the default cap.
+	for k, _ in opts {
+		ll.assert(
+			k == "memoryLimit",
+			"assets.importWasm: unknown opts key %q (recognised: \"memoryLimit\")",
+			k
+		)
 	}
-	return plapi.loadWasm(wasmName, memLimit)
+	if !maps.containsKey(opts, "memoryLimit") {
+		return plapi.loadWasm(wasmName)
+	}
+	limit := opts.memoryLimit
+	ll.assert(
+		is_int(limit) || is_string(limit),
+		"assets.importWasm: opts.memoryLimit must be int (bytes) or string (e.g. \"50MiB\"), got %v",
+		limit
+	)
+	return plapi.loadWasm(wasmName, limit)
 }
 
 export ll.toStrict({

--- a/tests/workflow-tengo/src/wasm/memory-cap-override.tpl.tengo
+++ b/tests/workflow-tengo/src/wasm/memory-cap-override.tpl.tengo
@@ -1,0 +1,23 @@
+// Per-import memory-cap override. The default cap is 32 MiB, so a 40 MiB
+// allocation traps (cf. memory-cap-overflow-near.tpl.tengo). Here we
+// raise the cap to 50 MiB via the `memoryLimit` option on
+// assets.importWasm; the same 40 MiB allocation now succeeds.
+//
+// 50 MiB is comfortably inside the backend's clamp range
+// [16 MiB, 64 MiB], so the live cap on this Store is exactly 50 MiB.
+
+self   := import("@platforma-sdk/workflow-tengo:tpl")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+
+self.defineOutputs(["ack"])
+
+self.body(func(_inputs) {
+	// Literal must be on the same line as importWasm( — tengo-builder's
+	// build-time regex is line-by-line. The opts map is hoisted into a
+	// local because Tengo's parser doesn't accept `{...}` as a second
+	// positional arg inline.
+	opts := { memoryLimit: 50 * 1024 * 1024 }
+	api := assets.importWasm("@platforma-tests/wasm-table-fixture:main", opts)["demo:tables/api"]
+	// 40 MiB > default 32 MiB; with the 50 MiB override this fits.
+	return { ack: string(api.table.consumeMemory(string(40 * 1024 * 1024))) }
+})

--- a/tests/workflow-tengo/src/wasm/memory-cap.test.ts
+++ b/tests/workflow-tengo/src/wasm/memory-cap.test.ts
@@ -75,3 +75,26 @@ tplTest.concurrent(
     ).rejects.toThrow(/wasm trap|memory|allocation|consume-memory/);
   },
 );
+
+// Per-import override raises the live cap. The fixture's consumeMemory is
+// asked for 40 MiB — over the 32 MiB default, but within the 50 MiB
+// override — so the allocation must succeed where it would otherwise trap
+// (see memory-cap-overflow-near.tpl.tengo for the same payload at the
+// default cap).
+tplTest.concurrent(
+  "assets.importWasm — opts.memoryLimit raises the live cap above the default",
+  async ({ pl, helper, expect, skip }) => {
+    if (!pl.hasCapability("wasm:v1")) {
+      skip();
+      return;
+    }
+    const result = await helper.renderTemplate(
+      false,
+      "wasm.memory-cap-override",
+      ["ack"],
+      () => ({}),
+    );
+    const ack = await result.computeOutput("ack", (a) => a?.getDataAsJson()).awaitStableValue();
+    expect(ack as string).toMatch(/consumed/);
+  },
+);

--- a/tools/tengo-builder/src/compiler/main.ts
+++ b/tools/tengo-builder/src/compiler/main.ts
@@ -2,6 +2,7 @@
 
 import * as path from "node:path";
 import * as fs from "node:fs";
+import * as zlib from "node:zlib";
 import { pathType } from "./util";
 import type { TemplatesAndLibs } from "./compiler";
 import { TengoTemplateCompiler } from "./compiler";
@@ -424,15 +425,24 @@ function addWasmFile(
   fullName: FullArtifactName,
   compiler: TengoTemplateCompiler,
 ) {
-  // wasm bytes are binary, but hashToSource carries strings only. We base64-encode
-  // the bytes; the sourceHash is sha256 of the base64 string so it stays consistent
-  // with the existing `hashToSource[hash] === stored value` invariant.
-  const bytes = fs.readFileSync(file);
-  assertWasmFileSize(file, bytes.length, fullName);
-  const source = bytes.toString("base64");
+  // wasm bytes are binary, but hashToSource carries strings only. The file is
+  // gzipped first (level 9 — block builds run rarely, so paying the slow-but-
+  // tight setting is fine) and then base64-encoded. The backend's wasm package
+  // sniffs the gzip header at PrecompileComponent time and gunzips before
+  // handing the bytes to wasmtime. Compressing here shrinks both the per-WASM
+  // resource footprint (a real wasm component compresses to ~30-40 % of its
+  // raw size) and the on-wire pack, which lets pframes-rs grow past the
+  // 3 MiB raw-size ceiling without hitting the backend's value-resource cap.
+  const raw = fs.readFileSync(file);
+  const compressed = zlib.gzipSync(raw, { level: zlib.constants.Z_BEST_COMPRESSION });
+  assertWasmFileSize(file, compressed.length, fullName);
+  const source = compressed.toString("base64");
   const wasm = new ArtifactSource(mode, fullName, getSha256(source), source, file, [], []);
 
-  logger.debug(`Adding dependency ${fullNameToString(fullName)} from ${file}`);
+  logger.debug(
+    `Adding dependency ${fullNameToString(fullName)} from ${file} ` +
+      `(${raw.length} B raw → ${compressed.length} B gzipped)`,
+  );
   compiler.addWasm(wasm);
 }
 

--- a/tools/tengo-builder/src/compiler/pack_limits.test.ts
+++ b/tools/tengo-builder/src/compiler/pack_limits.test.ts
@@ -50,9 +50,9 @@ describe("assertTemplatePackSize", () => {
     let err: unknown;
     try {
       assertTemplatePackSize("@t/pkg:main 1.0.0", MAX_TEMPLATE_PACK_BYTES_GZIPPED + 1, [
-        { name: "@small/wasm:main", rawBytes: 100 * 1024 },
-        { name: "@big/wasm:main", rawBytes: 1.5 * 1024 * 1024 },
-        { name: "@mid/wasm:main", rawBytes: 800 * 1024 },
+        { name: "@small/wasm:main", storedBytes: 100 * 1024 },
+        { name: "@big/wasm:main", storedBytes: 1.5 * 1024 * 1024 },
+        { name: "@mid/wasm:main", storedBytes: 800 * 1024 },
       ]);
     } catch (e) {
       err = e;
@@ -91,8 +91,8 @@ describe("collectWasmContributions", () => {
     return "A".repeat(len);
   }
 
-  it("reports direct WASM dependencies with raw byte size derived from base64 length", () => {
-    const base64 = base64OfLength(400); // 400 base64 chars → 300 raw bytes
+  it("reports direct WASM dependencies with stored byte size derived from base64 length", () => {
+    const base64 = base64OfLength(400); // 400 base64 chars → 300 binary bytes
     const tpl: CompiledTemplateV3 = {
       type: "pl.tengo-template.v3",
       hashToSource: { "hash-a": base64 },
@@ -110,12 +110,12 @@ describe("collectWasmContributions", () => {
       },
     };
     const got = collectWasmContributions(tpl);
-    expect(got).toEqual([{ name: "@w/wasm:a", rawBytes: 300 }]);
+    expect(got).toEqual([{ name: "@w/wasm:a", storedBytes: 300 }]);
   });
 
   it("recurses into sub-templates and deduplicates by artefact name", () => {
-    const base64a = base64OfLength(800); // 600 raw
-    const base64b = base64OfLength(400); // 300 raw
+    const base64a = base64OfLength(800); // 600 binary bytes
+    const base64b = base64OfLength(400); // 300 binary bytes
     const tpl: CompiledTemplateV3 = {
       type: "pl.tengo-template.v3",
       hashToSource: { "hash-a": base64a, "hash-b": base64b },
@@ -149,8 +149,8 @@ describe("collectWasmContributions", () => {
     };
     const got = collectWasmContributions(tpl).sort((a, b) => a.name.localeCompare(b.name));
     expect(got).toEqual([
-      { name: "@w/wasm:a", rawBytes: 600 },
-      { name: "@w/wasm:b", rawBytes: 300 },
+      { name: "@w/wasm:a", storedBytes: 600 },
+      { name: "@w/wasm:b", storedBytes: 300 },
     ]);
   });
 

--- a/tools/tengo-builder/src/compiler/pack_limits.ts
+++ b/tools/tengo-builder/src/compiler/pack_limits.ts
@@ -17,11 +17,16 @@ import { fullNameToString } from "./package";
 //      3.5 MiB per gzipped template pack, checked before the pack itself is
 //      stored as a TengoTemplatePackV1 value resource.
 
-// 2 MiB raw → ~2.67 MiB base64 + JSON wrapper → comfortably under the 3 MiB
-// per-value-resource cap with ~330 KiB headroom for the WasmV1Data wrapper
-// (Name, Version, Runtime, DefaultMemoryLimit, JSON syntax). WasmV1Data.Code
-// is a Go `[]byte`, which encoding/json serialises as base64 — that's where
-// the 4/3 expansion comes from.
+// Cap on the gzipped wasm payload that ends up in WasmV1Data.Code on the
+// backend. 2 MiB gzipped → ~2.67 MiB base64 + JSON wrapper → comfortably
+// under the 3 MiB per-value-resource cap with ~330 KiB headroom for the
+// WasmV1Data wrapper (Name, Version, Runtime, DefaultMemoryLimit, JSON
+// syntax). WasmV1Data.Code is a Go `[]byte`, which encoding/json serialises
+// as base64 — that's where the 4/3 expansion comes from.
+//
+// The tengo-builder gzips wasm files before adding them to the pack; this
+// cap therefore admits raw .wasm files several times larger than 2 MiB
+// (real wasm components compress to ~30-40 % of their raw size).
 export const MAX_WASM_FILE_BYTES = 2 * 1024 * 1024;
 
 // 100 KiB below the backend's 3.5 MiB so blocks don't break on small
@@ -41,8 +46,8 @@ export function assertWasmFileSize(
 ): void {
   if (byteLength <= MAX_WASM_FILE_BYTES) return;
   throw new Error(
-    `WASM artefact ${fullNameToString(fullName)} from ${file} is ${formatBytes(byteLength)}, ` +
-      `which exceeds tengo-builder's ${formatBytes(MAX_WASM_FILE_BYTES)} per-WASM cap. ` +
+    `WASM artefact ${fullNameToString(fullName)} from ${file} is ${formatBytes(byteLength)} ` +
+      `gzipped, which exceeds tengo-builder's ${formatBytes(MAX_WASM_FILE_BYTES)} per-WASM cap. ` +
       `The backend stores each WASM as a single value resource (3 MiB hard cap after base64+JSON ` +
       `marshal — see maxResourceDataSize in pl: platform/core/transaction/assertions.go). ` +
       `Strip debug info or run \`wasm-opt -Oz\` to shrink it.`,
@@ -52,8 +57,13 @@ export function assertWasmFileSize(
 export interface WasmContribution {
   /** Artefact name as stored under TemplateDataV3.wasm (e.g. "@pkg:id"). */
   readonly name: string;
-  /** Raw WASM bytes — decoded from the base64-encoded source in hashToSource. */
-  readonly rawBytes: number;
+  /**
+   * Bytes this artefact contributes to the pack, measured after gzip and
+   * before base64 — i.e. the size of the binary payload stored on the
+   * backend in WasmV1Data.Code. Decoded from the base64-encoded source in
+   * hashToSource.
+   */
+  readonly storedBytes: number;
 }
 
 /**
@@ -69,10 +79,10 @@ export function collectWasmContributions(tpl: CompiledTemplateV3): WasmContribut
     for (const [name, ref] of Object.entries(t.wasm ?? {})) {
       if (seen.has(name)) continue;
       const base64 = tpl.hashToSource[ref.sourceHash];
-      // base64 encodes 3 raw bytes per 4 chars; the off-by-padding is at most
-      // 2 bytes per artefact — fine for a human-readable size breakdown.
-      const rawBytes = base64 != null ? Math.floor((base64.length * 3) / 4) : 0;
-      seen.set(name, { name, rawBytes });
+      // base64 encodes 3 binary bytes per 4 chars; the off-by-padding is at
+      // most 2 bytes per artefact — fine for a human-readable size breakdown.
+      const storedBytes = base64 != null ? Math.floor((base64.length * 3) / 4) : 0;
+      seen.set(name, { name, storedBytes });
     }
     for (const sub of Object.values(t.templates ?? {})) walk(sub);
   }
@@ -86,12 +96,12 @@ export function assertTemplatePackSize(
   wasmContributions: readonly WasmContribution[],
 ): void {
   if (gzippedByteLength <= MAX_TEMPLATE_PACK_BYTES_GZIPPED) return;
-  const ranked = [...wasmContributions].sort((a, b) => b.rawBytes - a.rawBytes);
+  const ranked = [...wasmContributions].sort((a, b) => b.storedBytes - a.storedBytes);
   const breakdown =
     ranked.length === 0
       ? "\n  (no WASM artefacts in this pack — heavy libs, software descriptors, or sub-templates are the likely cause.)"
-      : "\nWASM artefacts in this pack (raw bytes):\n" +
-        ranked.map((w) => `  - ${w.name} — ${formatBytes(w.rawBytes)}`).join("\n");
+      : "\nWASM artefacts in this pack (gzipped, pre-base64):\n" +
+        ranked.map((w) => `  - ${w.name} — ${formatBytes(w.storedBytes)}`).join("\n");
   throw new Error(
     `Template pack ${templateName} is ${formatBytes(gzippedByteLength)} gzipped, ` +
       `which exceeds tengo-builder's ${formatBytes(MAX_TEMPLATE_PACK_BYTES_GZIPPED)} per-pack cap. ` +

--- a/tools/tengo-builder/src/compiler/source.test.ts
+++ b/tools/tengo-builder/src/compiler/source.test.ts
@@ -156,6 +156,36 @@ describe("import statements", () => {
       "variables are not allowed",
     );
   });
+
+  test("assets.importWasm with extra positional args keeps trailing args intact", () => {
+    // MILAB-6145: importWasm gained an optional 2nd opts arg
+    // (e.g. assets.importWasm("name", { memoryLimit: ... })). The build-
+    // time rewrite must preserve the trailing args — previously the
+    // substitution wrote its own `)` and corrupted multi-arg calls into
+    // syntactically broken output like `importWasm("normalized") opts)`.
+    const logger = createLogger("error");
+    const wasmImportWithOpts = `
+      assets := import("@platforma-sdk/workflow-tengo:assets")
+      opts := { memoryLimit: 50 * 1024 * 1024 }
+      wasm := assets.importWasm("@milaboratories/pframes-rs-wasip2:main", opts)
+    `;
+
+    const parsed = parseSource(logger, "dist", wasmImportWithOpts, stubTplName, true);
+
+    // The dependency is still discovered from the literal.
+    expect(parsed.dependencies).toContainEqual({
+      type: "wasm",
+      pkg: "@milaboratories/pframes-rs-wasip2",
+      id: "main",
+    });
+
+    // The rewritten source still calls importWasm with two args; the
+    // `, opts)` tail survives the rewrite. The normalized form replaces
+    // the package literal in place but leaves the closing tokens alone.
+    expect(parsed.src).toContain(`importWasm("@milaboratories/pframes-rs-wasip2:main", opts)`);
+    // No stray `) opts)` from the old broken substitution.
+    expect(parsed.src).not.toMatch(/\)\s*opts\)/);
+  });
 });
 
 describe("parseSingleSourceLine", () => {

--- a/tools/tengo-builder/src/compiler/source.ts
+++ b/tools/tengo-builder/src/compiler/source.ts
@@ -16,10 +16,16 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
 const namePattern = "[_a-zA-Z][_a-zA-Z0-9]*";
 
 const functionCallRE = (moduleName: string, fnName: string) => {
+  // `fnCall` captures from the function name through the first string
+  // argument (including the closing quote and any trailing whitespace);
+  // the closing-paren-or-comma check is a non-consuming lookahead, so
+  // any extra args (`assets.importWasm("name", { memoryLimit: ... })`)
+  // survive the rewrite in `compiler.ts` — only the literal is
+  // build-time material, anything past it is runtime config.
   return new RegExp(
     `\\b${moduleName}\\.(?<fnCall>(?<fnName>` +
       fnName +
-      `)\\s*\\(\\s*"(?<templateName>[^"]+)"\\s*\\))`,
+      `)\\s*\\(\\s*"(?<templateName>[^"]+)"\\s*)(?=[,)])`,
     "g",
   );
 };
@@ -454,10 +460,14 @@ function processAssetImport(
           artifacts.push(artifact);
 
           if (globalizeImports) {
-            // Replace all occurrences of this fnCall in originalLine
+            // Replace all occurrences of this fnCall in originalLine.
+            // fnCall ends right after the literal's closing quote + ws;
+            // the trailing `)` or `,` is preserved from the original
+            // line, so multi-arg calls (`fn("name", opts)`) keep their
+            // remaining args intact.
             originalLine = originalLine.replaceAll(
               fnCall,
-              `${fnName}("${artifact.pkg}:${artifact.id}")`,
+              `${fnName}("${artifact.pkg}:${artifact.id}"`,
             );
           }
         }


### PR DESCRIPTION
## Summary

- `tengo-builder` now gzips every `.wasm` (level 9) before base64-encoding it into the pack's `hashToSource`. Real wasm components compress to ~30-40 % of their raw size, so each `.wasm` file can now be several MiB raw before the per-WASM resource cap fires.
- `MAX_WASM_FILE_BYTES` (still 2 MiB) now applies to the gzipped payload; the error message and `WasmContribution.storedBytes` (renamed from `rawBytes`) reflect that.
- Companion change in [milaboratory/pl#1913](https://github.com/milaboratory/pl/pull/1913): the workflow controller sniffs the gzip header at precompile time and gunzips before handing bytes to wasmtime.

## Why

`pframes-rs` is approaching the 3 MiB per-value-resource cap. Compressing here gives ~3× raw-size headroom and shrinks the on-wire pack by a comparable amount, with no new capability token (no WASM-using installs in the wild).

## Stacked on

[#1665 (memory-cap override)](https://github.com/milaboratory/platforma/pull/1665) — the diff here includes those commits until that PR lands.

## Test plan

- [x] `pnpm run test` (tengo-builder package) — 51 passed.
- [x] `pnpm run check` (lint + format + typecheck) — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)