### PR TITLE
feat(pframe): add V10 addon interfaces with PTable export method

### DIFF
--- a/.changeset/pframe-ptable-v10-export.md
+++ b/.changeset/pframe-ptable-v10-export.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+---
+
+Declare next-generation PFrame addon interfaces (`PTableV10`, `PFrameReadAPIV13`, `PFrameV15`, `PFrameFactoryV6`). `PTableV10` adds an `export(path, headers, ops?)` method that streams the full, sorted table to a file, selecting the output format from the file extension (`csv`/`tsv`/`parquet`/`xlsx`). The new interfaces are fully self-contained and do not reference the V9-era interfaces (`PTableV9`, `PFrameReadAPIV12`, `PFrameV14`, `PFrameFactoryV5`), which will be removed once the published addon implements the new surface.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -4,7 +4,7 @@ import type {
   DataQuery,
   DataQueryBooleanExpression,
 } from "@milaboratories/pl-model-common";
-import type { PTableV9 } from "./table";
+import type { PTableV9, PTableV10 } from "./table";
 import type { PTableId } from "./common";
 
 /**
@@ -43,6 +43,32 @@ export interface UniqueValuesRequestV2 {
 export interface PFrameReadAPIV12 {
   /** Creates table from a pre-lowered data query. */
   createTable(tableId: PTableId, dataQuery: DataQuery): PTableV9;
+
+  /** Calculate set of unique values for a specific axis for the filtered set of records. */
+  getUniqueValues(
+    request: UniqueValuesRequestV2,
+    ops?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<UniqueValuesResponse>;
+}
+
+/**
+ * Read interface exposed by PFrames library.
+ *
+ * Identical to {@link PFrameReadAPIV12} but returns the {@link PTableV10}
+ * table view, which adds the `export` method.
+ *
+ * Spec-side operations (finding columns, listing columns, retrieving
+ * column specs, computing axis integrations) are not part of this
+ * surface — callers cache column specs themselves or route through
+ * WASM-spec. The data-side `createTable` accepts a pre-lowered
+ * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
+ * {@link UniqueValuesRequestV2}.
+ */
+export interface PFrameReadAPIV13 {
+  /** Creates table from a pre-lowered data query. */
+  createTable(tableId: PTableId, dataQuery: DataQuery): PTableV10;
 
   /** Calculate set of unique values for a specific axis for the filtered set of records. */
   getUniqueValues(

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,10 +1,18 @@
 import type { PFrameFactoryAPIV5 } from "./api_factory";
-import type { PFrameReadAPIV12 } from "./api_read";
+import type { PFrameReadAPIV12, PFrameReadAPIV13 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
 /** Full PFrame surface — factory operations plus data-side reads. */
 export interface PFrameV14 extends PFrameFactoryAPIV5, PFrameReadAPIV12 {}
+
+/**
+ * Full PFrame surface — factory operations plus data-side reads.
+ *
+ * Identical to {@link PFrameV14} but exposes {@link PFrameReadAPIV13}, whose
+ * tables add the `export` method.
+ */
+export interface PFrameV15 extends PFrameFactoryAPIV5, PFrameReadAPIV13 {}
 
 export type PFrameOptionsV2 = {
   /** PFrame ID for logging purposes */
@@ -22,6 +30,29 @@ export interface PFrameFactoryV5 {
    * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
    */
   createPFrame(options: PFrameOptionsV2): PFrameV14;
+
+  /**
+   * Dump active allocations from all PFrames instances in pprof format.
+   * The result of this function should be saved as `profile.pb.gz`.
+   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
+   * to view the allocation flamechart.
+   * @warning This method will always reject on Windows!
+   */
+  pprofDump: () => Promise<Uint8Array>;
+}
+
+/**
+ * PFrame management functions exposed by the PFrame module.
+ *
+ * Identical to {@link PFrameFactoryV5} but creates {@link PFrameV15} instances,
+ * whose tables add the `export` method.
+ */
+export interface PFrameFactoryV6 {
+  /**
+   * Create a new PFrame instance.
+   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
+   */
+  createPFrame(options: PFrameOptionsV2): PFrameV15;
 
   /**
    * Dump active allocations from all PFrames instances in pprof format.

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -47,3 +47,73 @@ export interface PTableV9 extends Disposable {
   /** Deallocates all underlying resources */
   dispose(): void;
 }
+
+/**
+ * Table view returned by `createTable`.
+ *
+ * PTable can be thought as having a composite primary key, consisting
+ * of axes, and a set of data columns derived from PColumn values.
+ * The table's column spec is owned by the caller — selector → index
+ * resolution runs on the caller side via WASM-spec.
+ */
+export interface PTableV10 extends Disposable {
+  /**
+   * Get PTable disk footprint in bytes.
+   *
+   * @param ops.withPredecessors When true, the footprint includes
+   *   every registered predecessor table reachable through the
+   *   query lineage. When false or omitted, only this table's own
+   *   materialised data is counted.
+   *
+   * Warning: This call materializes the join.
+   */
+  getFootprint(ops?: { withPredecessors?: boolean; signal?: AbortSignal }): Promise<number>;
+
+  /**
+   * Unified table shape
+   * Warning: This call materializes the join.
+   */
+  getShape(ops?: { signal?: AbortSignal }): Promise<PTableShape>;
+
+  /**
+   * Retrieve the data from the table. To retrieve only data required, it can be
+   * sliced both horizontally ({@link columnIndices}) and vertically
+   * ({@link range}).
+   * This call materializes the join.
+   *
+   * @param columnIndices unified indices of columns to be retrieved
+   * @param range optionally limit the range of records to retrieve
+   * */
+  getData(
+    columnIndices: number[],
+    ops?: {
+      range?: TableRange;
+      signal?: AbortSignal;
+    },
+  ): Promise<PTableVector[]>;
+
+  /**
+   * Stream the full, sorted table to a file at `path`. The output format is
+   * selected from the file extension: `csv`, `tsv`, `parquet`, or `xlsx`.
+   * Writing is bounded-memory.
+   * This call materializes the join.
+   *
+   * @param path destination file path; its extension selects the format
+   * @param headers column names in unified order (axes first, then data
+   *   columns). Length must equal the number of table fields — the data layer
+   *   is name-independent, so names are supplied by the caller.
+   *
+   * @remarks For `xlsx` the caller must ensure the row count is below Excel's
+   *   1,048,576-row per-sheet limit.
+   */
+  export(
+    path: string,
+    headers: string[],
+    ops?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<void>;
+
+  /** Deallocates all underlying resources */
+  dispose(): void;
+}


### PR DESCRIPTION
## What

Declares the next generation of PFrame addon interfaces in `@milaboratories/pl-model-middle-layer` (`internal_api`), adding a file-export capability to the PTable surface:

- **`PTableV10`** (`table.ts`) — same methods as `PTableV9` plus a new `export` method:
  ```ts
  export(
    path: string,
    headers: string[],
    ops?: { signal?: AbortSignal },
  ): Promise<void>;
  ```
  Streams the full, sorted table to `path`; the output format is selected from the file extension (`csv` / `tsv` / `parquet` / `xlsx`). `headers` carries the column names in unified order (axes first), since the data layer is name-independent.
- **`PFrameReadAPIV13`** (`api_read.ts`) — `createTable(...)` returns `PTableV10`.
- **`PFrameV15`** + **`PFrameFactoryV6`** (`pframe.ts`) — wire the new read API through the factory.

## Why

The native pframes-rs addon now supports bounded-memory table export to file. These interfaces expose that capability so the pf-driver can offer a native export path (to be wrapped into a request in a follow-up).

## Notes

- **Purely additive.** The V9-era interfaces (`PTableV9`, `PFrameReadAPIV12`, `PFrameV14`, `PFrameFactoryV5`) are untouched and still exported, so nothing currently consuming them changes.
- The new interfaces are **fully self-contained** — they do not `extends` or reference the V9-era versions, so those can be deleted cleanly once the addon implements the new surface. They reuse only the unchanged shared pieces (`PFrameFactoryAPIV5`, `UniqueValuesRequestV2`, `PFrameOptionsV2`, pl-model-common types).
- For `xlsx`, callers must keep the row count below Excel's 1,048,576-row per-sheet limit (documented on the method).

## Follow-ups (not in this PR)

Implement `PTableV10` in pframes-rs → adopt in pf-driver → wrap into the driver request layer → remove the V9 chain.

types-check / lint / format pass for the package.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR declares the next generation of PFrame addon interfaces (`PTableV10`, `PFrameReadAPIV13`, `PFrameV15`, `PFrameFactoryV6`) in `@milaboratories/pl-model-middle-layer`, adding a bounded-memory file-export capability to the table surface. All changes are purely additive — existing V9-era interfaces are untouched and continue to be exported.

- **`PTableV10`** mirrors `PTableV9` and adds `export(path, headers, ops?)`, which streams the full sorted table to a file, inferring format (`csv`/`tsv`/`parquet`/`xlsx`) from the extension; `headers` supplies column names since the data layer is name-independent.
- **`PFrameReadAPIV13`**, **`PFrameV15`**, and **`PFrameFactoryV6`** wire the new table type through the read API and factory chain, keeping the interfaces fully self-contained so the V9 chain can be deleted cleanly once the native addon ships the new surface.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — purely additive TypeScript interface declarations with no runtime behavior changes.

The change touches only type declarations and introduces no runtime logic. All new interfaces are auto-exported via the existing export * barrel, and the V9 chain is left intact. The one thing worth a second look before implementation lands: the method is named export, which is a JS/TS reserved word. Dot-call and class-method usage are valid, but destructuring shorthand (const { export } = table) silently fails with a syntax error and the name reads as a keyword at a glance — renaming to exportToFile or writeToFile would be safer for callers.

lib/model/middle-layer/src/pframe/internal_api/table.ts — specifically the export method name on PTableV10.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Adds PTableV10 interface — a self-contained copy of PTableV9 plus an export(path, headers, ops?) method; method name collides with the JS/TS reserved word `export` |
| lib/model/middle-layer/src/pframe/internal_api/api_read.ts | Adds PFrameReadAPIV13 — identical to PFrameReadAPIV12 but createTable() returns PTableV10; clean additive change |
| lib/model/middle-layer/src/pframe/internal_api/pframe.ts | Adds PFrameV15 (extends PFrameFactoryAPIV5 + PFrameReadAPIV13) and PFrameFactoryV6 (createPFrame returns PFrameV15); straightforward wiring of the new read API |
| .changeset/pframe-ptable-v10-export.md | Minor-bump changeset entry for @milaboratories/pl-model-middle-layer describing the new V10 interfaces |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PTableV9 {
        +getFootprint(ops?) Promise~number~
        +getShape(ops?) Promise~PTableShape~
        +getData(columnIndices, ops?) Promise~PTableVector[]~
        +dispose() void
    }

    class PTableV10 {
        +getFootprint(ops?) Promise~number~
        +getShape(ops?) Promise~PTableShape~
        +getData(columnIndices, ops?) Promise~PTableVector[]~
        +export(path, headers, ops?) Promise~void~
        +dispose() void
    }

    class PFrameReadAPIV12 {
        +createTable(tableId, dataQuery) PTableV9
        +getUniqueValues(request, ops?) Promise~UniqueValuesResponse~
    }

    class PFrameReadAPIV13 {
        +createTable(tableId, dataQuery) PTableV10
        +getUniqueValues(request, ops?) Promise~UniqueValuesResponse~
    }

    class PFrameV14 {
    }

    class PFrameV15 {
    }

    class PFrameFactoryV5 {
        +createPFrame(options) PFrameV14
        +pprofDump() Promise~Uint8Array~
    }

    class PFrameFactoryV6 {
        +createPFrame(options) PFrameV15
        +pprofDump() Promise~Uint8Array~
    }

    PFrameV14 --|> PFrameFactoryAPIV5
    PFrameV14 --|> PFrameReadAPIV12
    PFrameV15 --|> PFrameFactoryAPIV5
    PFrameV15 --|> PFrameReadAPIV13
    PFrameReadAPIV12 ..> PTableV9 : returns
    PFrameReadAPIV13 ..> PTableV10 : returns
    PFrameFactoryV5 ..> PFrameV14 : creates
    PFrameFactoryV6 ..> PFrameV15 : creates
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/middle-layer/src/pframe/internal_api/table.ts:109-115
**`export` is a reserved keyword used as a method name**

`export` is a JS/TS reserved word. While dot-call syntax (`table.export(...)`) and class/object-literal method declarations are valid, any caller who tries to destructure it as a shorthand (`const { export } = table`) gets a syntax error. It also reads as a keyword at first glance, slowing comprehension. Consider `exportToFile` or `writeToFile` to avoid the ambiguity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframe): add V10 addon interfaces w..."](https://github.com/milaboratory/platforma/commit/d2d7fe52e0b27ec0c7c7faa0b2111401612032f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34916464)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->