### PR TITLE
MILAB-6318: add getDataAsJsonOrUndefined to TreeNodeAccessor

### DIFF
--- a/.changeset/milab-6318-getdataasjson-or-undefined.md
+++ b/.changeset/milab-6318-getdataasjson-or-undefined.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": minor
+---
+
+MILAB-6318: add `TreeNodeAccessor.getDataAsJsonOrUndefined<T>()`, a not-ready-safe reader. It returns `undefined` while a resource is still computing instead of throwing "Resource has no content." — the throw `getDataAsJson` raises for a resolved-but-not-yet-fetched blob, which surfaces a transient "Some outputs have errors" banner during calculation on remote backends. A terminal-but-empty resource still throws, matching `getDataAsJson`.

--- a/.changeset/milab-6318-getdataasjson-or-undefined.md
+++ b/.changeset/milab-6318-getdataasjson-or-undefined.md
@@ -2,4 +2,4 @@
 "@platforma-sdk/model": minor
 ---
 
-MILAB-6318: add `TreeNodeAccessor.getDataAsJsonOrUndefined<T>()`, a not-ready-safe reader. It returns `undefined` while a resource is still computing instead of throwing "Resource has no content." — the throw `getDataAsJson` raises for a resolved-but-not-yet-fetched blob, which surfaces a transient "Some outputs have errors" banner during calculation on remote backends. A terminal-but-empty resource still throws, matching `getDataAsJson`.
+MILAB-6318: add `TreeNodeAccessor.getDataAsJsonOrUndefined<T>()`, a not-ready-safe reader. It returns `undefined` while a resource is still computing instead of throwing "Resource has no content." — the error `getDataAsJson` raises for a field that resolves before its resource is ready, which surfaces a transient "Some outputs have errors" banner during calculation on remote backends. A terminal-but-empty resource still throws, matching `getDataAsJson`.

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -1,16 +1,19 @@
 import { afterEach, expect, test, vi } from "vitest";
 import { TreeNodeAccessor } from "./accessor";
-import type { AccessorHandle, GlobalCfgRenderCtxMethods } from "./internal";
+import * as internal from "../internal";
+import type { AccessorHandle } from "./internal";
 
 const HANDLE = "test-handle" as AccessorHandle;
 
-function accessorWithCtx(ctx: Partial<GlobalCfgRenderCtxMethods>): TreeNodeAccessor {
-  globalThis.cfgRenderCtx = ctx as unknown as typeof globalThis.cfgRenderCtx;
+type RenderCtx = ReturnType<typeof internal.getCfgRenderCtx>;
+
+function accessorWithCtx(ctx: Partial<RenderCtx>): TreeNodeAccessor {
+  vi.spyOn(internal, "getCfgRenderCtx").mockReturnValue(ctx as RenderCtx);
   return new TreeNodeAccessor(HANDLE, []);
 }
 
 afterEach(() => {
-  globalThis.cfgRenderCtx = undefined as unknown as typeof globalThis.cfgRenderCtx;
+  vi.restoreAllMocks();
 });
 
 test("getDataAsJsonOrUndefined returns undefined while the resource is still computing", () => {

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { TreeNodeAccessor } from "./accessor";
+import type { AccessorHandle, GlobalCfgRenderCtxMethods } from "./internal";
+
+const HANDLE = "test-handle" as AccessorHandle;
+
+function accessorWithCtx(ctx: Partial<GlobalCfgRenderCtxMethods>): TreeNodeAccessor {
+  globalThis.cfgRenderCtx = ctx as unknown as typeof globalThis.cfgRenderCtx;
+  return new TreeNodeAccessor(HANDLE, []);
+}
+
+afterEach(() => {
+  globalThis.cfgRenderCtx = undefined as unknown as typeof globalThis.cfgRenderCtx;
+});
+
+test("getDataAsJsonOrUndefined returns undefined while the resource is still computing", () => {
+  const getDataAsString = vi.fn<() => string | undefined>(() => undefined);
+  const acc = accessorWithCtx({ getIsReadyOrError: () => false, getDataAsString });
+  expect(acc.getDataAsJsonOrUndefined()).toBeUndefined();
+  // Must short-circuit before reading content — that is the MILAB-6318 fix.
+  expect(getDataAsString).not.toHaveBeenCalled();
+});
+
+test("getDataAsJsonOrUndefined parses content once the resource is ready", () => {
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getDataAsString: () => JSON.stringify({ min_len: 7 }),
+  });
+  expect(acc.getDataAsJsonOrUndefined<{ min_len: number }>()).toEqual({ min_len: 7 });
+});
+
+test("getDataAsJsonOrUndefined throws when a ready resource has no content", () => {
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getDataAsString: () => undefined,
+  });
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow("Resource has no content.");
+});

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -204,23 +204,24 @@ export class TreeNodeAccessor {
 
   /**
    * Like {@link getDataAsJson}, but returns `undefined` while the resource is
-   * still being computed instead of throwing.
+   * still computing instead of throwing.
    *
-   * Prefer this in reactive output lambdas. A field that is resolved but whose
-   * blob has not been fetched yet (routine on remote backends) makes
-   * {@link getDataAsJson} throw "Resource has no content." mid-calculation,
-   * surfacing a transient "Some outputs have errors" banner that clears once
-   * the blob arrives (MILAB-6318).
+   * Prefer this in reactive output lambdas. A field that resolves before its
+   * resource is ready (routine on remote backends) makes {@link getDataAsJson}
+   * throw "Resource has no content." mid-calculation, surfacing a transient
+   * "Some outputs have errors" banner that clears once the resource finishes
+   * (MILAB-6318).
    *
    * A resource that has reached a terminal state (ready or error) but still
    * carries no content is a genuine error and throws, matching
    * {@link getDataAsJson}.
    */
   public getDataAsJsonOrUndefined<T>(): T | undefined {
+    // getIsReadyOrError() marks the computable unstable while not ready, which
+    // schedules recomputation once the resource finishes. Load-bearing, not a
+    // redundant guard over getDataAsJson — keep it.
     if (!this.getIsReadyOrError()) return undefined;
-    const content = this.getDataAsString();
-    if (content == undefined) throw new Error("Resource has no content.");
-    return JSON.parse(content);
+    return this.getDataAsJson<T>();
   }
 
   /**

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -203,6 +203,27 @@ export class TreeNodeAccessor {
   }
 
   /**
+   * Like {@link getDataAsJson}, but returns `undefined` while the resource is
+   * still being computed instead of throwing.
+   *
+   * Prefer this in reactive output lambdas. A field that is resolved but whose
+   * blob has not been fetched yet (routine on remote backends) makes
+   * {@link getDataAsJson} throw "Resource has no content." mid-calculation,
+   * surfacing a transient "Some outputs have errors" banner that clears once
+   * the blob arrives (MILAB-6318).
+   *
+   * A resource that has reached a terminal state (ready or error) but still
+   * carries no content is a genuine error and throws, matching
+   * {@link getDataAsJson}.
+   */
+  public getDataAsJsonOrUndefined<T>(): T | undefined {
+    if (!this.getIsReadyOrError()) return undefined;
+    const content = this.getDataAsString();
+    if (content == undefined) throw new Error("Resource has no content.");
+    return JSON.parse(content);
+  }
+
+  /**
    *
    */
   public getPColumns(


### PR DESCRIPTION
`getDataAsJson()` throws `"Resource has no content."` when a resource is resolved but its blob has not been fetched yet — routine on remote backends. In a reactive output lambda the throw surfaces a transient "Some outputs have errors" banner mid-calculation that clears once the blob arrives (MILAB-6318).

`getDataAsJsonOrUndefined<T>()` returns `undefined` while the resource is still computing (`getIsReadyOrError()` is false) and otherwise mirrors `getDataAsJson`, throwing only on a terminal-but-empty resource — a genuine error. Additive and non-breaking.

This is the durable fix for MILAB-6318. The reported blocks already ship per-site fixes (clonotype-clustering#119, antibody-tcr-lead-selection#149). Follow-ups: recommend this reader in the block-dev harness, then migrate the ~20 blocks that call `getDataAsJson`/`getKeyValueAsJson` in output lambdas.

Verified: `pnpm build --filter='@platforma-sdk/model'` green (23/23), `pnpm -C sdk/model fmt` clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `getDataAsJsonOrUndefined<T>()` to `TreeNodeAccessor` to avoid a transient "Some outputs have errors" banner on remote backends caused by `getDataAsJson` throwing when a resource is resolved but its blob hasn't been fetched yet.

- **`accessor.ts`**: New method short-circuits to `undefined` when `getIsReadyOrError()` is `false` (resource still computing), then delegates to the same `getDataAsString` + `JSON.parse` path as `getDataAsJson` once the resource reaches a terminal state — preserving the throw for genuinely empty terminal resources.
- **`accessor.test.ts`**: Three focused tests covering the not-ready/early-return, happy-path parse, and ready-but-no-content-throw branches, including a `vi.fn` assertion confirming the short-circuit doesn't touch the network layer.
- **`.changeset/...`**: Correctly bumped as a `minor` change for `@platforma-sdk/model`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive method, no existing behavior changed, all three code paths are tested.

The change introduces a single new public method that short-circuits before any network I/O when the resource is not yet in a terminal state. The three tests cover not-ready/early-return, happy-path parse, and terminal-but-empty-throw, and a spy assertion confirms the short-circuit is truly side-effect-free. No existing method is modified, the changeset correctly marks a minor bump, and the logic is a strict superset of getDataAsJson.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/render/accessor.ts | Adds `getDataAsJsonOrUndefined<T>()` as an additive, non-breaking method with correct guard logic mirroring `getDataAsJson`. |
| sdk/model/src/render/accessor.test.ts | New test file covering all three branches of `getDataAsJsonOrUndefined`, including short-circuit verification via spy. |
| .changeset/milab-6318-getdataasjson-or-undefined.md | Correctly records a `minor` bump for `@platforma-sdk/model` with a clear description of the new method and its rationale. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getDataAsJsonOrUndefined called] --> B{getIsReadyOrError?}
    B -- false\nstill computing --> C[return undefined\nno network call]
    B -- true\nready or error terminal state --> D[getDataAsString]
    D --> E{content == undefined?}
    E -- yes --> F[throw 'Resource has no content.']
    E -- no --> G[JSON.parse content\nreturn T]

    style C fill:#d4edda,stroke:#28a745
    style F fill:#f8d7da,stroke:#dc3545
    style G fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (2): Last reviewed commit: ["MILAB-6318: test getDataAsJsonOrUndefine..."](https://github.com/milaboratory/platforma/commit/2cadeba41876ff27c6d8c641592b647e0586b92e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35004486)</sub>

<!-- /greptile_comment -->