### PR TITLE
Cache footprint instead of recalculating each time

### DIFF
--- a/.changeset/all-days-teach.md
+++ b/.changeset/all-days-teach.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pf-driver": patch
+---
+
+Cache footprint instead of recalculating each time

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -322,7 +322,7 @@ export class AbstractPFrameDriver<
         bytesWritten = writeStream.bytesWritten;
       });
 
-      const overallSize = await pTable.getFootprint({ signal: combinedSignal });
+      const overallSize = await tableGuard.resource.cacheSize;
       this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
 
       // rowsWritten equals the clipped range length — the generator streams the
@@ -433,9 +433,7 @@ export class AbstractPFrameDriver<
         signal: combinedSignal,
       });
 
-      const overallSize = await pTable.getFootprint({
-        signal: combinedSignal,
-      });
+      const overallSize = await tableGuard.resource.cacheSize;
       this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
 
       return tableSpec.map((spec, i) => ({
@@ -530,9 +528,7 @@ export class AbstractPFrameDriver<
         signal: combinedSignal,
       });
 
-      const overallSize = await pTable.getFootprint({
-        signal: combinedSignal,
-      });
+      const overallSize = await tableGuard.resource.cacheSize;
 
       return { shape, overallSize };
     });
@@ -560,9 +556,7 @@ export class AbstractPFrameDriver<
         signal: combinedSignal,
       });
 
-      const overallSize = await pTable.getFootprint({
-        signal: combinedSignal,
-      });
+      const overallSize = await tableGuard.resource.cacheSize;
 
       return { data, overallSize };
     });

--- a/lib/node/pf-driver/src/ptable_pool.ts
+++ b/lib/node/pf-driver/src/ptable_pool.ts
@@ -21,6 +21,7 @@ import type { PTableDefPool } from "./ptable_def_pool";
 export class PTableHolder implements Disposable {
   private readonly abortController = new AbortController();
   private readonly combinedDisposeSignal: AbortSignal;
+  private cacheSizePromise?: Promise<number>;
 
   constructor(
     public readonly pFrame: PFrameHandle,
@@ -36,6 +37,18 @@ export class PTableHolder implements Disposable {
 
   public get disposeSignal(): AbortSignal {
     return this.combinedDisposeSignal;
+  }
+
+  public get cacheSize(): Promise<number> {
+    if (this.cacheSizePromise === undefined) {
+      this.cacheSizePromise = this.pTablePromise.then((pTable) =>
+        pTable.getFootprint({
+          withPredecessors: false,
+          signal: this.abortController.signal,
+        }),
+      );
+    }
+    return this.cacheSizePromise;
   }
 
   [Symbol.dispose](): void {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR avoids redundant `getFootprint` calls by computing the disk footprint once per `PTableHolder` (eagerly in the constructor) and caching it as `cacheSizePromise`. All four call-sites in `driver_impl.ts` are updated to await the cached promise instead of issuing a new WASM round-trip each time.

- **`ptable_pool.ts`**: `PTableHolder` gains `cacheSizePromise`, which chains off `pTablePromise` using `withPredecessors: false` (matching the original omitted-default behaviour). A `void .catch(() => {})` guards against unhandled-rejection warnings.
- **`driver_impl.ts`**: `await pTable.getFootprint(...)` replaced with `await tableGuard.resource.cacheSize` in `writePTableToFs`, `calculateTableData`, `getShape`, and `getData`.
- **Trade-off introduced**: the footprint computation now starts as soon as `pTablePromise` resolves, which is before the `tableConcurrencyLimiter` / `frameConcurrencyLimiter` is acquired; see inline comment for details.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only meaningful change to watch is that the footprint computation now starts outside the concurrency limiters.

The caching logic is straightforward, error handling is correct (`withPredecessors: false` matches the original default, the `catch` guard is properly scoped), and the four call-site changes are mechanical. The one concern is that `getFootprint` — which materialises the join — now fires eagerly in the `PTableHolder` constructor before any concurrency limiter is acquired, potentially adding background load that the limiters were meant to control.

lib/node/pf-driver/src/ptable_pool.ts — the eager `cacheSizePromise` initialization warrants a second look to confirm the WASM layer handles concurrent join-materialisation safely.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pf-driver/src/ptable_pool.ts | Adds cacheSizePromise in PTableHolder constructor, kicking off getFootprint eagerly (outside the concurrency limiters) using withPredecessors: false (matches the original omitted default) |
| lib/node/pf-driver/src/driver_impl.ts | All four getFootprint call-sites replaced with tableGuard.resource.cacheSize; footprint is now awaited inside the concurrency limiter but the computation started outside it |
| .changeset/all-days-teach.md | Patch-level changeset entry describing the footprint caching optimization |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as driver_impl (e.g. getShape)
    participant Pool as PTablePool
    participant Holder as PTableHolder
    participant PT as pTable (WASM)
    participant Limiter as ConcurrencyLimiter

    Caller->>Pool: acquire(def)
    Pool->>Holder: new PTableHolder(pFrameDisposeSignal, pTablePromise)
    Note over Holder: pTablePromise.then(getFootprint) registered<br/>(cacheSizePromise — starts OUTSIDE limiter)
    Caller->>Holder: await pTablePromise
    PT-->>Holder: pTable resolved
    Note over PT: cacheSizePromise: getFootprint() kicks off here (no limiter)
    Caller->>Limiter: tableConcurrencyLimiter.run()
    Limiter-->>Caller: acquired
    Caller->>PT: pTable.getShape()
    PT-->>Caller: shape
    Caller->>Holder: await cacheSize (pre-computed)
    Holder-->>Caller: overallSize
    Caller->>Limiter: release
    Caller->>Pool: pTableCache.cache(keep(), overallSize)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/node/pf-driver/src/ptable_pool.ts:36-42
**Footprint computation bypasses concurrency limiters**

`getFootprint` is now started eagerly in the constructor — triggered immediately when `pTablePromise` resolves — outside of `tableConcurrencyLimiter` / `frameConcurrencyLimiter`. The API doc marks this call as "materializes the join", which is the same expensive work that `getData` and `getShape` perform inside those limiters. This means up to N simultaneous join-materializations can now race in the background (one per newly-created `PTableHolder`), adding load beyond what the limiters were designed to bound. If the WASM layer serializes concurrent calls internally this is benign, but if it does not, high-frequency holder creation could saturate it before the limiters can gate anything.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Cache footprint instead of recalculating..."](https://github.com/milaboratory/platforma/commit/91f35d9b9fe5e93c0513ff11837af1e5773228dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35134516)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->