### PR TITLE
MILAB-6199: pl-client SSO login methods

### DIFF
--- a/.changeset/pl-client-sso-login-methods.md
+++ b/.changeset/pl-client-sso-login-methods.md
@@ -1,0 +1,5 @@
+---
+'@milaboratories/pl-client': minor
+---
+
+Add SSO login surface to `UnauthenticatedPlClient`: `ssoConfig()` projects the first advertised `SSOAuthMethod` from `authMethodsSync`, `beginSSOLogin()` requests a one-time PKCE nonce, and `loginSSO({ tokenResponse })` exchanges the IdP `/token` response for a Platforma JWT. New exported types: `SSOAuthMethod`, `SSOLoginAttempt`, `SSOFlowType`. Mirrors the spec in `text/work/projects/sso-and-access-control/parameterization.md`.

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -43,6 +43,7 @@ import {
 } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import type { MiLogger } from "@milaboratories/ts-helpers";
 import { isAbortedError } from "./errors";
+import { Timestamp } from "../proto-grpc/google/protobuf/timestamp";
 
 export interface PlCallOps {
   timeout?: number;
@@ -580,7 +581,6 @@ export class LLPlClient implements WireClientProviderFactory {
           basic: { login: user, password },
           expiration: `${ttl}s`,
           requestedRole: role,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
       });
       return notEmpty((await resp).data, "REST: empty response for login request").token;
@@ -617,10 +617,57 @@ export class LLPlClient implements WireClientProviderFactory {
           token: { token: Buffer.from(bytes).toString("base64") },
           expiration: `${ttl}s`,
           requestedRole: role,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
       });
       return notEmpty((await resp).data, "REST: empty response for login request").token;
+    }
+  }
+
+  /** Login via SSO: forwards the raw IdP /token JSON body to the backend.
+   * Backend validates signature + nonce + audience and mints a Platforma JWT. */
+  public async loginSSO(tokenResponse: Uint8Array): Promise<string> {
+    const cl = this.clientProvider.get();
+    if (cl instanceof GrpcPlApiClient) {
+      return (
+        await cl.login({
+          credentials: {
+            oneofKind: "sso",
+            sso: { tokenResponse },
+          },
+        }).response
+      ).token;
+    } else {
+      const resp = cl.POST("/v1/auth/login", {
+        body: {
+          sso: { tokenResponse: Buffer.from(tokenResponse).toString("base64") },
+        } as any,
+      });
+      return notEmpty((await resp).data, "REST: empty response for SSO login request").token;
+    }
+  }
+
+  /** Request a one-time PKCE nonce + its expiry from the backend. The desktop is
+   * expected to place the nonce verbatim into the OIDC auth-request before
+   * redirecting to the IdP; the backend enforces the expiry on {@link loginSSO}. */
+  public async beginSSOLogin(): Promise<{ nonce: string; expiresAt: Date }> {
+    const cl = this.clientProvider.get();
+    if (cl instanceof GrpcPlApiClient) {
+      const resp = (await cl.beginSSOLogin({}).response).flow;
+      if (resp.oneofKind !== "publicPkce") {
+        throw new Error(`beginSSOLogin: unsupported flow ${resp.oneofKind}`);
+      }
+      const exp = notEmpty(resp.publicPkce.expiresAt, "beginSSOLogin: missing expiresAt");
+      return {
+        nonce: resp.publicPkce.nonce,
+        expiresAt: Timestamp.toDate(exp),
+      };
+    } else {
+      const wsResponse = notEmpty(
+        (await cl.POST("/v1/auth/sso/begin-login", { body: {} })).data,
+        "REST: empty response for beginSSOLogin request",
+      );
+      const pkce = notEmpty(wsResponse.publicPkce, "REST: missing publicPkce in beginSSOLogin");
+      return { nonce: pkce.nonce, expiresAt: new Date(pkce.expiresAt) };
     }
   }
 
@@ -662,7 +709,6 @@ export class LLPlClient implements WireClientProviderFactory {
       );
       resp = {
         ...(pingData as unknown as grpcTypes.MaintenanceAPI_Ping_Response),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         capabilities: (pingData as any).capabilities ?? [],
       };
     }

--- a/lib/node/pl-client/src/core/unauth_client.ts
+++ b/lib/node/pl-client/src/core/unauth_client.ts
@@ -1,12 +1,43 @@
 import type { AuthInformation, PlClientConfig } from "./config";
-import type {
-  AuthAPI_ListMethods_Response,
-  MaintenanceAPI_Ping_Response,
+import {
+  type AuthAPI_ListMethods_Response,
+  type MaintenanceAPI_Ping_Response,
+  AuthAPI_ListMethods_SSOAuthMethod_FlowType,
 } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import { LLPlClient } from "./ll_client";
 import { type MiLogger, notEmpty } from "@milaboratories/ts-helpers";
 import { UnauthenticatedError } from "./errors";
 import type { BackendCapability } from "./capabilities";
+
+/** Login-flow shape advertised by the backend for a given SSO method. Extension
+ * point: future flow variants (e.g. backend-driven) sit alongside `public_pkce`. */
+export type SSOFlowType = "public_pkce";
+
+/** Typed projection of `AuthAPI.ListMethods.SSOAuthMethod` for desktop consumption.
+ * Carries everything needed to drive the PKCE flow + diagnostics fields the renderer
+ * may surface (`userIdClaim`, `groupsClaim`). */
+export type SSOAuthMethod = {
+  id: string;
+  description: string;
+  issuer: string;
+  clientId: string;
+  scopes: string;
+  resource: string;
+  prompt: string;
+  redirectPorts: number[];
+  subjectTokenSource: string;
+  userIdClaim: string;
+  groupsClaim: string;
+  flowType: SSOFlowType;
+};
+
+/** Server-issued material returned by {@link UnauthenticatedPlClient.beginSSOLogin}.
+ * Discriminated on `flow`; future flow variants extend the union. */
+export type SSOLoginAttempt = {
+  flow: "public_pkce";
+  nonce: string;
+  expiresAt: Date;
+};
 
 /** Primarily used for initial authentication (login) */
 export class UnauthenticatedPlClient {
@@ -42,7 +73,7 @@ export class UnauthenticatedPlClient {
 
   /** Classifies the advertised authentication methods by credential scheme.
    * On legacy backends (no auth:v2) the typed oneof is empty; callers fall through to {@link login}
-   * which uses the legacy GetJWTToken path. */
+   * which uses the legacy GetJWTToken path. SSO is surfaced via {@link ssoConfig}, not here. */
   public get supportedAuthSchemes(): { basic: boolean; token: boolean } {
     const result = { basic: false, token: false };
     for (const m of this.ll.authMethodsSync.methods) {
@@ -50,6 +81,33 @@ export class UnauthenticatedPlClient {
       else if (m.method.oneofKind === "token") result.token = true;
     }
     return result;
+  }
+
+  /** Projection of the first advertised SSO method, derived from {@link authMethodsSync}.
+   * v1: at most one SSO method per deployment, so callers do not need to discriminate. */
+  public ssoConfig(): SSOAuthMethod | undefined {
+    for (const method of this.ll.authMethodsSync.methods) {
+      if (method.method.oneofKind !== "sso") continue;
+      const sso = method.method.sso;
+      if (sso.flowType !== AuthAPI_ListMethods_SSOAuthMethod_FlowType.PUBLIC_PKCE) {
+        throw new Error(`ssoConfig: unsupported SSO flow type ${sso.flowType}`);
+      }
+      return {
+        id: method.id,
+        description: method.description,
+        issuer: sso.issuer,
+        clientId: sso.clientId,
+        scopes: sso.scopes,
+        resource: sso.resource,
+        prompt: sso.prompt,
+        redirectPorts: sso.redirectPorts,
+        subjectTokenSource: sso.subjectTokenSource,
+        userIdClaim: sso.userIdClaim,
+        groupsClaim: sso.groupsClaim,
+        flowType: "public_pkce",
+      };
+    }
+    return undefined;
   }
 
   /** Login with username+password.
@@ -80,6 +138,25 @@ export class UnauthenticatedPlClient {
         });
       }
       const jwtToken = notEmpty(token);
+      if (jwtToken === "") throw new Error("empty token");
+      return { jwtToken };
+    } catch (e: any) {
+      if (e.code === "UNAUTHENTICATED") throw new UnauthenticatedError(e.message);
+      throw new Error(e);
+    }
+  }
+
+  /** Request fresh server-issued login material. v1 only emits the public-PKCE flow;
+   * desktop MUST place the returned `nonce` verbatim into the OIDC auth-request. */
+  public async beginSSOLogin(): Promise<SSOLoginAttempt> {
+    const { nonce, expiresAt } = await this.ll.beginSSOLogin();
+    return { flow: "public_pkce", nonce, expiresAt };
+  }
+
+  /** Forward the verbatim IdP `/token` response body and receive a Platforma JWT. */
+  public async loginSSO(payload: { tokenResponse: Uint8Array }): Promise<AuthInformation> {
+    try {
+      const jwtToken = await this.ll.loginSSO(payload.tokenResponse);
       if (jwtToken === "") throw new Error("empty token");
       return { jwtToken };
     } catch (e: any) {


### PR DESCRIPTION
Add `ssoConfig()`, `beginSSOLogin()`, and `loginSSO()` to `UnauthenticatedPlClient`, plus the corresponding low-level methods on `LLPlClient` over both gRPC and REST transports. Export `SSOAuthMethod`, `SSOLoginAttempt`, and `SSOFlowType`.

`ssoConfig()` is a synchronous projection over `authMethodsSync`, returning the first advertised SSO method's full payload. `beginSSOLogin()` requests a one-time PKCE nonce from the backend. `loginSSO()` forwards the raw IdP `/token` response body and receives a Platforma JWT in return.

`supportedAuthSchemes` is unchanged (still `{ basic, token }`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds SSO login surface to `UnauthenticatedPlClient` — `ssoConfig()`, `beginSSOLogin()`, and `loginSSO()` — along with the corresponding low-level gRPC and REST implementations in `LLPlClient`, plus three new exported types (`SSOAuthMethod`, `SSOLoginAttempt`, `SSOFlowType`).

- `ssoConfig()` is a synchronous projection over `authMethodsSync` returning the first advertised SSO method; the `flowType` field is hardcoded to `\"public_pkce\"` rather than being read from the backend-advertised value.
- `loginSSO()` forwards the raw IdP `/token` body to the backend; unlike `loginBasic` and `loginWithToken`, neither the gRPC nor the REST call includes `expiration` or `requestedRole`, so SSO sessions always use the backend's default TTL instead of the client-configured `authTTLSeconds`.
- `beginSSOLogin()` requests a one-time PKCE nonce and maps it to `SSOLoginAttempt`; the gRPC and REST paths are symmetric and look correct.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The SSO login path is functional but will always produce sessions with the backend's default TTL, bypassing the client's configured `authTTLSeconds` — a behavioural gap that affects every SSO login on every transport.

The `loginSSO` method omits the `expiration` and `requestedRole` fields that both `loginBasic` and `loginWithToken` forward to the backend. Every SSO login in every deployment will silently use the backend default TTL rather than the value the client was configured with. This is a present behavioural defect on the core login path introduced by this PR.

`lib/node/pl-client/src/core/ll_client.ts` — the `loginSSO` method needs `expiration` and `requestedRole` added to both the gRPC and REST call sites, matching the pattern used by `loginBasic` and `loginWithToken`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/ll_client.ts | Adds `loginSSO` and `beginSSOLogin` low-level methods; `loginSSO` omits `expiration` and `requestedRole` that every other login path forwards, so SSO sessions bypass the configured TTL. |
| lib/node/pl-client/src/core/unauth_client.ts | Adds `ssoConfig()`, `beginSSOLogin()`, `loginSSO()` plus three exported types; flow type is hardcoded to `"public_pkce"` rather than read from the backend's advertised value. |
| .changeset/pl-client-sso-login-methods.md | Standard changeset entry marking the pl-client package as a minor release; description matches the implementation. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Desktop
    participant UnauthenticatedPlClient
    participant LLPlClient
    participant Backend

    Desktop->>UnauthenticatedPlClient: ssoConfig()
    UnauthenticatedPlClient->>LLPlClient: authMethodsSync (cached)
    LLPlClient-->>UnauthenticatedPlClient: AuthAPI_ListMethods_Response
    UnauthenticatedPlClient-->>Desktop: "SSOAuthMethod | undefined"

    Desktop->>UnauthenticatedPlClient: beginSSOLogin()
    UnauthenticatedPlClient->>LLPlClient: beginSSOLogin()
    LLPlClient->>Backend: POST /v1/auth/sso/begin-login
    Backend-->>LLPlClient: publicPkce nonce + expiresAt
    LLPlClient-->>UnauthenticatedPlClient: nonce + expiresAt
    UnauthenticatedPlClient-->>Desktop: SSOLoginAttempt

    Note over Desktop: Redirect to IdP with nonce in PKCE request
    Desktop->>Desktop: Receive IdP /token response body

    Desktop->>UnauthenticatedPlClient: "loginSSO({ tokenResponse })"
    UnauthenticatedPlClient->>LLPlClient: loginSSO(tokenResponse)
    Note over LLPlClient: No expiration or requestedRole sent
    LLPlClient->>Backend: POST /v1/auth/login sso credentials
    Backend-->>LLPlClient: Platforma JWT
    LLPlClient-->>UnauthenticatedPlClient: jwtToken
    UnauthenticatedPlClient-->>Desktop: "AuthInformation { jwtToken }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pl-client/src/core/ll_client.ts:628-647
**SSO login silently ignores `authTTLSeconds` and `role`**

Both `loginBasic` and `loginWithToken` forward `expiration: { seconds: ttl, nanos: 0 }` and `requestedRole` to the backend (gRPC) and include `expiration: \`${ttl}s\`` in the REST body. `loginSSO` sends neither, so the backend always uses its own default TTL. An SSO session could expire far sooner (or later) than the client-configured `authTTLSeconds`, and the `role` hint is silently dropped on every SSO login.

### Issue 2 of 2
lib/node/pl-client/src/core/unauth_client.ts:91-104
**`ssoConfig()` ignores backend-advertised `flowType`**

The method always returns `flowType: "public_pkce"` regardless of what the backend reports in `sso.flowType`. Since `SSOFlowType` is a string-union extension point (the jsdoc says future variants will extend the union), hardcoding the value means a backend that advertises a different flow type will be silently misreported to callers. At minimum the value should be read from the proto, or the code should assert equality and throw for unknown types so callers don't proceed with the wrong flow.

```suggestion
      if (sso.flowType !== 0 /* PUBLIC_PKCE */) {
        throw new Error(`ssoConfig: unsupported flow type ${sso.flowType}`);
      }
      return {
        id: method.id,
        description: method.description,
        issuer: sso.issuer,
        clientId: sso.clientId,
        scopes: sso.scopes,
        resource: sso.resource,
        prompt: sso.prompt,
        redirectPorts: sso.redirectPorts,
        subjectTokenSource: sso.subjectTokenSource,
        userIdClaim: sso.userIdClaim,
        groupsClaim: sso.groupsClaim,
        flowType: "public_pkce",
      };
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6199: pl-client SSO login methods"](https://github.com/milaboratory/platforma/commit/d33181c5f4853066118755c8ce3732f8fd4200f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35157045)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->