### PR TITLE
MILAB-6318: throw the resource error in getDataAsJsonOrUndefined

### DIFF
--- a/.changeset/milab-6318-getdataasjson-throw-on-error.md
+++ b/.changeset/milab-6318-getdataasjson-throw-on-error.md
@@ -2,4 +2,4 @@
 "@platforma-sdk/model": patch
 ---
 
-MILAB-6318: `getDataAsJsonOrUndefined` now throws the actual resource error when the resource has reached a terminal error state, instead of conflating it with a not-ready resource or returning stale content. Not-ready still returns `undefined` (loading); ready returns the parsed value.
+MILAB-6318: on error, `getDataAsJsonOrUndefined` now throws the resource's decoded error message instead of `getDataAsJson`'s generic "Resource has no content." Not-ready returns `undefined` (loading); ready returns the parsed value.

--- a/.changeset/milab-6318-getdataasjson-throw-on-error.md
+++ b/.changeset/milab-6318-getdataasjson-throw-on-error.md
@@ -2,4 +2,4 @@
 "@platforma-sdk/model": patch
 ---
 
-MILAB-6318: on error, `getDataAsJsonOrUndefined` now throws the resource's decoded error message instead of `getDataAsJson`'s generic "Resource has no content." Not-ready returns `undefined` (loading); ready returns the parsed value.
+MILAB-6318: on error, `getDataAsJsonOrUndefined` now throws the resource's error message (unwrapped from the backend's `{"message": ...}` envelope, tagged with the resolve path) instead of `getDataAsJson`'s generic "Resource has no content." Not-ready returns `undefined` (loading); ready returns the parsed value.

--- a/.changeset/milab-6318-getdataasjson-throw-on-error.md
+++ b/.changeset/milab-6318-getdataasjson-throw-on-error.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+MILAB-6318: `getDataAsJsonOrUndefined` now throws the actual resource error when the resource has reached a terminal error state, instead of conflating it with a not-ready resource or returning stale content. Not-ready still returns `undefined` (loading); ready returns the parsed value.

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -37,60 +37,53 @@ test("getDataAsJsonOrUndefined parses content once the resource is ready", () =>
   expect(acc.getDataAsJsonOrUndefined<{ min_len: number }>()).toEqual({ min_len: 7 });
 });
 
-test("getDataAsJsonOrUndefined throws the decoded error message when the resource errored", () => {
-  const errorLike = JSON.stringify({
-    type: "StandardError",
-    name: "Error",
-    message: "upstream blew up",
-  });
+test("getDataAsJsonOrUndefined throws the error node's message when the resource errored", () => {
+  // The backend serializes a resource error as {"message": "..."}; the thrown
+  // string is the unwrapped message, not the raw JSON envelope.
+  const resourceError = JSON.stringify({ message: "upstream blew up" });
   const acc = accessorWithCtx({
     getIsReadyOrError: () => true,
     getError: () => ERROR_HANDLE,
-    getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? errorLike : undefined),
+    getDataAsString: (handle: AccessorHandle) =>
+      handle === ERROR_HANDLE ? resourceError : undefined,
   });
-  // Anchored: asserts the *decoded* message, not the serialized ErrorLike JSON.
   expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^upstream blew up$/);
-});
-
-test("getDataAsJsonOrUndefined prefers a PlError's fullMessage over its message", () => {
-  // PlError carries fullMessage (SDK-developer detail); the single thrown string
-  // should be the richer one.
-  const errorLike = JSON.stringify({
-    type: "PlError",
-    name: "PlTengoError",
-    message: "short",
-    fullMessage: "detailed SDK message",
-  });
-  const acc = accessorWithCtx({
-    getIsReadyOrError: () => true,
-    getError: () => ERROR_HANDLE,
-    getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? errorLike : undefined),
-  });
-  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^detailed SDK message$/);
 });
 
 test("getDataAsJsonOrUndefined tags the thrown error with the resolve path", () => {
   // The path identifies which resolve failed when a lambda reads several fields.
-  const errorLike = JSON.stringify({ type: "StandardError", name: "Error", message: "boom" });
+  const resourceError = JSON.stringify({ message: "boom" });
   const acc = accessorWithCtx(
     {
       getIsReadyOrError: () => true,
       getError: () => ERROR_HANDLE,
       getDataAsString: (handle: AccessorHandle) =>
-        handle === ERROR_HANDLE ? errorLike : undefined,
+        handle === ERROR_HANDLE ? resourceError : undefined,
     },
     ["outputs", "isEmpty"],
   );
   expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^boom \(at outputs\.isEmpty\)$/);
 });
 
-test("getDataAsJsonOrUndefined falls back to the raw error content when it is not a serialized ErrorLike", () => {
+test("getDataAsJsonOrUndefined falls back to the raw content when it is not a message envelope", () => {
+  // Plain text (not JSON) → surfaced verbatim.
   const acc = accessorWithCtx({
     getIsReadyOrError: () => true,
     getError: () => ERROR_HANDLE,
     getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? "not json" : undefined),
   });
   expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^not json$/);
+});
+
+test("getDataAsJsonOrUndefined falls back to the raw content when JSON has no string message", () => {
+  // Valid JSON but not the {message} envelope → surfaced verbatim.
+  const raw = JSON.stringify({ code: 42 });
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getError: () => ERROR_HANDLE,
+    getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? raw : undefined),
+  });
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(raw);
 });
 
 test("getDataAsJsonOrUndefined throws a generic message when the errored node has no content", () => {

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -8,9 +8,9 @@ const ERROR_HANDLE = "error-handle" as AccessorHandle;
 
 type RenderCtx = ReturnType<typeof internal.getCfgRenderCtx>;
 
-function accessorWithCtx(ctx: Partial<RenderCtx>): TreeNodeAccessor {
+function accessorWithCtx(ctx: Partial<RenderCtx>, resolvePath: string[] = []): TreeNodeAccessor {
   vi.spyOn(internal, "getCfgRenderCtx").mockReturnValue(ctx as RenderCtx);
-  return new TreeNodeAccessor(HANDLE, []);
+  return new TreeNodeAccessor(HANDLE, resolvePath);
 }
 
 afterEach(() => {
@@ -50,6 +50,38 @@ test("getDataAsJsonOrUndefined throws the decoded error message when the resourc
   });
   // Anchored: asserts the *decoded* message, not the serialized ErrorLike JSON.
   expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^upstream blew up$/);
+});
+
+test("getDataAsJsonOrUndefined prefers a PlError's fullMessage over its message", () => {
+  // PlError carries fullMessage (SDK-developer detail); the single thrown string
+  // should be the richer one.
+  const errorLike = JSON.stringify({
+    type: "PlError",
+    name: "PlTengoError",
+    message: "short",
+    fullMessage: "detailed SDK message",
+  });
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getError: () => ERROR_HANDLE,
+    getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? errorLike : undefined),
+  });
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^detailed SDK message$/);
+});
+
+test("getDataAsJsonOrUndefined tags the thrown error with the resolve path", () => {
+  // The path identifies which resolve failed when a lambda reads several fields.
+  const errorLike = JSON.stringify({ type: "StandardError", name: "Error", message: "boom" });
+  const acc = accessorWithCtx(
+    {
+      getIsReadyOrError: () => true,
+      getError: () => ERROR_HANDLE,
+      getDataAsString: (handle: AccessorHandle) =>
+        handle === ERROR_HANDLE ? errorLike : undefined,
+    },
+    ["outputs", "isEmpty"],
+  );
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^boom \(at outputs\.isEmpty\)$/);
 });
 
 test("getDataAsJsonOrUndefined falls back to the raw error content when it is not a serialized ErrorLike", () => {

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -4,6 +4,7 @@ import * as internal from "../internal";
 import type { AccessorHandle } from "./internal";
 
 const HANDLE = "test-handle" as AccessorHandle;
+const ERROR_HANDLE = "error-handle" as AccessorHandle;
 
 type RenderCtx = ReturnType<typeof internal.getCfgRenderCtx>;
 
@@ -17,24 +18,38 @@ afterEach(() => {
 });
 
 test("getDataAsJsonOrUndefined returns undefined while the resource is still computing", () => {
-  const getDataAsString = vi.fn<() => string | undefined>(() => undefined);
-  const acc = accessorWithCtx({ getIsReadyOrError: () => false, getDataAsString });
+  const getError = vi.fn<(handle: AccessorHandle) => AccessorHandle | undefined>(() => undefined);
+  const getDataAsString = vi.fn<(handle: AccessorHandle) => string | undefined>(() => undefined);
+  const acc = accessorWithCtx({ getIsReadyOrError: () => false, getError, getDataAsString });
   expect(acc.getDataAsJsonOrUndefined()).toBeUndefined();
-  // Must short-circuit before reading content — that is the MILAB-6318 fix.
+  // Short-circuits before reading error or content — that is the MILAB-6318 fix.
+  expect(getError).not.toHaveBeenCalled();
   expect(getDataAsString).not.toHaveBeenCalled();
 });
 
 test("getDataAsJsonOrUndefined parses content once the resource is ready", () => {
   const acc = accessorWithCtx({
     getIsReadyOrError: () => true,
+    getError: () => undefined,
     getDataAsString: () => JSON.stringify({ min_len: 7 }),
   });
   expect(acc.getDataAsJsonOrUndefined<{ min_len: number }>()).toEqual({ min_len: 7 });
 });
 
-test("getDataAsJsonOrUndefined throws when a ready resource has no content", () => {
+test("getDataAsJsonOrUndefined throws the resource error when the resource errored", () => {
   const acc = accessorWithCtx({
     getIsReadyOrError: () => true,
+    getError: () => ERROR_HANDLE,
+    getDataAsString: (handle: AccessorHandle) =>
+      handle === ERROR_HANDLE ? "upstream blew up" : undefined,
+  });
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow("upstream blew up");
+});
+
+test("getDataAsJsonOrUndefined throws when a ready resource has no error and no content", () => {
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getError: () => undefined,
     getDataAsString: () => undefined,
   });
   expect(() => acc.getDataAsJsonOrUndefined()).toThrow("Resource has no content.");

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -36,14 +36,28 @@ test("getDataAsJsonOrUndefined parses content once the resource is ready", () =>
   expect(acc.getDataAsJsonOrUndefined<{ min_len: number }>()).toEqual({ min_len: 7 });
 });
 
-test("getDataAsJsonOrUndefined throws the resource error when the resource errored", () => {
+test("getDataAsJsonOrUndefined throws the decoded error message when the resource errored", () => {
+  const errorLike = JSON.stringify({
+    type: "StandardError",
+    name: "Error",
+    message: "upstream blew up",
+  });
   const acc = accessorWithCtx({
     getIsReadyOrError: () => true,
     getError: () => ERROR_HANDLE,
-    getDataAsString: (handle: AccessorHandle) =>
-      handle === ERROR_HANDLE ? "upstream blew up" : undefined,
+    getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? errorLike : undefined),
   });
-  expect(() => acc.getDataAsJsonOrUndefined()).toThrow("upstream blew up");
+  // Anchored: asserts the *decoded* message, not the serialized ErrorLike JSON.
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^upstream blew up$/);
+});
+
+test("getDataAsJsonOrUndefined falls back to the raw error content when it is not a serialized ErrorLike", () => {
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getError: () => ERROR_HANDLE,
+    getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? "not json" : undefined),
+  });
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^not json$/);
 });
 
 test("getDataAsJsonOrUndefined throws when a ready resource has no error and no content", () => {

--- a/sdk/model/src/render/accessor.test.ts
+++ b/sdk/model/src/render/accessor.test.ts
@@ -18,13 +18,14 @@ afterEach(() => {
 });
 
 test("getDataAsJsonOrUndefined returns undefined while the resource is still computing", () => {
-  const getError = vi.fn<(handle: AccessorHandle) => AccessorHandle | undefined>(() => undefined);
-  const getDataAsString = vi.fn<(handle: AccessorHandle) => string | undefined>(() => undefined);
-  const acc = accessorWithCtx({ getIsReadyOrError: () => false, getError, getDataAsString });
+  // Not ready → undefined, and crucially no throw (toBeUndefined fails on a throw).
+  // That is the MILAB-6318 fix.
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => false,
+    getError: () => undefined,
+    getDataAsString: () => undefined,
+  });
   expect(acc.getDataAsJsonOrUndefined()).toBeUndefined();
-  // Short-circuits before reading error or content — that is the MILAB-6318 fix.
-  expect(getError).not.toHaveBeenCalled();
-  expect(getDataAsString).not.toHaveBeenCalled();
 });
 
 test("getDataAsJsonOrUndefined parses content once the resource is ready", () => {
@@ -58,6 +59,16 @@ test("getDataAsJsonOrUndefined falls back to the raw error content when it is no
     getDataAsString: (handle: AccessorHandle) => (handle === ERROR_HANDLE ? "not json" : undefined),
   });
   expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^not json$/);
+});
+
+test("getDataAsJsonOrUndefined throws a generic message when the errored node has no content", () => {
+  // Errored, but the error node itself has nothing readable — generic fallback.
+  const acc = accessorWithCtx({
+    getIsReadyOrError: () => true,
+    getError: () => ERROR_HANDLE,
+    getDataAsString: () => undefined,
+  });
+  expect(() => acc.getDataAsJsonOrUndefined()).toThrow(/^Resource computation failed\.$/);
 });
 
 test("getDataAsJsonOrUndefined throws when a ready resource has no error and no content", () => {

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -21,6 +21,18 @@ export function ifDef<T, R>(value: T | undefined, cb: (value: T) => R): R | unde
   return value === undefined ? undefined : cb(value);
 }
 
+/**
+ * Decode an error node's serialized `ErrorLike` into a display message. Prefers
+ * a `PlError`'s `fullMessage` (the SDK-developer detail) when present; falls
+ * back to the raw string if it is not a serialized `ErrorLike`.
+ */
+function decodeErrorMessage(raw: string): string {
+  const parsed = parseErrorLikeSafe(raw);
+  if (!parsed.success) return raw;
+  const e = parsed.data;
+  return e.type === "PlError" ? (e.fullMessage ?? e.message) : e.message;
+}
+
 type FieldMapOps = {
   /**
    * Type of fields to iterate over.
@@ -221,15 +233,15 @@ export class TreeNodeAccessor {
     // Not ready → undefined (loading). getIsReadyOrError() registers the
     // readiness dependency, so the lambda re-runs once the resource finishes.
     if (!this.getIsReadyOrError()) return undefined;
-    // Errored → throw the actual error. The error node holds a serialized
-    // ErrorLike; decode it and throw its message, not getDataAsJson's generic
-    // "Resource has no content."
+    // Errored → throw the actual error, decoded from the error node and tagged
+    // with the resolve path for debugging context. Beats getDataAsJson's
+    // generic "Resource has no content."
     const error = this.getError();
     if (error !== undefined) {
       const raw = error.getDataAsString();
-      if (raw === undefined) throw new Error("Resource computation failed.");
-      const parsed = parseErrorLikeSafe(raw);
-      throw new Error(parsed.success ? parsed.data.message : raw);
+      const message = raw === undefined ? "Resource computation failed." : decodeErrorMessage(raw);
+      const path = this.resolvePath.join(".");
+      throw new Error(path ? `${message} (at ${path})` : message);
     }
     // Ready → parse the content.
     return this.getDataAsJson<T>();

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -11,7 +11,6 @@ import type {
   RangeBytes,
 } from "@milaboratories/pl-model-common";
 import { isPColumn, mapPObjectData } from "@milaboratories/pl-model-common";
-import { parseErrorLikeSafe } from "@milaboratories/pl-error-like";
 import { getCfgRenderCtx } from "../internal";
 import { FutureRef } from "./future";
 import type { AccessorHandle } from "./internal";
@@ -22,15 +21,19 @@ export function ifDef<T, R>(value: T | undefined, cb: (value: T) => R): R | unde
 }
 
 /**
- * Decode an error node's serialized `ErrorLike` into a display message. Prefers
- * a `PlError`'s `fullMessage` (the SDK-developer detail) when present; falls
- * back to the raw string if it is not a serialized `ErrorLike`.
+ * Decode an error node's content into a display message. The backend serializes
+ * a resource error as `{"message": "..."}` (`ResourceError`); unwrap that to the
+ * human-readable message. Falls back to the raw string when the content is not
+ * that envelope (e.g. plain text, or an unexpected shape).
  */
 function decodeErrorMessage(raw: string): string {
-  const parsed = parseErrorLikeSafe(raw);
-  if (!parsed.success) return raw;
-  const e = parsed.data;
-  return e.type === "PlError" ? (e.fullMessage ?? e.message) : e.message;
+  try {
+    const parsed = JSON.parse(raw) as { message?: unknown };
+    if (typeof parsed?.message === "string") return parsed.message;
+  } catch {
+    // Not JSON — surface the raw content.
+  }
+  return raw;
 }
 
 type FieldMapOps = {

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -11,6 +11,7 @@ import type {
   RangeBytes,
 } from "@milaboratories/pl-model-common";
 import { isPColumn, mapPObjectData } from "@milaboratories/pl-model-common";
+import { parseErrorLikeSafe } from "@milaboratories/pl-error-like";
 import { getCfgRenderCtx } from "../internal";
 import { FutureRef } from "./future";
 import type { AccessorHandle } from "./internal";
@@ -220,11 +221,18 @@ export class TreeNodeAccessor {
     // Not ready → undefined (loading). getIsReadyOrError() registers the
     // readiness dependency, so the lambda re-runs once the resource finishes.
     if (!this.getIsReadyOrError()) return undefined;
-    // Errored → surface the actual error, rather than getDataAsJson's generic
-    // "Resource has no content." throw (or returning stale content).
+    // Errored → surface the actual error. The error node's content is a
+    // serialized ErrorLike; decode it and throw its message, rather than
+    // getDataAsJson's generic "Resource has no content." (or returning stale
+    // content).
     const error = this.getError();
-    if (error !== undefined)
-      throw new Error(error.getDataAsString() ?? "Resource computation failed.");
+    if (error !== undefined) {
+      const raw = error.getDataAsString();
+      const parsed = raw === undefined ? undefined : parseErrorLikeSafe(raw);
+      throw new Error(
+        parsed?.success ? parsed.data.message : (raw ?? "Resource computation failed."),
+      );
+    }
     // Ready → parse the content.
     return this.getDataAsJson<T>();
   }

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -207,24 +207,23 @@ export class TreeNodeAccessor {
    * Like {@link getDataAsJson}, but does not throw while the resource is still
    * computing. Three states:
    *
-   * - **Not ready** → returns `undefined` (loading). A field that resolves
-   *   before its resource is ready (routine on remote backends) would make
-   *   {@link getDataAsJson} throw "Resource has no content." mid-calculation,
-   *   surfacing a transient "Some outputs have errors" banner that clears once
-   *   the resource finishes (MILAB-6318).
-   * - **Errored** → throws the resource error.
+   * - **Not ready** → returns `undefined` (loading).
+   * - **Errored** → throws the resource's error.
    * - **Ready** → returns the parsed content.
    *
-   * Prefer this over {@link getDataAsJson} in reactive output lambdas.
+   * Prefer this over {@link getDataAsJson} in reactive output lambdas: a field
+   * that resolves before its resource is ready (routine on remote backends)
+   * makes {@link getDataAsJson} throw "Resource has no content." mid-calculation,
+   * flashing a transient "Some outputs have errors" banner that clears when the
+   * resource finishes (MILAB-6318).
    */
   public getDataAsJsonOrUndefined<T>(): T | undefined {
     // Not ready → undefined (loading). getIsReadyOrError() registers the
     // readiness dependency, so the lambda re-runs once the resource finishes.
     if (!this.getIsReadyOrError()) return undefined;
-    // Errored → surface the actual error. The error node's content is a
-    // serialized ErrorLike; decode it and throw its message, rather than
-    // getDataAsJson's generic "Resource has no content." (or returning stale
-    // content).
+    // Errored → throw the actual error. The error node holds a serialized
+    // ErrorLike; decode it and throw its message, not getDataAsJson's generic
+    // "Resource has no content."
     const error = this.getError();
     if (error !== undefined) {
       const raw = error.getDataAsString();

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -228,10 +228,9 @@ export class TreeNodeAccessor {
     const error = this.getError();
     if (error !== undefined) {
       const raw = error.getDataAsString();
-      const parsed = raw === undefined ? undefined : parseErrorLikeSafe(raw);
-      throw new Error(
-        parsed?.success ? parsed.data.message : (raw ?? "Resource computation failed."),
-      );
+      if (raw === undefined) throw new Error("Resource computation failed.");
+      const parsed = parseErrorLikeSafe(raw);
+      throw new Error(parsed.success ? parsed.data.message : raw);
     }
     // Ready → parse the content.
     return this.getDataAsJson<T>();

--- a/sdk/model/src/render/accessor.ts
+++ b/sdk/model/src/render/accessor.ts
@@ -203,24 +203,29 @@ export class TreeNodeAccessor {
   }
 
   /**
-   * Like {@link getDataAsJson}, but returns `undefined` while the resource is
-   * still computing instead of throwing.
+   * Like {@link getDataAsJson}, but does not throw while the resource is still
+   * computing. Three states:
    *
-   * Prefer this in reactive output lambdas. A field that resolves before its
-   * resource is ready (routine on remote backends) makes {@link getDataAsJson}
-   * throw "Resource has no content." mid-calculation, surfacing a transient
-   * "Some outputs have errors" banner that clears once the resource finishes
-   * (MILAB-6318).
+   * - **Not ready** → returns `undefined` (loading). A field that resolves
+   *   before its resource is ready (routine on remote backends) would make
+   *   {@link getDataAsJson} throw "Resource has no content." mid-calculation,
+   *   surfacing a transient "Some outputs have errors" banner that clears once
+   *   the resource finishes (MILAB-6318).
+   * - **Errored** → throws the resource error.
+   * - **Ready** → returns the parsed content.
    *
-   * A resource that has reached a terminal state (ready or error) but still
-   * carries no content is a genuine error and throws, matching
-   * {@link getDataAsJson}.
+   * Prefer this over {@link getDataAsJson} in reactive output lambdas.
    */
   public getDataAsJsonOrUndefined<T>(): T | undefined {
-    // getIsReadyOrError() marks the computable unstable while not ready, which
-    // schedules recomputation once the resource finishes. Load-bearing, not a
-    // redundant guard over getDataAsJson — keep it.
+    // Not ready → undefined (loading). getIsReadyOrError() registers the
+    // readiness dependency, so the lambda re-runs once the resource finishes.
     if (!this.getIsReadyOrError()) return undefined;
+    // Errored → surface the actual error, rather than getDataAsJson's generic
+    // "Resource has no content." throw (or returning stale content).
+    const error = this.getError();
+    if (error !== undefined)
+      throw new Error(error.getDataAsString() ?? "Resource computation failed.");
+    // Ready → parse the content.
     return this.getDataAsJson<T>();
   }
 


### PR DESCRIPTION
Follow-up to #1671 (post-merge review feedback): *not ready → `undefined`, errored → throw, ready → value*.

`getDataAsJsonOrUndefined` relied on `getDataAsJson`'s generic `"Resource has no content."` throw to cover errors. That conflated an errored resource with a ready-but-empty one — and an errored resource that still held readable content was parsed and **returned**, hiding the error.

The three states are now explicit:
- **not ready** (`!getIsReadyOrError()`) → `undefined` (loading)
- **errored** (`getError()` present) → throws the resource's error message
- **ready** → parsed value

## Surfacing the Error Message

On error the lambda throws, so the output becomes `{ ok: false, errors }` and the message is shown to the user in the **"See errors"** modal (`PlAppErrorNotificationAlert`) — so the thrown string is worth getting right.

The backend serializes a resource error as `{"message": "..."}` (`ResourceError`, `core/pl/plapi/plapiproto/resource_types_pl_error.go`). The error branch unwraps that envelope to the human-readable message, tagged with the resolve path (e.g. `... (at outputs.isEmpty)`) so you can tell which resolve failed. Non-envelope content (plain text, or JSON without a string `message`) is surfaced verbatim; an errored node with no readable content falls back to `"Resource computation failed."`.



Eight tests cover every branch: not-ready → `undefined`, ready → value, errored → envelope unwrap, resolve-path tag, two raw-fallback shapes (non-JSON, JSON without a string `message`), errored-but-no-content → generic, and ready-but-empty → `"Resource has no content."`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds explicit error-state handling to `getDataAsJsonOrUndefined` in `TreeNodeAccessor`. Previously the method delegated to `getDataAsJson`, whose generic `"Resource has no content."` throw conflated an errored resource with a ready-but-empty one, and an errored resource with readable content would be silently parsed and returned.

- **`decodeErrorMessage` helper** (`accessor.ts`): parses the backend's `{"message": "..."}` (`ResourceError`) envelope and returns the human-readable message, falling back to the raw string for non-envelope content.
- **`getDataAsJsonOrUndefined` rewrite**: three explicit states — not ready → `undefined`, errored → throws the decoded message tagged with the resolve path, ready → parsed value.
- **Eight new tests** cover every branch: not-ready, ready, envelope unwrap, resolve-path tag, two raw-fallback shapes, errored-with-no-content, and ready-but-empty.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow and well-tested, and all three resource states are now handled explicitly with no code path left unguarded.

The rewrite of `getDataAsJsonOrUndefined` is self-contained: the not-ready short-circuit is preserved, the error branch decodes the well-defined `{"message":"..."}` envelope with a safe JSON-parse try/catch and a raw fallback, and the happy path is unchanged. Eight targeted tests exercise every branch. No regressions are introduced to callers.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/render/accessor.ts | Adds `decodeErrorMessage` helper and rewrites `getDataAsJsonOrUndefined` to handle not-ready/errored/ready states explicitly; logic is correct and well-guarded. |
| sdk/model/src/render/accessor.test.ts | Replaces two old tests with eight new ones covering all branches of the updated `getDataAsJsonOrUndefined`; fixtures correctly route by `AccessorHandle`. |
| .changeset/milab-6318-getdataasjson-throw-on-error.md | Standard changeset entry for a patch-level fix to `@platforma-sdk/model`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getDataAsJsonOrUndefined called] --> B{getIsReadyOrError?}
    B -- false --> C[return undefined]
    B -- true --> D{getError present?}
    D -- yes --> E[error.getDataAsString]
    E --> F{raw defined?}
    F -- no --> G[message = Resource computation failed.]
    F -- yes --> H[decodeErrorMessage raw]
    H --> I{JSON with string message?}
    I -- yes --> J[message = parsed.message]
    I -- no --> K[message = raw verbatim]
    G --> L{resolvePath non-empty?}
    J --> L
    K --> L
    L -- yes --> M[throw message at path]
    L -- no --> N[throw message]
    D -- no --> O[getDataAsJson - parse and return value]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["MILAB-6318: unwrap backend error envelop..."](https://github.com/milaboratory/platforma/commit/4dd7d164055d46779076cdc7c5f04fe92987ff04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35191240)</sub>

<!-- /greptile_comment -->