### PR TITLE
feat(pf-driver): adopt PFrames V6/V15/V10 interface, add exportPTable stub

### DIFF
--- a/.changeset/pframes-v15-interface-export-stub.md
+++ b/.changeset/pframes-v15-interface-export-stub.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/pl-model-common": minor
+"@milaboratories/pl-model-middle-layer": minor
+"@milaboratories/pf-driver": minor
+---
+
+Switch the PFrames addon surface to the `PFrameFactoryV6`/`PFrameV15`/`PTableV10` interface (`@milaboratories/pframes-rs-*` bumped to `1.1.41`) and drop the superseded `PFrameFactoryV5`/`PFrameV14`/`PFrameReadAPIV12`/`PTableV9` declarations.
+
+Add `PFrameDriver.exportPTable(handle, path)` to the driver surface and wire it through the service bridge. The method is a placeholder that always rejects with "not implemented" — the native export implementation will be added separately.

--- a/.changeset/ptabler-polars-pf-metadata-size.md
+++ b/.changeset/ptabler-polars-pf-metadata-size.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.software-ptabler": minor
+"@platforma-sdk/workflow-tengo": minor
+---
+
+Bump ptabler to `polars-pf==1.1.40` and the python runenv to `1.10.0`, which add the `metadataSize` field to each part's `stats` in the `ParquetPartitioned` `.datainfo` output.
+
+`pt/import-dir` now asserts `metadataSize` is present in the datainfo stats, so the workflow fails fast if the column data was produced by an older ptabler that does not emit it.

--- a/lib/model/common/src/drivers/pframe/driver.ts
+++ b/lib/model/common/src/drivers/pframe/driver.ts
@@ -103,6 +103,15 @@ export interface PFrameDriver {
     handle: PTableHandle,
     options: WritePTableToFsOptions,
   ): Promise<WritePTableToFsResult>;
+
+  /**
+   * Export the full, sorted table to a file at `path`. The output format is
+   * selected from the file extension (`csv`, `tsv`, `parquet`, or `xlsx`).
+   *
+   * Column headers are derived on the driver side from the table spec, so the
+   * caller only supplies the destination path (e.g. via the `Dialog` service).
+   */
+  exportPTable(handle: PTableHandle, path: string): Promise<void>;
 }
 
 //
@@ -117,4 +126,9 @@ type ExpectedPFrameDriverType = ExpectedPFrameDriverTypeF & ExpectedPFrameDriver
 type TypeEqualityGuard<A, B> = Exclude<A, B> | Exclude<B, A>;
 function assert<_T extends never>() {}
 
-assert<TypeEqualityGuard<Omit<PFrameDriver, "writePTableToFs">, ExpectedPFrameDriverType>>();
+assert<
+  TypeEqualityGuard<
+    Omit<PFrameDriver, "writePTableToFs" | "exportPTable">,
+    ExpectedPFrameDriverType
+  >
+>();

--- a/lib/model/common/src/services/node_service_handlers.ts
+++ b/lib/model/common/src/services/node_service_handlers.ts
@@ -29,6 +29,7 @@ export function createNodeServiceHandlers(driverKit: DriverKit): NodeServiceHand
       getSpec: (handle) => pFrameDriver.getSpec(handle),
       getData: (handle, columnIndices, range) => pFrameDriver.getData(handle, columnIndices, range),
       writePTableToFs: (handle, options) => pFrameDriver.writePTableToFs(handle, options),
+      exportPTable: (handle, path) => pFrameDriver.exportPTable(handle, path),
     },
   };
 }

--- a/lib/model/common/src/services/service_declarations.ts
+++ b/lib/model/common/src/services/service_declarations.ts
@@ -73,6 +73,7 @@ export const Services = {
       "getSpec",
       "getData",
       "writePTableToFs",
+      "exportPTable",
     ] as const,
   }),
   Dialog: service<Record<string, never>, DialogService>()({

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -4,7 +4,7 @@ import type {
   DataQuery,
   DataQueryBooleanExpression,
 } from "@milaboratories/pl-model-common";
-import type { PTableV9, PTableV10 } from "./table";
+import type { PTableV10 } from "./table";
 import type { PTableId } from "./common";
 
 /**
@@ -31,33 +31,8 @@ export interface UniqueValuesRequestV2 {
 }
 
 /**
- * Read interface exposed by PFrames library.
- *
- * Spec-side operations (finding columns, listing columns, retrieving
- * column specs, computing axis integrations) are not part of this
- * surface — callers cache column specs themselves or route through
- * WASM-spec. The data-side `createTable` accepts a pre-lowered
- * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
- * {@link UniqueValuesRequestV2}.
- */
-export interface PFrameReadAPIV12 {
-  /** Creates table from a pre-lowered data query. */
-  createTable(tableId: PTableId, dataQuery: DataQuery): PTableV9;
-
-  /** Calculate set of unique values for a specific axis for the filtered set of records. */
-  getUniqueValues(
-    request: UniqueValuesRequestV2,
-    ops?: {
-      signal?: AbortSignal;
-    },
-  ): Promise<UniqueValuesResponse>;
-}
-
-/**
- * Read interface exposed by PFrames library.
- *
- * Identical to {@link PFrameReadAPIV12} but returns the {@link PTableV10}
- * table view, which adds the `export` method.
+ * Read interface exposed by PFrames library. Returns the {@link PTableV10}
+ * table view, which provides the `export` method.
  *
  * Spec-side operations (finding columns, listing columns, retrieving
  * column specs, computing axis integrations) are not part of this

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,16 +1,11 @@
 import type { PFrameFactoryAPIV5 } from "./api_factory";
-import type { PFrameReadAPIV12, PFrameReadAPIV13 } from "./api_read";
+import type { PFrameReadAPIV13 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
-/** Full PFrame surface — factory operations plus data-side reads. */
-export interface PFrameV14 extends PFrameFactoryAPIV5, PFrameReadAPIV12 {}
-
 /**
- * Full PFrame surface — factory operations plus data-side reads.
- *
- * Identical to {@link PFrameV14} but exposes {@link PFrameReadAPIV13}, whose
- * tables add the `export` method.
+ * Full PFrame surface — factory operations plus data-side reads. Exposes
+ * {@link PFrameReadAPIV13}, whose tables provide the `export` method.
  */
 export interface PFrameV15 extends PFrameFactoryAPIV5, PFrameReadAPIV13 {}
 
@@ -23,29 +18,9 @@ export type PFrameOptionsV2 = {
   logger?: Logger;
 };
 
-/** PFrame management functions exposed by the PFrame module. */
-export interface PFrameFactoryV5 {
-  /**
-   * Create a new PFrame instance.
-   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
-   */
-  createPFrame(options: PFrameOptionsV2): PFrameV14;
-
-  /**
-   * Dump active allocations from all PFrames instances in pprof format.
-   * The result of this function should be saved as `profile.pb.gz`.
-   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
-   * to view the allocation flamechart.
-   * @warning This method will always reject on Windows!
-   */
-  pprofDump: () => Promise<Uint8Array>;
-}
-
 /**
- * PFrame management functions exposed by the PFrame module.
- *
- * Identical to {@link PFrameFactoryV5} but creates {@link PFrameV15} instances,
- * whose tables add the `export` method.
+ * PFrame management functions exposed by the PFrame module. Creates
+ * {@link PFrameV15} instances, whose tables provide the `export` method.
  */
 export interface PFrameFactoryV6 {
   /**

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -8,54 +8,6 @@ import type { PTableShape, PTableVector, TableRange } from "@milaboratories/pl-m
  * The table's column spec is owned by the caller — selector → index
  * resolution runs on the caller side via WASM-spec.
  */
-export interface PTableV9 extends Disposable {
-  /**
-   * Get PTable disk footprint in bytes.
-   *
-   * @param ops.withPredecessors When true, the footprint includes
-   *   every registered predecessor table reachable through the
-   *   query lineage. When false or omitted, only this table's own
-   *   materialised data is counted.
-   *
-   * Warning: This call materializes the join.
-   */
-  getFootprint(ops?: { withPredecessors?: boolean; signal?: AbortSignal }): Promise<number>;
-
-  /**
-   * Unified table shape
-   * Warning: This call materializes the join.
-   */
-  getShape(ops?: { signal?: AbortSignal }): Promise<PTableShape>;
-
-  /**
-   * Retrieve the data from the table. To retrieve only data required, it can be
-   * sliced both horizontally ({@link columnIndices}) and vertically
-   * ({@link range}).
-   * This call materializes the join.
-   *
-   * @param columnIndices unified indices of columns to be retrieved
-   * @param range optionally limit the range of records to retrieve
-   * */
-  getData(
-    columnIndices: number[],
-    ops?: {
-      range?: TableRange;
-      signal?: AbortSignal;
-    },
-  ): Promise<PTableVector[]>;
-
-  /** Deallocates all underlying resources */
-  dispose(): void;
-}
-
-/**
- * Table view returned by `createTable`.
- *
- * PTable can be thought as having a composite primary key, consisting
- * of axes, and a set of data columns derived from PColumn values.
- * The table's column spec is owned by the caller — selector → index
- * resolution runs on the caller side via WASM-spec.
- */
 export interface PTableV10 extends Disposable {
   /**
    * Get PTable disk footprint in bytes.

--- a/lib/node/pf-driver/src/csv_writer.ts
+++ b/lib/node/pf-driver/src/csv_writer.ts
@@ -9,7 +9,7 @@ import {
 } from "@milaboratories/pl-model-common";
 import { isNil } from "@milaboratories/helpers";
 
-/** Minimal subset of PTableV9 required by streamPTableRows. */
+/** Minimal subset of PTableV10 required by streamPTableRows. */
 export interface PTableDataSource {
   getData(
     columnIndices: number[],

--- a/lib/node/pf-driver/src/driver_decl.ts
+++ b/lib/node/pf-driver/src/driver_decl.ts
@@ -89,4 +89,11 @@ export interface AbstractInternalPFrameDriver<PColumnData> extends PFrameDriver,
     handle: PTableHandle,
     options: WritePTableToFsOptions,
   ): Promise<WritePTableToFsResult>;
+
+  /**
+   * Export the full, sorted table to a file, selecting the format from the
+   * file extension (`csv`/`tsv`/`parquet`/`xlsx`). Headers are derived from
+   * the table spec on the driver side.
+   */
+  exportPTable(handle: PTableHandle, path: string, signal?: AbortSignal): Promise<void>;
 }

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -341,6 +341,14 @@ export class AbstractPFrameDriver<
     });
   }
 
+  public async exportPTable(
+    _handle: PTableHandle,
+    _path: string,
+    _signal?: AbortSignal,
+  ): Promise<void> {
+    throw new PFrameDriverError("exportPTable is not implemented yet");
+  }
+
   //
   // PFrame instance methods
   //

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -30,7 +30,7 @@ export interface RemoteBlobProvider<TreeEntry extends JsonSerializable> {
 }
 
 export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposable {
-  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV14>;
+  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV15>;
   /**
    * WASM-spec frame built from this PFrame's columns. Source of truth
    * for spec-side operations: column discovery, selector resolution,

--- a/lib/node/pf-driver/src/ptable_pool.ts
+++ b/lib/node/pf-driver/src/ptable_pool.ts
@@ -26,7 +26,7 @@ export class PTableHolder implements Disposable {
   constructor(
     public readonly pFrame: PFrameHandle,
     pFrameDisposeSignal: AbortSignal,
-    public readonly pTablePromise: Promise<PFrameInternal.PTableV9>,
+    public readonly pTablePromise: Promise<PFrameInternal.PTableV10>,
     private readonly predecessor?: PoolEntry<PTableHandle, PTableHolder>,
   ) {
     this.combinedDisposeSignal = AbortSignal.any([

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.37
+polars-pf==1.1.40
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,14 +22,14 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.38
-      version: 1.1.38
+      specifier: 1.1.41
+      version: 1.1.41
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.38
-      version: 1.1.38
+      specifier: 1.1.41
+      version: 1.1.41
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.38
-      version: 1.1.38
+      specifier: 1.1.41
+      version: 1.1.41
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1865,7 +1865,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.38(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1985,10 +1985,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.38(encoding@0.1.13)
+        version: 1.1.41(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.38(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2468,10 +2468,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.38(encoding@0.1.13)
+        version: 1.1.41(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.38(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3142,7 +3142,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.38
+        version: 1.1.41
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5052,31 +5052,31 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.38':
-    resolution: {integrity: sha512-dAzaGazWbN2pevT1yv1o9Vmlmjhf7rZrSP8qyejlqCa40iwNxf6DRBqB9s2DSkWmuT3PpC3d0pJRWry04rAKeA==}
+  '@milaboratories/pframes-rs-node@1.1.41':
+    resolution: {integrity: sha512-gC9LaukKQhFlaY2ciV/ZTyiKqhIYHYaj4PerFWRc8Xnv339ABFLZooh+Q8aI8ylhHE+4klvFL0Eidg32k0jokw==}
 
-  '@milaboratories/pframes-rs-serv@1.1.38':
-    resolution: {integrity: sha512-xWEoG8Zo/SWVKEKBOSYAM1uDFmrkDJCnfP5QEsmnL5fdE/c+u3BGva++lvKdBOcr4l9yPFBUt6hF2H3s8ZfyEA==}
+  '@milaboratories/pframes-rs-serv@1.1.41':
+    resolution: {integrity: sha512-OnSL43+SJDOCgzHgQIhawS6nxe7ZfM3gOefHFJhe3t6L42bWJFF+8rUUPWbF+DybMXQuDBIOU8v4iwLJGsaQ5Q==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.38':
-    resolution: {integrity: sha512-m3WynMDBJkRmkDUvqDNfAfveYkuRQh+xxFG9by2uPyiZyt5BSo25KsuC7FxxbE9mRbu4kw/r4jxkMkkSXN2KFw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.41':
+    resolution: {integrity: sha512-90sD8WotapOKK/pjmMOsPHnlJ3qMfXbqJwdHfPyUEKHJLsrEYNatGdvHbRzCfPy6Sxl/yE1Bx1nzzEwcaIPyrw==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.38':
-    resolution: {integrity: sha512-3ZfQkiDnRJHScNxI/RJ/R9ztTqEb8ur67fcTDSRH9MgbfxBwT9z9rgk6zfmFn9df4xr2iSRHOFL8vT4sYz4g5w==}
+  '@milaboratories/pframes-rs-wasm@1.1.41':
+    resolution: {integrity: sha512-pl0jL1nS5hM9AHwTUuX3pf9W0EfbcydlZTSuDdKy6MOnrs1nnEUzY6pS+p+bnxKofhHM/LYwmbDKZiX/XCKoew==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.24.0
+      '@milaboratories/pl-model-common': 1.43.0
+      '@milaboratories/pl-model-middle-layer': 1.27.0
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-model-common@1.42.0':
-    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
+  '@milaboratories/pl-model-common@1.43.0':
+    resolution: {integrity: sha512-iXDytbsIy6fd2zRFqDbZceuxDpBmGH9wS2UDHpT3PAxmnneBBddW4/VILWw4HLzzXhvXYOz3FpGl/CNc76pTJQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.24.0':
-    resolution: {integrity: sha512-kOpEEAG+SqgKHFG0bwDqF4oowq+ArhgGCFpqDq97hZnnJdYVP2JQW8srgpMbT28r9rwgLWficD+UntBTJN/tVQ==}
+  '@milaboratories/pl-model-middle-layer@1.27.0':
+    resolution: {integrity: sha512-nDMBkj7P6JG+LfqeoR4nhmQiA77cAtvXSMvsV5ijsgZT8+A7Am+JXiwgHsii7vC9VvfSV80SUrv0MCvFrwR9qQ==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -11407,31 +11407,31 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.38(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.41(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-serv': 1.1.38
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pframes-rs-serv': 1.1.41
+      '@milaboratories/pl-model-common': 1.43.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.38':
+  '@milaboratories/pframes-rs-serv@1.1.41':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.24.0
+      '@milaboratories/pl-model-common': 1.43.0
+      '@milaboratories/pl-model-middle-layer': 1.27.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.38': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.41': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.38(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.38
+      '@milaboratories/pframes-rs-wasip2': 1.1.41
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11440,17 +11440,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.42.0':
+  '@milaboratories/pl-model-common@1.43.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.24.0':
+  '@milaboratories/pl-model-middle-layer@1.27.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': 1.43.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^4.0.37
       version: 4.0.37
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.8.8
-      version: 1.8.8
+      specifier: 1.10.0
+      version: 1.10.0
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -2778,7 +2778,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.8.8
+        version: 1.10.0
       '@platforma-sdk/package-builder':
         specifier: workspace:*
         version: link:../../../tools/package-builder
@@ -2787,7 +2787,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.8.8
+        version: 1.10.0
       '@platforma-sdk/package-builder':
         specifier: 'workspace:'
         version: link:../../tools/package-builder
@@ -3793,7 +3793,7 @@ importers:
         version: link:../ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.8.8
+        version: 1.10.0
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
@@ -5535,8 +5535,14 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.2.7':
     resolution: {integrity: sha512-vJiU68NKgyupW5meeWB/pZZ8y5wewPV6/EcRQ2BwUhSyikDQrn83XzBlc/nTu9UmbYmBqQTrt59x0qKtcC0ILw==}
 
+  '@platforma-open/milaboratories.runenv-python-3.12.10-clustering@0.1.1':
+    resolution: {integrity: sha512-hnr1tf0dwoqTyjtUVZcwQm13O0V8kz4jCUz+yvOgdvWMrbg4o/h1KbghtM8HivI+tRoowc629QJWdy0bc7inQA==}
+
   '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.4':
     resolution: {integrity: sha512-Yo47x/rm/FF8x/7q2o7TXdAS7pEWqBd/+aHnQzgNAF0DYljzln99mq1L4lMrQx08SJBGrh84ZtgQl/weTzWSIw==}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-humanness@0.2.0':
+    resolution: {integrity: sha512-YjKFPXe+caABLre5oZTwAxFHvVCEb5K8rVTEIUBhFYMtfLipVIix0LXi6LxWoOYdhoEeKgIc4zlWFDKs1xaEoQ==}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0':
     resolution: {integrity: sha512-nEM4eEj7pFT6yi+P5028qtgK5v9A9H0XdVHDtrKX7xW5Jipc1RIliOEU3gzaH0E7UAzPFQGSqShlwakRcGXwdQ==}
@@ -5550,11 +5556,14 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0':
     resolution: {integrity: sha512-CSLEjBYUdHDf66QAfgQ9jo+MoW63Wr0ygdIncJE2siO2jMUzYCqgCNd8bMjaMfZa3YBC9bHca3Cjxbp4VYc54A==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.13':
-    resolution: {integrity: sha512-tcBFvA8WopRz82OlDAduJYqpdaU3zquF3sj5bViPQNmuS1W6pzyO7cWBE2fkRtw2wfADnsGVxx5pJkkpn8BZsA==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0':
+    resolution: {integrity: sha512-Z9OIHbWfq0OsTUvmJIK6HBm8qLIli5xxHlGsiNx012YU69snwgi2edioMjUQ1vr5eWPA/9+Xs8Ih9z+aWbmUpQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.8.8':
-    resolution: {integrity: sha512-ku4W8q6q/etWO5zxp6vN5E8+Az9B0sxFoHhp536dOoBLx+sJTfjXAECYI3M97LrZkErk1bHTZCN+GU16lmMtug==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.14':
+    resolution: {integrity: sha512-HPpVvYGURPGUcxHgbDFRuL3jpYcDP+vPhaZD6zd+9/1RObkQtYkHR5UOKQYefC+gwMeyIiLhK+UYukgvvpYEnQ==}
+
+  '@platforma-open/milaboratories.runenv-python-3@1.10.0':
+    resolution: {integrity: sha512-v1NlxvEjYRdn+Bq2cr26rXj+etDtFx0EO6txpB4Q3Ts009S8dgJHrYZ9vrp+7e9u7f/EHn/X22r2ibaCNPql3g==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -11847,7 +11856,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.2.7': {}
 
+  '@platforma-open/milaboratories.runenv-python-3.12.10-clustering@0.1.1': {}
+
   '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.4': {}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-humanness@0.2.0': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0': {}
 
@@ -11857,17 +11870,22 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.13': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.8.8':
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.14': {}
+
+  '@platforma-open/milaboratories.runenv-python-3@1.10.0':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.13
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.14
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
+      '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.4
+      '@platforma-open/milaboratories.runenv-python-3.12.10-humanness': 0.2.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-parapred': 1.1.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.6.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.5
       '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': 1.1.0
+      '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': 0.1.0
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -296,7 +296,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.0.3
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.8.8
+  "@platforma-open/milaboratories.runenv-python-3": 1.10.0
 
   "shx": ^0.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -251,9 +251,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.38
-  "@milaboratories/pframes-rs-wasip2": 1.1.38
-  "@milaboratories/pframes-rs-wasm": 1.1.38
+  "@milaboratories/pframes-rs-node": 1.1.41
+  "@milaboratories/pframes-rs-wasip2": 1.1.41
+  "@milaboratories/pframes-rs-wasm": 1.1.41
 
   "quickjs-emscripten": 0.31.0
 

--- a/sdk/workflow-tengo/src/pt/import-dir.tpl.tengo
+++ b/sdk/workflow-tengo/src/pt/import-dir.tpl.tengo
@@ -25,7 +25,8 @@ _DATA_INFO_SCHEMA := {
                 `numberOfBytes,?`: {
                     `axes`: [`number`],
                     `column`: `number`
-                }
+                },
+                `metadataSize`: `number`
             },
             `axes`: [
                 {


### PR DESCRIPTION
## Summary

Bumps `@milaboratories/pframes-rs-*` to `1.1.41`, which exposes the `PFrameFactoryV6` / `PFrameV15` / `PTableV10` addon surface (the version that adds the table `export` method). Switches all driver consumers to the new interface and removes the superseded `PFrameFactoryV5` / `PFrameV14` / `PFrameReadAPIV12` / `PTableV9` declarations.

Also adds `PFrameDriver.exportPTable(handle, path)` to the driver surface, wired through the service bridge. The method is a **placeholder that always rejects with "not implemented"** — the native export implementation will land in a separate change.

## Changes

**Interface switch (Vx → Vx+1)**
- `internal_api/{pframe,api_read,table}.ts` — drop `PFrameFactoryV5` / `PFrameV14` / `PFrameReadAPIV12` / `PTableV9`; make the V6/V15/V13/V10 doc comments self-contained.
- `pf-driver/{pframe_pool,ptable_pool,csv_writer}.ts` — retype to `PFrameV15` / `PTableV10`.

**`exportPTable` stub**
- `driver.ts` (`PFrameDriver`), `driver_decl.ts` (`AbstractInternalPFrameDriver`) — new method on the interfaces.
- `driver_impl.ts` — implementation throws `PFrameDriverError("exportPTable is not implemented yet")`.
- `service_declarations.ts` + `node_service_handlers.ts` — bridge registration.

**Note:** `REQUIRES_PFRAMES_VERSION` is intentionally left unchanged.

## Verification

`turbo run types:check linter:check` green across `pl-model-common`, `pl-model-middle-layer`, and `pf-driver`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps `@milaboratories/pframes-rs-*` from `1.1.38` to `1.1.41`, switches all internal type references from the superseded V5/V14/V9/V12 interfaces to the new V6/V15/V10/V13 variants, and introduces an `exportPTable(handle, path)` stub on the driver surface that always rejects with "not implemented".

- **Interface version migration**: `PFrameFactoryV5`, `PFrameV14`, `PFrameReadAPIV12`, and `PTableV9` are removed; their V+1 successors become the single entry points throughout `internal_api/`, `pframe_pool.ts`, `ptable_pool.ts`, and `csv_writer.ts`.
- **`exportPTable` stub**: The method is declared on `PFrameDriver` (public) and `AbstractInternalPFrameDriver` (internal), wired through the service bridge in `service_declarations.ts` and `node_service_handlers.ts`, and implemented as an immediate rejection in `driver_impl.ts`.
- **`REQUIRES_PFRAMES_VERSION` intentionally unchanged**: The PR notes that because the export method is a placeholder, blocks built with this SDK do not yet require the new native binary on the host app.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the only new runtime behaviour is an immediate rejection from the exportPTable stub, which is correctly documented and wired through the service bridge.

The interface migration is mechanical and the type-equality guards confirm nothing was accidentally dropped. Both observations are forward-looking: the missing AbortSignal on the public interface will require a breaking change or an options-object refactor when the native export lands, and REQUIRES_PFRAMES_VERSION being two library releases behind adds a maintenance debt that must be paid in the follow-up PR.

driver.ts (public exportPTable signature) and block_flags.ts (version constant) are worth a second look before the native export implementation arrives.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/drivers/pframe/driver.ts | Adds exportPTable to PFrameDriver interface without an AbortSignal parameter; type-equality guard updated to omit the new method. |
| lib/model/common/src/flags/block_flags.ts | REQUIRES_PFRAMES_VERSION left at 1_001_031 (encoding 1.1.31) while the native library was bumped to 1.1.41; intentional per PR description but diverges from the 'bump in lockstep' convention noted in this file's comment. |
| lib/node/pf-driver/src/driver_impl.ts | Adds exportPTable stub that immediately throws PFrameDriverError; no other logic changed. |
| lib/node/pf-driver/src/driver_decl.ts | Adds exportPTable with optional AbortSignal to AbstractInternalPFrameDriver; consistent with internal interface conventions. |
| lib/model/common/src/services/node_service_handlers.ts | Wires exportPTable through the service bridge; no signal forwarded, consistent with the public PFrameDriver signature. |
| lib/model/common/src/services/service_declarations.ts | Registers exportPTable in the PFrame uiMethods list; straightforward addition. |
| lib/model/middle-layer/src/pframe/internal_api/pframe.ts | Removes PFrameV14 and PFrameFactoryV5; PFrameV15/PFrameFactoryV6 become the sole interfaces. Doc comments made self-contained. |
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Removes PTableV9; only PTableV10 (with export method) remains. |
| lib/model/middle-layer/src/pframe/internal_api/api_read.ts | Removes PFrameReadAPIV12; PFrameReadAPIV13 is now the sole read interface. Doc comment updated to be standalone. |
| lib/node/pf-driver/src/pframe_pool.ts | PFrameHolder type updated from PFrameV14 to PFrameV15; mechanical rename only. |
| lib/node/pf-driver/src/ptable_pool.ts | PTableHolder type updated from PTableV9 to PTableV10; mechanical rename only. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as UI (Block)
    participant Bridge as Service Bridge<br/>(node_service_handlers.ts)
    participant Driver as PFrameDriver<br/>(driver_impl.ts)

    UI->>Bridge: exportPTable(handle, path)
    Bridge->>Driver: exportPTable(handle, path)
    Driver-->>Bridge: throw PFrameDriverError("not implemented yet")
    Bridge-->>UI: Promise rejection
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/common/src/drivers/pframe/driver.ts:114
**Missing `AbortSignal` on the public interface**

The public `PFrameDriver.exportPTable` takes only `(handle, path)`, while the internal `AbstractInternalPFrameDriver` already declares an optional `signal?`. When the real export implementation lands it will need cancellation (the operation can be long-running), but adding a third parameter to the public signature will be a breaking change. The existing pattern used by `writePTableToFs` embeds the signal inside an options object — doing the same here now (e.g. `exportPTable(handle: PTableHandle, options: { path: string; signal?: AbortSignal }): Promise<void>`) would let the native implementation wire up cancellation without a future API break.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pf-driver): adopt PFrames V6/V15/V1..."](https://github.com/milaboratory/platforma/commit/fbff7177eee63eb0aa62db4a4dffb123c2def4f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35335615)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->