### PR TITLE
fix(pl-middle-layer): move semver to runtime dependencies

### DIFF
--- a/.changeset/semver-runtime-dep.md
+++ b/.changeset/semver-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Move `semver` from devDependencies to dependencies — it is imported at runtime by `block_registry/watcher.ts`. As a devDependency it was a phantom dependency: consumers like `@platforma-sdk/pl-cli` failed with `MODULE_NOT_FOUND: Cannot find package 'semver'` under pnpm 11's global virtual store (`pnpm dlx`), where ESM imports cannot resolve undeclared packages via hoisting.

--- a/lib/node/pl-middle-layer/package.json
+++ b/lib/node/pl-middle-layer/package.json
@@ -55,6 +55,7 @@
     "es-toolkit": "catalog:",
     "lru-cache": "catalog:",
     "quickjs-emscripten": "catalog:",
+    "semver": "catalog:",
     "undici": "catalog:",
     "utility-types": "catalog:",
     "yaml": "catalog:",
@@ -67,7 +68,6 @@
     "@types/node": "catalog:",
     "@types/semver": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
-    "semver": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2529,6 +2529,9 @@ importers:
       quickjs-emscripten:
         specifier: 'catalog:'
         version: 0.31.0
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.2
       undici:
         specifier: 'catalog:'
         version: 7.16.0
@@ -2560,9 +2563,6 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
-      semver:
-        specifier: 'catalog:'
-        version: 7.7.2
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Problem

`@platforma-sdk/pl-cli` fails on machines with pnpm 11:

```
ModuleLoadError: [MODULE_NOT_FOUND] import() failed to load .../pl-cli/dist/cli.js:
Cannot find package 'semver' imported from .../@milaboratories/pl-middle-layer/dist/block_registry/watcher.js
```

## Cause

`block_registry/watcher.ts` imports `semver` at runtime, but it was declared only in `devDependencies` (since 2a74806b0, Dec 2024) — a phantom dependency.

It went unnoticed because pnpm ≤10 `dlx` hoists all deps into `.pnpm/node_modules/`, where ESM resolution finds them. pnpm 11's global virtual store (default for `dlx`) only exposes hoisted deps via `NODE_PATH`, which Node ignores for ESM imports — so the undeclared import fails.

## Fix

Move `semver` from `devDependencies` to `dependencies`. `@types/semver` stays in `devDependencies`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a phantom dependency bug in `@milaboratories/pl-middle-layer` where `semver` was declared only in `devDependencies` despite being imported at runtime by `block_registry/watcher.ts`, causing `MODULE_NOT_FOUND` failures under pnpm 11's stricter ESM resolution.

- Moves `semver` from `devDependencies` to `dependencies` in `lib/node/pl-middle-layer/package.json`; `@types/semver` correctly remains in `devDependencies`.
- Updates `pnpm-lock.yaml` to reflect semver `7.7.2` under the runtime dependency section, and adds a patch-level changeset entry.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted correction of a missing runtime dependency with no behavioral changes to the code itself.

The runtime import of `semver` in `watcher.ts` is confirmed, `@types/semver` correctly stays in devDependencies, and the lockfile is consistent with the package.json change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/package.json | Moves semver from devDependencies to dependencies; @types/semver correctly stays in devDependencies |
| pnpm-lock.yaml | Lockfile updated to reflect semver (7.7.2) under runtime dependencies for pl-middle-layer |
| .changeset/semver-runtime-dep.md | Changeset entry documenting the patch-level fix moving semver to runtime dependencies |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm dlx @platforma-sdk/pl-cli"] --> B["Loads pl-middle-layer"]
    B --> C["block_registry/watcher.ts\nimport * as semver from 'semver'"]
    C --> D{semver in dependencies?}
    D -- "Before (devDeps only)" --> E["pnpm ≤10: hoisted → works\npnpm 11: ESM fails MODULE_NOT_FOUND"]
    D -- "After (runtime deps)" --> F["Resolved correctly\nfor all pnpm versions"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pl-middle-layer): move semver to run..."](https://github.com/milaboratory/platforma/commit/eb52193b7f17c7e5fcf44258d694819ceec08ee0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35589301)</sub>

<!-- /greptile_comment -->