### PR TITLE
feat(pf-driver): bump pframes to 1.1.42, migrate to PTableV11 export interface

### DIFF
--- a/.changeset/pframes-1-1-42-ptable-v11.md
+++ b/.changeset/pframes-1-1-42-ptable-v11.md
@@ -1,0 +1,11 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+"@milaboratories/pf-driver": patch
+"@milaboratories/pf-spec-driver": patch
+"@platforma-sdk/workflow-tengo": patch
+"@milaboratories/pl-middle-layer": patch
+---
+
+Bump `@milaboratories/pframes-rs-*` to 1.1.42 and migrate the PFrame driver to the `PTableV11` / `PFrameReadAPIV14` / `PFrameV16` / `PFrameFactoryV7` interface family.
+
+`exportPTable` now honours `columnIndices`: it builds a unified column-index → header-name map and passes it to `PTableV11.export`, which both selects the columns to export and names them (emitted in ascending index order). The superseded `PTableV10` / `PFrameReadAPIV13` / `PFrameV15` / `PFrameFactoryV6` interfaces are removed.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -4,7 +4,7 @@ import type {
   DataQuery,
   DataQueryBooleanExpression,
 } from "@milaboratories/pl-model-common";
-import type { PTableV10, PTableV11 } from "./table";
+import type { PTableV11 } from "./table";
 import type { PTableId } from "./common";
 
 /**
@@ -31,35 +31,8 @@ export interface UniqueValuesRequestV2 {
 }
 
 /**
- * Read interface exposed by PFrames library. Returns the {@link PTableV10}
- * table view, which provides the `export` method.
- *
- * Spec-side operations (finding columns, listing columns, retrieving
- * column specs, computing axis integrations) are not part of this
- * surface — callers cache column specs themselves or route through
- * WASM-spec. The data-side `createTable` accepts a pre-lowered
- * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
- * {@link UniqueValuesRequestV2}.
- */
-export interface PFrameReadAPIV13 {
-  /** Creates table from a pre-lowered data query. */
-  createTable(tableId: PTableId, dataQuery: DataQuery): PTableV10;
-
-  /** Calculate set of unique values for a specific axis for the filtered set of records. */
-  getUniqueValues(
-    request: UniqueValuesRequestV2,
-    ops?: {
-      signal?: AbortSignal;
-    },
-  ): Promise<UniqueValuesResponse>;
-}
-
-/**
  * Read interface exposed by PFrames library. Returns the {@link PTableV11}
  * table view, whose `export` takes a column-index → header map.
- *
- * Identical to {@link PFrameReadAPIV13} apart from the table view returned by
- * `createTable`.
  *
  * Spec-side operations (finding columns, listing columns, retrieving
  * column specs, computing axis integrations) are not part of this

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,19 +1,12 @@
 import type { PFrameFactoryAPIV5 } from "./api_factory";
-import type { PFrameReadAPIV13, PFrameReadAPIV14 } from "./api_read";
+import type { PFrameReadAPIV14 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
 /**
  * Full PFrame surface — factory operations plus data-side reads. Exposes
- * {@link PFrameReadAPIV13}, whose tables provide the `export` method.
- */
-export interface PFrameV15 extends PFrameFactoryAPIV5, PFrameReadAPIV13 {}
-
-/**
- * Full PFrame surface — factory operations plus data-side reads.
- *
- * Identical to {@link PFrameV15} but exposes {@link PFrameReadAPIV14}, whose
- * tables' `export` takes a column-index → header map.
+ * {@link PFrameReadAPIV14}, whose tables' `export` takes a column-index →
+ * header map.
  */
 export interface PFrameV16 extends PFrameFactoryAPIV5, PFrameReadAPIV14 {}
 
@@ -28,31 +21,8 @@ export type PFrameOptionsV2 = {
 
 /**
  * PFrame management functions exposed by the PFrame module. Creates
- * {@link PFrameV15} instances, whose tables provide the `export` method.
- */
-export interface PFrameFactoryV6 {
-  /**
-   * Create a new PFrame instance.
-   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
-   */
-  createPFrame(options: PFrameOptionsV2): PFrameV15;
-
-  /**
-   * Dump active allocations from all PFrames instances in pprof format.
-   * The result of this function should be saved as `profile.pb.gz`.
-   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
-   * to view the allocation flamechart.
-   * @warning This method will always reject on Windows!
-   */
-  pprofDump: () => Promise<Uint8Array>;
-}
-
-/**
- * PFrame management functions exposed by the PFrame module. Creates
  * {@link PFrameV16} instances, whose tables' `export` takes a
  * column-index → header map.
- *
- * Identical to {@link PFrameFactoryV6} apart from the created PFrame surface.
  */
 export interface PFrameFactoryV7 {
   /**

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -3,79 +3,8 @@ import type { PTableShape, PTableVector, TableRange } from "@milaboratories/pl-m
 /**
  * Table view returned by `createTable`.
  *
- * PTable can be thought as having a composite primary key, consisting
- * of axes, and a set of data columns derived from PColumn values.
- * The table's column spec is owned by the caller — selector → index
- * resolution runs on the caller side via WASM-spec.
- */
-export interface PTableV10 extends Disposable {
-  /**
-   * Get PTable disk footprint in bytes.
-   *
-   * @param ops.withPredecessors When true, the footprint includes
-   *   every registered predecessor table reachable through the
-   *   query lineage. When false or omitted, only this table's own
-   *   materialised data is counted.
-   *
-   * Warning: This call materializes the join.
-   */
-  getFootprint(ops?: { withPredecessors?: boolean; signal?: AbortSignal }): Promise<number>;
-
-  /**
-   * Unified table shape
-   * Warning: This call materializes the join.
-   */
-  getShape(ops?: { signal?: AbortSignal }): Promise<PTableShape>;
-
-  /**
-   * Retrieve the data from the table. To retrieve only data required, it can be
-   * sliced both horizontally ({@link columnIndices}) and vertically
-   * ({@link range}).
-   * This call materializes the join.
-   *
-   * @param columnIndices unified indices of columns to be retrieved
-   * @param range optionally limit the range of records to retrieve
-   * */
-  getData(
-    columnIndices: number[],
-    ops?: {
-      range?: TableRange;
-      signal?: AbortSignal;
-    },
-  ): Promise<PTableVector[]>;
-
-  /**
-   * Stream the full, sorted table to a file at `path`. The output format is
-   * selected from the file extension: `csv`, `tsv`, `parquet`, or `xlsx`.
-   * Writing is bounded-memory.
-   * This call materializes the join.
-   *
-   * @param path destination file path; its extension selects the format
-   * @param headers column names in unified order (axes first, then data
-   *   columns). Length must equal the number of table fields — the data layer
-   *   is name-independent, so names are supplied by the caller.
-   *
-   * @remarks For `xlsx` the caller must ensure the row count is below Excel's
-   *   1,048,576-row per-sheet limit.
-   */
-  export(
-    path: string,
-    headers: string[],
-    ops?: {
-      signal?: AbortSignal;
-    },
-  ): Promise<void>;
-
-  /** Deallocates all underlying resources */
-  dispose(): void;
-}
-
-/**
- * Table view returned by `createTable`.
- *
- * Identical to {@link PTableV10} but {@link PTableV11.export} takes a
- * `headers` map (unified column index → header name) that both selects the
- * columns to export and names them, instead of a positional `string[]`.
+ * {@link PTableV11.export} takes a `headers` map (unified column index →
+ * header name) that both selects the columns to export and names them.
  *
  * PTable can be thought as having a composite primary key, consisting
  * of axes, and a set of data columns derived from PColumn values.

--- a/lib/node/pf-driver/src/csv_writer.ts
+++ b/lib/node/pf-driver/src/csv_writer.ts
@@ -9,7 +9,7 @@ import {
 } from "@milaboratories/pl-model-common";
 import { isNil } from "@milaboratories/helpers";
 
-/** Minimal subset of PTableV10 required by streamPTableRows. */
+/** Minimal subset of PTable required by streamPTableRows. */
 export interface PTableDataSource {
   getData(
     columnIndices: number[],

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -349,8 +349,6 @@ export class AbstractPFrameDriver<
   ): Promise<void> {
     const { path, columnIndices } = options;
 
-    void columnIndices; // TODO
-
     this.logger("info", `[ExportPTable] ENTER (handle = ${handle}, path = ${path})`);
     const startTime = performance.now();
 
@@ -363,9 +361,10 @@ export class AbstractPFrameDriver<
       [signal, disposeSignal].filter((s): s is AbortSignal => !isNil(s)),
     );
 
-    // Headers mirror the CSV/TSV path (axes first, then data columns): the
-    // label annotation when present, otherwise the spec name.
-    const headers = def.tableSpec.map(columnLabel);
+    const headers: Record<number, string> = {};
+    for (const index of columnIndices) {
+      headers[index] = columnLabel(def.tableSpec[index]);
+    }
 
     return await this.tableConcurrencyLimiter.run(async () => {
       // Cap data rows per xlsx sheet below Excel's hard limit of 1,048,576.

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -30,7 +30,7 @@ export interface RemoteBlobProvider<TreeEntry extends JsonSerializable> {
 }
 
 export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposable {
-  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV15>;
+  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV16>;
   /**
    * WASM-spec frame built from this PFrame's columns. Source of truth
    * for spec-side operations: column discovery, selector resolution,

--- a/lib/node/pf-driver/src/ptable_pool.ts
+++ b/lib/node/pf-driver/src/ptable_pool.ts
@@ -26,7 +26,7 @@ export class PTableHolder implements Disposable {
   constructor(
     public readonly pFrame: PFrameHandle,
     pFrameDisposeSignal: AbortSignal,
-    public readonly pTablePromise: Promise<PFrameInternal.PTableV10>,
+    public readonly pTablePromise: Promise<PFrameInternal.PTableV11>,
     private readonly predecessor?: PoolEntry<PTableHandle, PTableHolder>,
   ) {
     this.combinedDisposeSignal = AbortSignal.any([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,14 +22,14 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.41
-      version: 1.1.41
+      specifier: 1.1.42
+      version: 1.1.42
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.41
-      version: 1.1.41
+      specifier: 1.1.42
+      version: 1.1.42
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.41
-      version: 1.1.41
+      specifier: 1.1.42
+      version: 1.1.42
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1865,7 +1865,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1985,10 +1985,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.41(encoding@0.1.13)
+        version: 1.1.42(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2468,10 +2468,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.41(encoding@0.1.13)
+        version: 1.1.42(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3142,7 +3142,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.41
+        version: 1.1.42
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5044,39 +5044,35 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@milaboratories/helpers@1.14.1':
-    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
-    engines: {node: '>=22'}
-
   '@milaboratories/helpers@1.14.2':
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.41':
-    resolution: {integrity: sha512-gC9LaukKQhFlaY2ciV/ZTyiKqhIYHYaj4PerFWRc8Xnv339ABFLZooh+Q8aI8ylhHE+4klvFL0Eidg32k0jokw==}
+  '@milaboratories/pframes-rs-node@1.1.42':
+    resolution: {integrity: sha512-Mzw2VjqeoJPoB1F8IKngVysJJcqeLvT6K+RkR6RH8SAFAiVPUvlhOdvATwZCYOMSgs8r3tQouI/qVeKdGYSoIQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.41':
-    resolution: {integrity: sha512-OnSL43+SJDOCgzHgQIhawS6nxe7ZfM3gOefHFJhe3t6L42bWJFF+8rUUPWbF+DybMXQuDBIOU8v4iwLJGsaQ5Q==}
+  '@milaboratories/pframes-rs-serv@1.1.42':
+    resolution: {integrity: sha512-it0Hx317mTod4o6+sujGR5mPwo3pseptX1ghSxJgaWHM18ZgLy1+VARKbp8LeoOoWrUqjhQFXcAKo4R8PTSQog==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.41':
-    resolution: {integrity: sha512-90sD8WotapOKK/pjmMOsPHnlJ3qMfXbqJwdHfPyUEKHJLsrEYNatGdvHbRzCfPy6Sxl/yE1Bx1nzzEwcaIPyrw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.42':
+    resolution: {integrity: sha512-xIFSI791uRvTbhlKKZ0a92xo4zRPORZVKk91py+6bSuBxsccXeW4e6EEDwv/j3IEPgMufVIKsRSfOUUNf+u26A==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.41':
-    resolution: {integrity: sha512-pl0jL1nS5hM9AHwTUuX3pf9W0EfbcydlZTSuDdKy6MOnrs1nnEUzY6pS+p+bnxKofhHM/LYwmbDKZiX/XCKoew==}
+  '@milaboratories/pframes-rs-wasm@1.1.42':
+    resolution: {integrity: sha512-94Y2FHNRjqTZmqe7U8cLM0eAZ0CSxfG9KQ9voyy+QdcqQ4bl+Fw891HGCt9BToNB6Ce938D3Dn69dLPAxAXCDw==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.43.0
-      '@milaboratories/pl-model-middle-layer': 1.27.0
+      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pl-model-middle-layer': 1.29.0
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-model-common@1.43.0':
-    resolution: {integrity: sha512-iXDytbsIy6fd2zRFqDbZceuxDpBmGH9wS2UDHpT3PAxmnneBBddW4/VILWw4HLzzXhvXYOz3FpGl/CNc76pTJQ==}
+  '@milaboratories/pl-model-common@1.45.0':
+    resolution: {integrity: sha512-T3yCPY112J/+b5OjK2qVaJ/sk5rdyA8GNa87YojwZmO9P8KAgngOZrnjmBTnyW3Z64iK4N6Lt64+c0AnPB9sig==}
 
-  '@milaboratories/pl-model-middle-layer@1.27.0':
-    resolution: {integrity: sha512-nDMBkj7P6JG+LfqeoR4nhmQiA77cAtvXSMvsV5ijsgZT8+A7Am+JXiwgHsii7vC9VvfSV80SUrv0MCvFrwR9qQ==}
+  '@milaboratories/pl-model-middle-layer@1.29.0':
+    resolution: {integrity: sha512-xUZnvi6yvU2iegXxU/alECmyxlG0RZxRP5gcUO9CfJ3kmx48NFYmDSLsolxtmunV0GYsMb3HjeMMe2oiH6ey7w==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -11412,35 +11408,33 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@milaboratories/helpers@1.14.1': {}
-
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.41(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.42(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-serv': 1.1.41
-      '@milaboratories/pl-model-common': 1.43.0
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pframes-rs-serv': 1.1.42
+      '@milaboratories/pl-model-common': 1.45.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.41':
+  '@milaboratories/pframes-rs-serv@1.1.42':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.43.0
-      '@milaboratories/pl-model-middle-layer': 1.27.0
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pl-model-middle-layer': 1.29.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.41': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.42': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.41
+      '@milaboratories/pframes-rs-wasip2': 1.1.42
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11449,17 +11443,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.43.0':
+  '@milaboratories/pl-model-common@1.45.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.27.0':
+  '@milaboratories/pl-model-middle-layer@1.29.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.43.0
+      '@milaboratories/pl-model-common': 1.45.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -251,9 +251,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.41
-  "@milaboratories/pframes-rs-wasip2": 1.1.41
-  "@milaboratories/pframes-rs-wasm": 1.1.41
+  "@milaboratories/pframes-rs-node": 1.1.42
+  "@milaboratories/pframes-rs-wasip2": 1.1.42
+  "@milaboratories/pframes-rs-wasm": 1.1.42
 
   "quickjs-emscripten": 0.31.0
 


### PR DESCRIPTION
## Summary

- Bump `@milaboratories/pframes-rs-{node,wasip2,wasm}` from 1.1.41 to **1.1.42** in `pnpm-workspace.yaml`.
- Migrate the PFrame driver to the new interface family: `PTableV11` / `PFrameReadAPIV14` / `PFrameV16` / `PFrameFactoryV7`, and **remove** the superseded `PTableV10` / `PFrameReadAPIV13` / `PFrameV15` / `PFrameFactoryV6`.
- Wire `columnIndices` through `exportPTable`: it now builds a unified column-index → header-name map and passes it to `PTableV11.export`, which both selects the columns to export and names them (data emitted in ascending index order). This removes the `void columnIndices; // TODO`.

## Details

`PTableV11.export` replaces the positional `headers: string[]` of V10 with a `Record<number, string>` map. The driver derives header names the same way as the CSV/TSV path (`columnLabel`: label annotation when present, otherwise the spec name), keyed by the requested unified column indices.

Touched:
- `lib/model/middle-layer/src/pframe/internal_api/{table,api_read,pframe}.ts` — drop the old interfaces, keep V11/V14/V16/V7.
- `lib/node/pf-driver/src/{driver_impl,ptable_pool,pframe_pool,csv_writer}.ts` — migrate type references and implement the header map.

## Testing

- `types:check` green across `pl-model-common`, `pl-model-middle-layer`, `pf-driver`.
- `exportPTable` end-to-end test (`driver_double.test.ts`) passes against the real 1.1.42 native addon — correct headers and sorted rows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps `@milaboratories/pframes-rs-{node,wasip2,wasm}` from `1.1.41` to `1.1.42` and migrates the PFrame driver to the new `PTableV11` / `PFrameReadAPIV14` / `PFrameV16` / `PFrameFactoryV7` interface family, removing the superseded V10/V13/V15/V6 interfaces.

- **Interface cleanup**: `PTableV10` (positional `string[]` export), `PFrameReadAPIV13`, `PFrameV15`, and `PFrameFactoryV6` are deleted across `table.ts`, `api_read.ts`, and `pframe.ts`; only the V11/V14/V16/V7 variants remain.
- **`exportPTable` wired up**: The previously no-op `void columnIndices; // TODO` is replaced with a loop that builds a `Record<number, string>` header map keyed by the requested column indices and passes it to `PTableV11.export`, which both selects and names the exported columns.
- **Type references updated**: `PTableHolder.pTablePromise` and `PFrameHolder.pFrameDataPromise` are re-typed to `PTableV11` and `PFrameV16` respectively.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The interface migration and header-map logic are correct, but the companion REQUIRES_PFRAMES_VERSION flag was not updated, which means blocks built against this SDK could load on older desktop apps that still serve the PTableV10 export(string[]) wire API causing a runtime failure.

The exportPTable implementation is sound and the type cleanup is clean. The missing REQUIRES_PFRAMES_VERSION update is the one gap: the new PTableV11.export(Record<number,string>) call is wire-incompatible with pframes < 1.1.42, so without the guard bump, blocks deployed to older runtimes would crash at the point they try to export a table.

pnpm-workspace.yaml flags the missed step inline; the corresponding fix lives in lib/model/common/src/flags/block_flags.ts (REQUIRES_PFRAMES_VERSION).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Bumps pframes-rs-{node,wasip2,wasm} from 1.1.41 to 1.1.42 but misses the companion REQUIRES_PFRAMES_VERSION update called out by the inline comment. |
| lib/node/pf-driver/src/driver_impl.ts | Removes void columnIndices TODO and builds a Record<number,string> header map passed to PTableV11.export; logic is correct assuming caller-validated indices. |
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Drops PTableV10 (positional string[] export) and retains only PTableV11 whose export takes a Record<number,string> headers map. |
| lib/node/pf-driver/src/ptable_pool.ts | Updates pTablePromise type from PTableV10 to PTableV11, consistent with the interface migration. |
| lib/node/pf-driver/src/pframe_pool.ts | Updates pFrameDataPromise type from PFrameV15 to PFrameV16, straight type migration. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant driver_impl as AbstractPFrameDriver
    participant PTablePool
    participant PTableV11 as PTableV11 (native addon)

    Caller->>driver_impl: "exportPTable(handle, {path, columnIndices})"
    driver_impl->>PTablePool: acquire(def)
    PTablePool-->>driver_impl: "PTableHolder {pTablePromise}"
    driver_impl->>PTableV11: await pTablePromise
    Note over driver_impl: Build headers Record<number,string> for each index in columnIndices
    driver_impl->>PTableV11: "export(path, headers, {signal})"
    PTableV11-->>driver_impl: void (file written)
    driver_impl-->>Caller: void
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-workspace.yaml:252-255
**`REQUIRES_PFRAMES_VERSION` not updated after pframes bump**

The comment immediately above the version lines reads: _"When bumping, also update `REQUIRES_PFRAMES_VERSION` in `lib/model/common/src/flags/block_flags.ts`."_ That file still holds `1_001_031` (matching `1.1.31`). This PR lifts pframes to `1.1.42` and simultaneously removes the `PTableV10`/`PFrameReadAPIV13`/`PFrameV15`/`PFrameFactoryV6` interfaces in favour of their V11/V14/V16/V7 replacements — a breaking wire-level change. A desktop app running pframes `< 1.1.42` would receive a `PTableV10` object whose `export(path, string[])` signature is incompatible with the `Record<number, string>` argument the new driver now passes, causing a runtime failure. `REQUIRES_PFRAMES_VERSION` should be updated to `1_001_042` so blocks built against this SDK refuse to load on older runtimes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pf-driver): bump pframes to 1.1.42 ..."](https://github.com/milaboratory/platforma/commit/c9dccff1069f1cdd524db51864b87a43393798d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35600232)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->