### PR TITLE
MILAB-6395: add raiseIfEmpty to pt SDK and ptabler ReadCsv

### DIFF
--- a/.changeset/pt-raise-if-empty.md
+++ b/.changeset/pt-raise-if-empty.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+`pt.workflow().frame()` accepts a new `raiseIfEmpty` option. When set to `false`, a zero-byte input file is read as an empty typed table using the declared `schema` instead of raising a polars `NoDataError`. Maps directly to ptabler's new `raiseIfEmpty` field on read steps. Requires `@platforma-open/milaboratories.software-ptabler` with the matching `raiseIfEmpty` support.

--- a/.changeset/ptabler-raise-if-empty.md
+++ b/.changeset/ptabler-raise-if-empty.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.software-ptabler": minor
+---
+
+ReadCsv / ReadNdjson / ReadParquet now accept a `raiseIfEmpty` option. When set to `false` and the input file is zero bytes, the step synthesises an empty `LazyFrame` from the declared `schema` instead of raising polars `NoDataError`. Defaults to `true` (existing strict behaviour). Use this together with a complete `schema` listing every column referenced downstream, so the empty frame has the right shape for subsequent `withColumns` / `filter` calls.

--- a/lib/ptabler/software/src/ptabler/steps/io.py
+++ b/lib/ptabler/software/src/ptabler/steps/io.py
@@ -28,6 +28,10 @@ class BaseReadLogic(PStep):
     infer_schema: Optional[bool]
     ignore_errors: Optional[bool]
     n_rows: Optional[int]
+    # When set to False, a zero-byte input file is treated as an empty table
+    # (using the declared `schema` for columns) instead of raising a polars
+    # NoDataError. Defaults to None (existing strict polars behavior).
+    raise_if_empty: Optional[bool]
 
     def _do_scan(self, file_path: str, scan_kwargs: Dict[str, Any]) -> pl.LazyFrame:
         """
@@ -51,16 +55,16 @@ class BaseReadLogic(PStep):
                 if col_spec.type:
                     polars_type_obj = toPolarsType(col_spec.type)
                     defined_column_types[col_spec.column] = polars_type_obj
-                
+
                 if col_spec.null_value is not None:
                     defined_null_values[col_spec.column] = col_spec.null_value
 
         if defined_column_types:
             scan_kwargs["schema_overrides"] = defined_column_types
-        
+
         if defined_null_values:
             scan_kwargs["null_values"] = defined_null_values
-        
+
         if self.n_rows is not None:
             scan_kwargs["n_rows"] = self.n_rows
 
@@ -71,8 +75,21 @@ class BaseReadLogic(PStep):
             scan_kwargs["ignore_errors"] = self.ignore_errors
 
         file_path = os.path.join(ctx.settings.root_folder, normalize_path(self.file))
+
+        if self.raise_if_empty is False:
+            try:
+                file_is_empty = os.path.getsize(file_path) == 0
+            except OSError:
+                file_is_empty = False
+            if file_is_empty:
+                ctx.put_table(
+                    self.name,
+                    pl.LazyFrame(schema=defined_column_types) if defined_column_types else pl.LazyFrame(),
+                )
+                return
+
         lazy_frame = self._do_scan(file_path, scan_kwargs)
-        
+
         ctx.put_table(self.name, lazy_frame)
 
 class ReadCsv(BaseReadLogic, tag="read_csv"):
@@ -90,6 +107,7 @@ class ReadCsv(BaseReadLogic, tag="read_csv"):
     infer_schema: Optional[bool] = None
     ignore_errors: Optional[bool] = None
     n_rows: Optional[int] = None
+    raise_if_empty: Optional[bool] = None
 
     def _do_scan(self, file_path: str, scan_kwargs: Dict[str, Any]) -> pl.LazyFrame:
         """
@@ -99,7 +117,9 @@ class ReadCsv(BaseReadLogic, tag="read_csv"):
             scan_kwargs["separator"] = self.delimiter
         if self.comment_prefix is not None:
             scan_kwargs["comment_prefix"] = self.comment_prefix
-    
+        if self.raise_if_empty is not None:
+            scan_kwargs["raise_if_empty"] = self.raise_if_empty
+
         return pl.scan_csv(file_path, **scan_kwargs)
 
 class ReadNdjson(BaseReadLogic, tag="read_ndjson"):
@@ -114,6 +134,7 @@ class ReadNdjson(BaseReadLogic, tag="read_ndjson"):
     infer_schema: Optional[bool] = None
     ignore_errors: Optional[bool] = None
     n_rows: Optional[int] = None
+    raise_if_empty: Optional[bool] = None
 
     def _do_scan(self, file_path: str, scan_kwargs: Dict[str, Any]) -> pl.LazyFrame:
         """
@@ -133,6 +154,7 @@ class ReadParquet(BaseReadLogic, tag="read_parquet"):
     infer_schema: Optional[bool] = None
     ignore_errors: Optional[bool] = None
     n_rows: Optional[int] = None
+    raise_if_empty: Optional[bool] = None
 
     def _do_scan(self, file_path: str, scan_kwargs: Dict[str, Any]) -> pl.LazyFrame:
         """

--- a/lib/ptabler/software/src/test/basic_test.py
+++ b/lib/ptabler/software/src/test/basic_test.py
@@ -1,7 +1,11 @@
 import unittest
 import os
+import tempfile
+import polars as pl
+from polars.testing import assert_frame_equal
 from ptabler.workflow import PWorkflow
 from ptabler.steps import GlobalSettings, ReadCsv, WriteCsv
+from ptabler.steps.io import ColumnSchema
 
 current_script_dir = os.path.dirname(os.path.abspath(__file__))
 test_data_root_dir = os.path.join(
@@ -43,3 +47,50 @@ class BasicTests(unittest.TestCase):
         finally:
             if os.path.exists(output_file_abs_path):
                 os.remove(output_file_abs_path)
+
+
+class ReadCsvEmptyFileTests(unittest.TestCase):
+    """Tests for ReadCsv with raise_if_empty=False on zero-byte input."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.empty_path = os.path.join(self.tmpdir, "empty.tsv")
+        open(self.empty_path, "w").close()  # 0 bytes
+        self.settings = GlobalSettings(root_folder=self.tmpdir)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_zero_byte_with_schema_yields_empty_typed_frame(self):
+        step = ReadCsv(
+            file="empty.tsv",
+            name="t",
+            delimiter="\t",
+            schema=[
+                ColumnSchema(column="a", type="String"),
+                ColumnSchema(column="b", type="Long"),
+            ],
+            infer_schema=False,
+            raise_if_empty=False,
+        )
+        ptw = PWorkflow(workflow=[step])
+        ctx = ptw.execute(global_settings=self.settings, lazy=True)
+        table_space, _, _ = ctx.into_parts()
+        df = table_space["t"].collect()
+        assert_frame_equal(
+            df,
+            pl.DataFrame(schema={"a": pl.Utf8, "b": pl.Int64}),
+        )
+
+    def test_zero_byte_default_still_raises(self):
+        step = ReadCsv(
+            file="empty.tsv",
+            name="t",
+            delimiter="\t",
+        )
+        ptw = PWorkflow(workflow=[step])
+        ctx = ptw.execute(global_settings=self.settings, lazy=True)
+        table_space, _, _ = ctx.into_parts()
+        with self.assertRaises(pl.exceptions.NoDataError):
+            table_space["t"].collect()

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -469,6 +469,12 @@ workflow := func() {
 		 *   - `nRows` {int} (optional): Stop reading after this many rows. If not specified, all rows will be read.
 		 *   - `ignoreErrors` {boolean} (optional): Return null if parsing fails due to schema mismatches. Defaults to `false`.
 		 *   - `commentPrefix` {string} (optional): The prefix string used to comment out lines in the CSV file.
+		 *   - `raiseIfEmpty` {boolean} (optional): When `false`, a zero-byte input file is read as an empty
+		 *                                          table using the declared `schema` for columns, instead of
+		 *                                          raising a polars `NoDataError`. Defaults to `true` (polars
+		 *                                          default). Provide a complete `schema` covering every column
+		 *                                          referenced downstream when opting into this — the synthesized
+		 *                                          empty frame only contains the columns you declared.
 		 * @returns {object} - A DataFrame object representing the loaded data.
 		 * @example
 		 *   // NDJSON from file reference
@@ -513,6 +519,7 @@ workflow := func() {
 			nRowsOpt := undefined
 			ignoreErrorsOpt := undefined
 			commentPrefixOpt := undefined
+			raiseIfEmptyOpt := undefined
 
 			if is_map(frameInput) && !is_undefined(frameInput.file) {
 				fileRef = frameInput.file
@@ -608,6 +615,13 @@ workflow := func() {
 					ll.panic("'commentPrefix' option must be a string. Got: %T", opts.commentPrefix)
 				}
 				commentPrefixOpt = opts.commentPrefix
+			}
+
+			if !is_undefined(opts.raiseIfEmpty) {
+				if !is_bool(opts.raiseIfEmpty) {
+					ll.panic("'raiseIfEmpty' option must be a boolean. Got: %T", opts.raiseIfEmpty)
+				}
+				raiseIfEmptyOpt = opts.raiseIfEmpty
 			}
 
 			if !is_undefined(fileRef) {
@@ -707,6 +721,10 @@ workflow := func() {
 
 			if !is_undefined(nRowsOpt) {
 				step.nRows = nRowsOpt
+			}
+
+			if !is_undefined(raiseIfEmptyOpt) {
+				step.raiseIfEmpty = raiseIfEmptyOpt
 			}
 
 			self.addRawStep(step)


### PR DESCRIPTION
Notion: [MILAB-6395 — [pframes] don't fail on empty files from mixcr](https://app.notion.com/p/3753a83ff4af80329c91c0be63735a8a)

## Summary
- **ptabler (`lib/ptabler/software`)**: `BaseReadLogic` (and thus `ReadCsv` / `ReadNdjson` / `ReadParquet`) accepts a new `raise_if_empty` field. When `False` and the input file is 0 bytes, the step synthesises an empty `LazyFrame` from the declared `schema` instead of letting polars raise `NoDataError`. `ReadCsv` also forwards the flag to `polars.scan_csv` as belt-and-suspenders. Default is `None` (existing strict behaviour).
- **workflow-tengo (`sdk/workflow-tengo`)**: `pt.workflow().frame()` accepts `raiseIfEmpty: bool`. Boolean-validated, serialised to the step JSON, mapped to ptabler's snake-cased field via msgspec `rename="camel"`. Docs updated.
- Two new ptabler unit tests cover the empty-file and default-still-raises paths.

## Why
Block workflows that read upstream tool output through ptabler currently die with an opaque `polars.exceptions.NoDataError: empty CSV` whenever the upstream produced a 0-byte file. That's a real failure mode (e.g. MiXCR JVM dying after the output handle is opened but before bytes are flushed). This change gives blocks a clean opt-in to "treat 0-byte as an empty table" without each block needing a bespoke shell guard.

Companion block-side adoption: [platforma-open/mixcr-clonotyping#194](https://github.com/platforma-open/mixcr-clonotyping/pull/194).

## Test plan
- [x] ptabler: `pnpm test` — 317/317 pass (315 prior + 2 new).
- [x] workflow-tengo: `pnpm type-check` clean, `pnpm test` 154 PASS / 0 FAIL.
- [ ] Once published, verify end-to-end in the companion mixcr-clonotyping PR against a project that previously hit the empty-CSV cascade.