### PR TITLE
package-builder: release the build:docker-dev flow + log public ECR gallery URL

### DIFF
--- a/.changeset/eager-foxes-deploy.md
+++ b/.changeset/eager-foxes-deploy.md
@@ -2,9 +2,9 @@
 "@platforma-sdk/package-builder": minor
 ---
 
-Add `build:docker-dev` flow for publishing block-software dev images to a public ECR.
+Add `build:dev-remote` flow for publishing block-software dev images to a public ECR.
 
-Block developers can now invoke `pnpm run build:docker-dev` (env `PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1`) to cross-compile a `linux/amd64` docker image and push it to `public.ecr.aws/u5p1x5q2/pl-containers` (override via `PL_DOCKER_REGISTRY` / `PL_DOCKER_REGISTRY_PUSH_TO`). `pnpm run build:dev` keeps its previous no-docker behaviour so the dev loop stays fast.
+Block developers can now invoke `pnpm run build:dev-remote` (env `PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1`) to cross-compile a `linux/amd64` docker image and push it to `public.ecr.aws/u5p1x5q2/pl-containers` (override via `PL_DOCKER_REGISTRY` / `PL_DOCKER_REGISTRY_PUSH_TO`). `pnpm run build:dev` keeps its previous no-docker behaviour so the dev loop stays fast.
 
 Other fixes shipped together:
 

--- a/.changeset/eager-foxes-deploy.md
+++ b/.changeset/eager-foxes-deploy.md
@@ -1,0 +1,15 @@
+---
+"@platforma-sdk/package-builder": minor
+---
+
+Add `build:docker-dev` flow for publishing block-software dev images to a public ECR.
+
+Block developers can now invoke `pnpm run build:docker-dev` (env `PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1`) to cross-compile a `linux/amd64` docker image and push it to `public.ecr.aws/u5p1x5q2/pl-containers` (override via `PL_DOCKER_REGISTRY` / `PL_DOCKER_REGISTRY_PUSH_TO`). `pnpm run build:dev` keeps its previous no-docker behaviour so the dev loop stays fast.
+
+Other fixes shipped together:
+
+- Drop the host-arch gate; cross-compile to `linux/amd64` via qemu on non-x64 hosts. CI-side strict-platform gate kept so only the linux/x64 matrix leg builds + pushes.
+- Disable buildkit SLSA provenance + SBOM attestations (`--provenance=false --sbom=false`) so identical source produces a stable digest. Without this the smart-skip in `publishDockerImage` never matched and every dev rebuild reuploaded.
+- Dedupe `publishDockerImages` iteration so python/conda → docker autogen entries don't run twice.
+- `docker push` failure now wraps the docker error with the `aws ecr-public … | docker login …` recipe.
+- `defaults.ts` adds `DEV_DOCKER_REGISTRY` (the default public ECR) and `DOCKER_BUILD_PLATFORM = "linux/amd64"`.

--- a/tools/package-builder/src/commands/build/all.ts
+++ b/tools/package-builder/src/commands/build/all.ts
@@ -47,7 +47,7 @@ export default class BuildAll extends Command {
       // Docker build defaults to OFF outside CI — including dev-local. Block
       // developers run 'pnpm run build:dev' on every save and do not want a
       // slow cross-compile + push on each iteration. To publish dev images,
-      // they invoke a separate script (template ships 'publish:docker:dev')
+      // they invoke a separate script (template ships 'build:docker-dev')
       // that sets PL_DOCKER_BUILD=1 + PL_DOCKER_AUTOPUSH=1.
       const buildDocker = cmdOpts.shouldDoAction(
         envs.isCI(),
@@ -88,7 +88,7 @@ export default class BuildAll extends Command {
 
       // Auto-push defaults to OFF outside CI. Dev iteration doesn't push;
       // explicit opt-in via --docker-autopush / PL_DOCKER_AUTOPUSH=1 (which
-      // 'publish:docker:dev' sets) flips it. Private packages never push by
+      // 'build:docker-dev' sets) flips it. Private packages never push by
       // default — the dev ECR is public.
       const autopush = cmdOpts.shouldDoAction(
         envs.isCI() && !core.pkgInfo.isPrivate,
@@ -108,6 +108,19 @@ export default class BuildAll extends Command {
           pushTo: flags["docker-push-to"],
           strictPlatformMatching: envs.isCI(),
         });
+
+        // For public ECR pushes, surface the human-readable Gallery URL so a
+        // developer can open the browser and confirm their image landed. The
+        // effective push destination is --docker-push-to if set, otherwise
+        // the --docker-registry / DEV_DOCKER_REGISTRY chain.
+        const effectiveRegistry = flags["docker-push-to"] ?? dockerRegistry;
+        if (effectiveRegistry?.startsWith("public.ecr.aws/")) {
+          const galleryUrl =
+            "https://" + effectiveRegistry.replace(/^public\.ecr\.aws/, "gallery.ecr.aws");
+          logger.info("================");
+          logger.info(`Public ECR repository: ${galleryUrl}`);
+          logger.info("===============");
+        }
       }
     } catch (e) {
       logger.debug(e);

--- a/tools/package-builder/src/commands/build/all.ts
+++ b/tools/package-builder/src/commands/build/all.ts
@@ -47,7 +47,7 @@ export default class BuildAll extends Command {
       // Docker build defaults to OFF outside CI — including dev-local. Block
       // developers run 'pnpm run build:dev' on every save and do not want a
       // slow cross-compile + push on each iteration. To publish dev images,
-      // they invoke a separate script (template ships 'build:docker-dev')
+      // they invoke a separate script (template ships 'build:dev-remote')
       // that sets PL_DOCKER_BUILD=1 + PL_DOCKER_AUTOPUSH=1.
       const buildDocker = cmdOpts.shouldDoAction(
         envs.isCI(),
@@ -88,7 +88,7 @@ export default class BuildAll extends Command {
 
       // Auto-push defaults to OFF outside CI. Dev iteration doesn't push;
       // explicit opt-in via --docker-autopush / PL_DOCKER_AUTOPUSH=1 (which
-      // 'build:docker-dev' sets) flips it. Private packages never push by
+      // 'build:dev-remote' sets) flips it. Private packages never push by
       // default — the dev ECR is public.
       const autopush = cmdOpts.shouldDoAction(
         envs.isCI() && !core.pkgInfo.isPrivate,
@@ -109,10 +109,6 @@ export default class BuildAll extends Command {
           strictPlatformMatching: envs.isCI(),
         });
 
-        // For public ECR pushes, surface the human-readable Gallery URL so a
-        // developer can open the browser and confirm their image landed. The
-        // effective push destination is --docker-push-to if set, otherwise
-        // the --docker-registry / DEV_DOCKER_REGISTRY chain.
         const effectiveRegistry = flags["docker-push-to"] ?? dockerRegistry;
         if (effectiveRegistry?.startsWith("public.ecr.aws/")) {
           const galleryUrl =

--- a/tools/package-builder/src/commands/build/all.ts
+++ b/tools/package-builder/src/commands/build/all.ts
@@ -113,7 +113,7 @@ export default class BuildAll extends Command {
         if (effectiveRegistry?.startsWith("public.ecr.aws/")) {
           const galleryUrl =
             "https://" + effectiveRegistry.replace(/^public\.ecr\.aws/, "gallery.ecr.aws");
-          logger.info("================");
+          logger.info("===============");
           logger.info(`Public ECR repository: ${galleryUrl}`);
           logger.info("===============");
         }


### PR DESCRIPTION
## Why

[milaboratory/platforma#1613](https://github.com/milaboratory/platforma/pull/1613) merged on 2026-06-02 introduced the `build:docker-dev` flow in `@platforma-sdk/package-builder`. The changeset that shipped with it (`popular-jars-bow.md`) had an **empty YAML front-matter**, so the automated `Version packages [skip ci]` consumer (commit `754f201d3`) just deleted the file without bumping any package version. As a result, the package on npm is still `@platforma-sdk/package-builder@3.12.0` — predating the dev-push code.

Block authors who try `pnpm run build:dev-remote` on an M1 Mac (e.g. Elena's `blocks/clonotype-convergence`) hit the old host-arch gate:
```
warn: Docker image generation was skipped because host architecture 'aarch64'
      is currently not supported by Platforma Backend docker feature
```
That gate was removed on `main` weeks ago, but never published.

## Changes

### 1. New changeset that actually bumps the package

`.changeset/eager-foxes-deploy.md` — minor bump for `@platforma-sdk/package-builder`. Lists what the merged-but-unreleased changes brought.

### 2. Public ECR gallery URL banner

After a successful autopush to a `public.ecr.aws/*` registry, `build/all.ts` prints:

```
================
Public ECR repository: https://gallery.ecr.aws/<alias>/<repo>
===============
```

The URL is derived from the effective push destination (`--docker-push-to` if set, else `--docker-registry` / `DEV_DOCKER_REGISTRY`). Banner is suppressed for non-public registries (no public gallery exists for private ECRs).

Also fixed a stale comment that referenced the old `publish:docker:dev` script name — it's `build:docker-dev` now in the boilerplate.

## Test plan

- [ ] Local smoke on `blocks/clonotype-convergence` (Elena's block) using a pnpm override pointing at this branch's pack: `pnpm run build:dev-remote` should build/push without the aarch64 gate warning, and the gallery URL banner should appear at the end.
- [ ] After this PR merges, the next "Version Packages" PR should include `@platforma-sdk/package-builder` → next minor version.
- [ ] After that release lands, blocks bump their `pnpm-workspace.yaml` catalog and the dev-push flow works out of the box (no override).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the unpublished `build:docker-dev` flow in `@platforma-sdk/package-builder` by adding a properly-formed changeset (the previous one had empty front-matter and was silently dropped by the version-packages bot). It also adds a convenience banner that prints the ECR public gallery URL after a successful autopush to `public.ecr.aws/*`.

- `.changeset/eager-foxes-deploy.md` — correct minor-bump front-matter so the next "Version Packages" run actually bumps the package and unblocks block developers hitting the old aarch64 gate.
- `tools/package-builder/src/commands/build/all.ts` — two stale script-name comments corrected (`publish:docker:dev` → `build:docker-dev`) and a new `gallery.ecr.aws` URL banner appended after `publishDockerImages` succeeds, gated on the effective registry starting with `public.ecr.aws/`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the changeset fix is mechanical and the gallery URL banner is a purely additive log statement with no effect on build or push behaviour.

The changeset file is the critical piece here and it looks correct. The banner code is straightforward: it is synchronous, inside the existing if (buildDocker && autopush) guard, and only fires after publishDockerImages returns successfully. The URL transformation (public.ecr.aws → gallery.ecr.aws) is accurate for the ECR public gallery format. The only finding is a one-character asymmetry in the separator lines.

No files require special attention; the changeset front-matter and the URL-construction logic are both straightforward to verify.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/package-builder/src/commands/build/all.ts | Two stale comments updated (publish:docker:dev → build:docker-dev) and a new banner added that prints the ECR public gallery URL after a successful autopush to public.ecr.aws/*; one minor asymmetric separator line cosmetic issue. |
| .changeset/eager-foxes-deploy.md | New changeset with correct YAML front-matter (minor bump for @platforma-sdk/package-builder); replaces the empty-front-matter file that was silently discarded by the version-packages bot. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BuildAll.run] --> B{buildDocker?}
    B -- no --> C[buildSoftwareArchives]
    B -- yes --> D[core.buildDockerImages\nregistry: dockerRegistry]
    D --> C
    C --> E[buildSwJsonFiles]
    E --> F{buildDocker AND autopush?}
    F -- no --> G[done]
    F -- yes --> H[core.publishDockerImages\npushTo: docker-push-to flag]
    H --> I{effectiveRegistry\nstarts with\npublic.ecr.aws/?}
    I -- no --> G
    I -- yes --> J[Compute galleryUrl\npublic.ecr.aws → gallery.ecr.aws]
    J --> K[logger.info banner\nPublic ECR repository URL]
    K --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/package-builder/src/commands/build/all.ts:120-122
The two separator lines around the banner are different lengths (`================` is 16 `=` characters, `===============` is 15). Easy to miss at a glance but looks slightly unpolished in the terminal.

```suggestion
          logger.info("================");
          logger.info(`Public ECR repository: ${galleryUrl}`);
          logger.info("================");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["package-builder: surface public ECR gall..."](https://github.com/milaboratory/platforma/commit/4b1c89835721794b986ddbb10439abb9b7189dc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35670733)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->