### PR TITLE
fix(pf-driver): gate xlsx export option in UI by table size

### DIFF
--- a/.changeset/xlsx-export-ui-gate.md
+++ b/.changeset/xlsx-export-ui-gate.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/pl-model-common": minor
+"@platforma-sdk/ui-vue": patch
+"@milaboratories/pf-driver": patch
+---
+
+Gate the xlsx export option in the UI on table size instead of failing after the dialog.
+
+`exportCsv` now calls `getShape` before opening the save dialog and drops the Excel filter when the table exceeds the per-sheet row limit, so oversized tables simply never offer xlsx rather than erroring out post-selection. The `pf-driver` rejection is kept as a safety net. The shared `XLSX_MAX_ROWS_PER_SHEET` constant is now exported from `@milaboratories/pl-model-common` so the UI gate and the driver check can't drift.

--- a/lib/model/common/src/drivers/pframe/data_types.ts
+++ b/lib/model/common/src/drivers/pframe/data_types.ts
@@ -266,6 +266,13 @@ export interface WritePTableToFsResult {
   bytesWritten: number;
 }
 
+/**
+ * Maximum number of data rows allowed per sheet in an `xlsx` export, kept below
+ * Excel's hard limit of 1,048,576. The driver rejects oversized `xlsx` exports
+ * (see {@link PFrameDriver.exportPTable}); UIs use it to gate the `xlsx` option.
+ */
+export const XLSX_MAX_ROWS_PER_SHEET = 1_000_000;
+
 /** Options for {@link PFrameDriver.exportPTable}. */
 export interface ExportPTableOptions {
   /** Destination file path; its extension selects the output format

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -34,6 +34,7 @@ import {
   sortPTableDef,
   resolveAnnotationParents,
   PFrameDriverError,
+  XLSX_MAX_ROWS_PER_SHEET,
 } from "@milaboratories/pl-model-common";
 import type { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
 import {
@@ -369,7 +370,6 @@ export class AbstractPFrameDriver<
     return await this.tableConcurrencyLimiter.run(async () => {
       // Cap data rows per xlsx sheet below Excel's hard limit of 1,048,576.
       if (path.toLowerCase().endsWith(".xlsx")) {
-        const XLSX_MAX_ROWS_PER_SHEET = 1_000_000;
         const shape = await pTable.getShape({ signal: combinedSignal });
         if (shape.rows > XLSX_MAX_ROWS_PER_SHEET) {
           const error = new PFrameDriverError(`exportPTable failed`);

--- a/sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts
+++ b/sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts
@@ -6,7 +6,7 @@ import type {
   PFrameSpecDriver,
   WritePTableToFsResult,
 } from "@platforma-sdk/model";
-import { getPTableColumnId } from "@platforma-sdk/model";
+import { getPTableColumnId, XLSX_MAX_ROWS_PER_SHEET } from "@platforma-sdk/model";
 import { isNil } from "es-toolkit";
 import { Nil } from "@milaboratories/helpers";
 import { getServices } from "../../internal/getServices";
@@ -88,11 +88,17 @@ export async function exportCsv(
   const baseFileName = nativeOptions.defaultFileName ?? `table_${formatTimestamp(new Date())}`;
 
   if (typeof pframe.exportPTable === "function") {
+    const { rows } = await pframe.getShape(nativeOptions.tableHandle);
+    const filters =
+      rows > XLSX_MAX_ROWS_PER_SHEET
+        ? NATIVE_EXPORT_FILTERS.filter(({ name }) => name !== "Excel")
+        : NATIVE_EXPORT_FILTERS;
+
     const { canceled, path } = await dialog.showSaveDialog({
       defaultFileName: `${baseFileName}.csv`,
-      filters: NATIVE_EXPORT_FILTERS,
+      filters,
     });
-    if (canceled || isNil(path) || !matchesFilterExtension(path, NATIVE_EXPORT_FILTERS)) {
+    if (canceled || isNil(path) || !matchesFilterExtension(path, filters)) {
       return undefined;
     }
 


### PR DESCRIPTION
## What

For oversized tables the `xlsx` export option is now removed from the save dialog instead of letting the export fail *after* the user picks it.

- **UI** (`export-csv.ts`): `exportCsv` calls `getShape` before opening the save dialog and drops the Excel filter when the table exceeds the per-sheet row limit. The path validation (`matchesFilterExtension`) uses the same dynamic filter list.
- **Driver** (`pf-driver`): the existing post-selection rejection in `exportPTable` is **kept as a safety net** — it's a public SDK method and other callers can still hit it.
- **Shared constant**: `XLSX_MAX_ROWS_PER_SHEET` is now exported from `@milaboratories/pl-model-common` and consumed by both the UI gate and the driver check, so the two can't drift.

## Why

Previously the user could select `xlsx`, go through the save dialog, and only then get a `PFrameDriverError`. Gating the option up front is the better UX; the driver guard remains for defense in depth.

## Notes

- Builds clean across `pl-model-common`, `pf-driver`, and `ui-vue`.
- Changeset included (`pl-model-common` minor for the new export, `ui-vue` / `pf-driver` patch).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR gates the xlsx export option in the save dialog by pre-checking the table's row count, so users with oversized tables never see Excel as a choice instead of hitting a driver error after selecting it. The driver-side rejection is intentionally kept as a defense-in-depth guard for non-UI callers.

- **`pl-model-common`**: exports `XLSX_MAX_ROWS_PER_SHEET = 1_000_000` as a shared constant so the UI and driver can't drift.
- **`export-csv.ts`**: calls `pframe.getShape` before opening the save dialog and strips the Excel filter when `rows > XLSX_MAX_ROWS_PER_SHEET`; `matchesFilterExtension` is updated to use the same dynamic filter list.
- **`driver_impl.ts`**: replaces the local inline constant with the shared import — no behaviour change.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only non-trivial change in the UI path is a pre-dialog getShape call with straightforward filtering logic, and the driver-side guard is unchanged.

The change is small and well-scoped. The one noteworthy wrinkle is that the Excel filter is excluded by matching the display name "Excel" rather than the extension "xlsx", so a future rename of that label would silently re-expose the option to oversized-table users — with only the driver guard standing between them and an error. Everything else (shared constant, updated matchesFilterExtension, changeset versioning) looks correct.

sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts — the filter exclusion logic is by display name rather than extension.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts | Adds a pre-dialog getShape call to suppress the Excel filter for oversized tables; filter exclusion is done by display name rather than extension, which is fragile to renames. |
| lib/model/common/src/drivers/pframe/data_types.ts | Exports XLSX_MAX_ROWS_PER_SHEET (1,000,000) as a shared constant with clear documentation; clean addition. |
| lib/node/pf-driver/src/driver_impl.ts | Removes the local inline constant in favour of the shared import; no behaviour change, logic is identical. |
| .changeset/xlsx-export-ui-gate.md | Changeset correctly marks pl-model-common as minor (new public export) and ui-vue/pf-driver as patch. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as exportCsv (UI)
    participant PF as pframe service
    participant DLG as dialog service
    participant DRV as pf-driver (exportPTable)

    UI->>PF: getShape(tableHandle)
    PF-->>UI: "{ rows }"

    alt "rows > XLSX_MAX_ROWS_PER_SHEET"
        UI->>DLG: showSaveDialog(filters without Excel)
    else "rows <= XLSX_MAX_ROWS_PER_SHEET"
        UI->>DLG: showSaveDialog(all filters incl. Excel)
    end

    DLG-->>UI: "{ canceled, path }"

    alt canceled or invalid extension
        UI-->>UI: return undefined
    else valid path
        UI->>DRV: "exportPTable(tableHandle, { path, columnIndices })"
        Note over DRV: Safety net: if path ends in .xlsx and rows > limit, throws PFrameDriverError
        DRV-->>UI: done
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/ui-vue/src/components/PlAgCsvExporter/export-csv.ts:92-95
Filtering by display name `"Excel"` creates a fragile coupling: if the label in `NATIVE_EXPORT_FILTERS` is ever renamed the filter silently stops working and xlsx will be offered to users with oversized tables again — the driver-side guard will then be the only protection. Filtering by extension is both more robust and self-evidently tied to the format being guarded.

```suggestion
    const filters =
      rows > XLSX_MAX_ROWS_PER_SHEET
        ? NATIVE_EXPORT_FILTERS.filter(({ extensions }) => !extensions.includes("xlsx"))
        : NATIVE_EXPORT_FILTERS;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pf-driver): gate xlsx export option ..."](https://github.com/milaboratory/platforma/commit/60b13d1ca21bdb0c0b9208fb371d7b64feae566e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35789088)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->