### PR TITLE
feat(pframe): declare self-contained datainfo interfaces (V6/V17/V8)

### DIFF
--- a/.changeset/pframe-self-contained-datainfo-v2.md
+++ b/.changeset/pframe-self-contained-datainfo-v2.md
@@ -1,0 +1,10 @@
+---
+"@milaboratories/pl-model-middle-layer": minor
+---
+
+Declare self-contained PFrame data info interfaces (V6/V17/V8). Adds
+`PColumnValueTypeSpec` (single-column `{ axes, column }`), `DataInfoV2`
+(self-contained data info with an embedded `typeSpec`), `AddColumnEntryV2`,
+`PFrameFactoryAPIV6`, `PFrameV17`, and `PFrameFactoryV8`. The legacy plural
+type info is preserved as `ValueTypeSpec` for the existing `AddColumnEntry`.
+Additive only — V5/V16/V7 are unchanged.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
@@ -44,6 +44,16 @@ export interface PFrameDataSourceV2 {
 }
 
 /**
+ * Structural type information for a single PColumn needed by the data side:
+ * the axis value types (in canonical order) and the column value type. Mirrors
+ * the on-disk `typeSpec` shape (`{ axes, column }`).
+ */
+export type PColumnValueTypeSpec = {
+  readonly axes: AxisValueType[];
+  readonly column: ColumnValueType;
+};
+
+/**
  * Union type representing all possible data storage formats for PColumn data.
  * The specific format used depends on data size, access patterns, and performance requirements.
  *
@@ -56,11 +66,31 @@ export type DataInfo<Blob> =
   | ParquetPartitionedDataInfo<ParquetChunk<Blob>>;
 
 /**
+ * Self-contained data info: a PColumn data storage format with an embedded
+ * {@link PColumnValueTypeSpec}, so the data layer can interpret the values
+ * without a separate spec. This is the on-disk `.datainfo` shape and the
+ * payload accepted by {@link PFrameFactoryAPIV6.addColumns}.
+ *
+ * Declared independently of {@link DataInfo} (not as an intersection) so the
+ * legacy v1 type can be removed without affecting this one.
+ *
+ * @template Blob - Type parameter representing the storage reference type (could be ResourceInfo, PFrameBlobId, etc.)
+ */
+export type DataInfoV2<Blob> = (
+  | JsonDataInfo
+  | JsonPartitionedDataInfo<Blob>
+  | BinaryPartitionedDataInfo<Blob>
+  | ParquetPartitionedDataInfo<ParquetChunk<Blob>>
+) & {
+  readonly typeSpec: PColumnValueTypeSpec;
+};
+
+/**
  * Structural type information needed by the data side: axis value
  * types and column value types, in their canonical order. Mirrors
  * the bridge-side `TypeSpec`.
  */
-export interface PColumnValueTypeSpec {
+export interface ValueTypeSpec {
   readonly axes: AxisValueType[];
   readonly columns: ColumnValueType[];
 }
@@ -70,9 +100,21 @@ export interface AddColumnEntry {
   /** Unique column identifier within the PFrame. */
   readonly id: PObjectId;
   /** Structural type info (axes / column value types). */
-  readonly typeSpec: PColumnValueTypeSpec;
+  readonly typeSpec: ValueTypeSpec;
   /** Data info for the column. */
   readonly data: DataInfo<PFrameBlobId>;
+}
+
+/**
+ * Single column entry for {@link PFrameFactoryAPIV6.addColumns}. The structural
+ * type info is carried inside {@link DataInfoV2.typeSpec} rather than as a
+ * separate field, so `data` is self-describing.
+ */
+export interface AddColumnEntryV2 {
+  /** Unique column identifier within the PFrame. */
+  readonly id: PObjectId;
+  /** Self-contained data info (carries its own `typeSpec`). */
+  readonly data: DataInfoV2<PFrameBlobId>;
 }
 
 /** API for populating a PFrame with columns and a data source. */
@@ -87,6 +129,32 @@ export interface PFrameFactoryAPIV5 extends Disposable {
    */
   addColumns(
     columns: AddColumnEntry[],
+    options?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<void>;
+
+  /** Releases all the data previously added to PFrame using methods above,
+   * any interactions with disposed PFrame will result in exception */
+  dispose(): void;
+}
+
+/**
+ * API for populating a PFrame with columns and a data source. Unlike
+ * {@link PFrameFactoryAPIV5}, each column's structural type info is embedded in
+ * its self-contained {@link AddColumnEntryV2.data} instead of a separate field.
+ */
+export interface PFrameFactoryAPIV6 extends Disposable {
+  /** Associates data source with this PFrame. */
+  setDataSource(dataSource: PFrameDataSourceV2): void;
+
+  /**
+   * Registers all PColumns at once: data info (self-contained, carrying its own
+   * `typeSpec`) is attached atomically. For parquet data info, schema resolution
+   * via network is performed during this call.
+   */
+  addColumns(
+    columns: AddColumnEntryV2[],
     options?: {
       signal?: AbortSignal;
     },

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,4 +1,4 @@
-import type { PFrameFactoryAPIV5 } from "./api_factory";
+import type { PFrameFactoryAPIV5, PFrameFactoryAPIV6 } from "./api_factory";
 import type { PFrameReadAPIV14 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
@@ -9,6 +9,13 @@ import type { PFrameId } from "./common";
  * header map.
  */
 export interface PFrameV16 extends PFrameFactoryAPIV5, PFrameReadAPIV14 {}
+
+/**
+ * Full PFrame surface — factory operations plus data-side reads. Like
+ * {@link PFrameV16} but with self-contained {@link PFrameFactoryAPIV6}
+ * (column `typeSpec` embedded in `data`).
+ */
+export interface PFrameV17 extends PFrameFactoryAPIV6, PFrameReadAPIV14 {}
 
 export type PFrameOptionsV2 = {
   /** PFrame ID for logging purposes */
@@ -30,6 +37,27 @@ export interface PFrameFactoryV7 {
    * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
    */
   createPFrame(options: PFrameOptionsV2): PFrameV16;
+
+  /**
+   * Dump active allocations from all PFrames instances in pprof format.
+   * The result of this function should be saved as `profile.pb.gz`.
+   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
+   * to view the allocation flamechart.
+   * @warning This method will always reject on Windows!
+   */
+  pprofDump: () => Promise<Uint8Array>;
+}
+
+/**
+ * PFrame management functions exposed by the PFrame module. Creates
+ * {@link PFrameV17} instances (self-contained column data info).
+ */
+export interface PFrameFactoryV8 {
+  /**
+   * Create a new PFrame instance.
+   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
+   */
+  createPFrame(options: PFrameOptionsV2): PFrameV17;
 
   /**
    * Dump active allocations from all PFrames instances in pprof format.


### PR DESCRIPTION
## What

Declares V+1 PFrame interfaces where a column's structural type info (`typeSpec`) is carried **inside** its data info rather than as a separate field, making the `addColumns` payload self-describing. This is the interface-declaration step of a larger refactor; implementation lands in `pframes-rs` and adoption (dropping V5/V16/V7) follows.

## Changes

**`pl-model-common`** (`drivers/pframe/data_info.ts`)
- Add `PColumnValueTypeSpec` (`{ axes, columns }`) — declared as a `type` alias so `DataInfo` remains assignable to `JsonSerializable` (it is serialized to disk as JSON).
- Add optional `typeSpec?: PColumnValueTypeSpec` to all four `DataInfo` variants.
- `keyLength` retained for backward compatibility.

**`pl-model-middle-layer`** (`pframe/internal_api/`)
- `PColumnValueTypeSpec` now re-exported from `pl-model-common` (de-duplicated).
- Add `SelfContainedDataInfo<Blob>` (`DataInfo & { typeSpec }`), `AddColumnEntryV2 { id, data }` (no separate `typeSpec`).
- Add `PFrameFactoryAPIV6`, `PFrameV17` (= V6 + ReadV14), `PFrameFactoryV8`.

## Compatibility

Purely additive. `PFrameFactoryAPIV5` / `PFrameV16` / `PFrameFactoryV7` and the original `AddColumnEntry` are unchanged and coexist; they are dropped once `pframes-rs` adopts the V+1 interfaces.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a purely additive interface-declaration step that embeds structural type info (`typeSpec`) directly inside each `DataInfo` variant, making `addColumns` payloads self-describing and removing the need for a separate per-column spec field.

- **`pl-model-common`**: introduces `PColumnValueTypeSpec` (as a `type` alias for `JsonSerializable` compatibility) and adds an optional `typeSpec?` field to all four `DataInfo` variants; `keyLength` is retained for backward compatibility.
- **`pl-model-middle-layer`**: de-duplicates `PColumnValueTypeSpec` (re-exported from common), adds `SelfContainedDataInfo<Blob>` (intersection type making `typeSpec` required), `AddColumnEntryV2`, `PFrameFactoryAPIV6`, `PFrameV17`, and `PFrameFactoryV8`; V5/V16/V7 are fully preserved.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are purely additive type declarations with no runtime code; no existing interfaces or consumers are modified.

The entire changeset is interface and type alias declarations. SelfContainedDataInfo correctly promotes the optional typeSpec? to required via TypeScript intersection distribution, PColumnValueTypeSpec is cleanly de-duplicated between packages, and all V5/V16/V7 surfaces remain untouched.

No files require special attention; the implementation in pframes-rs should validate that keyLength === typeSpec.axes.length for JsonDataInfo in self-contained mode.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/model/common/src/drivers/pframe/data_info.ts | Introduces PColumnValueTypeSpec type and adds optional typeSpec? field to all four DataInfo variants; existing fields and functions unchanged |
| lib/model/middle-layer/src/pframe/internal_api/api_factory.ts | De-duplicates PColumnValueTypeSpec (re-exported from pl-model-common), adds SelfContainedDataInfo intersection type, AddColumnEntryV2, and PFrameFactoryAPIV6; all additive alongside V5 |
| lib/model/middle-layer/src/pframe/internal_api/pframe.ts | Adds PFrameV17 (PFrameFactoryAPIV6 + PFrameReadAPIV14) and PFrameFactoryV8 interfaces; PFrameV16 and PFrameFactoryV7 untouched |

</details>


</details>


<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PColumnValueTypeSpec {
        +AxisValueType[] axes
        +ColumnValueType[] columns
    }
    class DataInfo {
        <<union>>
        +typeSpec?: PColumnValueTypeSpec
    }
    class SelfContainedDataInfo {
        <<intersection>>
        +typeSpec: PColumnValueTypeSpec
    }
    class AddColumnEntry {
        +PObjectId id
        +PColumnValueTypeSpec typeSpec
        +DataInfo data
    }
    class AddColumnEntryV2 {
        +PObjectId id
        +SelfContainedDataInfo data
    }
    class PFrameFactoryAPIV5 {
        <<interface>>
        +addColumns(AddColumnEntry[])
    }
    class PFrameFactoryAPIV6 {
        <<interface>>
        +addColumns(AddColumnEntryV2[])
    }
    class PFrameV16 {
        <<interface>>
    }
    class PFrameV17 {
        <<interface>>
    }
    class PFrameFactoryV7 {
        <<interface>>
        +createPFrame() PFrameV16
    }
    class PFrameFactoryV8 {
        <<interface>>
        +createPFrame() PFrameV17
    }
    DataInfo <|-- SelfContainedDataInfo : intersection
    PColumnValueTypeSpec --* SelfContainedDataInfo
    SelfContainedDataInfo --* AddColumnEntryV2
    PColumnValueTypeSpec --* AddColumnEntry
    PFrameFactoryAPIV5 <|.. PFrameV16
    PFrameFactoryAPIV6 <|.. PFrameV17
    PFrameFactoryV7 ..> PFrameV16 : creates
    PFrameFactoryV8 ..> PFrameV17 : creates
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/model/common/src/drivers/pframe/data_info.ts`, line 465-506 ([link](https://github.com/milaboratory/platforma/blob/9bbb0456f77dca32e173b8a0165b5794eb1fa322/lib/model/common/src/drivers/pframe/data_info.ts#L465-L506)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`typeSpec` is silently dropped by `dataInfoToEntries` / `entriesToDataInfo`**

   `dataInfoToEntries` reconstructs the target object explicitly (only copying `type`, `keyLength`/`partitionKeyLength`, and `data`/`parts`), so a `SelfContainedDataInfo` round-tripped through the entries format loses its `typeSpec`. The `DataInfoEntries` family has no `typeSpec` field, so this is intentional by design — but worth noting: any pipeline that serialises via entries and later expects a self-contained payload will need a separate mechanism to restore the spec.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/model/common/src/drivers/pframe/data_info.ts
   Line: 465-506

   Comment:
   **`typeSpec` is silently dropped by `dataInfoToEntries` / `entriesToDataInfo`**

   `dataInfoToEntries` reconstructs the target object explicitly (only copying `type`, `keyLength`/`partitionKeyLength`, and `data`/`parts`), so a `SelfContainedDataInfo` round-tripped through the entries format loses its `typeSpec`. The `DataInfoEntries` family has no `typeSpec` field, so this is intentional by design — but worth noting: any pipeline that serialises via entries and later expects a self-contained payload will need a separate mechanism to restore the spec.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/model/common/src/drivers/pframe/data_info.ts:56-62
**`keyLength` / `typeSpec.axes.length` can silently diverge**

For `JsonDataInfo`, `keyLength` is now documented as redundant with `typeSpec.axes.length`, but there is no type-level or runtime guard preventing callers from supplying a `SelfContainedDataInfo<…>` where the two values disagree. A consumer that trusts `keyLength` for key parsing would misinterpret row data if, for example, a caller copies an existing `keyLength` but constructs a `typeSpec` with a different axis count. Consider asserting `keyLength === typeSpec.axes.length` in a `isSelfContainedDataInfo` type-guard or in the factory's `addColumns` implementation when it lands.

### Issue 2 of 2
lib/model/common/src/drivers/pframe/data_info.ts:465-506
**`typeSpec` is silently dropped by `dataInfoToEntries` / `entriesToDataInfo`**

`dataInfoToEntries` reconstructs the target object explicitly (only copying `type`, `keyLength`/`partitionKeyLength`, and `data`/`parts`), so a `SelfContainedDataInfo` round-tripped through the entries format loses its `typeSpec`. The `DataInfoEntries` family has no `typeSpec` field, so this is intentional by design — but worth noting: any pipeline that serialises via entries and later expects a self-contained payload will need a separate mechanism to restore the spec.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframe): declare self-contained dat..."](https://github.com/milaboratory/platforma/commit/9bbb0456f77dca32e173b8a0165b5794eb1fa322) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35807940)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->