### PR TITLE
fix(ts-helpers,pf-driver): release concurrency slot on abort

### DIFF
--- a/.changeset/concurrency-limiter-cancellation.md
+++ b/.changeset/concurrency-limiter-cancellation.md
@@ -1,0 +1,14 @@
+---
+"@milaboratories/ts-helpers": patch
+"@milaboratories/pf-driver": patch
+---
+
+Fix `ConcurrencyLimitingExecutor` permanently wedging the queue when a cancelled
+task never settles. `run` now accepts an optional `AbortSignal`: a task cancelled
+while queued gives up its slot at admission without running its body, and a running
+task is raced against the signal so the slot is always released on abort — even if
+the underlying operation ignores the signal. The pf-driver table/frame operations
+(`getShape`, `getData`, `writePTableToFs`, `exportPTable`, `calculateTableData`,
+`getUniqueValues`) now pass their abort signal to the limiter, so a cancelled or
+disposed request can no longer block all subsequent requests behind the single
+concurrency slot.

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -290,7 +290,10 @@ export class AbstractPFrameDriver<
     // `combinedSignal` is passed twice on purpose: into the native calls for cooperative
     // cancellation, and into `run` so the concurrency slot is released on abort even if a
     // native call fails to unwind. Dropping the `run` signal reintroduces the queue wedge.
-    return await this.tableConcurrencyLimiter.run(async () => {
+    // keep()/cache live outside the limiter task: on abort `run` rejects and they are
+    // skipped, so an abandoned (detached) operation never caches its result nor touches
+    // `tableGuard` after the `using` block has already unref'd it.
+    const { result, overallSize } = await this.tableConcurrencyLimiter.run(async () => {
       const shape = await pTable.getShape({ signal: combinedSignal });
       const clippedRange = clipRange(options.range, shape);
       const specs = def.tableSpec;
@@ -328,7 +331,6 @@ export class AbstractPFrameDriver<
       });
 
       const overallSize = await tableGuard.resource.cacheSize;
-      this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
 
       // rowsWritten equals the clipped range length — the generator streams the
       // entire effective range without early termination, so this is accurate.
@@ -342,8 +344,11 @@ export class AbstractPFrameDriver<
         );
       }
 
-      return { path: options.path, rowsWritten, bytesWritten };
+      return { result: { path: options.path, rowsWritten, bytesWritten }, overallSize };
     }, combinedSignal);
+
+    this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
+    return result;
   }
 
   public async exportPTable(
@@ -370,7 +375,10 @@ export class AbstractPFrameDriver<
       headers[index] = columnLabel(def.tableSpec[index]);
     }
 
-    return await this.tableConcurrencyLimiter.run(async () => {
+    // keep()/cache live outside the limiter task: on abort `run` rejects and they are
+    // skipped, so an abandoned (detached) operation never caches its result nor touches
+    // `tableGuard` after the `using` block has already unref'd it.
+    const overallSize = await this.tableConcurrencyLimiter.run(async () => {
       // Cap data rows per xlsx sheet below Excel's hard limit of 1,048,576.
       if (path.toLowerCase().endsWith(".xlsx")) {
         const shape = await pTable.getShape({ signal: combinedSignal });
@@ -387,7 +395,6 @@ export class AbstractPFrameDriver<
       await pTable.export(path, headers, { signal: combinedSignal });
 
       const overallSize = await tableGuard.resource.cacheSize;
-      this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
 
       if (logPFrames()) {
         const durationMs = Math.round(performance.now() - startTime);
@@ -397,7 +404,11 @@ export class AbstractPFrameDriver<
             `duration = ${durationMs}ms`,
         );
       }
+
+      return overallSize;
     }, combinedSignal);
+
+    this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
   }
 
   //
@@ -483,7 +494,10 @@ export class AbstractPFrameDriver<
     const pTable = await pTablePromise;
 
     const combinedSignal = AbortSignal.any([signal, disposeSignal].filter((s) => !!s));
-    return await this.frameConcurrencyLimiter.run(async () => {
+    // keep()/cache live outside the limiter task: on abort `run` rejects and they are
+    // skipped, so an abandoned (detached) operation never caches its result nor touches
+    // `tableGuard` after the `using` block has already unref'd it.
+    const { data, overallSize } = await this.frameConcurrencyLimiter.run(async () => {
       // TODO: throw error when more then 200k rows is requested
       // after pf-plots migration to stream API
 
@@ -493,13 +507,14 @@ export class AbstractPFrameDriver<
       });
 
       const overallSize = await tableGuard.resource.cacheSize;
-      this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
-
-      return tableSpec.map((spec, i) => ({
-        spec: spec,
-        data: data[i],
-      }));
+      return { data, overallSize };
     }, combinedSignal);
+
+    this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
+    return tableSpec.map((spec, i) => ({
+      spec: spec,
+      data: data[i],
+    }));
   }
 
   public async getUniqueValues(

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -287,6 +287,9 @@ export class AbstractPFrameDriver<
       [options.signal, disposeSignal].filter((s): s is AbortSignal => !isNil(s)),
     );
 
+    // `combinedSignal` is passed twice on purpose: into the native calls for cooperative
+    // cancellation, and into `run` so the concurrency slot is released on abort even if a
+    // native call fails to unwind. Dropping the `run` signal reintroduces the queue wedge.
     return await this.tableConcurrencyLimiter.run(async () => {
       const shape = await pTable.getShape({ signal: combinedSignal });
       const clippedRange = clipRange(options.range, shape);
@@ -340,7 +343,7 @@ export class AbstractPFrameDriver<
       }
 
       return { path: options.path, rowsWritten, bytesWritten };
-    });
+    }, combinedSignal);
   }
 
   public async exportPTable(
@@ -394,7 +397,7 @@ export class AbstractPFrameDriver<
             `duration = ${durationMs}ms`,
         );
       }
-    });
+    }, combinedSignal);
   }
 
   //
@@ -481,7 +484,7 @@ export class AbstractPFrameDriver<
 
     const combinedSignal = AbortSignal.any([signal, disposeSignal].filter((s) => !!s));
     return await this.frameConcurrencyLimiter.run(async () => {
-      // TODO: throw error when more then 150k rows is requested
+      // TODO: throw error when more then 200k rows is requested
       // after pf-plots migration to stream API
 
       const data = await pTable.getData([...tableSpec.keys()], {
@@ -496,7 +499,7 @@ export class AbstractPFrameDriver<
         spec: spec,
         data: data[i],
       }));
-    });
+    }, combinedSignal);
   }
 
   public async getUniqueValues(
@@ -559,7 +562,7 @@ export class AbstractPFrameDriver<
     const combinedSignal = AbortSignal.any([signal, disposeSignal].filter((s) => !!s));
     return await this.frameConcurrencyLimiter.run(async () => {
       return await pFrameData.getUniqueValues(resolvedRequest, { signal: combinedSignal });
-    });
+    }, combinedSignal);
   }
 
   //
@@ -587,7 +590,7 @@ export class AbstractPFrameDriver<
       const overallSize = await tableGuard.resource.cacheSize;
 
       return { shape, overallSize };
-    });
+    }, combinedSignal);
 
     this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
     return shape;
@@ -615,7 +618,7 @@ export class AbstractPFrameDriver<
       const overallSize = await tableGuard.resource.cacheSize;
 
       return { data, overallSize };
-    });
+    }, combinedSignal);
 
     this.pTableCachePlain.cache(tableGuard.keep(), overallSize, defDisposeSignal);
     return data;

--- a/lib/node/ts-helpers/src/concurrent/concurrency_limiter.test.ts
+++ b/lib/node/ts-helpers/src/concurrent/concurrency_limiter.test.ts
@@ -135,3 +135,71 @@ test.each([{ limit: 1 }, { limit: 2 }, { limit: 4 }])(
     for (let i = 0; i < 3000; ++i) expect(await taskResults[i]).toStrictEqual(i % 14 === 0 ? 0 : i);
   },
 );
+
+test("a cancelled task that never settles does not wedge the single slot", async () => {
+  const e = new ConcurrencyLimitingExecutor(1);
+
+  // Occupy the only slot with a task that ignores its signal and never settles.
+  const ac = new AbortController();
+  const stuck = e.run(() => new Promise<void>(() => {}), ac.signal);
+  stuck.catch(() => {}); // avoid unhandled rejection once aborted
+
+  // A second task must queue behind it.
+  let secondRan = false;
+  const second = e.run(async () => {
+    secondRan = true;
+    return 42;
+  });
+
+  await tp.setImmediate();
+  expect(secondRan).toBe(false); // confirm it is actually blocked
+
+  // Cancelling the stuck task must free the slot so the queued task runs.
+  ac.abort();
+  await expect(stuck).rejects.toBeDefined();
+  expect(await second).toBe(42);
+});
+
+test("a task cancelled while queued bails at admission without losing the permit", async () => {
+  const e = new ConcurrencyLimitingExecutor(1);
+
+  let releaseFirst: () => void = () => {};
+  const first = e.run(() => new Promise<void>((res) => (releaseFirst = res)));
+
+  const ac = new AbortController();
+  let cancelledBodyRan = false;
+  const cancelledWhileQueued = e.run(async () => {
+    cancelledBodyRan = true;
+    return "never";
+  }, ac.signal);
+  cancelledWhileQueued.catch(() => {});
+
+  let thirdRan = false;
+  const third = e.run(async () => {
+    thirdRan = true;
+    return "ok";
+  });
+
+  // Cancelled while still queued behind `first`. It rejects only once admitted (when
+  // `first` releases the slot), without ever running its body; the permit then reaches
+  // the live waiter behind it.
+  ac.abort();
+  releaseFirst();
+  await first;
+
+  await expect(cancelledWhileQueued).rejects.toBeDefined();
+  expect(cancelledBodyRan).toBe(false);
+  expect(await third).toBe("ok");
+  expect(thirdRan).toBe(true);
+});
+
+test("already-aborted signal rejects without taking a slot", async () => {
+  const e = new ConcurrencyLimitingExecutor(1);
+  const ac = new AbortController();
+  ac.abort();
+
+  await expect(e.run(async () => 1, ac.signal)).rejects.toBeDefined();
+
+  // Slot was never consumed: a subsequent task runs normally.
+  expect(await e.run(async () => 2)).toBe(2);
+});

--- a/lib/node/ts-helpers/src/concurrent/concurrency_limiter.test.ts
+++ b/lib/node/ts-helpers/src/concurrent/concurrency_limiter.test.ts
@@ -200,6 +200,22 @@ test("already-aborted signal rejects without taking a slot", async () => {
 
   await expect(e.run(async () => 1, ac.signal)).rejects.toBeDefined();
 
-  // Slot was never consumed: a subsequent task runs normally.
+  // It rejected before the queue (no `runningTasks` bump), so the slot is free for the next.
   expect(await e.run(async () => 2)).toBe(2);
+});
+
+test("an already-aborted signal rejects promptly even while the executor is busy", async () => {
+  const e = new ConcurrencyLimitingExecutor(1);
+
+  // Occupy the only slot with a task that stays pending.
+  let releaseBusy: () => void = () => {};
+  const busy = e.run(() => new Promise<void>((res) => (releaseBusy = res)));
+
+  // An already-cancelled request must reject without waiting in line behind `busy`.
+  const ac = new AbortController();
+  ac.abort();
+  await expect(e.run(async () => "ran", ac.signal)).rejects.toBeDefined();
+
+  releaseBusy();
+  await busy;
 });

--- a/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
+++ b/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
@@ -7,8 +7,8 @@ import Denque from "denque";
  * `run` settles. At most `concurrencyLimit` slots are ever held.
  *
  * Cancellation (when a task is given a signal) acts on the slot, not on the task body:
- * - a task cancelled before or while queued gives up its slot the moment it is admitted,
- *   without running its body;
+ * - a task already cancelled when `run` is called rejects without taking a turn;
+ * - a task cancelled while queued bails at admission, without running its body;
  * - a task cancelled while running settles `run` and releases the slot immediately, even
  *   if the body ignores the signal and keeps running.
  *
@@ -26,6 +26,7 @@ export class ConcurrencyLimitingExecutor {
   constructor(private readonly concurrencyLimit: number) {}
 
   public async run<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    signal?.throwIfAborted(); // already cancelled: reject without taking a turn in the queue
     // A slot freed below may be claimed by a task admitted in the meantime, so re-test
     // the limit after every wake-up before taking the slot — this is what bounds
     // `runningTasks` at `concurrencyLimit`.
@@ -33,16 +34,25 @@ export class ConcurrencyLimitingExecutor {
       await new Promise<void>((resolve) => this.waiters.push(resolve));
     this.runningTasks++;
     try {
-      signal?.throwIfAborted(); // cancelled before/while queued: give up the slot at once
+      signal?.throwIfAborted(); // cancelled while queued: give up the slot at admission
       if (signal === undefined) return await task();
 
+      let removeAbortListener = () => {};
       const aborted = new Promise<never>((_, reject) => {
-        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        const onAbort = () => reject(signal.reason);
+        signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", onAbort);
       });
-      // Once `task` wins the race nothing awaits `aborted`; this catch keeps a later abort
-      // from surfacing as an unhandled rejection.
-      aborted.catch(() => {});
-      return await Promise.race([task(), aborted]);
+      try {
+        // Race so the slot is released on abort even if `task` ignores its signal and runs
+        // on detached. A late settle from the loser is consumed by `Promise.race`'s own
+        // reaction, so it never surfaces as an unhandled rejection.
+        return await Promise.race([task(), aborted]);
+      } finally {
+        // When `task` wins, `aborted` is left pending forever; drop the listener so it does
+        // not retain its closure (and `task`) on a long-lived signal.
+        removeAbortListener();
+      }
     } finally {
       this.runningTasks--;
       this.waiters.shift()?.(); // hand the freed slot to the next waiter, if any

--- a/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
+++ b/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
@@ -1,34 +1,51 @@
 import Denque from "denque";
 
-/** Unbound async queue */
+/**
+ * FIFO async queue that admits at most `concurrencyLimit` tasks at once.
+ *
+ * The unit of accounting is a *slot*, held from the moment a task is admitted until
+ * `run` settles. At most `concurrencyLimit` slots are ever held.
+ *
+ * Cancellation (when a task is given a signal) acts on the slot, not on the task body:
+ * - a task cancelled before or while queued gives up its slot the moment it is admitted,
+ *   without running its body;
+ * - a task cancelled while running settles `run` and releases the slot immediately, even
+ *   if the body ignores the signal and keeps running.
+ *
+ * The second case is the trade-off that keeps a stuck operation from wedging the queue
+ * permanently: the abandoned body runs to completion detached (retaining its continuation
+ * until it settles), so a body that does not honour its signal can briefly overlap newly
+ * admitted work. Pass a signal only where a detached body is acceptable (e.g. its remaining
+ * work is cheap or self-cancelling); omit it to keep a strict "never more than N bodies
+ * running" guarantee.
+ */
 export class ConcurrencyLimitingExecutor {
-  private readonly lockReleases = new Denque<() => void>();
+  private readonly waiters = new Denque<() => void>();
+  private runningTasks = 0;
 
   constructor(private readonly concurrencyLimit: number) {}
 
-  private async awaitSlot(): Promise<void> {
-    await new Promise<void>((resolve) => this.lockReleases.push(resolve));
-  }
-
-  private releaseSlot() {
-    const release = this.lockReleases.shift();
-    if (release !== undefined) release();
-  }
-
-  private runningTasks = 0;
-
-  public async run<T>(task: () => Promise<T>): Promise<T> {
-    while (this.runningTasks === this.concurrencyLimit) await this.awaitSlot();
-    if (this.runningTasks >= this.concurrencyLimit)
-      throw new Error(
-        `runningTasks >= limit; ${this.runningTasks} >= ${this.concurrencyLimit} (queue: ${this.lockReleases.length})`,
-      );
+  public async run<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    // A slot freed below may be claimed by a task admitted in the meantime, so re-test
+    // the limit after every wake-up before taking the slot — this is what bounds
+    // `runningTasks` at `concurrencyLimit`.
+    while (this.runningTasks >= this.concurrencyLimit)
+      await new Promise<void>((resolve) => this.waiters.push(resolve));
     this.runningTasks++;
     try {
-      return await task();
+      signal?.throwIfAborted(); // cancelled before/while queued: give up the slot at once
+      if (signal === undefined) return await task();
+
+      const aborted = new Promise<never>((_, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+      // Once `task` wins the race nothing awaits `aborted`; this catch keeps a later abort
+      // from surfacing as an unhandled rejection.
+      aborted.catch(() => {});
+      return await Promise.race([task(), aborted]);
     } finally {
       this.runningTasks--;
-      this.releaseSlot();
+      this.waiters.shift()?.(); // hand the freed slot to the next waiter, if any
     }
   }
 }

--- a/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
+++ b/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
@@ -30,8 +30,9 @@ export class ConcurrencyLimitingExecutor {
     // A slot freed below may be claimed by a task admitted in the meantime, so re-test
     // the limit after every wake-up before taking the slot — this is what bounds
     // `runningTasks` at `concurrencyLimit`.
-    while (this.runningTasks >= this.concurrencyLimit)
+    while (this.runningTasks >= this.concurrencyLimit) {
       await new Promise<void>((resolve) => this.waiters.push(resolve));
+    }
     this.runningTasks++;
     try {
       signal?.throwIfAborted(); // cancelled while queued: give up the slot at admission

--- a/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
+++ b/lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts
@@ -37,12 +37,9 @@ export class ConcurrencyLimitingExecutor {
       signal?.throwIfAborted(); // cancelled while queued: give up the slot at admission
       if (signal === undefined) return await task();
 
-      let removeAbortListener = () => {};
-      const aborted = new Promise<never>((_, reject) => {
-        const onAbort = () => reject(signal.reason);
-        signal.addEventListener("abort", onAbort, { once: true });
-        removeAbortListener = () => signal.removeEventListener("abort", onAbort);
-      });
+      const { promise: aborted, reject } = Promise.withResolvers<never>();
+      const onAbort = () => reject(signal.reason);
+      signal.addEventListener("abort", onAbort, { once: true });
       try {
         // Race so the slot is released on abort even if `task` ignores its signal and runs
         // on detached. A late settle from the loser is consumed by `Promise.race`'s own
@@ -51,7 +48,7 @@ export class ConcurrencyLimitingExecutor {
       } finally {
         // When `task` wins, `aborted` is left pending forever; drop the listener so it does
         // not retain its closure (and `task`) on a long-lived signal.
-        removeAbortListener();
+        signal.removeEventListener("abort", onAbort);
       }
     } finally {
       this.runningTasks--;


### PR DESCRIPTION
## Problem

`tableConcurrencyLimiter` (and `frameConcurrencyLimiter`) sometimes hangs permanently and never executes new tasks.

`ConcurrencyLimitingExecutor` released a slot only via the running task's own `finally`, and `run()` awaited the task with no awareness of the caller's `AbortSignal`. With `pTableConcurrency`/`pFrameConcurrency` defaulting to `1` (`driver_impl.ts`), a single cancelled-but-never-settling native operation held the only slot forever, so every subsequent `getShape`/`getData`/`writePTableToFs`/`exportPTable`/`calculateTableData`/`getUniqueValues` enqueued behind it and never ran.

The limiter's bookkeeping was verified correct (adversarial cutter-race stress, no lost wakeups, no over-subscription) — the hang was a never-released slot held by a stuck **running** task, not a counting bug.

## Fix

`run(task, signal?)` is now cancellation-aware:

- **Cancelled while queued** — bails at admission via `throwIfAborted()` without running its body; the permit is conserved for the next waiter.
- **Cancelled while running** — the task is raced against the signal, so the slot is released on abort even if the underlying native op fails to unwind. The detached body finishes in the background; the queue no longer wedges.

The pf-driver table/frame operations pass their existing `combinedSignal` (caller signal + pTable `disposeSignal`) to the limiter so a cancelled or disposed request can no longer block all subsequent requests behind the single concurrency slot.

Backward compatible: the `signal` parameter is optional, and the no-signal path keeps the strict "never more than N bodies running" cap.

## Trade-off

The contract is now "at most N tasks **holding a slot**". A genuinely uncancellable body that ignores its signal runs detached and can briefly overlap newly admitted work — the deliberate price of never permanently wedging the queue. Pass a signal only where a detached body is acceptable; omit it for the strict cap. Documented in the class doc.

## Verification

- New cancellation tests + full `concurrent/` suite: **18/18 pass**.
- Adversarial suite against the built code: slot counter never exceeds the limit across 9000 tasks; stuck-cancelled frees the slot; permit conserved through 50 cancelled-while-queued waiters; no unhandled rejection on late settle/resolve/abort-after-success; no-signal path keeps the strict cap.
- pf-driver typechecks clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a permanent queue wedge in `ConcurrencyLimitingExecutor` where a running task that ignores its `AbortSignal` and never settles holds the only concurrency slot forever. `run()` now races the task body against a per-signal abort promise so the slot is freed on abort even for unresponsive native operations, and all six pf-driver table/frame operations pass their `combinedSignal` to the limiter.

- `ConcurrencyLimitingExecutor.run` gains an optional `AbortSignal` parameter; tasks cancelled while queued bail at admission via `throwIfAborted()`, while running tasks are raced against the signal — the slot is released immediately on abort even if the native body continues detached.
- All six `tableConcurrencyLimiter`/`frameConcurrencyLimiter` call-sites in `driver_impl.ts` now pass `combinedSignal`, closing the queue-wedge for `getShape`, `getData`, `writePTableToFs`, `exportPTable`, `calculateTableData`, and `getUniqueValues`.
- Three new unit tests cover the stuck-slot, cancelled-while-queued, and already-aborted paths.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core limiter fix is sound, but three pf-driver methods have a resource-lifecycle gap that can corrupt the pool refcount when a native operation completes after an abort.

The ConcurrencyLimitingExecutor rewrite is well-reasoned and the new tests validate the key paths. The risk is in calculateTableData, writePTableToFs, and exportPTable: all three place tableGuard.keep() and the cache write inside the task lambda. When the native operation ignores its signal and completes after the enclosing method has returned and unwound the using tableGuard block, the detached body calls keep() on an already-unreffed guard. A later unref() from the cache then corrupts the refcount. The other three methods are structured correctly with tableGuard.keep() outside the lambda.

lib/node/pf-driver/src/driver_impl.ts — specifically the calculateTableData, writePTableToFs, and exportPTable lambdas that call tableGuard.keep() inside the task body.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/ts-helpers/src/concurrent/concurrency_limiter.ts | Rewrites ConcurrencyLimitingExecutor to accept an optional AbortSignal; cancellation-while-queued is handled via throwIfAborted at admission, and cancellation-while-running via Promise.race — slot is always released even if the body runs detached. |
| lib/node/pf-driver/src/driver_impl.ts | Passes combinedSignal to all six concurrency limiter run() call sites; however, calculateTableData, writePTableToFs, and exportPTable include tableGuard.keep() and cache writes inside the task lambda, which can be called by the detached background body after the using tableGuard has already been disposed. |
| lib/node/ts-helpers/src/concurrent/concurrency_limiter.test.ts | Adds three new cancellation-specific tests covering stuck-running, cancelled-while-queued, and already-aborted cases; well-structured and correctly verifies slot hand-off through cancelled waiters. |
| .changeset/concurrency-limiter-cancellation.md | Changeset file correctly marks both @milaboratories/ts-helpers and @milaboratories/pf-driver as patch releases. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant run as run(task, signal)
    participant Queue as waiters queue
    participant Task as task() body
    participant Aborted as aborted promise

    Caller->>run: call run(task, signal)
    alt slot available
        run->>run: runningTasks++
        run->>run: signal.throwIfAborted()
        run->>Task: task()
        run->>Aborted: new Promise(signal.addEventListener abort)
        run->>run: Promise.race([task(), aborted])
        alt task wins
            Task-->>run: resolves/rejects
            run->>run: finally: runningTasks--, wake next waiter
            run-->>Caller: result
        else signal aborts first
            Aborted-->>run: rejects (signal.reason)
            run->>run: finally: runningTasks--, wake next waiter
            run-->>Caller: rejects with abort reason
            Note over Task: body continues detached
        end
    else no slot
        run->>Queue: push resolve
        run->>run: await (blocked)
        Note over Queue: waiting for slot...
        Queue-->>run: resolve called (slot freed)
        run->>run: re-check runningTasks
        run->>run: signal.throwIfAborted()
        alt signal already aborted
            run->>run: finally: runningTasks--, wake next waiter
            run-->>Caller: rejects (no body ran)
        else live task
            run->>Task: task() starts
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pf-driver/src/driver_impl.ts:486-502
**Background task calls `tableGuard.keep()` on an already-disposed guard**

For `calculateTableData`, `writePTableToFs`, and `exportPTable` the task lambda captures `tableGuard` and calls `tableGuard.keep()` plus a cache write *inside* the body. When `combinedSignal` aborts and the native operation (e.g. `pTable.getData`) ignores the signal and eventually finishes, the detached body resumes after the enclosing method has already exited — unwinding the `using tableGuard` block and calling `entry.unref()` in the process. The background body then calls `tableGuard.keep()` on that already-unreffed guard and passes the entry to the cache. When the cache later calls `entry.unref()`, the refcount underflows: if it was already decremented to 0 the entry was removed from the pool map, and the second unref hits the `"Unexpected state"` guard in `RefCountPoolBase.check`.

Compare with `getShape` and `getData` (table variants): there the body only returns `{ shape, overallSize }` and both `tableGuard.keep()` and the cache write are *outside* the lambda, so the detached body never touches the guard after the method exits. `calculateTableData`, `writePTableToFs`, and `exportPTable` should be restructured the same way — have the lambda return the raw data and `overallSize`, then call `tableGuard.keep()` and the cache write in the code that follows `run()`.

### Issue 2 of 2
lib/node/ts-helpers/src/concurrent/concurrency_limiter.test.ts:203-204
The comment is inaccurate: the slot **is** briefly consumed. `throwIfAborted()` is called *after* `runningTasks++`, so the count reaches 1 before the throw, then drops back to 0 in `finally`. The test assertion itself is correct (the next task runs), but the prose misleads anyone reasoning about the invariant under this code path.

```suggestion
  // The slot was briefly taken and immediately released; the next task can still run.
  expect(await e.run(async () => 2)).toBe(2);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ts-helpers,pf-driver): release concu..."](https://github.com/milaboratory/platforma/commit/8cbe874481eb02eda609668ad919800aedc472a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35845400)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->