### PR TITLE
feat(pframes): adopt self-contained datainfo with embedded typeSpec

### DIFF
--- a/.changeset/seven-clowns-poke.md
+++ b/.changeset/seven-clowns-poke.md
@@ -1,0 +1,8 @@
+---
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+"@platforma-open/milaboratories.software-ptabler": patch
+"@platforma-sdk/workflow-tengo": patch
+---
+
+PFrames update

--- a/.changeset/seven-clowns-poke.md
+++ b/.changeset/seven-clowns-poke.md
@@ -1,8 +1,9 @@
 ---
+"@milaboratories/pl-model-middle-layer": patch
 "@milaboratories/pf-spec-driver": patch
 "@milaboratories/pf-driver": patch
 "@platforma-open/milaboratories.software-ptabler": patch
 "@platforma-sdk/workflow-tengo": patch
 ---
 
-PFrames update
+PFrames update: adopt self-contained datainfo (V6/V17/V8) interfaces and drop the superseded V5/V16/V7 ones.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_factory.ts
@@ -59,51 +59,30 @@ export type PColumnValueTypeSpec = {
  *
  * @template Blob - Type parameter representing the storage reference type (could be ResourceInfo, PFrameBlobId, etc.)
  */
-export type DataInfo<Blob> =
-  | JsonDataInfo
-  | JsonPartitionedDataInfo<Blob>
-  | BinaryPartitionedDataInfo<Blob>
-  | ParquetPartitionedDataInfo<ParquetChunk<Blob>>;
-
-/**
- * Self-contained data info: a PColumn data storage format with an embedded
- * {@link PColumnValueTypeSpec}, so the data layer can interpret the values
- * without a separate spec. This is the on-disk `.datainfo` shape and the
- * payload accepted by {@link PFrameFactoryAPIV6.addColumns}.
- *
- * Declared independently of {@link DataInfo} (not as an intersection) so the
- * legacy v1 type can be removed without affecting this one.
- *
- * @template Blob - Type parameter representing the storage reference type (could be ResourceInfo, PFrameBlobId, etc.)
- */
-export type DataInfoV2<Blob> = (
+export type DataInfo<Blob> = (
   | JsonDataInfo
   | JsonPartitionedDataInfo<Blob>
   | BinaryPartitionedDataInfo<Blob>
   | ParquetPartitionedDataInfo<ParquetChunk<Blob>>
 ) & {
-  readonly typeSpec: PColumnValueTypeSpec;
+  /**
+   * Self-contained structural type info. Present in data info produced by the
+   * new converter, absent in data info produced by the old one.
+   */
+  readonly typeSpec?: PColumnValueTypeSpec;
 };
 
 /**
- * Structural type information needed by the data side: axis value
- * types and column value types, in their canonical order. Mirrors
- * the bridge-side `TypeSpec`.
+ * Self-contained data info: {@link DataInfo} with a required
+ * {@link PColumnValueTypeSpec}, so the data layer can interpret the values
+ * without a separate spec. This is the on-disk `.datainfo` shape and the
+ * payload accepted by {@link PFrameFactoryAPIV6.addColumns}.
+ *
+ * @template Blob - Type parameter representing the storage reference type (could be ResourceInfo, PFrameBlobId, etc.)
  */
-export interface ValueTypeSpec {
-  readonly axes: AxisValueType[];
-  readonly columns: ColumnValueType[];
-}
-
-/** Single column entry for {@link PFrameFactoryAPIV5.addColumns}. */
-export interface AddColumnEntry {
-  /** Unique column identifier within the PFrame. */
-  readonly id: PObjectId;
-  /** Structural type info (axes / column value types). */
-  readonly typeSpec: ValueTypeSpec;
-  /** Data info for the column. */
-  readonly data: DataInfo<PFrameBlobId>;
-}
+export type DataInfoV2<Blob> = DataInfo<Blob> & {
+  readonly typeSpec: PColumnValueTypeSpec;
+};
 
 /**
  * Single column entry for {@link PFrameFactoryAPIV6.addColumns}. The structural
@@ -117,32 +96,10 @@ export interface AddColumnEntryV2 {
   readonly data: DataInfoV2<PFrameBlobId>;
 }
 
-/** API for populating a PFrame with columns and a data source. */
-export interface PFrameFactoryAPIV5 extends Disposable {
-  /** Associates data source with this PFrame. */
-  setDataSource(dataSource: PFrameDataSourceV2): void;
-
-  /**
-   * Registers all PColumns at once: specs are recorded and data info
-   * is attached atomically. For parquet data info, schema resolution
-   * via network is performed during this call.
-   */
-  addColumns(
-    columns: AddColumnEntry[],
-    options?: {
-      signal?: AbortSignal;
-    },
-  ): Promise<void>;
-
-  /** Releases all the data previously added to PFrame using methods above,
-   * any interactions with disposed PFrame will result in exception */
-  dispose(): void;
-}
-
 /**
- * API for populating a PFrame with columns and a data source. Unlike
- * {@link PFrameFactoryAPIV5}, each column's structural type info is embedded in
- * its self-contained {@link AddColumnEntryV2.data} instead of a separate field.
+ * API for populating a PFrame with columns and a data source. Each column's
+ * structural type info is embedded in its self-contained
+ * {@link AddColumnEntryV2.data} instead of a separate field.
  */
 export interface PFrameFactoryAPIV6 extends Disposable {
   /** Associates data source with this PFrame. */

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,19 +1,13 @@
-import type { PFrameFactoryAPIV5, PFrameFactoryAPIV6 } from "./api_factory";
+import type { PFrameFactoryAPIV6 } from "./api_factory";
 import type { PFrameReadAPIV14 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
 /**
  * Full PFrame surface — factory operations plus data-side reads. Exposes
- * {@link PFrameReadAPIV14}, whose tables' `export` takes a column-index →
- * header map.
- */
-export interface PFrameV16 extends PFrameFactoryAPIV5, PFrameReadAPIV14 {}
-
-/**
- * Full PFrame surface — factory operations plus data-side reads. Like
- * {@link PFrameV16} but with self-contained {@link PFrameFactoryAPIV6}
- * (column `typeSpec` embedded in `data`).
+ * the self-contained {@link PFrameFactoryAPIV6} (column `typeSpec` embedded in
+ * `data`) plus {@link PFrameReadAPIV14}, whose tables' `export` takes a
+ * column-index → header map.
  */
 export interface PFrameV17 extends PFrameFactoryAPIV6, PFrameReadAPIV14 {}
 
@@ -25,28 +19,6 @@ export type PFrameOptionsV2 = {
   /** Logger instance, no logging is performed when not provided */
   logger?: Logger;
 };
-
-/**
- * PFrame management functions exposed by the PFrame module. Creates
- * {@link PFrameV16} instances, whose tables' `export` takes a
- * column-index → header map.
- */
-export interface PFrameFactoryV7 {
-  /**
-   * Create a new PFrame instance.
-   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
-   */
-  createPFrame(options: PFrameOptionsV2): PFrameV16;
-
-  /**
-   * Dump active allocations from all PFrames instances in pprof format.
-   * The result of this function should be saved as `profile.pb.gz`.
-   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
-   * to view the allocation flamechart.
-   * @warning This method will always reject on Windows!
-   */
-  pprofDump: () => Promise<Uint8Array>;
-}
 
 /**
  * PFrame management functions exposed by the PFrame module. Creates

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -30,7 +30,7 @@ export interface RemoteBlobProvider<TreeEntry extends JsonSerializable> {
 }
 
 export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposable {
-  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV16>;
+  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV17>;
   /**
    * WASM-spec frame built from this PFrame's columns. Source of truth
    * for spec-side operations: column discovery, selector resolution,
@@ -120,11 +120,13 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
           .addColumns(
             jsonifiedColumns.map((c) => ({
               id: c.id,
-              typeSpec: {
-                axes: c.spec.axesSpec.map((a) => a.type),
-                columns: [c.spec.valueType],
+              data: {
+                ...c.data,
+                typeSpec: {
+                  axes: c.spec.axesSpec.map((a) => a.type),
+                  column: c.spec.valueType,
+                },
               },
-              data: c.data,
             })),
             { signal: this.disposeSignal },
           )

--- a/lib/ptabler/software/src/ptabler/steps/write_frame.py
+++ b/lib/ptabler/software/src/ptabler/steps/write_frame.py
@@ -44,6 +44,7 @@ __all__ = [
     "DataInfoAxis",
     "DataInfoColumn",
     "DataInfoPart",
+    "DataInfoTypeSpec",
     "NumberOfBytes",
     "Stats",
     "WriteFrame",
@@ -78,7 +79,13 @@ class DataInfoPart(Struct, rename="camel"):
     stats: Optional[Stats] = None
 
 
+class DataInfoTypeSpec(Struct, rename="camel"):
+    axes: List[AxisType]
+    column: ColumnType
+
+
 class DataInfo(Struct, tag="ParquetPartitioned", rename="camel"):
+    type_spec: DataInfoTypeSpec
     partition_key_length: int
     parts: Dict[str, DataInfoPart]
 

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.40
+polars-pf==1.1.43
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/lib/ptabler/software/src/test/write_frame_test.py
+++ b/lib/ptabler/software/src/test/write_frame_test.py
@@ -266,6 +266,8 @@ class WriteFrameHappyPathTest(unittest.TestCase):
             with open(datainfo_file, "rb") as f:
                 info = msgspec.json.decode(f.read(), type=DataInfo)
             self.assertEqual(info.partition_key_length, 0)
+            self.assertEqual(info.type_spec.axes, ["Long", "String"])
+            self.assertEqual(info.type_spec.column, "Double")
             self.assertEqual(set(info.parts.keys()), {"[]"})
             part = info.parts["[]"]
             self.assertEqual(part.data, "partition_0.parquet")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^4.0.37
       version: 4.0.37
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.10.0
-      version: 1.10.0
+      specifier: 1.10.3
+      version: 1.10.3
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -2778,7 +2778,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.0
+        version: 1.10.3
       '@platforma-sdk/package-builder':
         specifier: workspace:*
         version: link:../../../tools/package-builder
@@ -2787,7 +2787,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.0
+        version: 1.10.3
       '@platforma-sdk/package-builder':
         specifier: 'workspace:'
         version: link:../../tools/package-builder
@@ -3793,7 +3793,7 @@ importers:
         version: link:../ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.0
+        version: 1.10.3
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
@@ -5555,11 +5555,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0':
     resolution: {integrity: sha512-Z9OIHbWfq0OsTUvmJIK6HBm8qLIli5xxHlGsiNx012YU69snwgi2edioMjUQ1vr5eWPA/9+Xs8Ih9z+aWbmUpQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.14':
-    resolution: {integrity: sha512-HPpVvYGURPGUcxHgbDFRuL3jpYcDP+vPhaZD6zd+9/1RObkQtYkHR5UOKQYefC+gwMeyIiLhK+UYukgvvpYEnQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.17':
+    resolution: {integrity: sha512-dMZyTsNxEpFVxR6vANxGCQEm7dEkyB8APEmodjWHJfe1sqwWy2liWajJkjLfQ4g/T15UU3yle04zq++u3O/ahQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.0':
-    resolution: {integrity: sha512-v1NlxvEjYRdn+Bq2cr26rXj+etDtFx0EO6txpB4Q3Ts009S8dgJHrYZ9vrp+7e9u7f/EHn/X22r2ibaCNPql3g==}
+  '@platforma-open/milaboratories.runenv-python-3@1.10.3':
+    resolution: {integrity: sha512-ArdWMYMk4hkc8likdmI6h2sv0Eh3RV4mYkXeLn/WZFU/WpLYxv+eKKNeeTcQjov0AP8VkqN1cwhMCfqcv+UudA==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -11866,11 +11866,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.14': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.17': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.0':
+  '@platforma-open/milaboratories.runenv-python-3@1.10.3':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.14
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.17
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,14 +22,14 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.43
-      version: 1.1.43
+      specifier: 1.1.44
+      version: 1.1.44
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.43
-      version: 1.1.43
+      specifier: 1.1.44
+      version: 1.1.44
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.43
-      version: 1.1.43
+      specifier: 1.1.44
+      version: 1.1.44
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1865,7 +1865,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1985,10 +1985,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.43(encoding@0.1.13)
+        version: 1.1.44(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2468,10 +2468,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.43(encoding@0.1.13)
+        version: 1.1.44(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3142,7 +3142,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.43
+        version: 1.1.44
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5048,18 +5048,18 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.43':
-    resolution: {integrity: sha512-IUk4uWCPBM9W6woyoTbDdDsZ72ruufGeQ3WV5XNtincYvjMg8D9jo+PuSzq3tj25yRf2giNo7xcmA2q0ZgkJQg==}
+  '@milaboratories/pframes-rs-node@1.1.44':
+    resolution: {integrity: sha512-s3ccom18u336R//OYQOqjlqb9K94nXWO4uiB2q1wJW1Z7WXXWq+naTRlBLaQ84/t/CA6+m+BTTCD6v/GBxMexQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.43':
-    resolution: {integrity: sha512-wGiVs3UGwOGj3m+0xaSlb0JUli7BP0Sroobzg9UzfWKioS54c6MVd7qIlQNBRYZp4a3c1yDQaJGBz8+gWPOexg==}
+  '@milaboratories/pframes-rs-serv@1.1.44':
+    resolution: {integrity: sha512-u18UiJK+KkbfqwuZmDbgSia+/si48l1P+feZcEyl2JgtdHoaTlZaNenjViu0+fX6O3PRRwHndH0GZzq8IEp+bg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.43':
-    resolution: {integrity: sha512-Ga0EQFzbMG74G60H3YermfAz/B0wqzpvBnm+45ox1YDeadDfBg6e2re4CQ8ZvEeTqqHjbAyIIJtG/5rEm3ZvNQ==}
+  '@milaboratories/pframes-rs-wasip2@1.1.44':
+    resolution: {integrity: sha512-lS8poGIpnGK+w2LKwbmYGuT4khXVK0qeXOQpo9b7wyTgAMJmjFcV/MBlS7ql5cJ/NS86p27cZDBBAlEgfBFWfw==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.43':
-    resolution: {integrity: sha512-n8pbdBPGSPMDQlw1z1uqXIXj2mayCQLo9WIm/fvM/2PPdI0kyjNjsyBPWmRQuZY8DGT8rYhRR5uDss2NHGowoQ==}
+  '@milaboratories/pframes-rs-wasm@1.1.44':
+    resolution: {integrity: sha512-F4gk12I6QpseDQNHx66jYPlwL/MMmQ8yUsrEsHjVrDiQvJw5xvkrV26+8uF5foHP++gWoSO2BpOqEJQjHW/I/w==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.0
@@ -11410,18 +11410,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.43(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.44(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.43
+      '@milaboratories/pframes-rs-serv': 1.1.44
       '@milaboratories/pl-model-common': 1.46.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.43':
+  '@milaboratories/pframes-rs-serv@1.1.44':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.0
@@ -11429,12 +11429,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.43': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.44': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.43
+      '@milaboratories/pframes-rs-wasip2': 1.1.44
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,14 +22,14 @@ catalogs:
       specifier: ~1.13.4
       version: 1.13.4
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.42
-      version: 1.1.42
+      specifier: 1.1.43
+      version: 1.1.43
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.42
-      version: 1.1.42
+      specifier: 1.1.43
+      version: 1.1.43
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.42
-      version: 1.1.42
+      specifier: 1.1.43
+      version: 1.1.43
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -1865,7 +1865,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -1985,10 +1985,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.42(encoding@0.1.13)
+        version: 1.1.43(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2468,10 +2468,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.42(encoding@0.1.13)
+        version: 1.1.43(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3142,7 +3142,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.42
+        version: 1.1.43
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5048,31 +5048,31 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.42':
-    resolution: {integrity: sha512-Mzw2VjqeoJPoB1F8IKngVysJJcqeLvT6K+RkR6RH8SAFAiVPUvlhOdvATwZCYOMSgs8r3tQouI/qVeKdGYSoIQ==}
+  '@milaboratories/pframes-rs-node@1.1.43':
+    resolution: {integrity: sha512-IUk4uWCPBM9W6woyoTbDdDsZ72ruufGeQ3WV5XNtincYvjMg8D9jo+PuSzq3tj25yRf2giNo7xcmA2q0ZgkJQg==}
 
-  '@milaboratories/pframes-rs-serv@1.1.42':
-    resolution: {integrity: sha512-it0Hx317mTod4o6+sujGR5mPwo3pseptX1ghSxJgaWHM18ZgLy1+VARKbp8LeoOoWrUqjhQFXcAKo4R8PTSQog==}
+  '@milaboratories/pframes-rs-serv@1.1.43':
+    resolution: {integrity: sha512-wGiVs3UGwOGj3m+0xaSlb0JUli7BP0Sroobzg9UzfWKioS54c6MVd7qIlQNBRYZp4a3c1yDQaJGBz8+gWPOexg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.42':
-    resolution: {integrity: sha512-xIFSI791uRvTbhlKKZ0a92xo4zRPORZVKk91py+6bSuBxsccXeW4e6EEDwv/j3IEPgMufVIKsRSfOUUNf+u26A==}
+  '@milaboratories/pframes-rs-wasip2@1.1.43':
+    resolution: {integrity: sha512-Ga0EQFzbMG74G60H3YermfAz/B0wqzpvBnm+45ox1YDeadDfBg6e2re4CQ8ZvEeTqqHjbAyIIJtG/5rEm3ZvNQ==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.42':
-    resolution: {integrity: sha512-94Y2FHNRjqTZmqe7U8cLM0eAZ0CSxfG9KQ9voyy+QdcqQ4bl+Fw891HGCt9BToNB6Ce938D3Dn69dLPAxAXCDw==}
+  '@milaboratories/pframes-rs-wasm@1.1.43':
+    resolution: {integrity: sha512-n8pbdBPGSPMDQlw1z1uqXIXj2mayCQLo9WIm/fvM/2PPdI0kyjNjsyBPWmRQuZY8DGT8rYhRR5uDss2NHGowoQ==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-middle-layer': 1.30.0
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-model-common@1.45.0':
-    resolution: {integrity: sha512-T3yCPY112J/+b5OjK2qVaJ/sk5rdyA8GNa87YojwZmO9P8KAgngOZrnjmBTnyW3Z64iK4N6Lt64+c0AnPB9sig==}
+  '@milaboratories/pl-model-common@1.46.0':
+    resolution: {integrity: sha512-ieKPAQn40j731NuRWv+wRpgs3W0doxtQC3+aQC6dZQIo5kIzYqfZGrVQQUyNwfGbk3T3cCLH8dS8YZcBOEyIBQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.29.0':
-    resolution: {integrity: sha512-xUZnvi6yvU2iegXxU/alECmyxlG0RZxRP5gcUO9CfJ3kmx48NFYmDSLsolxtmunV0GYsMb3HjeMMe2oiH6ey7w==}
+  '@milaboratories/pl-model-middle-layer@1.30.0':
+    resolution: {integrity: sha512-OmoCfGd1eUySI3ILP6rGfytbBgUOd9Jw3HuCCiLGHbV8qevtiV1DwqohWp36KHGFCfpmtaiQyV2Q3Y5+3bdUJQ==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -11410,31 +11410,31 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.42(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.43(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.42
-      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pframes-rs-serv': 1.1.43
+      '@milaboratories/pl-model-common': 1.46.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.42':
+  '@milaboratories/pframes-rs-serv@1.1.43':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-middle-layer': 1.30.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.42': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.43': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.43(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.42
+      '@milaboratories/pframes-rs-wasip2': 1.1.43
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11443,17 +11443,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.45.0':
+  '@milaboratories/pl-model-common@1.46.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.29.0':
+  '@milaboratories/pl-model-middle-layer@1.30.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pl-model-common': 1.46.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -251,9 +251,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.42
-  "@milaboratories/pframes-rs-wasip2": 1.1.42
-  "@milaboratories/pframes-rs-wasm": 1.1.42
+  "@milaboratories/pframes-rs-node": 1.1.43
+  "@milaboratories/pframes-rs-wasip2": 1.1.43
+  "@milaboratories/pframes-rs-wasm": 1.1.43
 
   "quickjs-emscripten": 0.31.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -296,7 +296,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.0.3
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.10.0
+  "@platforma-open/milaboratories.runenv-python-3": 1.10.3
 
   "shx": ^0.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -251,9 +251,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.43
-  "@milaboratories/pframes-rs-wasip2": 1.1.43
-  "@milaboratories/pframes-rs-wasm": 1.1.43
+  "@milaboratories/pframes-rs-node": 1.1.44
+  "@milaboratories/pframes-rs-wasip2": 1.1.44
+  "@milaboratories/pframes-rs-wasm": 1.1.44
 
   "quickjs-emscripten": 0.31.0
 

--- a/sdk/workflow-tengo/src/pframes/util.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/util.lib.tengo
@@ -477,6 +477,12 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 	ll.assert(vt == "Int" || vt == "Long" || vt == "Float" || vt == "Double" || vt == "String",
 		"Unsupported value type: ", vt, spec)
 
+	axisTypes := []
+	for axis in spec.axesSpec {
+		axisTypes = append(axisTypes, axis.type)
+	}
+	typeSpec := { axes: axisTypes, column: vt }
+
     ll.assert(!is_undefined(data) && smart.isResource(data), "data must be a resource, got: %v", data)
 
 	ll.assert(!is_undefined(execBuilder), "execBuilder must be defined")
@@ -515,6 +521,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		// write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "JsonPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: 0,
 			parts: { "[]": jdataFile }
 		})
@@ -542,6 +549,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
         // write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "JsonPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: data.getDataAsJson().partitionKeyLength,
 			parts: parts
 		})
@@ -579,6 +587,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		// write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "JsonPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: superPartitionKeyLength + partitionKeyLength,
 			parts: parts
 		})
@@ -622,6 +631,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
         // write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "BinaryPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: data.getDataAsJson().partitionKeyLength,
 			parts: parts
 		})
@@ -680,6 +690,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		// write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "BinaryPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: superPartitionKeyLength + partitionKeyLength,
 			parts: parts
 		})
@@ -711,6 +722,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
         // write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "ParquetPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: data.getDataAsJson().partitionKeyLength,
 			parts: parts
 		})
@@ -754,6 +766,7 @@ addColumnToWd := func(name, spec, data, execBuilder, ops) {
 		// write data info
 		execBuilder.writeFile(makePath(name + ".datainfo"), {
 			type: "ParquetPartitioned",
+			typeSpec: typeSpec,
 			partitionKeyLength: superPartitionKeyLength + partitionKeyLength,
 			parts: parts
 		})

--- a/sdk/workflow-tengo/src/pt/import-dir.tpl.tengo
+++ b/sdk/workflow-tengo/src/pt/import-dir.tpl.tengo
@@ -15,6 +15,10 @@ util := import(":pt.util")
 // json schema of .datainfo file
 _DATA_INFO_SCHEMA := {
     `type`: `string,regex=ParquetPartitioned`,
+    `typeSpec`: {
+        `axes`: [`string,regex=Int|Long|String`],
+        `column`: `string,regex=Int|Long|Float|Double|String`
+    },
     `partitionKeyLength`: `number`,
     `parts`: {
         any: {


### PR DESCRIPTION
## What

Adopts the new PFrames `1.1.43` datainfo format, where a column's structural type info (`typeSpec`) is carried inside the data info itself rather than supplied separately. This unblocks the push that was failing after the pframes-rs bump.

## Changes

**pf-driver / pl-model-middle-layer (the build break)**
- `pframes-rs-node` `1.1.43` retyped its `PFrameFactory` from `PFrameFactoryV7` → `PFrameFactoryV8`, whose `addColumns` expects the self-contained `AddColumnEntryV2` payload.
- Migrated `pframe_pool.ts` to `PFrameV17` / `PFrameFactoryAPIV6` and the embedded-`typeSpec` payload.
- Deleted the superseded `PFrameFactoryAPIV5` / `PFrameV16` / `PFrameFactoryV7` / `AddColumnEntry` / `ValueTypeSpec`.
- Added optional `typeSpec` to `DataInfo<Blob>`; `DataInfoV2` is now `DataInfo<Blob>` with a required `typeSpec`.

**ptabler**
- Bumped `polars-pf` `1.1.40` → `1.1.43`. The converter now writes a top-level `typeSpec` (`{ axes, column }`) into each `.datainfo`.
- Added the `DataInfoTypeSpec` struct + `typeSpec` field to the `DataInfo` mirror and assert it in `write_frame` tests. All 315 unit tests pass.

**workflow-tengo**
- `pt/import-dir` now expects `typeSpec` in the `.datainfo` validation schema (the validator is strict about undeclared keys).

**runenv**
- Bumped the `runenv-python-3` catalog to `1.10.3` (ships the `polars-pf 1.1.43` wheel).

## Testing

- ptabler: `315` unit tests pass against `polars-pf 1.1.43`.
- workflow-tengo: `tests/workflow-tengo/src/pt/pt.test.ts` run against a local backend — `15` passed + `2` expected-fail, exercising the converter → `import-dir` path end-to-end with the new `typeSpec`.
- `tsc` / lint / format clean across the affected packages (pre-push `pnpm check`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adopts the new PFrames `1.1.43` self-contained datainfo format, where each column's `typeSpec` is embedded directly in the `.datainfo` payload rather than supplied as a separate argument. All affected layers — TypeScript model types, the Node pf-driver, the Python ptabler step, and the Tengo import-dir template — are updated consistently.

- Removes the superseded `PFrameFactoryAPIV5` / `PFrameV16` / `PFrameFactoryV7` / `AddColumnEntry` / `ValueTypeSpec` types and migrates the sole call-site in `pframe_pool.ts` to the V6/V17/V8 API with `column` (singular) inside the embedded `typeSpec`.
- Adds `DataInfoTypeSpec` to the Python `DataInfo` struct, adds test assertions for the new field, and bumps `polars-pf` to `1.1.43` / `runenv-python-3` to `1.10.3`.
- Extends the Tengo `import-dir` validation schema with a required `typeSpec` block, making the strict validator accept the new on-disk shape.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The migration is mechanically correct across all layers, but REQUIRES_PFRAMES_VERSION in block_flags.ts was not bumped alongside the pframes-rs-* catalog version, contrary to the explicit comment in pnpm-workspace.yaml.

The addColumns migration from V5→V6 (top-level typeSpec → embedded in data, 'columns' → 'column') looks correct, and the Python / Tengo changes are consistent. The one concrete gap is that REQUIRES_PFRAMES_VERSION still encodes 1.1.31 even though the PR introduces a hard dependency on the 1.1.43 V8 factory; blocks built with this SDK would declare compatibility with desktop apps that predate the new format, risking runtime failures on those older installs.

lib/model/common/src/flags/block_flags.ts — REQUIRES_PFRAMES_VERSION needs to be bumped to 1_001_043.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/flags/block_flags.ts | REQUIRES_PFRAMES_VERSION remains at 1_001_031 (1.1.31) despite the pframes-rs-* bump to 1.1.43; should be updated to 1_001_043 per the lockstep comment in pnpm-workspace.yaml. |
| pnpm-workspace.yaml | Bumps pframes-rs-* from 1.1.42 → 1.1.43 and runenv-python-3 from 1.10.0 → 1.10.3; the lockstep comment reminds that REQUIRES_PFRAMES_VERSION should be updated alongside, which was not done in this PR. |
| lib/node/pf-driver/src/pframe_pool.ts | Migrated addColumns call from V5 layout (top-level typeSpec with plural 'columns') to V6 layout (typeSpec embedded in data with singular 'column'); always derives typeSpec from the column spec, which is correct. |
| lib/model/middle-layer/src/pframe/internal_api/api_factory.ts | Removes deprecated V5 factory and related types (ValueTypeSpec, AddColumnEntry, PFrameFactoryAPIV5); DataInfo now carries an optional typeSpec, DataInfoV2 extends it with a required typeSpec. |
| sdk/workflow-tengo/src/pt/import-dir.tpl.tengo | Adds required typeSpec field to the strict JSON schema, reflecting that the new converter always writes typeSpec into .datainfo files. |
| lib/ptabler/software/src/ptabler/steps/write_frame.py | Adds DataInfoTypeSpec struct and a required type_spec field to DataInfo, aligning the Python output with the new self-contained datainfo format. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ptabler as ptabler (Python)
    participant datainfo as .datainfo file
    participant importdir as import-dir (Tengo)
    participant pool as PFramePool (Node)
    participant factory as PFrameFactoryV8 (pframes-rs-node)

    ptabler->>datainfo: "write ParquetPartitioned + typeSpec{axes, column}"
    importdir->>datainfo: validate schema (typeSpec required)
    importdir->>pool: pass DataInfo with optional typeSpec
    pool->>pool: mapColumnData to PFrameBlobId
    pool->>pool: inject typeSpec from PColumnSpec (axes, column)
    pool->>factory: addColumns(AddColumnEntryV2) with embedded typeSpec
    factory-->>pool: PFrameV17 ready
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframes): adopt self-contained data..."](https://github.com/milaboratory/platforma/commit/19a2ee0dca6dbfb6f49ac244e8b6704a3bee4bff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36177526)</sub>

<!-- /greptile_comment -->