### PR TITLE
MILAB-6390: surface multi-step progress in file.importFile + e2e test

### DIFF
--- a/.changeset/little-stars-dance.md
+++ b/.changeset/little-stars-dance.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+Support multi-step progress reports from data controller

--- a/sdk/workflow-tengo/src/feats.lib.tengo
+++ b/sdk/workflow-tengo/src/feats.lib.tengo
@@ -77,5 +77,10 @@ export ll.toStrict({
 	secretEnvSupport:         _isEnabled("secretEnvSupport"),
 
 	// true when backend supports "ContextDomain" query predicate in block resolver
-	contextDomainQuery:       _isEnabled("contextDomainQuery")
+	contextDomainQuery:       _isEnabled("contextDomainQuery"),
+
+	// true when backend populates the multi-step 'progress' map output field
+	// on Blob* import/upload resources. When false, the SDK synthesizes the
+	// same map shape locally (single entry "01" → handle).
+	multiStepProgress:        _isEnabled("multiStepProgress")
 })

--- a/sdk/workflow-tengo/src/file/index.lib.tengo
+++ b/sdk/workflow-tengo/src/file/index.lib.tengo
@@ -25,11 +25,15 @@ json := import("json")
  * @param importFileHandle string a string file import handle, in most cases obtained via the
  *                         LS controller in UI
  *
- * @return a structure with two field references
+ * @return a structure with three field references
  *         {
  *             file: field,
- *             handle: field
+ *             handle: field,
+ *             progress: field
  *         }
+ *         'progress' is a map resource whose entries are per-step
+ *         progress-bearing sub-resources (each queryable via the
+ *         'progress' API).
  */
 importFile := func(importFileHandle) {
 	validation.assertType(

--- a/sdk/workflow-tengo/src/file/internal.lib.tengo
+++ b/sdk/workflow-tengo/src/file/internal.lib.tengo
@@ -12,8 +12,25 @@
 ll := import(":ll")
 smart := import(":smart")
 validation := import(":validation")
+feats := import(":feats")
 
 json := import("json")
+
+// _progressField returns the 'progress' map for an import/upload resource.
+//
+// When the backend advertises 'multiStepProgress' (see feats.lib.tengo),
+// the resource exposes the map natively as an output field. Older backends
+// do not populate this field — to keep callers uniform, we synthesize the
+// same shape on the SDK side: a std/map/V1 with a single input entry
+// "01" pointing at the legacy single-step 'handle' resource (which already
+// serves the ProgressAPI). The zero-padded ordinal key matches the
+// backend's convention (see datactl/internal/mainctl/ctl.go createProgressMap).
+_progressField := func(importer, handleField) {
+	if feats.multiStepProgress {
+		return importer.getField("progress")
+	}
+	return smart.mapBuilder().addRef("01", handleField).build()
+}
 
 //
 // Resource types:
@@ -26,9 +43,12 @@ RTYPE_BLOB_DOWNLOAD := { Name: "BlobDownload", Version: "2" }
 
 /**
  * Create a task for importing blob from external service by URL
- * Produces 2 fields:
- *  'file' - reference to blob to appear once import gets finished.
- *  'handle' - reference to resource with 'progress' API.
+ * Produces 3 fields:
+ *  'file'     - reference to blob to appear once import gets finished.
+ *  'handle'   - reference to resource with 'progress' API.
+ *  'progress' - reference to a map resource whose entries are per-step
+ *               progress-bearing sub-resources (each queryable via the
+ *               'progress' API).
  */
 createBlobImportExternal := func(settings) {
 	validation.assertType(settings, {
@@ -38,18 +58,23 @@ createBlobImportExternal := func(settings) {
 	})
 
 	importer := smart.structBuilder(RTYPE_BLOB_IMPORT_EXTERNAL, json.encode(settings)).lockAndBuild()
+	handleField := importer.getField("handle")
 
 	return ll.toStrict({
 		file: importer.getField("blob"),
-		handle: importer.getField("handle")
+		handle: handleField,
+		progress: _progressField(importer, handleField)
 	})
 }
 
 /**
  * Create a task for importing blob from one of preconfigured storages.
- * Produces 2 fields:
- *  'file' - reference to blob to appear once import gets finished.
- *  'handle' - reference to resource with 'progress' API.
+ * Produces 3 fields:
+ *  'file'     - reference to blob to appear once import gets finished.
+ *  'handle'   - reference to resource with 'progress' API.
+ *  'progress' - reference to a map resource whose entries are per-step
+ *               progress-bearing sub-resources (each queryable via the
+ *               'progress' API).
  */
 createBlobImportInternal := func(settings) {
 	validation.assertType(settings, {
@@ -60,18 +85,23 @@ createBlobImportInternal := func(settings) {
 	})
 
 	importer := smart.structBuilder(RTYPE_BLOB_IMPORT_INTERNAL, json.encode(settings)).lockAndBuild()
+	handleField := importer.getField("handle")
 
 	return ll.toStrict({
 		file: importer.getField("blob"),
-		handle: importer.getField("handle")
+		handle: handleField,
+		progress: _progressField(importer, handleField)
 	})
 }
 
 /**
  * Create a task for getting a blob directly from the user via 'upload' procedure.
- * Produces 2 fields:
- *  'file' - reference to blob to appear once upload gets finished.
- *  'handle' - reference to resource with 'progress' and 'upload' APIs.
+ * Produces 3 fields:
+ *  'file'     - reference to blob to appear once upload gets finished.
+ *  'handle'   - reference to resource with 'progress' and 'upload' APIs.
+ *  'progress' - reference to a map resource whose entries are per-step
+ *               progress-bearing sub-resources (each queryable via the
+ *               'progress' API).
  */
 createBlobUpload := func(settings) {
 	validation.assertType(settings, {
@@ -82,10 +112,12 @@ createBlobUpload := func(settings) {
 	})
 
 	uploader := smart.structBuilder(RTYPE_BLOB_UPLOAD, json.encode(settings)).lockAndBuild()
+	handleField := uploader.getField("handle")
 
 	return ll.toStrict({
 		file: uploader.getField("blob"),
-		handle: uploader.getField("handle")
+		handle: handleField,
+		progress: _progressField(uploader, handleField)
 	})
 }
 

--- a/tests/workflow-tengo/src/file/progress_map.test.ts
+++ b/tests/workflow-tengo/src/file/progress_map.test.ts
@@ -1,0 +1,99 @@
+import type { ResourceInfo } from "@milaboratories/pl-tree";
+import { Pl } from "@milaboratories/pl-middle-layer";
+import { createUploadProgressClient } from "@milaboratories/pl-drivers";
+import { ConsoleLoggerAdapter } from "@milaboratories/ts-helpers";
+import { tplTest } from "@platforma-sdk/test";
+import * as env from "../env";
+
+type ProgressEntry = { name: string; info: ResourceInfo };
+
+tplTest(
+  "file import exposes 'progress' map with per-step progress resources",
+  async ({ helper, expect, driverKit, pl }) => {
+    // 1. List the data library via LsDriver and find a known test file.
+    const storages = await driverKit.lsDriver.getStorageList();
+    const library = storages.find((s) => s.name == env.libraryStorage);
+    if (library === undefined) {
+      throw new Error(`Library '${env.libraryStorage}' not found`);
+    }
+    const files = await driverKit.lsDriver.listFiles(library.handle, "");
+    const ourFile = files.entries.find((f) => f.name == "answer_to_the_ultimate_question.txt");
+    if (ourFile === undefined) {
+      throw new Error("Test file not found in the library");
+    }
+    if (ourFile.type !== "file") {
+      throw new Error("Expected a file, got a directory");
+    }
+    const importHandle = ourFile.handle;
+
+    // 2. Render a template that calls file.importFile and exposes the new
+    //    'progress' map field alongside the resulting blob.
+    const result = await helper.renderTemplate(
+      false,
+      "file.progress_map",
+      ["file", "progress"],
+      (tx) => ({
+        importHandle: tx.createValue(Pl.JsonObject, JSON.stringify(importHandle)),
+      }),
+    );
+
+    // 3. Walk the progress map: collect (entryName, ResourceInfo) per child.
+    //    The map is locked at creation, so once its fields list materializes
+    //    it stays stable for the lifetime of the import resource.
+    const progressEntries = result
+      .computeOutput("progress", (a) => {
+        if (a === undefined) return undefined;
+        const names = a.listInputFields();
+        if (names.length === 0) return undefined;
+        const out: (ProgressEntry | undefined)[] = names.map((name) => {
+          const child = a.traverse({ field: name, assertFieldType: "Input" });
+          return child === undefined ? undefined : { name, info: child.resourceInfo };
+        });
+        if (out.some((e) => e === undefined)) return undefined;
+        return out as ProgressEntry[];
+      })
+      .withPreCalculatedValueTree();
+
+    const entries = await progressEntries.awaitStableValue();
+    expect(entries).toBeDefined();
+    expect(entries!.length).toBeGreaterThanOrEqual(1);
+    // Steps are named zero-padded decimal strings starting at "01" to keep fields
+    // ordered following the execution order.
+    expect(entries![0].name).toBe("01");
+
+    // 4. Call ProgressAPI.GetStatus for each map entry. Each entry's
+    //    sub-resource must be reachable via the progress wire.
+    const logger = new ConsoleLoggerAdapter();
+    const progressClient = createUploadProgressClient(pl, logger);
+
+    for (const entry of entries!) {
+      const status = await progressClient.getStatus(entry.info);
+      expect(status).toBeDefined();
+      expect(typeof status.progress).toBe("number");
+      expect(typeof status.done).toBe("boolean");
+    }
+
+    // 5. End-to-end sanity: the import must complete and produce a usable
+    //    blob. Confirms the new 'progress' field plumbing didn't break the
+    //    underlying import chain.
+    const file = result
+      .computeOutput("file", (a, ctx) => {
+        if (a === undefined) return undefined;
+        return driverKit.blobDriver.getOnDemandBlob(a.persist(), ctx);
+      })
+      .withPreCalculatedValueTree();
+
+    const fileStableValue = await file.awaitStableValue();
+    expect(fileStableValue).toBeDefined();
+    const fileContent = Buffer.from(
+      await driverKit.blobDriver.getContent(fileStableValue!.handle),
+    ).toString();
+    expect(fileContent).toEqual("42\n");
+
+    // 6. After the import has finished, every progress entry must report done.
+    for (const entry of entries!) {
+      const status = await progressClient.getStatus(entry.info);
+      expect(status.done).toBe(true);
+    }
+  },
+);

--- a/tests/workflow-tengo/src/file/progress_map.tpl.tengo
+++ b/tests/workflow-tengo/src/file/progress_map.tpl.tengo
@@ -1,0 +1,17 @@
+// Test template: imports a file via file.importFile and exposes both the
+// resulting blob and the new 'progress' map field, so the test can walk
+// the map and query each per-step progress sub-resource.
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+file := import("@platforma-sdk/workflow-tengo:file")
+
+self.defineOutputs(["file", "progress"])
+
+self.body(func(inputs) {
+	importResult := file.importFile(inputs.importHandle)
+
+	return {
+		file: file.exportFile(importResult.file),
+		progress: importResult.progress
+	}
+})


### PR DESCRIPTION
Backend now exposes a 'progress' output field on Blob* import/upload resources, advertised via the 'multiStepProgress' feature flag.

- feats.lib.tengo: declare multiStepProgress flag.
- file/internal.lib.tengo: return the new 'progress' field from the three createBlob* helpers. When the backend lacks the flag, synthesize the same shape locally (std/map/V1 with single entry "01" -> legacy handle) so callers see one uniform interface.
- file/index.lib.tengo: doc the extra return field.
- tests/workflow-tengo: integration test that lists the data library via LsDriver, runs a template calling file.importFile, walks the progress map and calls ProgressAPI.GetStatus per entry.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR surfaces multi-step progress reporting for blob import/upload resources. The backend now populates a `progress` output field (a `std/map/V1` whose entries are per-step progress sub-resources); older backends are handled transparently by the SDK synthesizing the same map shape with a single `"01"` → handle entry.

- **`feats.lib.tengo`**: adds the `multiStepProgress` feature flag via the standard `_isEnabled` mechanism.
- **`file/internal.lib.tengo`**: introduces `_progressField` which branches on the flag and returns either the backend's native field or a synthesized map; all three `createBlob*` helpers are updated to include the new `progress` key.
- **`progress_map.test.ts` / `progress_map.tpl.tengo`**: new end-to-end test that lists a known file from the data library, runs the import template, walks the progress map entries, calls `ProgressAPI.GetStatus` per entry, and confirms both blob content and `done: true` after the import completes.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the backward-compatibility path (SDK-synthesized map) is well-constructed and the new field is additive.

The core SDK change is backward-compatible and the `_progressField` helper correctly handles both code paths. The integration test covers the happy path end-to-end. The only thing worth a second look is the `length >= 1` assertion paired with a hardcoded `[0].name` check in the test, which could give a misleading failure if the entry count ever grows beyond one step.

tests/workflow-tengo/src/file/progress_map.test.ts — the assertion on entry count and name index.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/feats.lib.tengo | Adds `multiStepProgress` feature flag via the existing `_isEnabled` pattern; consistent with all other flags in the catalogue. |
| sdk/workflow-tengo/src/file/internal.lib.tengo | Introduces `_progressField` helper that branches on the feature flag: returns the native backend field or a synthesized `std/map/V1` with a single `"01"` entry. Correctly captures `handleField` once and reuses it in all three `createBlob*` functions. |
| sdk/workflow-tengo/src/file/index.lib.tengo | Documentation-only update adding the new `progress` return field description; no logic changes. |
| tests/workflow-tengo/src/file/progress_map.test.ts | New integration test walks the progress map, verifies per-step status, and confirms blob integrity. Minor: `length >= 1` assertion is looser than the "exactly one step" comment warrants for the non-federative case. |
| tests/workflow-tengo/src/file/progress_map.tpl.tengo | Minimal template that exposes `file` and `progress` outputs; correctly mirrors `simple1.tpl.tengo` but returns `importResult.progress` instead of `importResult.handle`. |
| .changeset/little-stars-dance.md | Changeset correctly marks the workflow-tengo package as a minor bump. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[file.importFile / createBlobImport*] --> B{feats.multiStepProgress?}
    B -- true --> C[importer.getField - backend-native map field]
    B -- false --> D[smart.mapBuilder - SDK-synthesized map with entry 01 to handleField]
    C --> E[progress map resource std/map/V1]
    D --> E
    E --> F[entry 01 - sub-resource]
    F --> G[ProgressAPI.GetStatus]
    A --> H[return: file + handle + progress]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/workflow-tengo/src/file/progress_map.test.ts:59-61
**Length assertion vs entry-name assertion mismatch**

The comment says "exactly one step" but the assertion uses `toBeGreaterThanOrEqual(1)`. If `entries` ever has more than one element, `entries![0].name` is compared without verifying `entries` is exactly length 1. On a federated import (future scenario) the first entry might not be `"01"`, causing a misleading failure — or silently passing if a second entry named `"01"` appears at index 0.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6390: surface multi-step progress ..."](https://github.com/milaboratory/platforma/commit/5971b062284105fe4fa01b142c6f169947435088) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36261004)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->