### PR TITLE
MILAB-6145: propagate wasm deps through cached template upload path

### DIFF
--- a/.changeset/cached-wasm-template-propagation.md
+++ b/.changeset/cached-wasm-template-propagation.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Propagate wasm dependencies through the cached template upload path. `flattenV3Tree` in `template_cache.ts` previously skipped `tpl.wasm` entries entirely — the loadTemplateCached path (used by dev-v2 blocks and others) silently stripped wasm field declarations during upload, leaving the backend's `PlTemplateV1` resource with no `wasm/<alias>` fields. As a result `RuntimeV1.deps.Wasm` was empty at render time and `plapi.loadWasm` aborted with `alias "<id>" is not a wasm dependency of this template` even though the bytes were bundled in the block-pack. Adds `hashWasmV3`, a `processWasm` helper, and the wasm field wiring in `processTemplate`, mirroring the handling already present in `direct_template_loader_v3.ts`.

--- a/lib/node/pl-middle-layer/src/mutator/template/template_cache.ts
+++ b/lib/node/pl-middle-layer/src/mutator/template/template_cache.ts
@@ -18,6 +18,7 @@ import {
   PlTemplateOverrideV1,
   PlTemplateSoftwareV1,
   PlTemplateV1,
+  PlWasmV1,
 } from "@milaboratories/pl-model-backend";
 import type {
   CompiledTemplateV3,
@@ -27,6 +28,7 @@ import type {
   TemplateLibDataV3,
   TemplateSoftwareData,
   TemplateSoftwareDataV3,
+  TemplateWasmDataV3,
 } from "@milaboratories/pl-model-backend";
 import { notEmpty } from "@milaboratories/ts-helpers";
 import type { BlockPackSpecPrepared } from "../../model";
@@ -147,6 +149,16 @@ function hashSoftwareV3(sw: TemplateSoftwareDataV3): string {
     .update(sw.name)
     .update(sw.version)
     .update(sw.sourceHash)
+    .digest("hex");
+}
+
+function hashWasmV3(wasm: TemplateWasmDataV3): string {
+  return createHash("sha256")
+    .update(PlWasmV1.type.name)
+    .update(PlWasmV1.type.version)
+    .update(wasm.name)
+    .update(wasm.version)
+    .update(wasm.sourceHash)
     .digest("hex");
 }
 
@@ -316,6 +328,25 @@ function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
     return hash;
   }
 
+  function processWasm(wasm: TemplateWasmDataV3): string {
+    const hash = hashWasmV3(wasm);
+    if (!seen.has(hash)) {
+      seen.add(hash);
+      nodes.push({
+        hash,
+        create: (tx) =>
+          tx.createValue(
+            PlWasmV1.type,
+            JSON.stringify(
+              PlWasmV1.fromV3Data(wasm, getSourceCode(wasm.name, sources, wasm.sourceHash)).data,
+            ),
+          ),
+        childHashes: [],
+      });
+    }
+    return hash;
+  }
+
   function processTemplate(tpl: TemplateDataV3): string {
     // Process children first (bottom-up)
     const childHashes: string[] = [];
@@ -340,6 +371,11 @@ function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
       const h = processTemplate(sub);
       childHashes.push(h);
       children.push({ fieldName: `${PlTemplateV1.tplPrefix}/${tplId}`, hash: h });
+    }
+    for (const [wasmId, wasm] of Object.entries(tpl.wasm ?? {})) {
+      const h = processWasm(wasm);
+      childHashes.push(h);
+      children.push({ fieldName: `${PlTemplateV1.wasmPrefix}/${wasmId}`, hash: h });
     }
 
     // Compose hash from own content + child hash strings (NOT child content).


### PR DESCRIPTION
## Summary

- `flattenV3Tree` in `template_cache.ts` previously had no handling for `tpl.wasm` — the `loadTemplateCached` path (used by dev-v2 blocks and others) silently stripped wasm field declarations during upload, leaving the backend's `PlTemplateV1` resource with no `wasm/<alias>` fields. `RuntimeV1.deps.Wasm` was empty at render time, so `plapi.loadWasm` aborted with `alias "<id>" is not a wasm dependency of this template` even though the bytes were bundled in the block-pack.
- Adds `hashWasmV3`, a `processWasm` helper, and the wasm field wiring in `processTemplate`, mirroring the handling already present in `direct_template_loader_v3.ts`.

## Test plan
- [x] End-to-end smoke against a dev-v2 rarefaction block calling `:pframes.build-query-wasm` against a local source-built backend with `wasm:v1` capability — block now reaches `Done` with `outputErrors: false` (previously failed with "alias is not a wasm dependency"). Both upload paths (`loadTemplateCached` here, `direct_template_loader_v3.ts` already wired) now create matching `wasm/<alias>` fields on the backend `PlTemplateV1` resource.
- [ ] CI runs against the rest of the suite.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `flattenV3Tree` in `template_cache.ts` silently discarded `tpl.wasm` entries, leaving `PlTemplateV1` backend resources with no `wasm/<alias>` fields on the cached upload path. Blocks using `plapi.loadWasm` over the `loadTemplateCached` path therefore always aborted at render time with "alias is not a wasm dependency of this template".

- Adds `hashWasmV3` and a `processWasm` closure in `flattenV3Tree`, following the same `seen`-set deduplication and `CacheableNode` structure used for libs and software.
- Wires wasm entries in `processTemplate`'s child loop, appending `wasm/<alias>` fields to the template resource (matching `PlTemplateV1.wasmPrefix`) and including their hashes in the parent's hash composition.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted additive fix that brings the cached upload path into parity with the direct loader path without touching any existing logic.

The new processWasm closure and hashWasmV3 function mirror the established patterns for processLib and processSoftware exactly: same seen-set deduplication, same CacheableNode with childHashes: [], same tx.createValue call, and same use of wasm.sourceHash as a proxy for source content. The field name wasm/<alias> is derived from PlTemplateV1.wasmPrefix, matching both direct_template_loader_v3.ts and the backend Go constant. The wasm children are included in the parent template's hash composition, so the cache will correctly invalidate existing entries that are missing wasm fields.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/mutator/template/template_cache.ts | Adds hashWasmV3, processWasm, and wasm-child wiring in flattenV3Tree — structurally correct, consistent with all sibling node types, and properly integrated into the hash and child-field plumbing. |
| .changeset/cached-wasm-template-propagation.md | Changeset entry for @milaboratories/pl-middle-layer at patch level; description accurately captures the root cause and fix. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant loadTemplateCached
    participant flattenV3Tree
    participant processTemplate
    participant processWasm
    participant materialize
    participant Backend

    Caller->>loadTemplateCached: spec (CompiledTemplateV3)
    loadTemplateCached->>flattenV3Tree: data
    flattenV3Tree->>processTemplate: data.template
    loop for each tpl.wasm entry
        processTemplate->>processWasm: wasm (TemplateWasmDataV3)
        processWasm-->>processTemplate: hash (CacheableNode added)
    end
    processTemplate-->>flattenV3Tree: rootHash
    flattenV3Tree-->>loadTemplateCached: nodes[]
    loadTemplateCached->>materialize: nodes, rootHash
    materialize->>Backend: createValue(PlWasmV1, base64Source)
    materialize->>Backend: createStruct(PlTemplateV1) + createField(wasm/alias)
    Backend-->>materialize: SignedResourceId
    materialize-->>loadTemplateCached: rootId
    loadTemplateCached-->>Caller: SignedResourceId
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6145: propagate wasm deps through ..."](https://github.com/milaboratory/platforma/commit/f54a040cf8d3f858bd8389616e6cb039a885b02c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36291645)</sub>

<!-- /greptile_comment -->