### PR TITLE
feat(pframes): O(1) get-column-by-id in pf-driver + V5 wasm interfaces

### DIFF
--- a/.changeset/pf-driver-getcolumn-o1.md
+++ b/.changeset/pf-driver-getcolumn-o1.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pf-driver": patch
+---
+
+pf-driver: retain the resolved column-spec map on the JS side in `PFrameHolder` and serve `getColumnSpec` (and the column lookup inside `getUniqueValues`) from it as an O(1) map read, instead of scanning `pFrameSpec.listColumns()` on every call.

--- a/.changeset/wasm-pframe-v5-getcolumn.md
+++ b/.changeset/wasm-pframe-v5-getcolumn.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+---
+
+PFrames wasm: add self-contained `PFrameWasmAPIV5` factory and `PFrameWasmV4` per-frame interfaces. `PFrameWasmV4` adds `getColumn(columnId)` for O(1) single-column lookup by id; both `getColumn` and `listColumns` return `PColumnIdAndSpec` (the new interfaces drop `PColumnInfo`). These supersede the V4 factory / V3 per-frame interfaces and will replace them once the new PFrames build is adopted.

--- a/.changeset/wasm-pframe-v5-getcolumn.md
+++ b/.changeset/wasm-pframe-v5-getcolumn.md
@@ -2,4 +2,7 @@
 "@milaboratories/pl-model-middle-layer": patch
 ---
 
-PFrames wasm: add self-contained `PFrameWasmAPIV5` factory and `PFrameWasmV4` per-frame interfaces. `PFrameWasmV4` adds `getColumn(columnId)` for O(1) single-column lookup by id; both `getColumn` and `listColumns` return `PColumnIdAndSpec` (the new interfaces drop `PColumnInfo`). These supersede the V4 factory / V3 per-frame interfaces and will replace them once the new PFrames build is adopted.
+PFrames internal API: add self-contained Vx+1 interfaces that supersede the current ones and will replace them once the new PFrames build is adopted.
+
+- wasm: `PFrameWasmAPIV5` factory and `PFrameWasmV4` per-frame interface. `PFrameWasmV4` adds `getColumn(columnId)` for O(1) single-column lookup by id; both `getColumn` and `listColumns` return `PColumnIdAndSpec` (the new interfaces drop `PColumnInfo`).
+- node: `PFrameReadAPIV15` read interface and `PTableV12` table view. `PTableV12.export` moves `headers` into `ops` as an ordered `[columnIndex, headerName][]` list instead of a positional `Record<number, string>` map.

--- a/lib/model/common/src/drivers/pframe/spec/spec.ts
+++ b/lib/model/common/src/drivers/pframe/spec/spec.ts
@@ -730,12 +730,6 @@ export function getColumnIdAndSpec<Data>(column: PColumn<Data>): PColumnIdAndSpe
   };
 }
 
-/** Information returned by {@link PFrame.listColumns} method */
-export interface PColumnInfo extends PColumnIdAndSpec {
-  /** True if data was associated with this PColumn */
-  readonly hasData: boolean;
-}
-
 export interface AxisId {
   /** Type of the axis or column value. For an axis should not use non-key
    * types like float or double. */

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -6,7 +6,6 @@ import type {
   AxesSpec,
   AxesId,
   PColumnIdAndSpec,
-  PColumnInfo,
   PColumnSpec,
   SingleAxisSelector,
   AxisQualification,
@@ -222,7 +221,7 @@ export interface PFrameSpecDriver {
   createSpecFrame(specs: Record<string, PColumnSpec>): PoolEntry<SpecFrameHandle>;
 
   /** List all columns currently registered in the frame. */
-  listColumns(handle: SpecFrameHandle): PColumnInfo[];
+  listColumns(handle: SpecFrameHandle): PColumnIdAndSpec[];
 
   /** Discover columns compatible with given axes integration. */
   discoverColumns(

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -4,7 +4,7 @@ import type {
   DataQuery,
   DataQueryBooleanExpression,
 } from "@milaboratories/pl-model-common";
-import type { PTableV11 } from "./table";
+import type { PTableV11, PTableV12 } from "./table";
 import type { PTableId } from "./common";
 
 /**
@@ -28,6 +28,39 @@ export interface UniqueValuesRequestV2 {
 
   /** Max number of values to return. Overflow is reported in the response. */
   readonly limit: number;
+}
+
+/**
+ * Read interface exposed by PFrames library. Returns the {@link PTableV12}
+ * table view, whose `export` takes an `ops.headers` list of
+ * `[column index, header name]` pairs.
+ *
+ * Self-contained: does not extend any earlier read interface. Once this
+ * version is adopted, every earlier `PFrameReadAPIV*` and per-table
+ * `PTableV*` interface is dropped, so this declaration repeats the full
+ * method surface rather than referencing the predecessors.
+ *
+ * Same surface as {@link PFrameReadAPIV14}; the only change is that
+ * {@link PFrameReadAPIV15.createTable} returns {@link PTableV12}.
+ *
+ * Spec-side operations (finding columns, listing columns, retrieving
+ * column specs, computing axis integrations) are not part of this
+ * surface — callers cache column specs themselves or route through
+ * WASM-spec. The data-side `createTable` accepts a pre-lowered
+ * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
+ * {@link UniqueValuesRequestV2}.
+ */
+export interface PFrameReadAPIV15 {
+  /** Creates table from a pre-lowered data query. */
+  createTable(tableId: PTableId, dataQuery: DataQuery): PTableV12;
+
+  /** Calculate set of unique values for a specific axis for the filtered set of records. */
+  getUniqueValues(
+    request: UniqueValuesRequestV2,
+    ops?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<UniqueValuesResponse>;
 }
 
 /**

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -4,7 +4,6 @@ import type {
   BuildQueryInput,
   JoinEntry,
   PColumnIdAndSpec,
-  PColumnInfo,
   PColumnSpec,
   PObjectId,
   PTableColumnId,
@@ -220,7 +219,7 @@ export interface PFrameWasmV3 extends Disposable {
   /**
    * Lists all columns currently registered in this PFrame, with their ids and specs.
    */
-  listColumns(): PColumnInfo[];
+  listColumns(): PColumnIdAndSpec[];
 
   /**
    * Discovers columns compatible with a given axes integration. Include and

--- a/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts
@@ -3,6 +3,7 @@ import type {
   AxesSpec,
   BuildQueryInput,
   JoinEntry,
+  PColumnIdAndSpec,
   PColumnInfo,
   PColumnSpec,
   PObjectId,
@@ -22,6 +23,116 @@ import type {
 } from "./delete_column";
 import type { DiscoverColumnsRequestV2, DiscoverColumnsResponse } from "./discover_columns";
 import type { FindColumnsRequest, FindColumnsResponse } from "./find_columns";
+
+/**
+ * V5 PFrame API factory — pure spec-layer operations plus frame construction.
+ *
+ * Self-contained: does not extend any earlier factory interface. Once this
+ * version is adopted, every earlier `PFrameWasmAPIV*` and per-frame
+ * `PFrameWasmV*` interface is dropped, so this declaration repeats the full
+ * method surface rather than referencing the predecessors.
+ */
+export interface PFrameWasmAPIV5 {
+  /**
+   * Creates a new PFrame from a map of column IDs to column specifications.
+   */
+  createPFrame(spec: Record<string, PColumnSpec>): PFrameWasmV4;
+
+  /**
+   * Expands an {@link AxesSpec} into {@link AxesId}s with parent information
+   * resolved.
+   */
+  expandAxes(spec: AxesSpec): AxesId;
+
+  /**
+   * Collapses {@link AxesId} into {@link AxesSpec}.
+   */
+  collapseAxes(ids: AxesId): AxesSpec;
+
+  /**
+   * Finds the index of an axis matching the given selector.
+   * Returns -1 if no matching axis is found.
+   */
+  findAxis(spec: AxesSpec, selector: SingleAxisSelector): number;
+
+  /**
+   * Finds the flat index of a table column matching the given
+   * selector within a table spec. Returns -1 if not found.
+   */
+  findTableColumn(tableSpec: PTableColumnSpec[], selector: PTableColumnId): number;
+
+  /**
+   * Assembles a {@link SpecQueryJoinEntry} from a terminal column plus an
+   * ordered path of wrapping steps (linker hops, filter joins).
+   *
+   * Right-fold over `path` starting from `Column(column)`: each `linker` step
+   * wraps the current subquery as `linkerJoin`, each `filter` step as
+   * `innerJoin` with the filter column. `qualifications` annotate the
+   * outermost entry only.
+   */
+  buildQuery(input: BuildQueryInput): SpecQueryJoinEntry;
+
+  /**
+   * Upgrades selector-based legacy record filters into index-based data-layer
+   * boolean expressions, resolved against the provided unified table spec
+   * (axes first, then columns).
+   */
+  rewriteLegacyFilters(request: {
+    tableSpec: PTableColumnSpec[];
+    filters: PTableRecordFilter[];
+  }): DataQueryBooleanExpression[];
+}
+
+/**
+ * V4 PFrame interface — per-frame instance operations.
+ *
+ * Self-contained: does not extend any earlier per-frame interface. Once this
+ * version is adopted, every earlier `PFrameWasmV*` interface is dropped, so
+ * this declaration repeats the full method surface rather than referencing
+ * the predecessors.
+ */
+export interface PFrameWasmV4 extends Disposable {
+  /**
+   * Deletes columns from a columns specification.
+   */
+  deleteColumns(request: DeleteColumnFromColumnsRequest): DeleteColumnFromColumnsResponse;
+
+  /**
+   * Returns the id and spec of the single column registered under `columnId`
+   * in this PFrame, or `null` if no such column is registered. Same shape as
+   * the entries of {@link PFrameWasmV4.listColumns}.
+   */
+  getColumn(columnId: PObjectId): PColumnIdAndSpec | null;
+
+  /**
+   * Lists all columns currently registered in this PFrame, with their ids and specs.
+   */
+  listColumns(): PColumnIdAndSpec[];
+
+  /**
+   * Discovers columns compatible with a given axes integration. Include and
+   * exclude filters are applied in order (exclude removes matches from the
+   * include set). Each hit carries its traversal `path`; feed the hit's
+   * column id and `path` into {@link PFrameWasmAPIV5.buildQuery} to
+   * materialize it as a {@link SpecQueryJoinEntry}.
+   */
+  discoverColumns(request: DiscoverColumnsRequestV2): DiscoverColumnsResponse;
+
+  /**
+   * Finds columns in the PFrame matching the given filter criteria.
+   */
+  findColumns(request: FindColumnsRequest): FindColumnsResponse;
+
+  /**
+   * Evaluates a query specification against this PFrame.
+   */
+  evaluateQuery(request: SpecQuery): EvaluateQueryResponse;
+
+  /**
+   * Rewrites a legacy query format (V4) to the current SpecQuery format.
+   */
+  rewriteLegacyQuery(request: LegacyQuery): SpecQuery;
+}
 
 /**
  * V4 PFrame API factory — pure spec-layer operations plus frame construction.

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -74,3 +74,85 @@ export interface PTableV11 extends Disposable {
   /** Deallocates all underlying resources */
   dispose(): void;
 }
+
+/**
+ * Table view returned by `createTable`.
+ *
+ * Self-contained: does not extend any earlier per-table interface. Once this
+ * version is adopted, every earlier `PTableV*` interface is dropped, so this
+ * declaration repeats the full method surface rather than referencing the
+ * predecessors.
+ *
+ * Same surface as {@link PTableV11} except {@link PTableV12.export} moves
+ * `headers` into `ops` and passes them as an ordered list of
+ * `[unified column index, header name]` pairs instead of a
+ * `Record<number, string>` map.
+ *
+ * PTable can be thought as having a composite primary key, consisting
+ * of axes, and a set of data columns derived from PColumn values.
+ * The table's column spec is owned by the caller — selector → index
+ * resolution runs on the caller side via WASM-spec.
+ */
+export interface PTableV12 extends Disposable {
+  /**
+   * Get PTable disk footprint in bytes.
+   *
+   * @param ops.withPredecessors When true, the footprint includes
+   *   every registered predecessor table reachable through the
+   *   query lineage. When false or omitted, only this table's own
+   *   materialised data is counted.
+   *
+   * Warning: This call materializes the join.
+   */
+  getFootprint(ops?: { withPredecessors?: boolean; signal?: AbortSignal }): Promise<number>;
+
+  /**
+   * Unified table shape
+   * Warning: This call materializes the join.
+   */
+  getShape(ops?: { signal?: AbortSignal }): Promise<PTableShape>;
+
+  /**
+   * Retrieve the data from the table. To retrieve only data required, it can be
+   * sliced both horizontally ({@link columnIndices}) and vertically
+   * ({@link range}).
+   * This call materializes the join.
+   *
+   * @param columnIndices unified indices of columns to be retrieved
+   * @param range optionally limit the range of records to retrieve
+   * */
+  getData(
+    columnIndices: number[],
+    ops?: {
+      range?: TableRange;
+      signal?: AbortSignal;
+    },
+  ): Promise<PTableVector[]>;
+
+  /**
+   * Stream the sorted table to a file at `path`. The output format is
+   * selected from the file extension: `csv`, `tsv`, `parquet`, or `xlsx`.
+   * Writing is bounded-memory.
+   * This call materializes the join.
+   *
+   * @param path destination file path; its extension selects the format
+   * @param ops.headers list of `[unified column index, header name]` pairs
+   *   (unified index: axes first, then data columns). Only the columns listed
+   *   are exported, in ascending index order — the list both selects the
+   *   columns and names them (the data layer is name-independent, so names
+   *   are supplied by the caller).
+   *
+   * @remarks For `xlsx` the caller must ensure the row count is below Excel's
+   *   1,048,576-row per-sheet limit.
+   */
+  export(
+    path: string,
+    ops?: {
+      headers: [number, string][];
+      signal?: AbortSignal;
+    },
+  ): Promise<void>;
+
+  /** Deallocates all underlying resources */
+  dispose(): void;
+}

--- a/lib/model/pf-spec-driver/src/spec_driver.test.ts
+++ b/lib/model/pf-spec-driver/src/spec_driver.test.ts
@@ -211,9 +211,6 @@ describe("SpecDriver", () => {
 
     const ids = columns.map((c) => c.columnId).sort();
     expect(ids).toEqual(["col1", "col2"]);
-    for (const c of columns) {
-      expect(c.hasData).toBe(false);
-    }
   });
 
   test("buildQuery wraps a bare column with no path (no handle needed)", async () => {

--- a/lib/model/pf-spec-driver/src/spec_driver.ts
+++ b/lib/model/pf-spec-driver/src/spec_driver.ts
@@ -11,7 +11,6 @@ import type {
   AxesSpec,
   BuildQueryInput,
   DataQueryBooleanExpression,
-  PColumnInfo,
   PColumnSpec,
   PFrameSpecDriver,
   PTableColumnId,
@@ -27,6 +26,7 @@ import type {
   DeleteColumnResponse,
   EvaluateQueryResponse,
   SpecQuery,
+  PColumnIdAndSpec,
 } from "@milaboratories/pl-model-common";
 import {
   PFrameSpecDriverError,
@@ -71,7 +71,7 @@ export class SpecDriver implements PFrameSpecDriver, AsyncDisposable {
     }
   }
 
-  listColumns(handle: SpecFrameHandle): PColumnInfo[] {
+  listColumns(handle: SpecFrameHandle): PColumnIdAndSpec[] {
     const pframe = this.frames.getByKey(handle);
     try {
       if (logPFrames()) {

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -458,9 +458,8 @@ export class AbstractPFrameDriver<
     handle: PFrameHandle,
     columnId: PObjectId,
   ): Promise<PColumnSpec | null> {
-    const { pFrameSpec } = this.pFrames.getByKey(handle);
-    const info = pFrameSpec.listColumns().find((c) => c.columnId === columnId);
-    return info?.spec ?? null;
+    const { columnSpecs } = this.pFrames.getByKey(handle);
+    return columnSpecs[columnId] ?? null;
   }
 
   public async listColumns(handle: PFrameHandle): Promise<PColumnIdAndSpec[]> {
@@ -529,26 +528,26 @@ export class AbstractPFrameDriver<
       );
     }
 
-    const { pFrameDataPromise, pFrameSpec, disposeSignal } = this.pFrames.getByKey(handle);
+    const { pFrameDataPromise, columnSpecs, disposeSignal } = this.pFrames.getByKey(handle);
     const pFrameData = await pFrameDataPromise;
 
-    const column = pFrameSpec.listColumns().find((c) => c.columnId === request.columnId);
-    if (!column) {
+    const columnSpec = columnSpecs[request.columnId];
+    if (!columnSpec) {
       const error = new PFrameDriverError(`getUniqueValues failed`);
       error.cause = new Error(`column ${request.columnId} is not registered in the PFrame`);
       throw error;
     }
 
-    const axisIds = expandAxes(column.spec.axesSpec);
+    const axisIds = expandAxes(columnSpec.axesSpec);
     const tableSpec: PTableColumnSpec[] = [
-      ...column.spec.axesSpec.map(
+      ...columnSpec.axesSpec.map(
         (axisSpec, i): PTableColumnSpec => ({
           type: "axis",
           id: axisIds[i],
           spec: axisSpec,
         }),
       ),
-      { type: "column", id: request.columnId, spec: column.spec },
+      { type: "column", id: request.columnId, spec: columnSpec },
     ];
 
     let axisIndex: number | undefined;

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -11,6 +11,7 @@ import {
   type PColumn,
   type PColumnSpec,
   type PFrameHandle,
+  type PObjectId,
 } from "@milaboratories/pl-model-common";
 import { hashJson, PFrameInternal } from "@milaboratories/pl-model-middle-layer";
 import { RefCountPoolBase, type PoolEntry } from "@milaboratories/helpers";
@@ -37,6 +38,7 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
    * legacy-query lowering.
    */
   public readonly pFrameSpec: PFrameInternal.PFrameWasmV3;
+  public readonly columnSpecs: Record<PObjectId, PColumnSpec>;
   private readonly abortController = new AbortController();
 
   private readonly localBlobs: PoolEntry<PFrameInternal.PFrameBlobId>[] = [];
@@ -51,13 +53,14 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
     columns: PColumn<PFrameInternal.DataInfo<TreeEntry>>[],
   ) {
     const ValueTypes = new Set(Object.values(ValueType));
-    const specColumnsMap: Record<string, PColumnSpec> = {};
+    const specColumnsMap: Record<PObjectId, PColumnSpec> = {};
     for (const c of columns) {
       if (ValueTypes.has(c.spec.valueType)) {
         specColumnsMap[c.id] = resolveAnnotationParents(c.spec);
       }
     }
     this.pFrameSpec = createPFrameSpec(specColumnsMap);
+    this.columnSpecs = specColumnsMap;
 
     try {
       const makeLocalBlobId = (blob: TreeEntry): PFrameInternal.PFrameBlobId => {
@@ -131,7 +134,7 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
             { signal: this.disposeSignal },
           )
           .then(() => pFrameData)
-          .catch((err) => {
+          .catch((err: unknown) => {
             this.dispose();
             pFrameData.dispose();
             const error = new PFrameDriverError("PFrame creation failed asynchronously");

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -38,7 +38,7 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
    * legacy-query lowering.
    */
   public readonly pFrameSpec: PFrameInternal.PFrameWasmV3;
-  public readonly columnSpecs: Record<PObjectId, PColumnSpec>;
+  public readonly columnSpecs: Readonly<Record<PObjectId, PColumnSpec>>;
   private readonly abortController = new AbortController();
 
   private readonly localBlobs: PoolEntry<PFrameInternal.PFrameBlobId>[] = [];
@@ -53,7 +53,7 @@ export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposa
     columns: PColumn<PFrameInternal.DataInfo<TreeEntry>>[],
   ) {
     const ValueTypes = new Set(Object.values(ValueType));
-    const specColumnsMap: Record<PObjectId, PColumnSpec> = {};
+    const specColumnsMap: Record<PObjectId, PColumnSpec> = Object.create(null);
     for (const c of columns) {
       if (ValueTypes.has(c.spec.valueType)) {
         specColumnsMap[c.id] = resolveAnnotationParents(c.spec);


### PR DESCRIPTION
## What

Two related changes around fetching a single PColumn spec by id.

### 1. pf-driver: O(1) get-column-by-id
`PFrameDriver.getColumnSpec(handle, columnId)` (called from the visualizations `PFrameFacade`) and the column lookup inside `getUniqueValues` previously did `pFrameSpec.listColumns().find(c => c.columnId === id)` — O(n) per call, round-tripping through WASM and rebuilding the full column list every time.

`PFrameHolder` already built a resolved `Record<string, PColumnSpec>` to hand to the WASM spec frame, then discarded it. It now also retains that as a JS-side `ReadonlyMap<PObjectId, PColumnSpec>` (`columnSpecs`), and both call sites read from it directly. No new public methods; the visualizations caller is unchanged and gets the speedup for free.

### 2. New self-contained wasm interfaces (V5 factory / V4 per-frame)
Adds `PFrameWasmAPIV5` and `PFrameWasmV4` to `pl-model-middle-layer`. `PFrameWasmV4` adds `getColumn(columnId): PColumnIdAndSpec | null` for O(1) lookup by id; both `getColumn` and `listColumns` return `PColumnIdAndSpec` (the new interfaces drop `PColumnInfo`).

These are fully self-contained — no `extends` of any earlier version, every method re-declared with full docs, cross-references pointing at the V4/V5 siblings. They supersede the V4 factory / V3 per-frame interfaces. Once PFrames implements `getColumn` and we adopt the new build, drivers switch to V4/V5 and every older `PFrameWasmV*`/`PFrameWasmAPIV*` interface is removed.

## Notes
- Type-checks pass for both packages; pf-driver tests (45) pass.
- The pf-driver lookup now returns the JS-side `resolveAnnotationParents(spec)` (the value fed into WASM) rather than WASM's round-tripped spec. Equivalent for current consumers, but worth a sanity check against a real plot.
- Changesets included for both `pf-driver` and `pl-model-middle-layer`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces two related improvements: an O(1) JS-side column lookup in `pf-driver` by retaining the resolved `columnSpecs` map on `PFrameHolder`, and a new generation of self-contained WASM interfaces (`PFrameWasmAPIV5` / `PFrameWasmV4`) plus a new `PFrameReadAPIV15` / `PTableV12` read interface that are designed to supersede their predecessors once the matching PFrames build ships.

- `PFrameHolder` now keeps the `Readonly<Record<PObjectId, PColumnSpec>>` map it already built for WASM, and `getColumnSpec` / `getUniqueValues` in `driver_impl.ts` read from it directly instead of calling `pFrameSpec.listColumns().find()` on every call.
- `PFrameWasmV4` adds a `getColumn(columnId)` method for O(1) per-frame lookup; both `getColumn` and `listColumns` return `PColumnIdAndSpec`, and `PColumnInfo` (which added a `hasData` boolean) is removed across the board.
- `PTableV12.export()` restructures the signature by moving `headers` into the `ops` bag as a required field, while `ops` itself remains optional — creating an asymmetry where an `AbortSignal` cannot be passed without also supplying headers.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the runtime behaviour of existing callers is unchanged, and the new V4/V5 interfaces are additive with no consumers yet.

The JS-side map lookup is a straightforward optimisation with no behavioural change for current callers; the new WASM interfaces are declaration-only and not yet wired up. The only design note is the `headers`-in-optional-`ops` shape in `PTableV12.export()`, which is a future-facing interface with no current callers.

lib/model/middle-layer/src/pframe/internal_api/table.ts — the `PTableV12.export()` signature deserves a second look before callers adopt it.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pf-driver/src/pframe_pool.ts | Adds `columnSpecs` as a `Readonly<Record<PObjectId, PColumnSpec>>` retained from the map built for WASM; uses `Object.create(null)` for safe key-space and assigns the reference directly after building. |
| lib/node/pf-driver/src/driver_impl.ts | Both `getColumnSpec` and the column lookup in `getUniqueValues` now read from the JS-side `columnSpecs` map instead of calling `pFrameSpec.listColumns().find()`; `listColumns` still delegates to WASM. |
| lib/model/middle-layer/src/pframe/internal_api/api_wasm.ts | Adds self-contained `PFrameWasmAPIV5` factory and `PFrameWasmV4` per-frame interface; updates `PFrameWasmV3.listColumns` return type from `PColumnInfo[]` to `PColumnIdAndSpec[]`. |
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Adds `PTableV12` with `export()` where `headers` is required inside an optional `ops` bag — makes it impossible to pass only an `AbortSignal`. |
| lib/model/middle-layer/src/pframe/internal_api/api_read.ts | Adds `PFrameReadAPIV15` self-contained read interface backed by `PTableV12`; structure mirrors V14 except for the updated table type. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PFramePool.getByKey(handle)"] --> B["PFrameHolder"]
    B --> C["pFrameSpec: PFrameWasmV3\n(WASM spec frame)"]
    B --> D["columnSpecs: Readonly<Record<PObjectId, PColumnSpec>>\n(JS-side map, new)"]
    B --> E["pFrameDataPromise: Promise<PFrameV17>\n(data layer)"]
    F["getColumnSpec(handle, id)"] -->|"O(1) map read"| D
    G["getUniqueValues(handle, req)"] -->|"O(1) map read"| D
    H["listColumns(handle)"] -->|"still calls WASM"| C
    I["PFrameWasmAPIV5 (new)"] -->|"createPFrame()"| J["PFrameWasmV4 (new)\n+ getColumn(id): PColumnIdAndSpec | null\n+ listColumns(): PColumnIdAndSpec[]"]
    K["PFrameWasmAPIV4 (existing)"] -->|"createPFrame()"| L["PFrameWasmV3 (updated)\nlistColumns(): PColumnIdAndSpec[]"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pf-driver/src/driver_impl.ts`, line 461-467 ([link](https://github.com/milaboratory/platforma/blob/51c4c8e0f37cc573e1d9f75ac649ebd11a31c1e2/lib/node/pf-driver/src/driver_impl.ts#L461-L467)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`getColumnSpec` and `listColumns` now return specs from different sources**

   `getColumnSpec` (line 461-462) returns the JS-side `resolveAnnotationParents` result stored in `columnSpecs`, while `listColumns` (line 465-467) still calls `pFrameSpec.listColumns()` and returns WASM's round-tripped view of the same spec. If the WASM layer ever normalises, enriches, or drops fields during round-trip serialisation, a caller comparing results from both methods on the same column id will observe different `PColumnSpec` values. The PR notes this is "equivalent for current consumers", but the behavioural contract between these two public methods now implicitly depends on WASM being a no-op serialisation round-trip.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pf-driver/src/driver_impl.ts
   Line: 461-467

   Comment:
   **`getColumnSpec` and `listColumns` now return specs from different sources**

   `getColumnSpec` (line 461-462) returns the JS-side `resolveAnnotationParents` result stored in `columnSpecs`, while `listColumns` (line 465-467) still calls `pFrameSpec.listColumns()` and returns WASM's round-tripped view of the same spec. If the WASM layer ever normalises, enriches, or drops fields during round-trip serialisation, a caller comparing results from both methods on the same column id will observe different `PColumnSpec` values. The PR notes this is "equivalent for current consumers", but the behavioural contract between these two public methods now implicitly depends on WASM being a no-op serialisation round-trip.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/model/middle-layer/src/pframe/internal_api/table.ts:148-154
**`signal` cannot be passed without `headers`**

`headers` is required inside the optional `ops` bag, so `table.export(path, { signal: abortSignal })` is a TypeScript compile error — callers that only need cancellation support are forced to provide headers too. Every other async method on this table (`getFootprint`, `getShape`, `getData`) places `signal` at the top level of the optional ops bag and can receive it independently. Making `headers` optional within ops (or keeping it as a required positional argument like `PTableV11`) would restore that symmetry and avoid surprising callers.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(pframes): add V12 PTable / V15 read..."](https://github.com/milaboratory/platforma/commit/65cdc71604223dc991802d0ff1da365af31b16b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36396725)</sub>

<!-- /greptile_comment -->