### PR TITLE
feat(model): add getNumberOfRows for PColumn

### DIFF
--- a/.changeset/pcolumn-get-number-of-rows.md
+++ b/.changeset/pcolumn-get-number-of-rows.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": minor
+---
+
+Add `getNumberOfRows(data)` helper returning a PColumn's row count as `number | undefined`. Sums per-chunk `stats.numberOfRows` for `ParquetPartitioned` columns (no blob download) and counts entries for inline `Json` / `PColumnValues` data; returns `undefined` for `JsonPartitioned`/`BinaryPartitioned`, when data is still computing, or when any parquet chunk lacks the stat.

--- a/etc/blocks/model-test/model/src/index.ts
+++ b/etc/blocks/model-test/model/src/index.ts
@@ -4,6 +4,7 @@ import {
   PluginModel,
   createPlDataTable,
   createPlDataTableStateV2,
+  getNumberOfRows,
   type PlDataTableStateV2,
   type PluginName,
   type InferHrefType,
@@ -140,6 +141,12 @@ export const platforma = BlockModelV3.create(blockDataModel)
   .output("blockSpecFrameTest", (ctx) => {
     ctx.getService("pframeSpec").createSpecFrame({});
     return `blockSpecFrame: created (auto-disposed)`;
+  })
+
+  // Row count of the workflow's parquet column, via getNumberOfRows over the real accessor.
+  .output("parquetRowCount", (ctx) => {
+    const columns = ctx.outputs?.resolve("parquetFrame")?.getPColumns();
+    return columns?.length && getNumberOfRows(columns[0].data);
   })
 
   .outputWithStatus("blockTableTest", (ctx) => {

--- a/etc/blocks/model-test/model/src/index.ts
+++ b/etc/blocks/model-test/model/src/index.ts
@@ -146,7 +146,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   // Row count of the workflow's parquet column, via getNumberOfRows over the real accessor.
   .output("parquetRowCount", (ctx) => {
     const columns = ctx.outputs?.resolve("parquetFrame")?.getPColumns();
-    return columns?.length && getNumberOfRows(columns[0].data);
+    return columns?.length ? getNumberOfRows(columns[0].data) : undefined;
   })
 
   .outputWithStatus("blockTableTest", (ctx) => {

--- a/etc/blocks/model-test/test/src/wf.test.ts
+++ b/etc/blocks/model-test/test/src/wf.test.ts
@@ -80,6 +80,13 @@ blockTest(
       stable: true,
     });
 
+    // getNumberOfRows over the real parquet column (TSV has 3 data rows).
+    expect(blockState.outputs?.parquetRowCount).toStrictEqual({
+      ok: true,
+      value: 3,
+      stable: true,
+    });
+
     // Plugin outputs are keyed with a prefix — access via plain record
     const outputs = blockState.outputs as Record<string, unknown> | undefined;
 

--- a/etc/blocks/model-test/workflow/src/main.tpl.tengo
+++ b/etc/blocks/model-test/workflow/src/main.tpl.tengo
@@ -48,11 +48,33 @@ wf.body(func(args) {
 		partitionKeyLength: 0
 	})
 
+	// Parquet variant: exercises getNumberOfRows on a real ParquetPartitioned column.
+	pfParquet := xsv.importFile(tsvFile, "tsv", {
+		axes: [{
+			column: "item",
+			spec: {
+				name: "item",
+				type: "String"
+			}
+		}],
+		columns: [{
+			column: "score",
+			id: "score",
+			spec: {
+				name: "mock_score",
+				valueType: "Int"
+			}
+		}],
+		storageFormat: "Parquet",
+		partitionKeyLength: 0
+	})
+
 	return {
 		outputs: {
 			theOutput: args.tagToWorkflow,
 			delayedContent: result.getStdoutContent(),
-			tableFrame: pframes.exportFrame(pf)
+			tableFrame: pframes.exportFrame(pf),
+			parquetFrame: pframes.exportFrame(pfParquet)
 		},
 		exports: {}
 	}

--- a/sdk/model/src/render/util/pcolumn_data.test.ts
+++ b/sdk/model/src/render/util/pcolumn_data.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, expect, test, vi } from "vitest";
+import type {
+  DataInfo,
+  ParquetChunkMetadata,
+  PColumnValues,
+} from "@milaboratories/pl-model-common";
+import * as internal from "../../internal";
+import type { AccessorHandle } from "../internal";
+import { TreeNodeAccessor } from "../accessor";
+import {
+  getNumberOfRows,
+  RT_JSON_PARTITIONED,
+  RT_PARQUET_PARTITIONED,
+  RT_PARQUET_SUPER_PARTITIONED,
+} from "./pcolumn_data";
+
+type RenderCtx = ReturnType<typeof internal.getCfgRenderCtx>;
+
+/**
+ * Fake resource in a mocked resource tree.
+ * - `type`   — resource type name (e.g. {@link RT_PARQUET_PARTITIONED}).
+ * - `data`   — the resource's own JSON payload (what `getDataAsString` returns).
+ *              For a ParquetChunk resource this is the {@link ParquetChunkMetadata}.
+ * - `fields` — input fields: stringified partition key → child handle.
+ * - `ready`  — readiness flag (default true).
+ */
+type FakeResource = {
+  type: string;
+  data?: unknown;
+  fields?: Record<string, string>;
+  ready?: boolean;
+};
+
+/**
+ * Builds a handle-dispatched render context over a fake resource tree, so a
+ * `TreeNodeAccessor` rooted at `topHandle` walks real partition fields and reads
+ * real chunk metadata — the same path a parquet PColumn takes at runtime.
+ */
+function accessorOver(tree: Record<string, FakeResource>, topHandle: string): TreeNodeAccessor {
+  const get = (h: AccessorHandle): FakeResource => {
+    const r = tree[h as string];
+    if (r === undefined) throw new Error(`no fake resource for handle ${String(h)}`);
+    return r;
+  };
+  const ctx: Partial<RenderCtx> = {
+    getIsReadyOrError: (h) => get(h).ready ?? true,
+    getError: () => undefined,
+    getResourceType: (h) => ({ name: get(h).type, version: "1" }),
+    getInputsLocked: () => true,
+    getDataAsString: (h) => {
+      const data = get(h).data;
+      return data === undefined ? undefined : JSON.stringify(data);
+    },
+    listInputFields: (h) => Object.keys(get(h).fields ?? {}),
+    resolveWithCommon: (h, _common, ...steps) => {
+      const step = steps[0];
+      const field = typeof step === "string" ? step : step.field;
+      return get(h).fields?.[field] as AccessorHandle | undefined;
+    },
+  };
+  vi.spyOn(internal, "getCfgRenderCtx").mockReturnValue(ctx as RenderCtx);
+  return new TreeNodeAccessor(topHandle as AccessorHandle, []);
+}
+
+/** Realistic ParquetChunk resource payload with a row count. */
+function chunkMeta(numberOfRows: number): ParquetChunkMetadata {
+  return {
+    dataDigest: `digest-${numberOfRows}`,
+    stats: {
+      numberOfRows,
+      size: { axes: [8 * numberOfRows], column: 4 * numberOfRows },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("getNumberOfRows sums chunk row counts for a real parquet partitioned column", () => {
+  // Tree: ParquetPartitioned root with two partition fields, each pointing at a
+  // ParquetChunk resource whose own JSON payload carries stats.numberOfRows.
+  const acc = accessorOver(
+    {
+      top: {
+        type: RT_PARQUET_PARTITIONED,
+        data: { partitionKeyLength: 1 },
+        fields: { '["s1"]': "chunkA", '["s2"]': "chunkB" },
+      },
+      chunkA: { type: "PColumnData/ParquetChunk", data: chunkMeta(100) },
+      chunkB: { type: "PColumnData/ParquetChunk", data: chunkMeta(50) },
+    },
+    "top",
+  );
+
+  expect(getNumberOfRows(acc)).toBe(150);
+});
+
+test("getNumberOfRows sums across super partitions for a parquet super-partitioned column", () => {
+  const acc = accessorOver(
+    {
+      topSuper: {
+        type: RT_PARQUET_SUPER_PARTITIONED,
+        data: { superPartitionKeyLength: 1, partitionKeyLength: 1 },
+        fields: { '["g1"]': "innerP", '["g2"]': "innerQ" },
+      },
+      innerP: {
+        type: RT_PARQUET_PARTITIONED,
+        data: { partitionKeyLength: 1 },
+        fields: { '["s1"]': "chunkA" },
+      },
+      innerQ: {
+        type: RT_PARQUET_PARTITIONED,
+        data: { partitionKeyLength: 1 },
+        fields: { '["s1"]': "chunkB", '["s2"]': "chunkC" },
+      },
+      chunkA: { type: "PColumnData/ParquetChunk", data: chunkMeta(10) },
+      chunkB: { type: "PColumnData/ParquetChunk", data: chunkMeta(20) },
+      chunkC: { type: "PColumnData/ParquetChunk", data: chunkMeta(30) },
+    },
+    "topSuper",
+  );
+
+  expect(getNumberOfRows(acc)).toBe(60);
+});
+
+test("getNumberOfRows returns undefined when any parquet chunk lacks stats.numberOfRows", () => {
+  const acc = accessorOver(
+    {
+      top: {
+        type: RT_PARQUET_PARTITIONED,
+        data: { partitionKeyLength: 1 },
+        fields: { '["s1"]': "chunkA", '["s2"]': "chunkB" },
+      },
+      chunkA: { type: "PColumnData/ParquetChunk", data: chunkMeta(100) },
+      // stats omitted entirely (it is Partial on the chunk metadata).
+      chunkB: { type: "PColumnData/ParquetChunk", data: { dataDigest: "no-stats" } },
+    },
+    "top",
+  );
+
+  expect(getNumberOfRows(acc)).toBeUndefined();
+});
+
+test("getNumberOfRows returns undefined while a parquet column is still computing", () => {
+  const acc = accessorOver(
+    {
+      top: {
+        type: RT_PARQUET_PARTITIONED,
+        data: { partitionKeyLength: 1 },
+        fields: { '["s1"]': "chunkA" },
+        ready: false,
+      },
+      chunkA: { type: "PColumnData/ParquetChunk", data: chunkMeta(100) },
+    },
+    "top",
+  );
+
+  expect(getNumberOfRows(acc)).toBeUndefined();
+});
+
+test("getNumberOfRows returns undefined for JsonPartitioned (counts live in opaque blobs)", () => {
+  const acc = accessorOver(
+    {
+      top: {
+        type: RT_JSON_PARTITIONED,
+        data: { partitionKeyLength: 1 },
+        fields: { '["s1"]': "blobA", '["s2"]': "blobB" },
+      },
+      blobA: { type: "Blob", data: {} },
+      blobB: { type: "Blob", data: {} },
+    },
+    "top",
+  );
+
+  expect(getNumberOfRows(acc)).toBeUndefined();
+});
+
+test("getNumberOfRows counts entries of an inline Json DataInfo", () => {
+  const json: DataInfo<TreeNodeAccessor> = {
+    type: "Json",
+    keyLength: 1,
+    data: { '["a"]': 1, '["b"]': 2, '["c"]': 3 },
+  };
+
+  expect(getNumberOfRows(json)).toBe(3);
+});
+
+test("getNumberOfRows counts inline explicit values", () => {
+  const values: PColumnValues = [
+    { key: ["a"], val: 1 },
+    { key: ["b"], val: 2 },
+  ];
+
+  expect(getNumberOfRows(values)).toBe(2);
+});
+
+test("getNumberOfRows returns undefined for undefined data", () => {
+  expect(getNumberOfRows(undefined)).toBeUndefined();
+});

--- a/sdk/model/src/render/util/pcolumn_data.ts
+++ b/sdk/model/src/render/util/pcolumn_data.ts
@@ -1,5 +1,6 @@
 import type {
   DataInfo,
+  ParquetChunkMetadata,
   PartitionedDataInfoEntries,
   PColumn,
   PColumnLazy,
@@ -543,6 +544,61 @@ export function convertOrParsePColumnData(
   if (acc instanceof TreeNodeAccessor) return parsePColumnData(acc);
 
   throw new Error(`Unexpected input type: ${typeof acc}`);
+}
+
+/**
+ * Returns the total number of rows in a PColumn, or `undefined` when the count
+ * cannot be determined without downloading data blobs.
+ *
+ * Derivable cases:
+ * - Inline values ({@link PColumnValues}): one entry per row.
+ * - Inline `Json` {@link DataInfo}: one entry per row.
+ * - Parquet (`ParquetPartitioned` / `ParquetSuperPartitioned`): summed from
+ *   each chunk's precomputed {@link ParquetChunkMetadata.stats} `numberOfRows`,
+ *   read from the chunk resource metadata without downloading the parquet files.
+ *
+ * Returns `undefined` when:
+ * - the data is `undefined` or still computing / not ready,
+ * - the data is `JsonPartitioned` or `BinaryPartitioned` (per-part row counts
+ *   live inside opaque blobs and are not readable here),
+ * - any parquet chunk is missing `stats.numberOfRows`.
+ *
+ * Note: do not confuse row count with `keyLength` / `partitionKeyLength`, which
+ * are axis-tuple lengths, not row counts.
+ */
+export function getNumberOfRows(data: PColumnDataUniversal | undefined): number | undefined {
+  if (data === undefined) return undefined;
+
+  // Inline explicit values: one entry per row.
+  if (Array.isArray(data)) return data.length;
+
+  const entries = convertOrParsePColumnData(data);
+  if (entries === undefined) return undefined;
+
+  switch (entries.type) {
+    case "Json":
+      // Inline Json: one entry per row.
+      return entries.data.length;
+
+    case "JsonPartitioned":
+    case "BinaryPartitioned":
+      // Per-part row counts live inside opaque blobs; not knowable without download.
+      return undefined;
+
+    case "ParquetPartitioned": {
+      let total = 0;
+      for (const { value } of entries.parts) {
+        // The part accessor points at a ParquetChunk resource whose JSON payload
+        // is ParquetChunkMetadata. Reading it does not download the parquet file
+        // (the file lives in a separate `blob` sub-field of the chunk resource).
+        const rows = value.getDataAsJsonOrUndefined<ParquetChunkMetadata>()?.stats?.numberOfRows;
+        // stats / numberOfRows are Partial: if any chunk lacks it, the total is unknowable.
+        if (typeof rows !== "number") return undefined;
+        total += rows;
+      }
+      return total;
+    }
+  }
 }
 
 export function isPColumnReady(

--- a/sdk/model/src/render/util/pcolumn_data.ts
+++ b/sdk/model/src/render/util/pcolumn_data.ts
@@ -7,6 +7,7 @@ import type {
   PColumnValues,
 } from "@milaboratories/pl-model-common";
 import {
+  assertNever,
   dataInfoToEntries,
   isDataInfo,
   isDataInfoEntries,
@@ -598,6 +599,9 @@ export function getNumberOfRows(data: PColumnDataUniversal | undefined): number 
       }
       return total;
     }
+
+    default:
+      assertNever(entries);
   }
 }
 


### PR DESCRIPTION
## What

Adds `getNumberOfRows(data: PColumnDataUniversal | undefined): number | undefined` to `@platforma-sdk/model` (`sdk/model/src/render/util/pcolumn_data.ts`), for use in block models.

Row count is derived by data variant:

| Variant | Result |
|---|---|
| inline `PColumnValues` | entry count |
| inline `Json` `DataInfo` | entry count |
| `ParquetPartitioned` / super-partitioned | sum of per-chunk `stats.numberOfRows`, read from chunk metadata **without downloading blobs** |
| `JsonPartitioned` / `BinaryPartitioned` | `undefined` (counts live inside opaque blobs) |
| still computing / missing chunk stat / `undefined` input | `undefined` |

`numberOfRows` is always present in real `pt`/xsv-import parquet (written by the Rust pframes engine), so the parquet path returns a real count in practice.

## Tests

- **Unit** (`pcolumn_data.test.ts`, mocked render ctx) — exhaustive per-variant coverage incl. the `undefined` contract (partitioned-blob formats, missing stats, not-ready).
- **Block e2e** (`etc/blocks/model-test`) — the model output `parquetRowCount` calls `getNumberOfRows` inside the real model VM over a `pt`-generated `ParquetPartitioned` column; asserts `3`. Workflow gains a parquet export (`parquetFrame`) alongside the existing Binary frame.

Both green against a local backend.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `getNumberOfRows(data: PColumnDataUniversal | undefined): number | undefined` to `@platforma-sdk/model`, giving block models a way to read row counts from parquet columns without downloading blobs, and from inline `Json`/`PColumnValues` data by counting entries.

- **Core helper** (`pcolumn_data.ts`): sums `stats.numberOfRows` across all `ParquetPartitioned` chunk resources, counts entries for inline `Json`/`PColumnValues`, and returns `undefined` for `JsonPartitioned`/`BinaryPartitioned` or any not-ready/missing-stat state.
- **Unit tests** (`pcolumn_data.test.ts`): exhaustive per-variant coverage via a mock render context, including both flat and super-partitioned layouts and all `undefined` contracts.
- **Block e2e** (`model-test`): a new `parquetFrame` workflow output exercises `getNumberOfRows` over a real `ParquetPartitioned` accessor and asserts a row count of 3.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the new helper is well-tested and the identified issues are edge cases that do not affect the described use-case.

The logic in getNumberOfRows is correct for all documented data variants, and test coverage is thorough. The two flagged items are: the && idiom in the model output that returns 0 instead of undefined when getPColumns() resolves to an empty array, and the absence of an assertNever guard in the switch statement.

etc/blocks/model-test/model/src/index.ts (columns?.length && ... pattern) and sdk/model/src/render/util/pcolumn_data.ts (switch exhaustiveness guard).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/render/util/pcolumn_data.ts | Adds getNumberOfRows helper; switch handles all 4 DataInfoEntries variants correctly but lacks an assertNever default guard for future-proofing. |
| sdk/model/src/render/util/pcolumn_data.test.ts | Comprehensive unit tests covering all data variants, edge cases (missing stats, not-ready, undefined), and both parquet levels (partitioned + super-partitioned). |
| etc/blocks/model-test/model/src/index.ts | Adds parquetRowCount output using getNumberOfRows; the columns?.length && ... pattern returns 0 instead of undefined when getPColumns() yields an empty array. |
| etc/blocks/model-test/test/src/wf.test.ts | Adds e2e assertion for parquetRowCount === 3 over a TSV with 3 data rows, verifying the real accessor path end-to-end. |
| etc/blocks/model-test/workflow/src/main.tpl.tengo | Adds a second xsv.importFile call with Parquet storageFormat to produce parquetFrame alongside the existing binary tableFrame. |
| .changeset/pcolumn-get-number-of-rows.md | Correct minor-version changeset entry for @platforma-sdk/model describing the new helper accurately. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getNumberOfRows(data)"] --> B{data === undefined?}
    B -- yes --> Z["return undefined"]
    B -- no --> C{Array.isArray?}
    C -- yes --> D["return data.length\n(PColumnValues)"]
    C -- no --> E["convertOrParsePColumnData(data)\n→ DataInfoEntries"]
    E --> F{entries === undefined?}
    F -- yes --> Z
    F -- no --> G{entries.type}
    G -- Json --> H["return entries.data.length"]
    G -- JsonPartitioned\nBinaryPartitioned --> Z
    G -- ParquetPartitioned --> I["iterate entries.parts"]
    I --> J{chunk.stats.numberOfRows\nexists?}
    J -- missing in any chunk --> Z
    J -- all present --> K["return Σ numberOfRows"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
etc/blocks/model-test/model/src/index.ts:149
When `getPColumns()` resolves but returns an empty array, `columns?.length` is `0` — a falsy number — so the `&&` short-circuits and the output becomes `0` (not `undefined`). A `0` return value looks like "zero rows" to callers, but the intent here is "result unavailable". Using `columns?.length ? ... : undefined` makes the two cases explicit.

```suggestion
    return columns?.length ? getNumberOfRows(columns[0].data) : undefined;
```

### Issue 2 of 2
sdk/model/src/render/util/pcolumn_data.ts:588-602
The `switch` on `entries.type` covers all four current `DataInfoEntries` variants, so it is exhaustive today. Adding a `default: assertNever(entries)` guard would cause a compile error if a new variant is introduced without updating this function, preventing a silent `undefined` return.

```suggestion
    case "ParquetPartitioned": {
      let total = 0;
      for (const { value } of entries.parts) {
        // The part accessor points at a ParquetChunk resource whose JSON payload
        // is ParquetChunkMetadata. Reading it does not download the parquet file
        // (the file lives in a separate `blob` sub-field of the chunk resource).
        const rows = value.getDataAsJsonOrUndefined<ParquetChunkMetadata>()?.stats?.numberOfRows;
        // stats / numberOfRows are Partial: if any chunk lacks it, the total is unknowable.
        if (typeof rows !== "number") return undefined;
        total += rows;
      }
      return total;
    }

    default:
      assertNever(entries);
  }
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(model): add getNumberOfRows for PCo..."](https://github.com/milaboratory/platforma/commit/d4622fa00b7692f24b8876e1299fa42a596eb81c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36457552)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->