### PR TITLE
feat(pframes): add V18 PFrame / V9 factory node interfaces

### DIFF
--- a/.changeset/pframe-v18-factory-v9.md
+++ b/.changeset/pframe-v18-factory-v9.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+---
+
+PFrames internal API: add self-contained `PFrameV18` and `PFrameFactoryV9` node interfaces that wire the V15 read side into the combined frame/factory surface. `PFrameV18` combines `PFrameFactoryAPIV6` with `PFrameReadAPIV15` (whose tables' `export` takes an ordered `[columnIndex, headerName][]` list); `PFrameFactoryV9.createPFrame` returns `PFrameV18`. They supersede `PFrameV17` / `PFrameFactoryV8` and will replace them once the new PFrames build is adopted.

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,5 +1,5 @@
 import type { PFrameFactoryAPIV6 } from "./api_factory";
-import type { PFrameReadAPIV14 } from "./api_read";
+import type { PFrameReadAPIV14, PFrameReadAPIV15 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
@@ -10,6 +10,18 @@ import type { PFrameId } from "./common";
  * column-index → header map.
  */
 export interface PFrameV17 extends PFrameFactoryAPIV6, PFrameReadAPIV14 {}
+
+/**
+ * Full PFrame surface — factory operations plus data-side reads. Exposes
+ * the self-contained {@link PFrameFactoryAPIV6} (column `typeSpec` embedded in
+ * `data`) plus {@link PFrameReadAPIV15}, whose tables' `export` takes an
+ * `ops.headers` list of `[column index, header name]` pairs.
+ *
+ * Same surface as {@link PFrameV17}; the only change is that the read side is
+ * upgraded from {@link PFrameReadAPIV14} to {@link PFrameReadAPIV15}, so
+ * {@link PFrameReadAPIV15.createTable} returns {@link PTableV12}.
+ */
+export interface PFrameV18 extends PFrameFactoryAPIV6, PFrameReadAPIV15 {}
 
 export type PFrameOptionsV2 = {
   /** PFrame ID for logging purposes */
@@ -30,6 +42,31 @@ export interface PFrameFactoryV8 {
    * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
    */
   createPFrame(options: PFrameOptionsV2): PFrameV17;
+
+  /**
+   * Dump active allocations from all PFrames instances in pprof format.
+   * The result of this function should be saved as `profile.pb.gz`.
+   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
+   * to view the allocation flamechart.
+   * @warning This method will always reject on Windows!
+   */
+  pprofDump: () => Promise<Uint8Array>;
+}
+
+/**
+ * PFrame management functions exposed by the PFrame module. Creates
+ * {@link PFrameV18} instances (self-contained column data info).
+ *
+ * Same surface as {@link PFrameFactoryV8}; the only change is that
+ * {@link PFrameFactoryV9.createPFrame} returns {@link PFrameV18}, whose tables'
+ * `export` takes an `ops.headers` list of `[column index, header name]` pairs.
+ */
+export interface PFrameFactoryV9 {
+  /**
+   * Create a new PFrame instance.
+   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
+   */
+  createPFrame(options: PFrameOptionsV2): PFrameV18;
 
   /**
    * Dump active allocations from all PFrames instances in pprof format.


### PR DESCRIPTION
## What

Adds the missing combined node PFrame interfaces that wire the freshly-published V15 read side (1.30.2) into the frame/factory surface:

- **`PFrameV18`** = `PFrameFactoryAPIV6` + `PFrameReadAPIV15` — same surface as `PFrameV17`, but the read side is upgraded so `createTable` returns `PTableV12` (whose `export` takes an ordered `[columnIndex, headerName][]` list in `ops.headers` instead of a positional `Record<number, string>` map).
- **`PFrameFactoryV9`** — same surface as `PFrameFactoryV8`, but `createPFrame` returns `PFrameV18`.

They supersede `PFrameV17` / `PFrameFactoryV8` and will replace them once the new PFrames build is adopted.

## Why

1.30.2 published the leaf interfaces `PFrameReadAPIV15` / `PTableV12`, but no combined `PFrameV18` / `PFrameFactoryV9` to carry them through the factory chain. `PFrameV17` is still wired to `PFrameReadAPIV14` / `PTableV11`, so the `pframes-rs` node addon (which implements the combined `PFrameV17` and types its factory as `PFrameFactoryV8`) has no published top-level interface to migrate to. This PR closes that gap so node can adopt the V12 `export` signature, matching the existing combined-interface convention.

## Notes

- Additive only — no existing interface changed. Includes a `patch` changeset for `@milaboratories/pl-model-middle-layer`.
- Verified: `types:check`, `formatter:check`, and `build` pass; `PFrameV18` / `PFrameFactoryV9` are present in the built barrel `dist/pframe/internal_api/index.d.ts`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds two new combined PFrame interfaces — `PFrameV18` and `PFrameFactoryV9` — that wire the already-published `PFrameReadAPIV15` / `PTableV12` leaf interfaces into the top-level frame/factory surface, closing the gap left after v1.30.2. No existing interface is modified.

- **`PFrameV18`** extends `PFrameFactoryAPIV6` + `PFrameReadAPIV15`, upgrading the read side so `createTable` returns `PTableV12` (whose `export` accepts an ordered `[columnIndex, headerName][]` list in `ops.headers` instead of a positional `Record<number, string>` map).
- **`PFrameFactoryV9`** mirrors `PFrameFactoryV8` exactly, with `createPFrame` returning `PFrameV18` instead of `PFrameV17`; a `patch` changeset is included for `@milaboratories/pl-model-middle-layer`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Purely additive type declarations with no runtime code; existing interfaces and consumers are untouched.

Both changed files are additive only — new TypeScript interface declarations that do not alter any existing interface, implementation, or export. The new interfaces correctly compose the already-published PFrameFactoryAPIV6 and PFrameReadAPIV15 building blocks, the JSDoc is accurate and internally consistent, and the changeset targets the correct package at the correct bump level.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/pframe/internal_api/pframe.ts | Adds PFrameV18 (PFrameFactoryAPIV6 + PFrameReadAPIV15) and PFrameFactoryV9 (createPFrame returns PFrameV18); strictly additive, no existing interface touched beyond the import line. |
| .changeset/pframe-v18-factory-v9.md | Patch-level changeset for @milaboratories/pl-model-middle-layer describing the new V18/V9 interfaces; content is accurate and matches the code change. |

</details>

</details>

<details><summary><h3>Class Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class PFrameFactoryAPIV6 {
        <<interface>>
    }
    class PFrameReadAPIV14 {
        <<interface>>
        +createTable(tableId, dataQuery) PTableV11
        +getUniqueValues(request, ops) Promise~UniqueValuesResponse~
    }
    class PFrameReadAPIV15 {
        <<interface>>
        +createTable(tableId, dataQuery) PTableV12
        +getUniqueValues(request, ops) Promise~UniqueValuesResponse~
    }
    class PFrameV17 {
        <<interface>>
    }
    class PFrameV18 {
        <<interface, NEW>>
    }
    class PFrameFactoryV8 {
        <<interface>>
        +createPFrame(options) PFrameV17
        +pprofDump() Promise~Uint8Array~
    }
    class PFrameFactoryV9 {
        <<interface, NEW>>
        +createPFrame(options) PFrameV18
        +pprofDump() Promise~Uint8Array~
    }

    PFrameV17 --|> PFrameFactoryAPIV6
    PFrameV17 --|> PFrameReadAPIV14
    PFrameV18 --|> PFrameFactoryAPIV6
    PFrameV18 --|> PFrameReadAPIV15
    PFrameFactoryV8 ..> PFrameV17 : creates
    PFrameFactoryV9 ..> PFrameV18 : creates
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframes): add V18 PFrame / V9 facto..."](https://github.com/milaboratory/platforma/commit/f7c21df7df8bd295dbcf054fdf1c414ea3cf842e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36653238)</sub>

<!-- /greptile_comment -->