### PR TITLE
Fix: do not use swinfo blobref

### DIFF
--- a/.changeset/beige-ends-ask.md
+++ b/.changeset/beige-ends-ask.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Do not use 'blobRef' from software info. It never had non-empty value

--- a/lib/node/pl-drivers/src/drivers/ls.test.ts
+++ b/lib/node/pl-drivers/src/drivers/ls.test.ts
@@ -55,13 +55,19 @@ test("should ok when list files from remote storage in ls driver", async () => {
     expect(testDir!.name).toEqual("ls_dir_structure_test");
 
     const secondDirs = await driver.listFiles(library, testDir!.fullPath);
-    expect(secondDirs.entries).toHaveLength(2);
+    expect(
+      secondDirs.entries,
+      `unexpected entries for ${testDir!.fullPath}: ${JSON.stringify(secondDirs.entries, null, 2)}`,
+    ).toHaveLength(2);
     expect(secondDirs.entries[0].type).toEqual("dir");
     expect(universalPath(secondDirs.entries[0].fullPath)).toEqual("ls_dir_structure_test/abc");
     expect(secondDirs.entries[0].name).toEqual("abc");
 
     const f = await driver.listFiles(library, secondDirs.entries[0].fullPath);
-    expect(f.entries).toHaveLength(1);
+    expect(
+      f.entries,
+      `unexpected entries for ${secondDirs.entries[0].fullPath}: ${JSON.stringify(f.entries, null, 2)}`,
+    ).toHaveLength(1);
     expect(f.entries[0].type).toEqual("file");
     expect(universalPath(f.entries[0].fullPath)).toEqual("ls_dir_structure_test/abc/42.txt");
     expect(f.entries[0].name).toEqual("42.txt");

--- a/sdk/workflow-tengo/src/assets/index.lib.tengo
+++ b/sdk/workflow-tengo/src/assets/index.lib.tengo
@@ -41,7 +41,6 @@ importAsset := func(assetName) {
 		resource: smart.resource(asset.id),
 		name: asset.name,
 		version: asset.version,
-		blobRef: asset.blobRef,
 		descriptor: ll.toStrict(json.decode(asset.descriptor)) // raw sw.json data with asset entrypoint descriptor
 	})
 }

--- a/sdk/workflow-tengo/src/assets/swinfo.lib.tengo
+++ b/sdk/workflow-tengo/src/assets/swinfo.lib.tengo
@@ -19,7 +19,6 @@ newSoftwareInfo := func(sw) {
 		resource: smart.resource(sw.id),
 		name: sw.name,
 		version: sw.version,
-		blobRef: sw.blobRef,
 		descriptor: ll.toStrict(json.decode(sw.descriptor)) // raw sw.json data with software entrypoint descriptor
 	})
 }

--- a/tests/workflow-tengo/src/assets/assets.test.ts
+++ b/tests/workflow-tengo/src/assets/assets.test.ts
@@ -14,7 +14,6 @@ tplTest.concurrent("software-metadata-loads", async ({ helper, expect }) => {
   const val = (await mainResult.awaitStableValue()) as {
     name: string;
     version: string;
-    blobRef: any;
     descriptor: any;
     execs: string[];
   };
@@ -22,7 +21,6 @@ tplTest.concurrent("software-metadata-loads", async ({ helper, expect }) => {
   expect(val.name).eq("@platforma-sdk/workflow-tengo-tests:assets.software-meta");
   expect(val.version).not.eq("");
   expect(val.execs.length).gt(0);
-  expect(val).toHaveProperty("blobRef");
   expect(val).toHaveProperty("descriptor");
 });
 
@@ -33,14 +31,12 @@ tplTest.concurrent("asset-metadata-loads", async ({ helper, expect }) => {
   const val = (await mainResult.awaitStableValue()) as {
     name: string;
     version: string;
-    blobRef: any;
     descriptor: any;
     execs: string[];
   };
 
   expect(val.name).eq("@platforma-sdk/workflow-tengo-tests:assets.asset-meta");
   expect(val.version).not.eq("");
-  expect(val).toHaveProperty("blobRef");
   expect(val).toHaveProperty("descriptor");
 });
 

--- a/tests/workflow-tengo/src/assets/import-asset.tpl.tengo
+++ b/tests/workflow-tengo/src/assets/import-asset.tpl.tengo
@@ -11,8 +11,7 @@ self.body(func(inputs) {
 		main: {
 			name: asset.name,
 			version: asset.version,
-			descriptor: ll.fromStrict(asset.descriptor),
-			blobRef: ll.fromStrict(asset.blobRef)
+			descriptor: ll.fromStrict(asset.descriptor)
 		}
 	}
 

--- a/tests/workflow-tengo/src/assets/import-software.tpl.tengo
+++ b/tests/workflow-tengo/src/assets/import-software.tpl.tengo
@@ -12,7 +12,6 @@ self.body(func(inputs) {
 			name: sw.name,
 			version: sw.version,
 			descriptor: ll.fromStrict(sw.descriptor),
-			blobRef: ll.fromStrict(sw.blobRef),
 			execs: ll.getExecutorsList()
 		}
 	}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the `blobRef` field from the software info object in `swinfo.lib.tengo`, since it was always populated with an empty value by the backend. It also adds richer failure messages to two test assertions in `ls.test.ts` to improve CI debugging.

- **`swinfo.lib.tengo`**: Drops `blobRef` from the `ll.toStrict`-wrapped map returned by `newSoftwareInfo`/`importSoftware`. Because `ll.toStrict` panics on access to missing keys, any code still reading `sw.blobRef` will fail at runtime.
- **`ls.test.ts`**: Enhances `toHaveLength` assertions with JSON-serialized entry payloads as the failure message — a pure test ergonomics improvement.
- **`.changeset/beige-ends-ask.md`**: Registers a patch release for `@platforma-sdk/workflow-tengo`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core library change is correct, but the test template that directly consumes sw.blobRef was not updated and will throw a runtime panic every time the software-metadata-loads test runs.

The import-software.tpl.tengo test template and the matching assertion in assets.test.ts both still reference sw.blobRef, which no longer exists in the strict map. Because ll.toStrict panics on missing key access, the test will error out rather than fail gracefully, and CI will be broken for that test suite until both files are updated.

tests/workflow-tengo/src/assets/import-software.tpl.tengo and tests/workflow-tengo/src/assets/assets.test.ts need to be updated to drop the blobRef field and its assertion.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/assets/swinfo.lib.tengo | Removes blobRef from the software info strict map; the field was always empty per the PR description. |
| lib/node/pl-drivers/src/drivers/ls.test.ts | Adds descriptive failure messages to two toHaveLength assertions for easier debugging on CI; no logic change. |
| .changeset/beige-ends-ask.md | Patch-level changeset for @platforma-sdk/workflow-tengo documenting removal of the always-empty blobRef field. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["assets.importSoftware(swName)"] --> B["plapi.getSoftwareInfo(swName)"]
    B --> C["newSoftwareInfo(sw)"]
    C --> D["ll.toStrict({ resource, name, version, descriptor })"]
    D -->|"blobRef REMOVED"| E["strict map — panics on unknown key access"]
    E --> F["import-software.tpl.tengo\nsw.blobRef ← PANIC"]
    E --> G["Other callers\n(no blobRef access) ← OK"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: print list of items in storage in ..."](https://github.com/milaboratory/platforma/commit/3e9d73efece6166740b3f90aa0fc1795447cbcb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36687083)</sub>

<!-- /greptile_comment -->