### PR TITLE
feat(pf-driver): embed inline-column typeSpec into dataInfo before lowering

### DIFF
--- a/.changeset/inline-column-self-contained-typespec.md
+++ b/.changeset/inline-column-self-contained-typespec.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-model-common": patch
+"@milaboratories/pf-driver": patch
+---
+
+Make inline-column data info self-contained: the pf-driver now embeds each inline column's `typeSpec` (`{ axes, column }`) into its `dataInfo` before query lowering, so the data layer no longer relies on the inline column's `spec` field for type information. `ColumnIdAndTypeSpec.spec` is changed to the singular `ColumnTypeSpec` to match the data-layer wire format.

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -17,6 +17,18 @@ export type TypeSpec = {
   columns: ColumnValueType[];
 };
 
+/**
+ * Structural type information for a single column: the axis value types (in
+ * order) and the single column value type. Mirrors the self-contained
+ * `typeSpec` shape carried by the data layer (`{ axes, column }`).
+ */
+export type ColumnTypeSpec = {
+  /** List of axis value types defining the dimensions of the data */
+  axes: AxisValueType[];
+  /** The single column value type */
+  column: ColumnValueType;
+};
+
 // ============ Operand Types ============
 
 /**

--- a/lib/model/common/src/drivers/pframe/query/query_data.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_data.ts
@@ -30,7 +30,7 @@ import type {
   QuerySparseToDenseColumn,
   QuerySymmetricJoin,
   QueryTransformColumns,
-  TypeSpec,
+  ColumnTypeSpec,
 } from "./query_common";
 
 /**
@@ -42,8 +42,8 @@ import type {
 type ColumnIdAndTypeSpec = {
   /** Unique identifier of the column */
   id: PObjectId;
-  /** Type specification defining axes and column types */
-  spec: TypeSpec;
+  /** Type specification defining the axes and the single column value type */
+  spec: ColumnTypeSpec;
 };
 
 /**

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -65,6 +65,7 @@ import {
 } from "./pframe_pool";
 import { PTableDefPool } from "./ptable_def_pool";
 import { PTablePool } from "./ptable_pool";
+import { embedInlineColumnTypeSpecs } from "./ptable_shared";
 import {
   PTableCachePerFrame,
   PTableCachePerFrameOpsDefaults,
@@ -239,7 +240,9 @@ export class AbstractPFrameDriver<
     using pFrameGuard = new PoolEntryGuard(this.createPFrame(columns));
     const pFrameSpec = this.pFrames.getByKey(pFrameGuard.key).pFrameSpec;
     const sortedQuery = sortSpecQuery(mapSpecQueryColumns(def.query, (c) => c.id));
-    const { tableSpec, dataQuery } = pFrameSpec.evaluateQuery(sortedQuery);
+    const { tableSpec, dataQuery } = pFrameSpec.evaluateQuery(
+      embedInlineColumnTypeSpecs(sortedQuery),
+    );
 
     using pTableGuard = new PoolEntryGuard(
       this.pTableDefs.acquire({

--- a/lib/node/pf-driver/src/ptable_shared.test.ts
+++ b/lib/node/pf-driver/src/ptable_shared.test.ts
@@ -1,0 +1,81 @@
+import type {
+  JsonDataInfo,
+  PColumnSpec,
+  PObjectId,
+  SpecQuery,
+} from "@milaboratories/pl-model-common";
+import type { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
+import { test } from "vitest";
+import { embedInlineColumnTypeSpecs } from "./ptable_shared";
+
+const COLUMN_SPEC: PColumnSpec = {
+  kind: "PColumn",
+  name: "inline1",
+  valueType: "Int",
+  axesSpec: [
+    { name: "a1", type: "String" },
+    { name: "a2", type: "Long" },
+  ],
+};
+
+function inlineColumnNode(): SpecQuery {
+  return {
+    type: "inlineColumn",
+    spec: { columnId: "col1" as PObjectId, spec: COLUMN_SPEC },
+    dataInfo: { type: "Json", keyLength: 2, data: { '["a",1]': 10 } },
+  };
+}
+
+/** Narrow to an inline column node and expose the (injected) typeSpec. */
+function inlineDataInfo(query: SpecQuery): JsonDataInfo & {
+  typeSpec?: PFrameInternal.PColumnValueTypeSpec;
+} {
+  if (query.type !== "inlineColumn") throw new Error(`expected inlineColumn, got ${query.type}`);
+  return query.dataInfo;
+}
+
+test("embedInlineColumnTypeSpecs injects typeSpec derived from the column spec", ({ expect }) => {
+  const result = embedInlineColumnTypeSpecs(inlineColumnNode());
+  const dataInfo = inlineDataInfo(result);
+
+  // typeSpec is the self-contained { axes, column } shape, derived from the
+  // inline column's PColumnSpec (axis types in order + the value type).
+  expect(dataInfo.typeSpec).toEqual({
+    axes: ["String", "Long"],
+    column: "Int",
+  });
+});
+
+test("embedInlineColumnTypeSpecs preserves existing dataInfo fields", ({ expect }) => {
+  const result = embedInlineColumnTypeSpecs(inlineColumnNode());
+  const dataInfo = inlineDataInfo(result);
+
+  expect(dataInfo.type).toBe("Json");
+  expect(dataInfo.keyLength).toBe(2);
+  expect(dataInfo.data).toEqual({ '["a",1]': 10 });
+});
+
+test("embedInlineColumnTypeSpecs leaves the inline column spec untouched", ({ expect }) => {
+  const result = embedInlineColumnTypeSpecs(inlineColumnNode());
+  if (result.type !== "inlineColumn") throw new Error("expected inlineColumn");
+  expect(result.spec).toEqual({ columnId: "col1" as PObjectId, spec: COLUMN_SPEC });
+});
+
+test("embedInlineColumnTypeSpecs traverses into nested join entries", ({ expect }) => {
+  const query: SpecQuery = {
+    type: "fullJoin",
+    entries: [{ entry: inlineColumnNode(), qualifications: [] }],
+  };
+
+  const result = embedInlineColumnTypeSpecs(query);
+  if (result.type !== "fullJoin") throw new Error("expected fullJoin");
+  const dataInfo = inlineDataInfo(result.entries[0].entry);
+
+  expect(dataInfo.typeSpec).toEqual({ axes: ["String", "Long"], column: "Int" });
+});
+
+test("embedInlineColumnTypeSpecs leaves non-inline nodes unchanged", ({ expect }) => {
+  const query: SpecQuery = { type: "column", column: "col1" as PObjectId };
+  const result = embedInlineColumnTypeSpecs(query);
+  expect(result).toEqual(query);
+});

--- a/lib/node/pf-driver/src/ptable_shared.test.ts
+++ b/lib/node/pf-driver/src/ptable_shared.test.ts
@@ -74,6 +74,30 @@ test("embedInlineColumnTypeSpecs traverses into nested join entries", ({ expect 
   expect(dataInfo.typeSpec).toEqual({ axes: ["String", "Long"], column: "Int" });
 });
 
+test("embedInlineColumnTypeSpecs traverses outerJoin primary and secondary entries", ({
+  expect,
+}) => {
+  const query: SpecQuery = {
+    type: "outerJoin",
+    primary: { entry: inlineColumnNode(), qualifications: [] },
+    secondary: [{ entry: inlineColumnNode(), qualifications: [] }],
+  };
+
+  const result = embedInlineColumnTypeSpecs(query);
+  if (result.type !== "outerJoin") throw new Error("expected outerJoin");
+
+  // Both traversal paths (primary via traverseEntry, secondary via map) must
+  // reach the inline column and embed its typeSpec.
+  expect(inlineDataInfo(result.primary.entry).typeSpec).toEqual({
+    axes: ["String", "Long"],
+    column: "Int",
+  });
+  expect(inlineDataInfo(result.secondary[0].entry).typeSpec).toEqual({
+    axes: ["String", "Long"],
+    column: "Int",
+  });
+});
+
 test("embedInlineColumnTypeSpecs leaves non-inline nodes unchanged", ({ expect }) => {
   const query: SpecQuery = { type: "column", column: "col1" as PObjectId };
   const result = embedInlineColumnTypeSpecs(query);

--- a/lib/node/pf-driver/src/ptable_shared.ts
+++ b/lib/node/pf-driver/src/ptable_shared.ts
@@ -1,12 +1,35 @@
 import type {
   DataQuery,
+  JsonDataInfo,
   PFrameHandle,
   PObjectId,
   PTableColumnSpec,
   PTableDef,
   PTableHandle,
+  SpecQuery,
 } from "@milaboratories/pl-model-common";
+import { traverseQuerySpec } from "@milaboratories/pl-model-common";
 import { hashJson, PFrameInternal } from "@milaboratories/pl-model-middle-layer";
+
+/**
+ * Make every inline column in a `SpecQuery` self-contained by embedding its
+ * column `typeSpec` (`{ axes, column }`) into `dataInfo`, derived from the
+ * column's `PColumnSpec`.
+ */
+export function embedInlineColumnTypeSpecs(query: SpecQuery): SpecQuery {
+  return traverseQuerySpec(query, {
+    column: (c) => c,
+    node: (node) => {
+      if (node.type !== "inlineColumn") return node;
+      const { axesSpec, valueType } = node.spec.spec;
+      const dataInfo: JsonDataInfo & { typeSpec: PFrameInternal.PColumnValueTypeSpec } = {
+        ...node.dataInfo,
+        typeSpec: { axes: axesSpec.map((a) => a.type), column: valueType },
+      };
+      return { ...node, dataInfo };
+    },
+  });
+}
 
 /**
  * PTable definition stored in the def / table pools. Always
@@ -39,7 +62,9 @@ export function lowerLegacyPTableDef(
     filters: [...legacyDef.partitionFilters, ...legacyDef.filters],
     sorting: legacyDef.sorting,
   };
-  return pFrameSpec.evaluateQuery(pFrameSpec.rewriteLegacyQuery(legacy));
+  return pFrameSpec.evaluateQuery(
+    embedInlineColumnTypeSpecs(pFrameSpec.rewriteLegacyQuery(legacy)),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Make inline-column data info self-contained so the data layer reads the column type from `dataInfo.typeSpec` instead of the inline column's `spec` field (which is being phased out in favour of AS-aliases + a spec map passed to `evaluateQuery`).

## Changes

- **pf-driver** — `embedInlineColumnTypeSpecs` walks the `SpecQuery` and embeds each inline column's `typeSpec` (`{ axes, column }`, derived from its `PColumnSpec`) into `dataInfo`. Applied before `evaluateQuery` on both lowering paths:
  - `createPTableV2` (`driver_impl.ts`)
  - the legacy path used by `calculateTableData` / `createPTable` (`ptable_shared.ts` → `lowerLegacyPTableDef`)
- **pl-model-common** — `ColumnIdAndTypeSpec.spec` changed from `TypeSpec` (`{ axes, columns[] }`) to the singular `ColumnTypeSpec` (`{ axes, column }`), matching the data-layer wire format actually produced by the WASM-spec lowering. Adds the `ColumnTypeSpec` type. The `id` field is unchanged.
- Unit tests for `embedInlineColumnTypeSpecs` (injection, field preservation, nested-join traversal, non-inline pass-through).

## Why

The data engine previously derived an inline column's `typeSpec` from its `spec` field. To allow `spec` to be dropped, the type now travels inside `dataInfo`. The compatibility logic for the *new* format lives here in platforma (the engine just requires `dataInfo.typeSpec`); legacy query upgrades remain handled engine-side.

## Coordination

This requires a pframes-rs (node addon + WASM) build whose inline-column deserializer reads `dataInfo.typeSpec` and no longer injects it from `spec`. That build must be the one this repo pins when this lands. Against the currently published pframes-rs the injection is harmless/idempotent.

## Verification

- `pl-model-common`, `pl-model-middle-layer`, `pf-driver` type-check; pf-driver lint + format clean.
- pf-driver test suite: 50/50 pass (45 existing + 5 new).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes inline-column `dataInfo` self-contained by embedding each inline column's `typeSpec` (`{ axes, column }`) into `dataInfo` before the query is handed to `evaluateQuery`, removing the data engine's dependency on the inline column's `spec` field for type information. A new `ColumnTypeSpec` (singular `column`) type is introduced in `pl-model-common` and replaces the plural `TypeSpec` in the data-layer's `ColumnIdAndTypeSpec`.

- **`embedInlineColumnTypeSpecs`** in `ptable_shared.ts` walks a `SpecQuery` tree via `traverseQuerySpec`, intercepts every `inlineColumn` node, and spreads `typeSpec: { axes: axesSpec.map(a => a.type), column: valueType }` into `dataInfo`; it is applied on both the V2 path (`createPTableV2` in `driver_impl.ts`) and the legacy path (`lowerLegacyPTableDef` in `ptable_shared.ts`).
- **`ColumnTypeSpec`** (`{ axes, column }`) is added to `query_common.ts` and replaces `TypeSpec` as the `spec` field in the internal `ColumnIdAndTypeSpec` type, tightening the representation to a single column value type.
- Five new unit tests cover injection, field preservation, `spec` immutability, `fullJoin` traversal, and non-inline pass-through.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the embedding is idempotent and harmless against the currently published pframes-rs build, and both lowering paths are correctly wired.

The core logic is correct and well-tested. The only open questions are the `patch` changeset classification for a structural change in exported data-layer types, a missing `outerJoin` traversal test, and `ColumnTypeSpec` not being re-exported from the package index — all non-blocking.

The changeset file and `query_data.ts` are worth a second look to confirm the `patch` version classification is intentional given the shape change in the exported data-layer types.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pf-driver/src/ptable_shared.ts | Adds `embedInlineColumnTypeSpecs` — correctly traverses a `SpecQuery` tree via `traverseQuerySpec` and embeds `{ axes, column }` typeSpec into each inline column's `dataInfo`; `lowerLegacyPTableDef` wired correctly. |
| lib/node/pf-driver/src/driver_impl.ts | Imports and applies `embedInlineColumnTypeSpecs` on the V2 lowering path (`createPTableV2`) before `evaluateQuery`; one-line change, correct ordering after `sortSpecQuery`. |
| lib/model/common/src/drivers/pframe/query/query_common.ts | Adds `ColumnTypeSpec` (singular `column`) alongside the existing `TypeSpec` (plural `columns`); well-documented. Not re-exported through the package index (same as `TypeSpec`). |
| lib/model/common/src/drivers/pframe/query/query_data.ts | Switches `ColumnIdAndTypeSpec.spec` from `TypeSpec` (plural `columns`) to `ColumnTypeSpec` (singular `column`), making all three dependent exported types use the new singular shape; `ColumnTypeSpec` is not re-exported from the package index. |
| lib/node/pf-driver/src/ptable_shared.test.ts | New unit tests cover injection, field preservation, spec immutability, and fullJoin traversal; `outerJoin` (primary/secondary) traversal path not explicitly tested. |
| .changeset/inline-column-self-contained-typespec.md | Documents the self-contained dataInfo change; classified as `patch` for both packages despite the structural change in exported data-layer types. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant embedInlineColumnTypeSpecs
    participant traverseQuerySpec
    participant evaluateQuery as pFrameSpec.evaluateQuery

    Caller->>embedInlineColumnTypeSpecs: SpecQuery (may contain inlineColumn nodes)
    embedInlineColumnTypeSpecs->>traverseQuerySpec: "query + {column: id, node: embedFn}"
    loop For each node (bottom-up)
        traverseQuerySpec-->>traverseQuerySpec: recurse into children (joins, unary wrappers)
        alt "node.type === inlineColumn"
            traverseQuerySpec->>embedInlineColumnTypeSpecs: node visitor called
            embedInlineColumnTypeSpecs-->>traverseQuerySpec: "{ ...node, dataInfo: { ...dataInfo, typeSpec: {axes, column} } }"
        else other node
            traverseQuerySpec-->>traverseQuerySpec: return unchanged
        end
    end
    traverseQuerySpec-->>embedInlineColumnTypeSpecs: transformed SpecQuery
    embedInlineColumnTypeSpecs-->>Caller: SpecQuery with embedded typeSpecs
    Caller->>evaluateQuery: transformed SpecQuery
    evaluateQuery-->>Caller: "{ tableSpec, dataQuery }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/model/common/src/drivers/pframe/query/query_data.ts:42-47
**`ColumnTypeSpec` not re-exported from the package index**

`ColumnTypeSpec` is defined in and exported from `query_common.ts`, but `query/index.ts` only re-exports from `query_spec` and `query_data`. The new type is therefore not reachable via a standard `import ... from "@milaboratories/pl-model-common"`. Any consumer wanting an explicit `ColumnTypeSpec` annotation must use a deep internal import path. `TypeSpec` was treated the same way (also not re-exported), so this is consistent with the existing pattern — but given that `ColumnTypeSpec` is now the canonical shape for the `spec` field of the exported `DataQueryInlineColumn`, `DataQuerySparseToDenseColumn`, and `DataQueryTransformColumns` types, it may be worth adding it to `query/index.ts` exports.

### Issue 2 of 3
lib/node/pf-driver/src/ptable_shared.test.ts:63-79
**Traversal test coverage gap: `outerJoin` primary/secondary paths not covered**

The test suite exercises `fullJoin` traversal, but `outerJoin` has two distinct traversal paths (`primary` and `secondary`) that go through `traverseEntry` separately in `traverseQuerySpec`. A test with an inline column in the `primary` position (and another in `secondary`) would more explicitly demonstrate that both paths reach the `node` visitor. The underlying `traverseQuerySpec` logic is correct for all node types, so this is a coverage-only gap — but the `outerJoin` case is structurally different enough from `fullJoin` to deserve an explicit test.

### Issue 3 of 3
.changeset/inline-column-self-contained-typespec.md:1-6
**Changeset bump may underrepresent the type-level API change**

`ColumnIdAndTypeSpec.spec` changed from `TypeSpec` (`{ axes, columns: ColumnValueType[] }`) to `ColumnTypeSpec` (`{ axes, column: ColumnValueType }`). Because `ColumnIdAndTypeSpec` is a local type, the visible surface of the change lands on the exported `DataQueryInlineColumn`, `DataQuerySparseToDenseColumn`, and `DataQueryTransformColumns` types — all of which now expect `{ axes, column }` (singular) instead of `{ axes, columns: [] }` (plural). No current codebase consumer constructs those types directly (grep confirms only `query_data.ts` references them), so there are no known breakages, but strictly this is a structural change in published exported types. Worth confirming the `patch` classification is intentional given the coordination notes in the PR description.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pf-driver): embed inline-column typ..."](https://github.com/milaboratory/platforma/commit/958289c6d3b6040d295977d48ad4cb88c621808c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36946530)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->