### PR TITLE
feat(pframe): caching object store contract + driver cache metrics

### DIFF
--- a/.changeset/caching-object-store-contract.md
+++ b/.changeset/caching-object-store-contract.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+"@milaboratories/pf-driver": patch
+"@milaboratories/pl-middle-layer": patch
+---
+
+Add the caching object store contract to `PFrameInternal`: `CacheConfig`, `CacheCounters`, `CacheMetrics`, `CachingObjectStore`, `CachingObjectStoreOptions`, and `HttpHelpers.createCachingObjectStore`. These declare the type surface for a persistent byte-range cache that wraps an upstream `ObjectStore` and exposes metrics/reset/disposal; the runtime implementation lands in `@milaboratories/pframes-rs-node`. The reserved caching slot is dropped from `RequestHandlerOptions` — caching is composed by wrapping the store before it reaches the request handler.
+
+Wire `getCacheMetrics()` / `resetCache()` through the driver: declared on `AbstractInternalPFrameDriver` alongside `pprofDump`, added to the internal `RemoteBlobProvider` interface, and delegated from `AbstractPFrameDriver` to its remote blob provider. Until the cache is wired into the parquet object store, both the production and test-double providers return `null` metrics and treat reset as a no-op.

--- a/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
@@ -165,14 +165,96 @@ export abstract class BaseObjectStore implements ObjectStore {
   ): Promise<void>;
 }
 
+/** Configuration for {@link HttpHelpers.createCachingObjectStore} */
+export type CacheConfig = {
+  /** Filesystem path where the cache persists its data */
+  cachePath: string;
+  /** Hard total size budget in bytes; the cache self-stabilizes near this size */
+  maxSizeBytes: number;
+  /**
+   * Max share of the budget a single file may occupy (0..1); when a file exceeds it, that
+   * file's oldest ranges are evicted first. Stops one large scan from flushing the working set.
+   */
+  admissionFraction: number;
+  /** Upper bound on previously-evicted (ghost) files remembered to guide readmission; resident files are already byte-bounded */
+  maxFilesTracked: number;
+};
+
+/**
+ * Cumulative cache event counters. Surfaced both as lifetime totals (persisted across restarts)
+ * and as a per-process session view, @see CacheMetrics.
+ */
+export type CacheCounters = {
+  /** Requests fully served from cache */
+  hits: number;
+  /** Requests that fell through to upstream */
+  misses: number;
+  /** Bytes served from cache */
+  bytesServed: number;
+  /** Bytes downloaded from upstream on misses */
+  bytesFetched: number;
+  /** Bytes evicted to keep the cache within its total size budget, @see CacheConfig.maxSizeBytes */
+  bytesEvictedByBudget: number;
+  /** Bytes evicted because a single file exceeded its allowed share of the budget, @see CacheConfig.admissionFraction */
+  bytesEvictedByFileCap: number;
+  /** Files promoted on observed reuse, so they are retained longer than first-time entries */
+  promotions: number;
+  /** Previously evicted files that were re-requested and readmitted */
+  ghostReadmissions: number;
+};
+
+/** Snapshot of cache state and counters, @see CachingObjectStore.getMetrics */
+export type CacheMetrics = {
+  /** Current resident bytes */
+  sizeBytes: number;
+  /** Number of files with resident (cached) bytes */
+  residentFiles: number;
+  /** Number of previously-evicted (ghost) files remembered, <= @see CacheConfig.maxFilesTracked */
+  ghostFiles: number;
+  /** Counters cumulative across all sessions (persisted) */
+  lifetime: CacheCounters;
+  /** The same counters scoped to the current process */
+  session: CacheCounters;
+};
+
+/**
+ * Options for caching object store creation, @see HttpHelpers.createCachingObjectStore.
+ * Standalone (not extending {@link ObjectStoreOptions}): a caching store is a decorator over
+ * `upstream`, so source-store options do not apply to it.
+ */
+export interface CachingObjectStoreOptions {
+  /** Upstream store consulted on cache misses */
+  upstream: ObjectStore;
+  /** Cache configuration */
+  config: CacheConfig;
+  /** Logger instance, no logging is performed when not provided */
+  logger?: Logger;
+}
+
+/**
+ * An {@link ObjectStore} that serves byte ranges from a persistent local cache, fetching misses
+ * from an upstream store. This is the single handle for the cache: pass it as
+ * {@link RequestHandlerOptions.store}, read {@link CachingObjectStore.getMetrics}, and dispose it
+ * to release the cache, @see HttpHelpers.createCachingObjectStore.
+ */
+export interface CachingObjectStore extends ObjectStore, AsyncDisposable {
+  /** Instantaneous cache state plus lifetime/session counters */
+  getMetrics(): CacheMetrics;
+  /** Drop all cached data and zero the counters (test/benchmark use) */
+  reset(): void;
+}
+
 /** Object store base URL in format accepted by Apache DataFusion and DuckDB */
 export type ObjectStoreUrl = Branded<string, "PFrameInternal.ObjectStoreUrl">;
 
 /** HTTP(S) request handler creation options */
 export type RequestHandlerOptions = {
-  /** Object store to serve files from, @see HttpHelpers.createFsStore */
+  /**
+   * Object store to serve files from. Compose caching by wrapping the upstream store with
+   * {@link HttpHelpers.createCachingObjectStore} and passing the result here,
+   * @see HttpHelpers.createFsStore
+   */
   store: ObjectStore;
-  /** Here will go caching options... */
 };
 
 /** Server configuration options */
@@ -238,6 +320,13 @@ export interface HttpHelpers {
    * Rejects if the provided path does not exist or is not a directory.
    */
   createFsStore(options: FsStoreOptions): Promise<ObjectStore>;
+
+  /**
+   * Wrap an upstream object store in a persistent byte-range cache backed by SQLite.
+   * The returned store is itself an {@link ObjectStore} (pass it to {@link createRequestHandler})
+   * and additionally exposes metrics and reset. Dispose it to close the cache database.
+   */
+  createCachingObjectStore(options: CachingObjectStoreOptions): Promise<CachingObjectStore>;
 
   /**
    * Create an HTTP request handler for serving files from an object store.

--- a/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
@@ -241,7 +241,7 @@ export interface CachingObjectStore extends ObjectStore, AsyncDisposable {
   /** Instantaneous cache state plus lifetime/session counters */
   getMetrics(): CacheMetrics;
   /** Drop all cached data and zero the counters (test/benchmark use) */
-  reset(): void;
+  reset(): Promise<void>;
 }
 
 /** Object store base URL in format accepted by Apache DataFusion and DuckDB */

--- a/lib/node/pf-driver/src/driver_decl.ts
+++ b/lib/node/pf-driver/src/driver_decl.ts
@@ -19,6 +19,7 @@ import type {
   ExportPTableOptions,
 } from "@milaboratories/pl-model-common";
 import type { PoolEntry } from "@milaboratories/helpers";
+import type { PFrameInternal } from "@milaboratories/pl-model-middle-layer";
 
 export type {
   WritePTableToFsOptions,
@@ -43,6 +44,15 @@ export interface AbstractInternalPFrameDriver<PColumnData> extends PFrameDriver,
    * @warning This method will always reject on Windows!
    */
   pprofDump(): Promise<Uint8Array>;
+
+  /**
+   * Metrics from the byte-range cache backing the parquet object store,
+   * or `null` when no caching layer is configured.
+   */
+  getCacheMetrics(): Promise<PFrameInternal.CacheMetrics | null>;
+
+  /** Drop all cached parquet byte ranges; no-op when no caching layer is configured. */
+  resetCache(): Promise<void>;
 
   /** Create a new PFrame */
   createPFrame(def: PFrameDef<PColumn<PColumnData>>): PoolEntry<PFrameHandle>;

--- a/lib/node/pf-driver/src/driver_double.ts
+++ b/lib/node/pf-driver/src/driver_double.ts
@@ -116,6 +116,12 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<FileName> {
     return this.server.info;
   }
 
+  public async getCacheMetrics(): Promise<PFrameInternal.CacheMetrics | null> {
+    return null;
+  }
+
+  public async resetCache(): Promise<void> {}
+
   async [Symbol.asyncDispose](): Promise<void> {
     await this.server.stop();
     await this.pool[Symbol.asyncDispose]();

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -81,7 +81,10 @@ export interface LocalBlobProvider<TreeEntry extends JsonSerializable>
   extends PoolLocalBlobProvider<TreeEntry>, AsyncDisposable {}
 
 export interface RemoteBlobProvider<TreeEntry extends JsonSerializable>
-  extends PoolRemoteBlobProvider<TreeEntry>, AsyncDisposable {}
+  extends PoolRemoteBlobProvider<TreeEntry>, AsyncDisposable {
+  getCacheMetrics(): Promise<PFrameInternal.CacheMetrics | null>;
+  resetCache(): Promise<void>;
+}
 
 export type AbstractPFrameDriverOps = PTableCachePerFrameOps &
   PTableCachePlainOps & {
@@ -126,6 +129,14 @@ export class AbstractPFrameDriver<
 
   public async pprofDump(): Promise<Uint8Array> {
     return await PFrameFactory.pprofDump();
+  }
+
+  public async getCacheMetrics(): Promise<PFrameInternal.CacheMetrics | null> {
+    return await this.remoteBlobProvider.getCacheMetrics();
+  }
+
+  public async resetCache(): Promise<void> {
+    await this.remoteBlobProvider.resetCache();
   }
 
   public constructor({

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -288,6 +288,7 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.server.stop();
+    // TODO: await this.cache[Symbol.asyncDispose]();
     await this.pool[Symbol.asyncDispose]();
   }
 }

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -251,6 +251,7 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
   constructor(
     private readonly pool: RemoteBlobPool,
     private readonly server: PFrameInternal.HttpServer,
+    // TODO: private readonly cache: PFrameInternal.CachingObjectStore,
   ) {}
 
   public static async init(
@@ -260,6 +261,7 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
   ): Promise<RemoteBlobProviderImpl> {
     const pool = new RemoteBlobPool(blobDriver, logger);
     const store = new BlobStore({ remoteBlobProvider: pool, logger });
+    // TODO: const cachingStore = HttpHelpers.createCachingObjectStore({ ... });
 
     const handler = HttpHelpers.createRequestHandler({ store });
     const server = await HttpHelpers.createHttpServer({ ...serverOptions, handler });
@@ -274,6 +276,14 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
 
   public httpServerInfo(): PFrameInternal.HttpServerInfo {
     return this.server.info;
+  }
+
+  public async getCacheMetrics(): Promise<PFrameInternal.CacheMetrics | null> {
+    return null; // TODO: this.cache.getMetrics()
+  }
+
+  public async resetCache(): Promise<void> {
+    // TODO: this.cache.reset()
   }
 
   async [Symbol.asyncDispose](): Promise<void> {


### PR DESCRIPTION
## Summary

Adds the **type contract** for a persistent byte-range cache that wraps the parquet `ObjectStore`, and wires cache metrics/reset through the PFrame driver. This is the first link in the chain — the runtime cache implementation lands separately in `@milaboratories/pframes-rs-node`, after which the driver providers stop returning stubs.

## Contract (`@milaboratories/pl-model-middle-layer`)

New under `PFrameInternal` (in `http_helpers.ts`):
- `CacheConfig`, `CacheCounters`, `CacheMetrics`, `CachingObjectStoreOptions`
- `CachingObjectStore` — an `ObjectStore` decorator (`extends ObjectStore, AsyncDisposable`) exposing `getMetrics()` / `reset()`
- `HttpHelpers.createCachingObjectStore(options)` — factory returning the wrapped store

The reserved caching slot is removed from `RequestHandlerOptions`: caching is composed by wrapping the upstream store **before** it reaches the request handler, not by the handler itself.

## Driver wiring (`@milaboratories/pf-driver`, `@milaboratories/pl-middle-layer`)

`getCacheMetrics()` / `resetCache()` added alongside `pprofDump`:
- declared on `AbstractInternalPFrameDriver`
- added to the internal `RemoteBlobProvider` interface (not the pool-level base)
- `AbstractPFrameDriver` delegates both to its remote blob provider

Until the cache is wired into the parquet object store, both the production `RemoteBlobProviderImpl` and the fs-backed test double return `null` metrics and treat reset as a no-op (Null Object).

## Notes
- No code calls `createCachingObjectStore` yet, so this builds against the currently published `pframes-rs-node`.
- Metric names are policy-neutral where possible; eviction counters (`bytesEvictedByBudget`, `bytesEvictedByFileCap`) name their cause and link to the config knob each measures.
- `types:check` / `linter:check` / `formatter:check` pass on all three changed packages.
- Changeset included (patch bump for the three packages).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR establishes the TypeScript type contract for a persistent byte-range cache wrapping the parquet `ObjectStore`, and threads `getCacheMetrics()` / `resetCache()` through the driver stack. No cache is actually activated yet — both the production and test-double providers return null metrics and no-op resets as placeholders until the Rust implementation lands in `pframes-rs-node`.

- **`http_helpers.ts`** defines `CacheConfig`, `CacheCounters`, `CacheMetrics`, `CachingObjectStore`, `CachingObjectStoreOptions`, and `HttpHelpers.createCachingObjectStore`. The placeholder `caching options` comment is removed from `RequestHandlerOptions` in favour of documentation pointing to the new decorator API.
- **`driver_decl.ts` / `driver_impl.ts`** surface `getCacheMetrics()` and `resetCache()` on `AbstractInternalPFrameDriver`, extending the internal `RemoteBlobProvider` interface and delegating from `AbstractPFrameDriver`.
- **`driver_double.ts` / `pool/driver.ts`** add null-object stubs so the driver stack type-checks and builds cleanly before the real cache is wired.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all cache methods are currently stubs and no production path is activated yet.

The change is purely additive: new type definitions, new interface methods, and null-object stub implementations. Nothing in the hot path changes behaviour. The two items worth a follow-up are a missing TODO for cache disposal in asyncDispose (easy to forget when the real implementation lands) and the synchronous return type of reset() which may conflict with the async NAPI binding that the Rust implementation will likely produce.

lib/node/pl-middle-layer/src/pool/driver.ts — asyncDispose needs a paired TODO for cache disposal; lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts — reset() return type worth reconsidering before the NAPI implementation is written.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts | Adds CacheConfig/CacheCounters/CacheMetrics types, CachingObjectStore interface, and createCachingObjectStore factory to HttpHelpers. Clean contract, but reset() synchronous return type may need revisiting when the NAPI implementation arrives. |
| lib/node/pf-driver/src/driver_decl.ts | Adds getCacheMetrics() and resetCache() to AbstractInternalPFrameDriver alongside pprofDump. Straightforward interface extension with correct nullable return for the no-cache case. |
| lib/node/pf-driver/src/driver_impl.ts | Extends RemoteBlobProvider interface and delegates getCacheMetrics()/resetCache() to it in AbstractPFrameDriver. Correct null-object delegation pattern. |
| lib/node/pf-driver/src/driver_double.ts | Adds null-object stubs for getCacheMetrics()/resetCache() on the fs-backed test double. No logic, just satisfying the new interface requirement. |
| lib/node/pl-middle-layer/src/pool/driver.ts | Adds cache method stubs and TODO comments for future wiring; asyncDispose is missing a paired TODO for cache disposal, which could lead to a resource leak when the implementation lands. |
| .changeset/caching-object-store-contract.md | Patch changeset for the three affected packages; description accurately reflects the changes. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant AbstractPFrameDriver
    participant RemoteBlobProvider
    participant CachingObjectStore
    participant ObjectStore

    Note over CachingObjectStore,ObjectStore: Not yet wired — stubs return null / no-op

    Caller->>AbstractPFrameDriver: getCacheMetrics()
    AbstractPFrameDriver->>RemoteBlobProvider: getCacheMetrics()
    RemoteBlobProvider-->>AbstractPFrameDriver: null (TODO: this.cache.getMetrics())
    AbstractPFrameDriver-->>Caller: null

    Caller->>AbstractPFrameDriver: resetCache()
    AbstractPFrameDriver->>RemoteBlobProvider: resetCache()
    RemoteBlobProvider-->>AbstractPFrameDriver: (no-op, TODO: this.cache.reset())
    AbstractPFrameDriver-->>Caller: void

    Note over RemoteBlobProvider,ObjectStore: Future wiring (pframes-rs-node)
    RemoteBlobProvider->>CachingObjectStore: "createCachingObjectStore({ upstream: blobStore, config })"
    CachingObjectStore->>ObjectStore: on cache miss → request(filename, params)
    ObjectStore-->>CachingObjectStore: ObjectStoreResponse
    CachingObjectStore-->>RemoteBlobProvider: cached ObjectStoreResponse
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/node/pl-middle-layer/src/pool/driver.ts`, line 289-292 ([link](https://github.com/milaboratory/platforma/blob/48f82102c8b572897eab18883edc08c7016ee4d8/lib/node/pl-middle-layer/src/pool/driver.ts#L289-L292)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `asyncDispose` method has no reminder to dispose the `CachingObjectStore` when the TODO is eventually wired in. `CachingObjectStore extends AsyncDisposable` and its JSDoc explicitly says "Dispose it to close the cache database." Omitting `await this.cache[Symbol.asyncDispose]()` here would leave the SQLite connection open on driver teardown. A paired TODO comment makes it far less likely to be overlooked.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/node/pl-middle-layer/src/pool/driver.ts
   Line: 289-292

   Comment:
   The `asyncDispose` method has no reminder to dispose the `CachingObjectStore` when the TODO is eventually wired in. `CachingObjectStore extends AsyncDisposable` and its JSDoc explicitly says "Dispose it to close the cache database." Omitting `await this.cache[Symbol.asyncDispose]()` here would leave the SQLite connection open on driver teardown. A paired TODO comment makes it far less likely to be overlooked.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pl-middle-layer/src/pool/driver.ts:289-292
The `asyncDispose` method has no reminder to dispose the `CachingObjectStore` when the TODO is eventually wired in. `CachingObjectStore extends AsyncDisposable` and its JSDoc explicitly says "Dispose it to close the cache database." Omitting `await this.cache[Symbol.asyncDispose]()` here would leave the SQLite connection open on driver teardown. A paired TODO comment makes it far less likely to be overlooked.

```suggestion
  async [Symbol.asyncDispose](): Promise<void> {
    // TODO: await this.cache[Symbol.asyncDispose]();
    await this.server.stop();
    await this.pool[Symbol.asyncDispose]();
  }
```

### Issue 2 of 2
lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts:244
`reset()` is typed as synchronous (`void`), but the backing store is described as SQLite-based. napi-rs exposes Rust async operations to Node.js as `Promise`-returning methods; a `reset()` that deletes all cached rows will almost certainly be async at the FFI boundary. Locking in `void` now means the contract will require a breaking change once the Rust implementation is written. Defining it as `reset(): Promise<void>` from the start avoids that churn, and the driver layer already wraps everything in `async`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pframe): caching object store contr..."](https://github.com/milaboratory/platforma/commit/48f82102c8b572897eab18883edc08c7016ee4d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36968073)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->