### PR TITLE
feat(pf-driver): adopt PFrames 1.1.46 export interfaces

### DIFF
--- a/.changeset/pframes-1-1-46-export-headers-list.md
+++ b/.changeset/pframes-1-1-46-export-headers-list.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+"@milaboratories/pf-driver": patch
+---
+
+Adopt PFrames 1.1.46: bump `@milaboratories/pframes-rs-{node,wasip2,wasm}` to 1.1.46 and migrate the pf-driver to the new internal interfaces (`PFrameFactoryV9` / `PFrameV18` / `PTableV12`). `PTable.export` now takes `headers` as an ordered `[unifiedColumnIndex, headerName][]` list inside `ops` instead of a `Record<number, string>` map. The superseded `PFrameFactoryV8`, `PFrameV17`, `PTableV11`, and `PFrameReadAPIV14` interfaces are removed.

--- a/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/api_read.ts
@@ -4,7 +4,7 @@ import type {
   DataQuery,
   DataQueryBooleanExpression,
 } from "@milaboratories/pl-model-common";
-import type { PTableV11, PTableV12 } from "./table";
+import type { PTableV12 } from "./table";
 import type { PTableId } from "./common";
 
 /**
@@ -40,9 +40,6 @@ export interface UniqueValuesRequestV2 {
  * `PTableV*` interface is dropped, so this declaration repeats the full
  * method surface rather than referencing the predecessors.
  *
- * Same surface as {@link PFrameReadAPIV14}; the only change is that
- * {@link PFrameReadAPIV15.createTable} returns {@link PTableV12}.
- *
  * Spec-side operations (finding columns, listing columns, retrieving
  * column specs, computing axis integrations) are not part of this
  * surface — callers cache column specs themselves or route through
@@ -53,30 +50,6 @@ export interface UniqueValuesRequestV2 {
 export interface PFrameReadAPIV15 {
   /** Creates table from a pre-lowered data query. */
   createTable(tableId: PTableId, dataQuery: DataQuery): PTableV12;
-
-  /** Calculate set of unique values for a specific axis for the filtered set of records. */
-  getUniqueValues(
-    request: UniqueValuesRequestV2,
-    ops?: {
-      signal?: AbortSignal;
-    },
-  ): Promise<UniqueValuesResponse>;
-}
-
-/**
- * Read interface exposed by PFrames library. Returns the {@link PTableV11}
- * table view, whose `export` takes a column-index → header map.
- *
- * Spec-side operations (finding columns, listing columns, retrieving
- * column specs, computing axis integrations) are not part of this
- * surface — callers cache column specs themselves or route through
- * WASM-spec. The data-side `createTable` accepts a pre-lowered
- * `DataQuery`; `getUniqueValues` takes pre-resolved indices via
- * {@link UniqueValuesRequestV2}.
- */
-export interface PFrameReadAPIV14 {
-  /** Creates table from a pre-lowered data query. */
-  createTable(tableId: PTableId, dataQuery: DataQuery): PTableV11;
 
   /** Calculate set of unique values for a specific axis for the filtered set of records. */
   getUniqueValues(

--- a/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/pframe.ts
@@ -1,25 +1,13 @@
 import type { PFrameFactoryAPIV6 } from "./api_factory";
-import type { PFrameReadAPIV14, PFrameReadAPIV15 } from "./api_read";
+import type { PFrameReadAPIV15 } from "./api_read";
 import type { Logger } from "./common";
 import type { PFrameId } from "./common";
 
 /**
  * Full PFrame surface — factory operations plus data-side reads. Exposes
  * the self-contained {@link PFrameFactoryAPIV6} (column `typeSpec` embedded in
- * `data`) plus {@link PFrameReadAPIV14}, whose tables' `export` takes a
- * column-index → header map.
- */
-export interface PFrameV17 extends PFrameFactoryAPIV6, PFrameReadAPIV14 {}
-
-/**
- * Full PFrame surface — factory operations plus data-side reads. Exposes
- * the self-contained {@link PFrameFactoryAPIV6} (column `typeSpec` embedded in
  * `data`) plus {@link PFrameReadAPIV15}, whose tables' `export` takes an
  * `ops.headers` list of `[column index, header name]` pairs.
- *
- * Same surface as {@link PFrameV17}; the only change is that the read side is
- * upgraded from {@link PFrameReadAPIV14} to {@link PFrameReadAPIV15}, so
- * {@link PFrameReadAPIV15.createTable} returns {@link PTableV12}.
  */
 export interface PFrameV18 extends PFrameFactoryAPIV6, PFrameReadAPIV15 {}
 
@@ -34,31 +22,7 @@ export type PFrameOptionsV2 = {
 
 /**
  * PFrame management functions exposed by the PFrame module. Creates
- * {@link PFrameV17} instances (self-contained column data info).
- */
-export interface PFrameFactoryV8 {
-  /**
-   * Create a new PFrame instance.
-   * @warning Use concurrency limiting to avoid OOM crashes when multiple instances are simultaneously in use.
-   */
-  createPFrame(options: PFrameOptionsV2): PFrameV17;
-
-  /**
-   * Dump active allocations from all PFrames instances in pprof format.
-   * The result of this function should be saved as `profile.pb.gz`.
-   * Use {@link https://pprof.me/} or {@link https://www.speedscope.app/}
-   * to view the allocation flamechart.
-   * @warning This method will always reject on Windows!
-   */
-  pprofDump: () => Promise<Uint8Array>;
-}
-
-/**
- * PFrame management functions exposed by the PFrame module. Creates
- * {@link PFrameV18} instances (self-contained column data info).
- *
- * Same surface as {@link PFrameFactoryV8}; the only change is that
- * {@link PFrameFactoryV9.createPFrame} returns {@link PFrameV18}, whose tables'
+ * {@link PFrameV18} instances (self-contained column data info), whose tables'
  * `export` takes an `ops.headers` list of `[column index, header name]` pairs.
  */
 export interface PFrameFactoryV9 {

--- a/lib/model/middle-layer/src/pframe/internal_api/table.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/table.ts
@@ -3,90 +3,14 @@ import type { PTableShape, PTableVector, TableRange } from "@milaboratories/pl-m
 /**
  * Table view returned by `createTable`.
  *
- * {@link PTableV11.export} takes a `headers` map (unified column index →
- * header name) that both selects the columns to export and names them.
- *
- * PTable can be thought as having a composite primary key, consisting
- * of axes, and a set of data columns derived from PColumn values.
- * The table's column spec is owned by the caller — selector → index
- * resolution runs on the caller side via WASM-spec.
- */
-export interface PTableV11 extends Disposable {
-  /**
-   * Get PTable disk footprint in bytes.
-   *
-   * @param ops.withPredecessors When true, the footprint includes
-   *   every registered predecessor table reachable through the
-   *   query lineage. When false or omitted, only this table's own
-   *   materialised data is counted.
-   *
-   * Warning: This call materializes the join.
-   */
-  getFootprint(ops?: { withPredecessors?: boolean; signal?: AbortSignal }): Promise<number>;
-
-  /**
-   * Unified table shape
-   * Warning: This call materializes the join.
-   */
-  getShape(ops?: { signal?: AbortSignal }): Promise<PTableShape>;
-
-  /**
-   * Retrieve the data from the table. To retrieve only data required, it can be
-   * sliced both horizontally ({@link columnIndices}) and vertically
-   * ({@link range}).
-   * This call materializes the join.
-   *
-   * @param columnIndices unified indices of columns to be retrieved
-   * @param range optionally limit the range of records to retrieve
-   * */
-  getData(
-    columnIndices: number[],
-    ops?: {
-      range?: TableRange;
-      signal?: AbortSignal;
-    },
-  ): Promise<PTableVector[]>;
-
-  /**
-   * Stream the sorted table to a file at `path`. The output format is
-   * selected from the file extension: `csv`, `tsv`, `parquet`, or `xlsx`.
-   * Writing is bounded-memory.
-   * This call materializes the join.
-   *
-   * @param path destination file path; its extension selects the format
-   * @param headers map from unified column index (axes first, then data
-   *   columns) to the header name to use for that column. Only the columns
-   *   present as keys are exported, in ascending index order — the map both
-   *   selects the columns and names them (the data layer is name-independent,
-   *   so names are supplied by the caller).
-   *
-   * @remarks For `xlsx` the caller must ensure the row count is below Excel's
-   *   1,048,576-row per-sheet limit.
-   */
-  export(
-    path: string,
-    headers: Record<number, string>,
-    ops?: {
-      signal?: AbortSignal;
-    },
-  ): Promise<void>;
-
-  /** Deallocates all underlying resources */
-  dispose(): void;
-}
-
-/**
- * Table view returned by `createTable`.
- *
  * Self-contained: does not extend any earlier per-table interface. Once this
  * version is adopted, every earlier `PTableV*` interface is dropped, so this
  * declaration repeats the full method surface rather than referencing the
  * predecessors.
  *
- * Same surface as {@link PTableV11} except {@link PTableV12.export} moves
- * `headers` into `ops` and passes them as an ordered list of
- * `[unified column index, header name]` pairs instead of a
- * `Record<number, string>` map.
+ * {@link PTableV12.export} takes an `ops.headers` list of
+ * `[unified column index, header name]` pairs that both selects the columns
+ * to export and names them.
  *
  * PTable can be thought as having a composite primary key, consisting
  * of axes, and a set of data columns derived from PColumn values.

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -384,10 +384,10 @@ export class AbstractPFrameDriver<
       [signal, disposeSignal].filter((s): s is AbortSignal => !isNil(s)),
     );
 
-    const headers: Record<number, string> = {};
-    for (const index of columnIndices) {
-      headers[index] = columnLabel(def.tableSpec[index]);
-    }
+    const headers: [number, string][] = columnIndices.map((index): [number, string] => [
+      index,
+      columnLabel(def.tableSpec[index]),
+    ]);
 
     // keep()/cache live outside the limiter task: on abort `run` rejects and they are
     // skipped, so an abandoned (detached) operation never caches its result nor touches
@@ -406,7 +406,7 @@ export class AbstractPFrameDriver<
         }
       }
 
-      await pTable.export(path, headers, { signal: combinedSignal });
+      await pTable.export(path, { headers, signal: combinedSignal });
 
       const overallSize = await tableGuard.resource.cacheSize;
 

--- a/lib/node/pf-driver/src/pframe_pool.ts
+++ b/lib/node/pf-driver/src/pframe_pool.ts
@@ -31,7 +31,7 @@ export interface RemoteBlobProvider<TreeEntry extends JsonSerializable> {
 }
 
 export class PFrameHolder<TreeEntry extends JsonSerializable> implements Disposable {
-  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV17>;
+  public readonly pFrameDataPromise: Promise<PFrameInternal.PFrameV18>;
   /**
    * WASM-spec frame built from this PFrame's columns. Source of truth
    * for spec-side operations: column discovery, selector resolution,

--- a/lib/node/pf-driver/src/ptable_pool.ts
+++ b/lib/node/pf-driver/src/ptable_pool.ts
@@ -26,7 +26,7 @@ export class PTableHolder implements Disposable {
   constructor(
     public readonly pFrame: PFrameHandle,
     pFrameDisposeSignal: AbortSignal,
-    public readonly pTablePromise: Promise<PFrameInternal.PTableV11>,
+    public readonly pTablePromise: Promise<PFrameInternal.PTableV12>,
     private readonly predecessor?: PoolEntry<PTableHandle, PTableHolder>,
   ) {
     this.combinedDisposeSignal = AbortSignal.any([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.44
-      version: 1.1.44
+      specifier: 1.1.46
+      version: 1.1.46
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.44
-      version: 1.1.44
+      specifier: 1.1.46
+      version: 1.1.46
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.44
-      version: 1.1.44
+      specifier: 1.1.46
+      version: 1.1.46
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -2180,7 +2180,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2300,10 +2300,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.44(encoding@0.1.13)
+        version: 1.1.46(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2783,10 +2783,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.44(encoding@0.1.13)
+        version: 1.1.46(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3457,7 +3457,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.44
+        version: 1.1.46
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5369,31 +5369,31 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.44':
-    resolution: {integrity: sha512-s3ccom18u336R//OYQOqjlqb9K94nXWO4uiB2q1wJW1Z7WXXWq+naTRlBLaQ84/t/CA6+m+BTTCD6v/GBxMexQ==}
+  '@milaboratories/pframes-rs-node@1.1.46':
+    resolution: {integrity: sha512-TYvlvW3E59LXdfLrkklmJF1Eb29oxIrP6CTbE/RQxHrcBw0kkDUaR+VG2L/b+OQRTORi9YNrqJhWzhJOIrPWFQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.44':
-    resolution: {integrity: sha512-u18UiJK+KkbfqwuZmDbgSia+/si48l1P+feZcEyl2JgtdHoaTlZaNenjViu0+fX6O3PRRwHndH0GZzq8IEp+bg==}
+  '@milaboratories/pframes-rs-serv@1.1.46':
+    resolution: {integrity: sha512-0ohN+yvePXG4pP6TY9S0N5mrP1WYSjv30iKk1VjlCTW2HqjyMa7MPGsnJaVX3BVUzB7IQJs0BZ5GP3oHsEZm6g==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.44':
-    resolution: {integrity: sha512-lS8poGIpnGK+w2LKwbmYGuT4khXVK0qeXOQpo9b7wyTgAMJmjFcV/MBlS7ql5cJ/NS86p27cZDBBAlEgfBFWfw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.46':
+    resolution: {integrity: sha512-aKKcPzyud13WmiEV2+2lbT0/qcuPJx/d3yztoXZHU++gwDRu1LXq2c/hjphYMPQ/g2zDXewMtzeBHknypi95UQ==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.44':
-    resolution: {integrity: sha512-F4gk12I6QpseDQNHx66jYPlwL/MMmQ8yUsrEsHjVrDiQvJw5xvkrV26+8uF5foHP++gWoSO2BpOqEJQjHW/I/w==}
+  '@milaboratories/pframes-rs-wasm@1.1.46':
+    resolution: {integrity: sha512-1NJ4PTzTuXUfNCiYCkOvclP34SPTXRVJei5vHmPt4guawX/u8m+zYhyQcnARZoDGMV21VNuxTPAeqRzBPSzr3w==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.4
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-model-common@1.46.0':
-    resolution: {integrity: sha512-ieKPAQn40j731NuRWv+wRpgs3W0doxtQC3+aQC6dZQIo5kIzYqfZGrVQQUyNwfGbk3T3cCLH8dS8YZcBOEyIBQ==}
+  '@milaboratories/pl-model-common@1.46.1':
+    resolution: {integrity: sha512-ABOz/w7dA4t2zUpZHXI74MTNW6LmPFSLxgfhOPFdO6vodIY8draVN+ag2U21WlYIoSgdJwSXJrXJWdu1cefrIg==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.0':
-    resolution: {integrity: sha512-OmoCfGd1eUySI3ILP6rGfytbBgUOd9Jw3HuCCiLGHbV8qevtiV1DwqohWp36KHGFCfpmtaiQyV2Q3Y5+3bdUJQ==}
+  '@milaboratories/pl-model-middle-layer@1.30.4':
+    resolution: {integrity: sha512-U81Fk33PFBxBDTt8s1Ue31z1yM4Yx8ZOPu0SrANT8oevlIfgDYZHEtPzPfUBprh3Yq4/4VrEqkRpTLbP6I6s4g==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -11737,31 +11737,31 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.44(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.46(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.44
-      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pframes-rs-serv': 1.1.46
+      '@milaboratories/pl-model-common': 1.46.1
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.44':
+  '@milaboratories/pframes-rs-serv@1.1.46':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.4
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.44': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.46': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.44
+      '@milaboratories/pframes-rs-wasip2': 1.1.46
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11770,17 +11770,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.0':
+  '@milaboratories/pl-model-common@1.46.1':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.0':
+  '@milaboratories/pl-model-middle-layer@1.30.4':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-common': 1.46.1
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -252,9 +252,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.44
-  "@milaboratories/pframes-rs-wasip2": 1.1.44
-  "@milaboratories/pframes-rs-wasm": 1.1.44
+  "@milaboratories/pframes-rs-node": 1.1.46
+  "@milaboratories/pframes-rs-wasip2": 1.1.46
+  "@milaboratories/pframes-rs-wasm": 1.1.46
 
   "quickjs-emscripten": 0.31.0
 


### PR DESCRIPTION
## Summary

Adopts PFrames **1.1.46** (pframes-rs [PR #265](https://github.com/milaboratory/pframes-rs/pull/265)) and migrates the pf-driver to the new internal interfaces.

## Changes

- **Bump** `@milaboratories/pframes-rs-{node,wasip2,wasm}` `1.1.44` → `1.1.46` in the catalog.
- **Adopt new interfaces** in `pf-driver`:
  - `PFrameV17` → `PFrameV18` (`pframe_pool.ts`)
  - `PTableV11` → `PTableV12` (`ptable_pool.ts`)
  - `PTable.export` now takes `headers` as an ordered `[unifiedColumnIndex, headerName][]` list inside `ops` instead of a `Record<number, string>` map (`driver_impl.ts`).
- **Remove** the superseded `PFrameFactoryV8`, `PFrameV17`, `PTableV11`, and `PFrameReadAPIV14` interfaces from `pl-model-middle-layer`, and clean up their now-dangling doc references.

## Verification

- `types:check` clean on `pl-model-middle-layer` and `pf-driver`.
- `pf-driver` build + full test suite pass (51 tests), including `exportPTable writes a CSV with derived headers`, which exercises the new `export` signature against pframes-rs 1.1.46.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adopts PFrames 1.1.46 by bumping `@milaboratories/pframes-rs-{node,wasip2,wasm}` from 1.1.44 → 1.1.46 and migrating the pf-driver to the new internal interfaces. The key interface change is `PTable.export`'s `headers` parameter moving from a `Record<number, string>` positional argument to a `[number, string][]` list passed inside `ops`.

- Removes superseded `PFrameFactoryV8`, `PFrameV17`, `PTableV11`, and `PFrameReadAPIV14` interfaces from `pl-model-middle-layer`, cleaning up cross-version doc references.
- Migrates `driver_impl.ts` to the new `PTableV12.export` call shape and updates `pframe_pool.ts` / `ptable_pool.ts` to reference the new `PFrameV18` / `PTableV12` types.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The pf-driver migration is clean and the new export call shape is correctly wired. The one gap is `REQUIRES_PFRAMES_VERSION` not being bumped alongside the pframes package pin.

The interface migration (`PFrameV18`, `PTableV12`, new `export` signature) is straightforward and well-tested. The only deviation from the codebase's own process is that `REQUIRES_PFRAMES_VERSION` remains at `1_001_031` (v1.1.31) while pframes is now at 1.1.46. Both the constant's docstring and the `pnpm-workspace.yaml` comment explicitly ask for this to be updated in lockstep; skipping it means blocks that embed the constant as their `requiresPFramesVersion` will under-declare their runtime requirement.

lib/model/common/src/flags/block_flags.ts — `REQUIRES_PFRAMES_VERSION` needs to be bumped to `1_001_046`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pf-driver/src/driver_impl.ts | Migrates `exportPTable` to the new `PTableV12.export` signature — builds headers as `[number, string][]` and passes them inside `ops`. Logic is equivalent to the old `Record<number, string>` path. |
| lib/model/middle-layer/src/pframe/internal_api/table.ts | Removes the now-superseded `PTableV11` interface; keeps only `PTableV12` with `headers` in `ops`. |
| lib/model/middle-layer/src/pframe/internal_api/pframe.ts | Removes `PFrameV17` and `PFrameFactoryV8`; updates `PFrameFactoryV9` doc to remove the superseded cross-version reference. |
| lib/node/pf-driver/src/pframe_pool.ts | Trivially updates the type of `pFrameDataPromise` from `PFrameV17` to `PFrameV18`. |
| lib/node/pf-driver/src/ptable_pool.ts | Trivially updates the type of `pTablePromise` from `PTableV11` to `PTableV12`. |
| lib/model/common/src/flags/block_flags.ts | `REQUIRES_PFRAMES_VERSION` remains at `1_001_031` (v1.1.31) despite pframes being bumped to 1.1.46; the constant's own docstring and the pnpm-workspace comment both instruct updating it in lockstep with every bump. |
| pnpm-workspace.yaml | Updates the pframes catalog pins from 1.1.44 to 1.1.46 across all three variants. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Driver as pf-driver<br/>(driver_impl.ts)
    participant Pool as PTablePool<br/>(ptable_pool.ts)
    participant Holder as PTableHolder
    participant WASM as pframes-rs-node<br/>(PFrameV18 / PTableV12)

    Driver->>Pool: acquire(def)
    Pool->>Holder: "new PTableHolder(..., pTablePromise: Promise<PTableV12>)"
    Holder-->>Pool: PTableHolder

    Driver->>Holder: pTablePromise
    Holder-->>Driver: PTableV12 instance

    note over Driver: Build headers as<br/>[number, string][] from columnIndices

    Driver->>WASM: "pTable.export(path, { headers, signal })"
    note over WASM: headers list sorted by index<br/>write file (csv/tsv/parquet/xlsx)
    WASM-->>Driver: void
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pf-driver): adopt PFrames 1.1.46 ex..."](https://github.com/milaboratory/platforma/commit/088af690209816421275a0c867f98016fada92b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36979321)</sub>

<!-- /greptile_comment -->