### PR TITLE
Support additional axes in batch mode

### DIFF
--- a/.changeset/batch-xsv-additional-axes.md
+++ b/.changeset/batch-xsv-additional-axes.md
@@ -2,4 +2,8 @@
 "@platforma-sdk/workflow-tengo": minor
 ---
 
-pframes.processColumn: batch-mode Xsv outputs can now declare additional body-produced axes via `settings.axes`, alongside `settings.batchKeyColumns`. Previously the two were mutually exclusive, so a body that emitted new axes beyond the batch keys had no way to declare them (only ResourceMap outputs supported this). The combined output key is `[isolation…, batchKey…, additional…]`.
+pframes.processColumn batch-mode Xsv outputs: two improvements.
+
+- **Additional axes.** Batch Xsv outputs can now declare additional body-produced axes via `settings.axes`, alongside `settings.batchKeyColumns`. Previously the two were mutually exclusive, so a body that emitted new axes beyond the batch keys had no way to declare them (only ResourceMap outputs supported this). The combined output key is `[isolation…, batchKey…, additional…]`.
+
+- **Honor `storageFormat`.** The batch path now respects the output's `storageFormat` (`Json` / `Binary` / `Parquet`) when building the partition / super-partition resources, matching the standard `processColumn` path. Previously it hardcoded Json super-partitioning, which (a) forced large outputs down pfconv's O(n²) single-partition Json import and (b) silently corrupted any output that requested `Parquet`/`Binary` (a `ParquetPartitioned` wrapped in a `JsonSuperPartitioned` container). The default is now `Parquet` (columnar, scales linearly); an unknown `storageFormat` is rejected with a clear error.

--- a/.changeset/batch-xsv-additional-axes.md
+++ b/.changeset/batch-xsv-additional-axes.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+pframes.processColumn: batch-mode Xsv outputs can now declare additional body-produced axes via `settings.axes`, alongside `settings.batchKeyColumns`. Previously the two were mutually exclusive, so a body that emitted new axes beyond the batch keys had no way to declare them (only ResourceMap outputs supported this). The combined output key is `[isolation…, batchKey…, additional…]`.

--- a/sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo
@@ -255,25 +255,38 @@ processColumnBatch := func(input, bodyTpl, outputs, opts) {
 
 			additionalAxes := slices.normalize(output.settings.axes)
 
-			// The body emits batch-key axis columns, additional-axis columns, and
-			// value columns into one file; their XSV header names (the `column`
-			// field — not the output `id`) must all be distinct or the xsv import
-			// would read two columns under the same header. Reserve this output's
-			// own batch-key axis headers and value headers, then check each
-			// additional axis header against them and against each other.
+			// Two distinct namespaces must each stay collision-free:
+			//   - `column`    — the XSV header pfconv reads (batch-key axes,
+			//                   additional axes, and value columns share one file).
+			//   - `spec.name` — the axis identifier in the output axesSpec
+			//                   ([isolation…, batchKey…, additional…]); a duplicate
+			//                   name would give the PColumn two axes with the same id.
+			// Batch-key axes use their axis name for both. Seed each namespace with
+			// the pre-existing entries, then check every additional axis.
 			_outputHeaders := {}
+			_axisNames := {}
+			for axSpec in isolationAxesSpec {
+				_axisNames[axSpec.name] = "isolation axis"
+			}
 			for axName in batchKeyColumnsNames {
 				_outputHeaders[axName] = "batch-key axis"
+				_axisNames[axName] = "batch-key axis"
 			}
 			for col in output.settings.columns {
 				_outputHeaders[col.column] = "value column"
 			}
 			for axis in additionalAxes {
-				prior := _outputHeaders[axis.column]
-				ll.assert(is_undefined(prior),
+				priorHeader := _outputHeaders[axis.column]
+				ll.assert(is_undefined(priorHeader),
 					"Xsv output %q: additional axis column %q collides with %s of the same name; rename one of them",
-					output.name, axis.column, prior)
+					output.name, axis.column, priorHeader)
 				_outputHeaders[axis.column] = "additional axis"
+
+				priorName := _axisNames[axis.spec.name]
+				ll.assert(is_undefined(priorName),
+					"Xsv output %q: additional axis %q has spec.name %q colliding with %s; give every axis a unique name",
+					output.name, axis.column, axis.spec.name, priorName)
+				_axisNames[axis.spec.name] = "additional axis"
 			}
 
 			// Resolve the storage format explicitly so the per-scope xsv import and

--- a/sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo
@@ -10,6 +10,12 @@
  * the shared processColumn result object produced by
  * `pCommon.createProcessColumnResult`.
  *
+ * Output additional axes: both batch output forms accept body-produced axes
+ * beyond the batch keys. ResourceMap declares them via `output.spec.axesSpec`;
+ * Xsv declares them via `settings.axes` (full `{ column, spec }`, same as
+ * standard-mode Xsv) alongside `settings.batchKeyColumns`. The resulting key is
+ * `[isolation..., batchKey..., additional...]`.
+ *
  * See `processColumn` in `:pframes` for the public API docs.
  */
 
@@ -229,14 +235,14 @@ processColumnBatch := func(input, bodyTpl, outputs, opts) {
 				pUtil.validateXsvType(output.xsvType)
 			}
 
-			// batchKeyColumns references existing batch axes; axes defines new
-			// ones — mutually exclusive within one Xsv output.
+			// batchKeyColumns references existing batch axes by name; settings.axes
+			// (optional) declares additional NEW axes the body emits in its output
+			// file, same { column, spec } form as standard-mode Xsv. The final
+			// import axes are batch-key axes followed by the additional axes, so the
+			// output key reads [isolation..., batchKey..., newAxis...].
 			batchKeyColumnsNames := output.settings.batchKeyColumns
 			ll.assert(!is_undefined(batchKeyColumnsNames),
 				"Xsv output %q is missing settings.batchKeyColumns (required in batch mode; list the axis names emitted by the body)",
-				output.name)
-			ll.assert(is_undefined(output.settings.axes),
-				"Xsv output %q cannot set both batchKeyColumns and axes in settings; these are mutually exclusive — keep batchKeyColumns only",
 				output.name)
 
 			batchAxes := slices.map(batchKeyColumnsNames, func(colName) {
@@ -247,12 +253,34 @@ processColumnBatch := func(input, bodyTpl, outputs, opts) {
 				return { column: colName, spec: axSpec }
 			})
 
-			// Replace batchKeyColumns with the built axes and pin
-			// partitionKeyLength=0. pfconv MUST have partitionKeyLength < len(axes);
-			// with 0 it embeds all rows as a single "[]" partition whose JSON maps
-			// axis_value → column_value.
+			additionalAxes := slices.normalize(output.settings.axes)
+
+			// The body emits batch-key axis columns, additional-axis columns, and
+			// value columns into one file; their XSV header names (the `column`
+			// field — not the output `id`) must all be distinct or the xsv import
+			// would read two columns under the same header. Reserve this output's
+			// own batch-key axis headers and value headers, then check each
+			// additional axis header against them and against each other.
+			_outputHeaders := {}
+			for axName in batchKeyColumnsNames {
+				_outputHeaders[axName] = "batch-key axis"
+			}
+			for col in output.settings.columns {
+				_outputHeaders[col.column] = "value column"
+			}
+			for axis in additionalAxes {
+				prior := _outputHeaders[axis.column]
+				ll.assert(is_undefined(prior),
+					"Xsv output %q: additional axis column %q collides with %s of the same name; rename one of them",
+					output.name, axis.column, prior)
+				_outputHeaders[axis.column] = "additional axis"
+			}
+
+			// Pin partitionKeyLength=0: pfconv MUST have partitionKeyLength < len(axes);
+			// with 0 it embeds all rows as a single "[]" partition whose JSON maps the
+			// full (batch-key + additional) axis tuple → column_value.
 			modifiedSettings := maps.merge(output.settings, {
-				axes: batchAxes,
+				axes: batchAxes + additionalAxes,
 				batchKeyColumns: undefined,
 				partitionKeyLength: 0
 			})

--- a/sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo
@@ -276,13 +276,26 @@ processColumnBatch := func(input, bodyTpl, outputs, opts) {
 				_outputHeaders[axis.column] = "additional axis"
 			}
 
+			// Resolve the storage format explicitly so the per-scope xsv import and
+			// the super-partition wrappers (orchestrator/split) agree on the resource
+			// type. Default to "Parquet" — columnar storage scales linearly, whereas
+			// Json single-partition import is O(n²) in pfconv for large outputs.
+			storageFormat := output.settings.storageFormat
+			if is_undefined(storageFormat) {
+				storageFormat = "Parquet"
+			}
+			ll.assert(storageFormat == "Json" || storageFormat == "Binary" || storageFormat == "Parquet",
+				"Xsv output %q has invalid storageFormat %q; expected \"Json\", \"Binary\", or \"Parquet\"",
+				output.name, storageFormat)
+
 			// Pin partitionKeyLength=0: pfconv MUST have partitionKeyLength < len(axes);
-			// with 0 it embeds all rows as a single "[]" partition whose JSON maps the
-			// full (batch-key + additional) axis tuple → column_value.
+			// with 0 it embeds all rows as a single "[]" partition keyed by the full
+			// (batch-key + additional) axis tuple → column_value.
 			modifiedSettings := maps.merge(output.settings, {
 				axes: batchAxes + additionalAxes,
 				batchKeyColumns: undefined,
-				partitionKeyLength: 0
+				partitionKeyLength: 0,
+				storageFormat: storageFormat
 			})
 			decomposition := pUtil.decomposePfconvImportCfg(modifiedSettings, {
 				additionalAxesSpec: iterationAxesSpec

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-helpers.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-helpers.lib.tengo
@@ -233,10 +233,44 @@ groupColumnData := func(data, isolationIndices, batchKeyIndices, batchKeyLength,
 	return groups
 }
 
+/**
+ * Maps an Xsv output `storageFormat` to the PColumn data resource types used to
+ * wrap batch results: `partitioned` for a single scope / empty output,
+ * `superPartitioned` for multi-scope (isolation) collection.
+ *
+ * Mirrors the storageFormat branching in `:pframes.process-pcolumn-data` so the
+ * batch path honors `storageFormat` (Json/Binary/Parquet) instead of assuming
+ * Json. The per-scope `xsv.importFile` produces a `<format>Partitioned`; the
+ * super-partition wrapper must use the matching `<format>SuperPartitioned`.
+ *
+ * @param storageFormat  "Json" | "Binary" | "Parquet"
+ * @returns { partitioned, superPartitioned } resource type descriptors
+ */
+xsvDataResTypes := func(storageFormat) {
+	if storageFormat == "Binary" {
+		return {
+			partitioned: pConstants.RTYPE_P_COLUMN_DATA_BINARY_PARTITIONED,
+			superPartitioned: pConstants.RTYPE_P_COLUMN_DATA_BINARY_SUPER_PARTITIONED
+		}
+	} else if storageFormat == "Json" {
+		return {
+			partitioned: pConstants.RTYPE_P_COLUMN_DATA_JSON_PARTITIONED,
+			superPartitioned: pConstants.RTYPE_P_COLUMN_DATA_JSON_SUPER_PARTITIONED
+		}
+	} else if storageFormat == "Parquet" {
+		return {
+			partitioned: pConstants.RTYPE_P_COLUMN_DATA_PARQUET_PARTITIONED,
+			superPartitioned: pConstants.RTYPE_P_COLUMN_DATA_PARQUET_SUPER_PARTITIONED
+		}
+	}
+	ll.panic("Unknown storageFormat for batch Xsv output: %v (expected \"Json\", \"Binary\", or \"Parquet\")", storageFormat)
+}
+
 export ll.toStrict({
 	resolveData: resolveData,
 	classifyPColumnData: classifyPColumnData,
 	recordsInGroup: recordsInGroup,
 	forEachOutputField: forEachOutputField,
-	groupColumnData: groupColumnData
+	groupColumnData: groupColumnData,
+	xsvDataResTypes: xsvDataResTypes
 })

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo
@@ -283,12 +283,14 @@ self.body(func(inputs) {
 			// as the orchestrator's empty-scope fallback), and no partitions
 			// are added.
 			if len(batchFiles) == 0 {
-				batchKeyLength := len(params.batchKeyHeaders)
+				// Full key arity = batch-key axes + any additional axes declared
+				// on the output (settings.axes carries both after decomposition).
+				keyLength := len(output.settings.axes)
 				for column in output.settings.columns {
 					id := pUtil.xsvColumnId(column)
 					result[output.name + "/" + id] = smart.structBuilder(
 						pConstants.RTYPE_P_COLUMN_DATA_JSON_PARTITIONED,
-						json.encode({ partitionKeyLength: batchKeyLength })
+						json.encode({ partitionKeyLength: keyLength })
 					).lockAndBuild()
 				}
 				continue

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo
@@ -20,6 +20,7 @@ assets := import(":assets")
 pConstants := import(":pframes.constants")
 pUtil := import(":pframes.util")
 xsv := import(":pframes.xsv")
+batchHelpers := import(":pframes.process-pcolumn-batch-helpers")
 text := import("text")
 
 json := import("json")
@@ -286,10 +287,11 @@ self.body(func(inputs) {
 				// Full key arity = batch-key axes + any additional axes declared
 				// on the output (settings.axes carries both after decomposition).
 				keyLength := len(output.settings.axes)
+				emptyResType := batchHelpers.xsvDataResTypes(output.settings.storageFormat).partitioned
 				for column in output.settings.columns {
 					id := pUtil.xsvColumnId(column)
 					result[output.name + "/" + id] = smart.structBuilder(
-						pConstants.RTYPE_P_COLUMN_DATA_JSON_PARTITIONED,
+						emptyResType,
 						json.encode({ partitionKeyLength: keyLength })
 					).lockAndBuild()
 				}

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo
@@ -230,11 +230,14 @@ self.body(func(inputs) {
 				})
 			)
 		} else if output.type == "Xsv" {
+			// The body's per-scope file embeds the full (batch-key + additional)
+			// axis tuple as in-jdata keys; the inner key length equals the number
+			// of declared import axes, not just the batch keys.
 			outputMaps[key] = smart.structBuilder(
 				pConstants.RTYPE_P_COLUMN_DATA_JSON_SUPER_PARTITIONED,
 				json.encode({
 					superPartitionKeyLength: isolationKeyLength,
-					partitionKeyLength: batchKeyLength
+					partitionKeyLength: len(output.settings.axes)
 				})
 			)
 		}
@@ -429,9 +432,10 @@ self.body(func(inputs) {
 				json.encode({ keyLength: batchKeyLength + output.keyLength })
 			).lockAndBuild()
 		} else if output.type == "Xsv" {
+			// Empty column still declares the full (batch-key + additional) key arity.
 			result[key] = smart.structBuilder(
 				pConstants.RTYPE_P_COLUMN_DATA_JSON_PARTITIONED,
-				json.encode({ partitionKeyLength: batchKeyLength })
+				json.encode({ partitionKeyLength: len(output.settings.axes) })
 			).lockAndBuild()
 		}
 	})

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo
@@ -232,9 +232,10 @@ self.body(func(inputs) {
 		} else if output.type == "Xsv" {
 			// The body's per-scope file embeds the full (batch-key + additional)
 			// axis tuple as in-jdata keys; the inner key length equals the number
-			// of declared import axes, not just the batch keys.
+			// of declared import axes, not just the batch keys. The super-partition
+			// resource type must match the import's storageFormat (Json/Binary/Parquet).
 			outputMaps[key] = smart.structBuilder(
-				pConstants.RTYPE_P_COLUMN_DATA_JSON_SUPER_PARTITIONED,
+				batchHelpers.xsvDataResTypes(output.settings.storageFormat).superPartitioned,
 				json.encode({
 					superPartitionKeyLength: isolationKeyLength,
 					partitionKeyLength: len(output.settings.axes)
@@ -432,9 +433,10 @@ self.body(func(inputs) {
 				json.encode({ keyLength: batchKeyLength + output.keyLength })
 			).lockAndBuild()
 		} else if output.type == "Xsv" {
-			// Empty column still declares the full (batch-key + additional) key arity.
+			// Empty column still declares the full (batch-key + additional) key arity,
+			// in the output's declared storageFormat.
 			result[key] = smart.structBuilder(
-				pConstants.RTYPE_P_COLUMN_DATA_JSON_PARTITIONED,
+				batchHelpers.xsvDataResTypes(output.settings.storageFormat).partitioned,
 				json.encode({ partitionKeyLength: len(output.settings.axes) })
 			).lockAndBuild()
 		}

--- a/tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo
@@ -12,6 +12,7 @@ bodyTplBlob := assets.importTemplate(":pframes.proc_batch_body_blob")
 bodyTplResourceMap := assets.importTemplate(":pframes.proc_batch_body_resource_map")
 bodyTplNdjson := assets.importTemplate(":pframes.proc_batch_body_ndjson")
 bodyTplExtraAxis := assets.importTemplate(":pframes.proc_batch_body_extra_axis")
+bodyTplExtraAxisBlob := assets.importTemplate(":pframes.proc_batch_body_extra_axis_blob")
 
 self.awaitState("InputsLocked")
 self.awaitState("params", "ResourceReady")
@@ -22,9 +23,10 @@ self.body(func(inputs) {
 	// Select body template:
 	// - params.bodyMode == "resourceMap" → body returns a ResourceMap keyed by batch key
 	// - params.bodyMode == "ndjson"      → body parses NDJSON content via pt, writes parquet
-	// - params.bodyMode == "extraAxis"   → body emits a new "half" axis column in its Xsv output
-	// - params.batch.passContent=false   → body treats __value__ as a Blob file ref
-	// - default                          → body reads __value__ as a content string
+	// - params.bodyMode == "extraAxis"     → body emits a new "half" axis column (passContent=true)
+	// - params.bodyMode == "extraAxisBlob" → body appends a "tag" axis via pt (passContent=false)
+	// - params.batch.passContent=false     → body treats __value__ as a Blob file ref
+	// - default                            → body reads __value__ as a content string
 	bodyTpl := bodyTplContent
 	if params.bodyMode == "resourceMap" {
 		bodyTpl = bodyTplResourceMap
@@ -32,6 +34,8 @@ self.body(func(inputs) {
 		bodyTpl = bodyTplNdjson
 	} else if params.bodyMode == "extraAxis" {
 		bodyTpl = bodyTplExtraAxis
+	} else if params.bodyMode == "extraAxisBlob" {
+		bodyTpl = bodyTplExtraAxisBlob
 	} else if !is_undefined(params.batch.passContent) && !params.batch.passContent {
 		bodyTpl = bodyTplBlob
 	}

--- a/tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo
@@ -11,6 +11,7 @@ bodyTplContent := assets.importTemplate(":pframes.proc_batch_body")
 bodyTplBlob := assets.importTemplate(":pframes.proc_batch_body_blob")
 bodyTplResourceMap := assets.importTemplate(":pframes.proc_batch_body_resource_map")
 bodyTplNdjson := assets.importTemplate(":pframes.proc_batch_body_ndjson")
+bodyTplExtraAxis := assets.importTemplate(":pframes.proc_batch_body_extra_axis")
 
 self.awaitState("InputsLocked")
 self.awaitState("params", "ResourceReady")
@@ -21,6 +22,7 @@ self.body(func(inputs) {
 	// Select body template:
 	// - params.bodyMode == "resourceMap" → body returns a ResourceMap keyed by batch key
 	// - params.bodyMode == "ndjson"      → body parses NDJSON content via pt, writes parquet
+	// - params.bodyMode == "extraAxis"   → body emits a new "half" axis column in its Xsv output
 	// - params.batch.passContent=false   → body treats __value__ as a Blob file ref
 	// - default                          → body reads __value__ as a content string
 	bodyTpl := bodyTplContent
@@ -28,6 +30,8 @@ self.body(func(inputs) {
 		bodyTpl = bodyTplResourceMap
 	} else if params.bodyMode == "ndjson" {
 		bodyTpl = bodyTplNdjson
+	} else if params.bodyMode == "extraAxis" {
+		bodyTpl = bodyTplExtraAxis
 	} else if !is_undefined(params.batch.passContent) && !params.batch.passContent {
 		bodyTpl = bodyTplBlob
 	}

--- a/tests/workflow-tengo/src/pframes/proc_batch_basic.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_basic.test.ts
@@ -117,6 +117,10 @@ eTplTest.concurrent(
     const hcData = theResult.inputs["tsv.heavyChain.data"];
     assertResource(hcData);
     expect(hcData.resourceType.name).toEqual("PColumnData/JsonPartitioned");
+    // Well-formed empty column: zero parts (no partition input fields). The
+    // resource carries only partitionKeyLength in its data; parts are input
+    // fields, so an empty column simply has none.
+    expect(Object.keys(hcData.inputs).length).toEqual(0);
   },
 );
 

--- a/tests/workflow-tengo/src/pframes/proc_batch_body_extra_axis.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch_body_extra_axis.tpl.tengo
@@ -1,0 +1,58 @@
+// proc_batch_body_extra_axis — body template exercising additional axes on a
+// batch-mode Xsv output. Receives batch TSV content as __value__ (string) with
+// columns "key" (batch-key axis) + "heavyChain" (value). It splits every
+// sequence into two halves and emits one output row per half, introducing a new
+// "half" axis column (Long) that the body — not the input — produces. The Xsv
+// output declares "half" via settings.axes alongside batchKeyColumns: ["key"].
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+ll := import("@platforma-sdk/workflow-tengo:ll")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
+
+text := import("text")
+
+hwSoftware := assets.importSoftware("@platforma-open/milaboratories.software-test-utils:hello-world")
+
+self.defineOutputs(
+	"tsv"
+)
+
+self.body(func(inputs) {
+	batchContent := inputs[pConstants.VALUE_FIELD_NAME]
+
+	if !is_string(batchContent) {
+		ll.panic("expected string batch content, got: %v", batchContent)
+	}
+
+	lines := text.split(batchContent, "\n")
+	for len(lines) > 0 && lines[len(lines) - 1] == "" {
+		lines = lines[:len(lines) - 1]
+	}
+
+	// Input header is "key\theavyChain"; output adds the new "half" axis column.
+	outLines := ["key\thalf\theavyChain"]
+	for i := 1; i < len(lines); i++ {
+		fields := text.split(lines[i], "\t")
+		key := fields[0]
+		seq := fields[1]
+		mid := len(seq) / 2
+		outLines = append(outLines, key + "\t0\t" + seq[:mid])
+		outLines = append(outLines, key + "\t1\t" + seq[mid:])
+	}
+	outContent := text.join(outLines, "\n") + "\n"
+
+	// hello-world is an identity run; the transformed file is written directly.
+	run := exec.builder().
+		cpu(1).ram("50Mi").
+		software(hwSoftware).
+		arg("a").
+		writeFile("batch.tsv", outContent).
+		saveFile("batch.tsv").
+		run()
+
+	return {
+		tsv: run.getFile("batch.tsv")
+	}
+})

--- a/tests/workflow-tengo/src/pframes/proc_batch_body_extra_axis_blob.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch_body_extra_axis_blob.tpl.tengo
@@ -1,0 +1,29 @@
+// proc_batch_body_extra_axis_blob — passContent=false counterpart of
+// proc_batch_body_extra_axis. Receives __value__ as a Blob batch file (not a
+// string), so it can't transform in Tengo; instead it uses pt to append a
+// constant additional-axis column ("tag"). This exercises the passContent=false
+// route (pt slice of a saved Blob → body → concat → import) with additional axes,
+// verifying the pipeline still emits correct 2-component keys.
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
+
+self.defineOutputs(
+	"tsv"
+)
+
+self.body(func(inputs) {
+	batchFile := inputs[pConstants.VALUE_FIELD_NAME]
+
+	// Batch file columns: "key" (batch-key axis) + "heavyChain" (value).
+	// Append a constant "tag" column — the body-produced additional axis.
+	wf := pt.workflow()
+	df := wf.frame(batchFile, { xsvType: "tsv" })
+	df.withColumns(pt.lit("a").alias("tag")).save("out.tsv", { format: "tsv" })
+	res := wf.run()
+
+	return {
+		tsv: res.getFile("out.tsv")
+	}
+})

--- a/tests/workflow-tengo/src/pframes/proc_batch_extra_axis.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_extra_axis.test.ts
@@ -1,0 +1,138 @@
+import type { PColumnSpec } from "@milaboratories/pl-middle-layer";
+import { assertJson, assertResource, eTplTest } from "./extended_tpl_test";
+import { getLongTestTimeout } from "@milaboratories/test-helpers";
+import { vi } from "vitest";
+import {
+  createJsonData,
+  expectPanic,
+  jsonParams,
+  readJsonPartition,
+  runBatch,
+  singleAxisSpec,
+  twoAxisSpec,
+} from "./proc_batch_common";
+
+vi.setConfig({ testTimeout: getLongTestTimeout(60_000) });
+
+// Xsv output that declares a body-produced "half" axis (Long) alongside the
+// batch-key axis "key". The body splits each sequence in half, emitting one row
+// per half — the "half" column is produced by the body, not the input.
+const xsvSettingsExtraAxis = {
+  batchKeyColumns: ["key"],
+  axes: [{ column: "half", spec: { name: "half", type: "Long" } }],
+  columns: [
+    { column: "heavyChain", id: "heavyChain", spec: { valueType: "String", name: "heavyChain" } },
+  ],
+  storageFormat: "Json",
+} as const;
+
+eTplTest.concurrent(
+  "batch mode: Xsv output with an additional body-produced axis (no isolation)",
+  async ({ helper, expect, stHelper }) => {
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "extraAxis",
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data1", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsExtraAxis }],
+        batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: true },
+      }),
+      data1: createJsonData(tx, 1, { '["k1"]': "EVQL", '["k2"]': "QVQL" }),
+    }));
+
+    expect(theResult.resourceType.name).toEqual("PFrame");
+
+    // Spec must carry both the batch-key axis and the new "half" axis, in order.
+    const hcSpecRes = theResult.inputs["tsv.heavyChain.spec"];
+    assertJson(hcSpecRes);
+    const hcSpec = hcSpecRes.content as PColumnSpec;
+    expect(hcSpec.axesSpec).toHaveLength(2);
+    expect(hcSpec.axesSpec[0]).toMatchObject({ name: "key", type: "String" });
+    expect(hcSpec.axesSpec[1]).toMatchObject({ name: "half", type: "Long" });
+
+    // Data: single "[]" partition, jdata keyed by [key, half].
+    const hcData = theResult.inputs["tsv.heavyChain.data"];
+    assertResource(hcData);
+    expect(Object.keys(hcData.inputs)).toEqual(["[]"]);
+    const content = readJsonPartition(hcData);
+    expect(content).toMatchObject({
+      '["k1",0]': "EV",
+      '["k1",1]': "QL",
+      '["k2",0]': "QV",
+      '["k2",1]': "QL",
+    });
+  },
+);
+
+eTplTest.concurrent(
+  "batch mode: additional axis with isolation axis (super-partitioned)",
+  async ({ helper, expect, stHelper }) => {
+    // 2 samples × 2 keys; output keyed [sampleId (isolation), key (batch), half (new)].
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "extraAxis",
+        primaryEntries: [{ spec: twoAxisSpec, dataInputName: "data1", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsExtraAxis }],
+        batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: true },
+      }),
+      data1: createJsonData(tx, 2, {
+        '["A","k1"]': "EVQL",
+        '["A","k2"]': "QVQL",
+        '["B","k1"]': "DIQM",
+        '["B","k2"]': "EIVL",
+      }),
+    }));
+
+    expect(theResult.resourceType.name).toEqual("PFrame");
+
+    const hcSpecRes = theResult.inputs["tsv.heavyChain.spec"];
+    assertJson(hcSpecRes);
+    const hcSpec = hcSpecRes.content as PColumnSpec;
+    expect(hcSpec.axesSpec).toHaveLength(3);
+    expect(hcSpec.axesSpec[0]).toMatchObject({ name: "sampleId", type: "String" });
+    expect(hcSpec.axesSpec[1]).toMatchObject({ name: "key", type: "String" });
+    expect(hcSpec.axesSpec[2]).toMatchObject({ name: "half", type: "Long" });
+
+    // Data resource exists and is keyed by the full [sampleId, key, half] tuple
+    // (3 axes asserted above). The exact post-export partition layout for the
+    // isolation case is exercised structurally by the spec assertions; the
+    // partition-content shape is covered by the no-isolation case above.
+    assertResource(theResult.inputs["tsv.heavyChain.data"]);
+  },
+);
+
+// An additional axis column whose name collides with a value column must be
+// rejected before rendering — the body would emit two columns of the same name.
+const xsvSettingsAxisCollision = {
+  batchKeyColumns: ["key"],
+  axes: [{ column: "heavyChain", spec: { name: "extra", type: "Long" } }],
+  columns: [
+    { column: "heavyChain", id: "heavyChain", spec: { valueType: "String", name: "heavyChain" } },
+  ],
+  storageFormat: "Json",
+} as const;
+
+eTplTest.concurrent(
+  "batch mode: additional axis colliding with a value column is rejected",
+  async ({ helper, expect, stHelper }) => {
+    await expectPanic(
+      helper,
+      stHelper,
+      expect,
+      (tx) => ({
+        params: jsonParams(tx, {
+          bodyMode: "extraAxis",
+          primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data1", header: "heavyChain" }],
+          primaryJoin: "full",
+          outputs: [
+            { type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsAxisCollision },
+          ],
+          batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: true },
+        }),
+        data1: createJsonData(tx, 1, { '["k1"]': "EVQL", '["k2"]': "QVQL" }),
+      }),
+      /additional axis column .* collides with/,
+    );
+  },
+);

--- a/tests/workflow-tengo/src/pframes/proc_batch_extra_axis.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_extra_axis.test.ts
@@ -136,3 +136,51 @@ eTplTest.concurrent(
     );
   },
 );
+
+// Additional axes via the passContent=false route: the body receives a Blob
+// batch file (pt-sliced from a saved frame, not in-memory line slicing) and
+// appends a constant "tag" axis via pt. Verifies the slice → body → concat →
+// import pipeline still produces correct 2-component keys [key, tag].
+const xsvSettingsTagAxis = {
+  batchKeyColumns: ["key"],
+  axes: [{ column: "tag", spec: { name: "tag", type: "String" } }],
+  columns: [
+    { column: "heavyChain", id: "heavyChain", spec: { valueType: "String", name: "heavyChain" } },
+  ],
+  storageFormat: "Json",
+} as const;
+
+eTplTest.concurrent(
+  "batch mode: additional axis via passContent=false (pt-slicing path)",
+  async ({ helper, expect, stHelper }) => {
+    // 3 records, batch size 2 → 2 batches, so the per-scope concat path is hit.
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "extraAxisBlob",
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data1", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsTagAxis }],
+        batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: false },
+      }),
+      data1: createJsonData(tx, 1, { '["k1"]': "EVQL", '["k2"]': "QVQL", '["k3"]': "DIQM" }),
+    }));
+
+    expect(theResult.resourceType.name).toEqual("PFrame");
+
+    const hcSpecRes = theResult.inputs["tsv.heavyChain.spec"];
+    assertJson(hcSpecRes);
+    const hcSpec = hcSpecRes.content as PColumnSpec;
+    expect(hcSpec.axesSpec).toHaveLength(2);
+    expect(hcSpec.axesSpec[0]).toMatchObject({ name: "key", type: "String" });
+    expect(hcSpec.axesSpec[1]).toMatchObject({ name: "tag", type: "String" });
+
+    const hcData = theResult.inputs["tsv.heavyChain.data"];
+    assertResource(hcData);
+    const content = readJsonPartition(hcData);
+    expect(content).toMatchObject({
+      '["k1","a"]': "EVQL",
+      '["k2","a"]': "QVQL",
+      '["k3","a"]': "DIQM",
+    });
+  },
+);

--- a/tests/workflow-tengo/src/pframes/proc_batch_filter.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_filter.test.ts
@@ -16,38 +16,6 @@ import {
 
 vi.setConfig({ testTimeout: getLongTestTimeout(60_000) });
 
-// Sets both batchKeyColumns and axes on one Xsv output — must be rejected as
-// mutually exclusive.
-const xsvSettingsBadBoth = {
-  batchKeyColumns: ["key"],
-  axes: [{ column: "key", spec: { name: "key", type: "String" } }],
-  columns: [
-    { column: "heavyChain", id: "heavyChain", spec: { valueType: "String", name: "heavyChain" } },
-  ],
-  storageFormat: "Json",
-} as const;
-
-eTplTest.concurrent(
-  "batch mode: Xsv output with both batchKeyColumns and axes is rejected",
-  async ({ helper, expect, stHelper }) => {
-    await expectPanic(
-      helper,
-      stHelper,
-      expect,
-      (tx) => ({
-        params: jsonParams(tx, {
-          primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data1", header: "heavyChain" }],
-          primaryJoin: "full",
-          outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsBadBoth }],
-          batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: true },
-        }),
-        data1: createJsonData(tx, 1, { '["k1"]': "EVQL", '["k2"]': "QVQL" }),
-      }),
-      /cannot set both batchKeyColumns and axes/,
-    );
-  },
-);
-
 eTplTest.concurrent(
   "batch mode: maxBatches step 2 — too many isolation scopes panics",
   async ({ helper, expect, stHelper }) => {

--- a/tests/workflow-tengo/src/pframes/proc_batch_format.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_format.test.ts
@@ -5,6 +5,7 @@ import { getLongTestTimeout } from "@milaboratories/test-helpers";
 import { vi } from "vitest";
 import {
   createJsonData,
+  expectPanic,
   jsonParams,
   readJsonPartition,
   runBatch,
@@ -204,5 +205,96 @@ eTplTest.concurrent(
       const content = JSON.parse(Buffer.from(blob.content).toString());
       expect(Object.keys(content).length).toEqual(6);
     }
+  },
+);
+
+// Parquet storage + isolation exercises the storageFormat branching for the
+// super-partition wrapper (PColumnData/super/ParquetPartitioned). Before the
+// storageFormat fix the orchestrator hardcoded the Json super-partition type, so
+// a Parquet output with isolation produced a corrupt Json-wrapped resource.
+eTplTest.concurrent(
+  "batch mode: storageFormat=Parquet with isolation (super-partitioned)",
+  async ({ helper, expect, stHelper }) => {
+    const recs: Record<string, string> = {};
+    for (const sample of ["A", "B"]) {
+      for (let i = 0; i < 4; i++) recs[`["${sample}","k${i}"]`] = `${sample}${i}`;
+    }
+
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        primaryEntries: [{ spec: twoAxisSpec, dataInputName: "data", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "parquet", settings: parquetXsvSettings }],
+        batch: { size: 2, keyColumns: ["key"], format: "parquet", passContent: false },
+      }),
+      data: createJsonData(tx, 2, recs),
+    }));
+
+    const hcData = theResult.inputs["tsv.heavyChain.data"];
+    assertResource(hcData);
+    // Super-partitioned by sampleId, and the storage type must be Parquet (not Json).
+    expect(hcData.resourceType.name).toContain("Parquet");
+    expect(Object.keys(hcData.inputs).sort()).toEqual(['["A"]', '["B"]']);
+  },
+);
+
+// storageFormat now defaults to "Parquet" (omitted in settings).
+const xsvSettingsNoStorageFormat = {
+  batchKeyColumns: ["key"],
+  columns: [
+    { column: "heavyChain", id: "heavyChain", spec: { valueType: "String", name: "heavyChain" } },
+  ],
+} as const;
+
+eTplTest.concurrent(
+  "batch mode: storageFormat defaults to Parquet when omitted",
+  async ({ helper, expect, stHelper }) => {
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [
+          { type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsNoStorageFormat },
+        ],
+        batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: true },
+      }),
+      data: createJsonData(tx, 1, { '["k1"]': "EVQL", '["k2"]': "QVQL" }),
+    }));
+
+    const hcData = theResult.inputs["tsv.heavyChain.data"];
+    assertResource(hcData);
+    expect(hcData.resourceType.name).toContain("Parquet");
+  },
+);
+
+// An unknown storageFormat must be rejected up front.
+const xsvSettingsBadStorageFormat = {
+  batchKeyColumns: ["key"],
+  columns: [
+    { column: "heavyChain", id: "heavyChain", spec: { valueType: "String", name: "heavyChain" } },
+  ],
+  storageFormat: "Avro",
+} as const;
+
+eTplTest.concurrent(
+  "batch mode: invalid storageFormat is rejected",
+  async ({ helper, expect, stHelper }) => {
+    await expectPanic(
+      helper,
+      stHelper,
+      expect,
+      (tx) => ({
+        params: jsonParams(tx, {
+          primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data", header: "heavyChain" }],
+          primaryJoin: "full",
+          outputs: [
+            { type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsBadStorageFormat },
+          ],
+          batch: { size: 2, keyColumns: ["key"], format: "tsv", passContent: true },
+        }),
+        data: createJsonData(tx, 1, { '["k1"]': "EVQL", '["k2"]': "QVQL" }),
+      }),
+      /invalid storageFormat/,
+    );
   },
 );


### PR DESCRIPTION
This PR adds support for additional axes in processColumn batch mode for XSV type. It also adds support for all storage formats.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR lifts the previous mutual exclusion between `batchKeyColumns` and `axes` in batch-mode Xsv outputs, allowing a body template to produce extra axis columns beyond the batch keys. The combined output key becomes `[isolation…, batchKey…, additional…]`, and `partitionKeyLength` is updated throughout the orchestrator and split templates to reflect the full axis arity.

- **`process-column-batch.lib.tengo`**: removes the exclusion assertion, merges additional axes via `slices.normalize`, and adds a per-column-header collision guard before calling `decomposePfconvImportCfg` with the merged axis list.
- **`process-pcolumn-batch.tpl.tengo` and `process-pcolumn-batch-split.tpl.tengo`**: replace `batchKeyLength` with `len(output.settings.axes)` in the `partitionKeyLength` field of both super-partitioned containers and empty-batch fallback resources.
- **New test file** covers the no-isolation case (verifies spec and partition data), the isolation case (structural spec check), and a collision-rejection test; the existing rejection test for the old mutual-exclusion rule is removed.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core feature is correctly implemented and logically consistent with the existing batch-mode design. The main risk is that empty-batch and super-partitioned fallback paths still hardcode the JSON resource type, which would silently produce wrong results for Binary or Parquet storage formats — but this is pre-existing behaviour not introduced here.

The axis-merging logic, partitionKeyLength updates, and collision detection are all correct and consistent. The PR description's claim of 'all storage formats' is not fully backed by the empty-batch fallback paths (which hardcode JSON), and the test suite only covers storageFormat:Json and passContent:true, leaving two code paths unverified. The feature itself works as described for the exercised scenarios.

The empty-batch fallback paths in process-pcolumn-batch.tpl.tengo (empty-scope Xsv fallback) and process-pcolumn-batch-split.tpl.tengo (zero-batchFiles path) warrant attention for the storageFormat gap. process-column-batch.lib.tengo could additionally validate spec.name uniqueness across the merged axis list.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo | Core logic change: removes the batchKeyColumns/axes mutual-exclusion assertion, merges additional user-declared axes via slices.normalize, and adds per-output column-header collision detection. Logic is sound, though the collision check covers column headers only (not spec.name values). |
| sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo | Two partitionKeyLength values updated from the legacy batchKeyLength to len(output.settings.axes), which now covers batch-key + additional axes. Both the super-partitioned container creation and the empty-scope fallback are correctly updated. |
| sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo | Empty-Xsv-batch fallback updated from len(params.batchKeyHeaders) to len(output.settings.axes). The ResourceMap empty-batch path still correctly uses batchKeyHeaders. The non-empty path goes through xsv.importFile unchanged. |
| tests/workflow-tengo/src/pframes/proc_batch_extra_axis.test.ts | New test file covering: no-isolation extra-axis (verifies spec and data layout), isolation extra-axis (structural check), and column-header collision rejection. All tests use passContent:true and storageFormat:Json; non-JSON formats and passContent:false are not covered. |
| tests/workflow-tengo/src/pframes/proc_batch_body_extra_axis.tpl.tengo | New body template that splits each sequence into two halves and emits a half (Long) axis column alongside the batch-key key column; straightforward and correct for the test scenario. |
| tests/workflow-tengo/src/pframes/proc_batch_filter.test.ts | Removes the now-obsolete batchKeyColumns + axes are mutually exclusive rejection test, which is correct since the mutual-exclusion assertion was lifted. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["processColumnBatch\n(process-column-batch.lib.tengo)"] --> B{output.type == Xsv?}
    B -- yes --> C["batchAxes = map batchKeyColumns → axisSpec"]
    C --> D["additionalAxes = slices.normalize(settings.axes)\n(NEW: was rejected before)"]
    D --> E["Collision check: column headers\nbatch-key ∪ value ∪ additional axes"]
    E --> F["modifiedSettings.axes = batchAxes + additionalAxes\npartitionKeyLength = 0"]
    F --> G["decomposePfconvImportCfg(modifiedSettings)"]
    G --> H["processedOutput.settings = purifiedCfg\n(axes field = full merged list)"]
    H --> I["process-pcolumn-batch.tpl.tengo\n(orchestrator)"]
    I --> J{hasIsolation?}
    J -- yes --> K["Super-partitioned container\npartitionKeyLength = len(settings.axes)\nNEW: was batchKeyLength"]
    J -- no --> L{any data?}
    L -- yes --> M["Split template per isolation scope"]
    L -- no --> N["Empty fallback\nRTYPE_JSON_PARTITIONED\npartitionKeyLength = len(settings.axes)\nNEW: was batchKeyLength"]
    M --> O["process-pcolumn-batch-split.tpl.tengo"]
    O --> P{batchFiles empty?}
    P -- no --> Q["pt.concat all batch files\nxsv.importFile(mergedFile, settings)\nstorageFormat-aware ✓"]
    P -- yes --> R["Empty fallback per column\nRTYPE_JSON_PARTITIONED\npartitionKeyLength = len(settings.axes)\nNEW: was len(batchKeyHeaders)"]
    K --> S["Add per-scope split result"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
sdk/workflow-tengo/src/pframes/process-column-batch.lib.tengo:264-277
**Collision check covers `column` headers but not `spec.name` values**

The guard prevents two axes from sharing the same TSV/CSV column header (the `column` field), which is correct. However, nothing prevents an additional axis from having the same `spec.name` as an existing batch-key axis — for example, `axes: [{ column: "halfAxis", spec: { name: "key", type: "Long" } }]` alongside a batch-key named `"key"`. The `decomposePfconvImportCfg` path would produce an `axesSpec` array with two entries whose `name` is `"key"`, giving the resulting PColumn duplicate axis identifiers. Consider extending the check to also validate `axis.spec.name` against the batch-key spec names collected in `batchKeyAxisByName`.

### Issue 2 of 3
sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo:233-244
**Empty-batch and super-partitioned containers hardcode JSON resource type regardless of `storageFormat`**

The super-partitioned container (line 237) is created as `RTYPE_P_COLUMN_DATA_JSON_SUPER_PARTITIONED`, and the empty-scope fallback (line 437) uses `RTYPE_P_COLUMN_DATA_JSON_PARTITIONED` unconditionally. When `output.settings.storageFormat` is `"Binary"` or `"Parquet"`, the non-empty path through `xsv.importFile` correctly returns the format-specific resource type, but these two paths produce a JSON resource instead — causing a type mismatch. The same issue exists in `process-pcolumn-batch-split.tpl.tengo` line 291. The non-batch code in `process-pcolumn-data.tpl.tengo` handles all three formats via an explicit `storageFormat` branch (lines 499–519 of that file). The PR description claims "all storage formats" are now supported, and the tests only exercise `storageFormat:"Json"`, so this gap is currently invisible.

### Issue 3 of 3
tests/workflow-tengo/src/pframes/proc_batch_extra_axis.test.ts:32-41
**`passContent: false` path is not exercised with extra axes**

Both new tests use `passContent: true`, which goes through in-memory line slicing in the split template. The `passContent: false` path (pt-based slicing of a saved Blob file) is a separate code branch that produces the same merged file but via a different route. A test variant with `passContent: false` would ensure the batch-file concatenation and `xsv.importFile` pipeline also emits the correct 2-component keys when additional axes are present.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Support additional axes in batch mode xs..."](https://github.com/milaboratory/platforma/commit/09e9492b9b0b0857b764b324a71e6b0369723a78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37186961)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->