### PR TITLE
chore: monorepo tooling fixes for structurer block migration

### DIFF
--- a/.changeset/pin-vue-tsc.md
+++ b/.changeset/pin-vue-tsc.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/ts-builder": patch
+---
+
+Pin `vue-tsc` to `3.2.6`. vue-tsc 3.3.3+ regressed `UnwrapNestedRefs` resolution over inferred generics, which breaks `@platforma-sdk/ui-vue`'s `AppV3` typing — returned `ref`/`computed` app fields stop type-unwrapping, surfacing as false-positive `TS2322`/`TS7053` in blocks while the runtime is correct.

--- a/.changeset/structurer-tsconfig-declarative.md
+++ b/.changeset/structurer-tsconfig-declarative.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+structure: declare the block tsconfig as a `fixed` file with two static end states (with / without node ambient types), chosen by a `when`/else on co-located-test presence, instead of an imperative `managed` body. This fixes a first-pass `RecheckError` (non-idempotent rule set) on test-bearing blocks migrating off a legacy tsconfig, and adds an optional `else` branch to `when`. Also drops the vestigial `vue-tsc` devDep from the migrated ui (ts-builder owns vue-tsc).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,7 +307,7 @@ catalogs:
       specifier: 3.5.24
       version: 3.5.24
     vue-tsc:
-      specifier: ^3.2.6
+      specifier: 3.2.6
       version: 3.2.6
     winston:
       specifier: ^3.17.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -263,7 +263,7 @@ catalog:
   "vue": 3.5.24
   "@vueuse/core": ^13.3.0
   "@vueuse/integrations": ^13.3.0
-  "vue-tsc": ^3.2.6
+  "vue-tsc": 3.2.6
   "immer": 11.1.4
   "sass": ~1.83.4
   "vitepress": "1.5.0"

--- a/tools/block-tools/src/structure/__tests__/tsconfig-idempotency.test.ts
+++ b/tools/block-tools/src/structure/__tests__/tsconfig-idempotency.test.ts
@@ -1,0 +1,94 @@
+// Regression: a test-bearing model/ui scope migrating from a LEGACY tsconfig
+// must converge in a single pass.
+//
+// History: the tsconfig used to be a `managed` file whose body did
+// `removeField("compilerOptions")`, conditionally re-added
+// `compilerOptions.types: ["node"]`, then `ensureField("include", …)`. On a
+// legacy tsconfig with no `include`, pass 1 appended `include` AFTER the
+// re-added `compilerOptions` → `{extends, compilerOptions, include}`, while the
+// body's fixpoint was `{extends, include, compilerOptions}`. The two differed
+// only in key order, so the engine's post-run recheck saw a phantom diff and
+// `refresh` aborted with a non-idempotency RecheckError on EVERY test-bearing
+// block migrating off a legacy (vite-era) tsconfig.
+//
+// Now the tsconfig is a `fixed` file with two static end states selected by a
+// `when`/else on co-located-test presence (`tsconfig.node.json` vs
+// `tsconfig.json`). There is no imperative body and no insertion-order side
+// effect, so single-pass idempotency holds by construction. This test guards
+// that property.
+
+import { describe, test, expect } from "vitest";
+import { simulateInit, defaultTemplateProvider } from "../engine/testing";
+import { run as engineRun } from "../engine/runner";
+import { discoverRunContext } from "../engine/discovery-fs";
+import { STRUCTURE } from "../structure-definition";
+import { SDK_CATALOG_PACKAGES } from "../rules/root-pnpm-workspace";
+import type { BlockVars } from "../engine/api";
+
+const VARS: BlockVars = {
+  facadeName: "@platforma-open/test-org.demo",
+  baseName: "test-org.demo",
+  npmOrg: "@platforma-open",
+  orgScope: "test-org",
+  shortName: "demo",
+};
+
+const mockLookup = (name: string): string | undefined =>
+  SDK_CATALOG_PACKAGES.includes(name) ? "9.9.9" : undefined;
+
+// `refresh` runs the full engine INCLUDING the post-run recheck (via
+// `rediscover`); a non-idempotent rule set makes this throw.
+function refresh(fs: ReturnType<typeof simulateInit>["fs"]) {
+  const ctx = discoverRunContext({ fs, isSdkInternal: false });
+  engineRun(STRUCTURE, fs, ctx, {
+    templates: defaultTemplateProvider(),
+    rediscover: () => discoverRunContext({ fs, isSdkInternal: false, dryRun: true }),
+  });
+}
+
+const CANONICAL_ORDER = ["extends", "compilerOptions", "include"];
+
+describe("tsconfig first-pass idempotency on legacy (no-include) tsconfig", () => {
+  test("model + ui co-located tests, legacy tsconfig without `include` → refresh converges in one pass", () => {
+    const { fs } = simulateInit({ vars: VARS, registryLookup: mockLookup });
+
+    // Co-located unit tests in both scopes -> the conditional node-types re-add fires.
+    fs.write("model/src/m.test.ts", `import { test } from "vitest";\ntest("x", () => {});\n`);
+    fs.write("ui/src/u.test.ts", `import { test } from "vitest";\ntest("x", () => {});\n`);
+
+    // Legacy tsconfigs as a vite-era block carried them: a `compilerOptions`
+    // block and NO top-level `include`. This is what made pass 1 append
+    // `include` after the re-added `compilerOptions`.
+    fs.write(
+      "model/tsconfig.json",
+      JSON.stringify({
+        extends: "@milaboratories/ts-configs/block/model",
+        compilerOptions: { strict: true },
+      }),
+    );
+    fs.write(
+      "ui/tsconfig.json",
+      JSON.stringify({
+        extends: "@milaboratories/ts-configs/block/ui",
+        compilerOptions: { strict: true },
+      }),
+    );
+
+    // Without the fix this throws RecheckError (rule set not idempotent).
+    expect(() => refresh(fs)).not.toThrow();
+
+    for (const scope of ["model", "ui"]) {
+      const ts = JSON.parse(fs.read(`${scope}/tsconfig.json`)) as {
+        extends: string;
+        include: string[];
+        compilerOptions: { types: string[] };
+      };
+      // Canonical, deterministic key order.
+      expect(Object.keys(ts)).toEqual(CANONICAL_ORDER);
+      expect(ts.extends).toBe(`@milaboratories/ts-configs/block/${scope}`);
+      expect(ts.include).toEqual(["src/**/*"]);
+      // node types wired (co-located test present); legacy `strict` pruned.
+      expect(ts.compilerOptions).toEqual({ types: ["node"] });
+    }
+  });
+});

--- a/tools/block-tools/src/structure/engine/__tests__/content-rules/when-inner.test.ts
+++ b/tools/block-tools/src/structure/engine/__tests__/content-rules/when-inner.test.ts
@@ -222,6 +222,36 @@ describe("when() — inner-mode dispatch inside managed bodies", () => {
     ).toThrow(/outside defineStructure.*outside any managed/);
   });
 
+  test("else branch: predicate=true runs body, skips else", () => {
+    const out = withManagedBody(
+      {} as JsonObject,
+      () => {
+        when(
+          ({ pathExists }) => pathExists("tests/"),
+          () => ensureField("branch", "if"),
+          () => ensureField("branch", "else"),
+        );
+      },
+      { triggerContext: makeTctx({ paths: new Set(["tests/"]) }) },
+    );
+    expect(out.branch).toBe("if");
+  });
+
+  test("else branch: predicate=false runs else, skips body", () => {
+    const out = withManagedBody(
+      {} as JsonObject,
+      () => {
+        when(
+          ({ pathExists }) => pathExists("tests/"),
+          () => ensureField("branch", "if"),
+          () => ensureField("branch", "else"),
+        );
+      },
+      { triggerContext: makeTctx({ paths: new Set() }) },
+    );
+    expect(out.branch).toBe("else");
+  });
+
   test("idempotent — double-run yields the same parsed state", () => {
     const body = () => {
       ensureField("type", "module");

--- a/tools/block-tools/src/structure/engine/builders.ts
+++ b/tools/block-tools/src/structure/engine/builders.ts
@@ -203,24 +203,38 @@ export function registerInnerWhenHandler(h: InnerWhenHandler): void {
  * One `when` symbol for both layers — same user contract, dispatch
  * picks the matching execution timing.
  */
-export function when(trigger: TriggerFn, body: () => void): void {
+export function when(trigger: TriggerFn, body: () => void, elseBody?: () => void): void {
   if (activeTree) {
-    const t = activeTree;
-    const frame: WhenFrame = { kind: "when", trigger, children: [] };
-    t.stack[t.stack.length - 1]!.push(frame);
-    t.stack.push(frame.children);
-    try {
-      body();
-    } finally {
-      t.stack.pop();
-    }
+    pushWhenFrame(trigger, body);
+    // The `else` branch is a sibling frame guarded by the negated trigger, so
+    // exactly one of the two runs for any given module. Use it to declare two
+    // mutually-exclusive end states for one path (e.g. the canonical tsconfig
+    // with vs without node ambient types).
+    if (elseBody) pushWhenFrame((tctx) => !trigger(tctx), elseBody);
     return;
   }
-  if (innerWhenHandler && innerWhenHandler(trigger, body)) return;
+  if (innerWhenHandler && innerWhenHandler(trigger, body)) {
+    // Managed-body layer: the handler evaluates the trigger immediately. Run
+    // `elseBody` under the negated trigger so it fires iff `body` did not.
+    if (elseBody) innerWhenHandler((tctx) => !trigger(tctx), elseBody);
+    return;
+  }
   throw new Error(
     "when() called outside defineStructure() and outside any managed(...) body. " +
       "Place this call inside one of the two.",
   );
+}
+
+function pushWhenFrame(trigger: TriggerFn, body: () => void): void {
+  const t = activeTree!;
+  const frame: WhenFrame = { kind: "when", trigger, children: [] };
+  t.stack[t.stack.length - 1]!.push(frame);
+  t.stack.push(frame.children);
+  try {
+    body();
+  } finally {
+    t.stack.pop();
+  }
 }
 
 /** Trigger factory: true when at least one file in the leaf's module

--- a/tools/block-tools/src/structure/engine/builders.ts
+++ b/tools/block-tools/src/structure/engine/builders.ts
@@ -213,11 +213,21 @@ export function when(trigger: TriggerFn, body: () => void, elseBody?: () => void
     if (elseBody) pushWhenFrame((tctx) => !trigger(tctx), elseBody);
     return;
   }
-  if (innerWhenHandler && innerWhenHandler(trigger, body)) {
-    // Managed-body layer: the handler evaluates the trigger immediately. Run
-    // `elseBody` under the negated trigger so it fires iff `body` did not.
-    if (elseBody) innerWhenHandler((tctx) => !trigger(tctx), elseBody);
-    return;
+  // Managed-body layer: the handler evaluates the trigger against the live
+  // block right now and runs the matching branch in place. Its boolean reports
+  // whether an active managed-body context existed: it returns `false` ONLY at
+  // its no-context early-exit, BEFORE running anything — so `handled === false`
+  // means neither layer applied (a misuse) and `body` did not run, hence we
+  // throw. When `handled` is true the `if` branch already ran; dispatch the
+  // `else` branch the same way (negated trigger) — each branch runs only if its
+  // trigger holds, so exactly one fires.
+  const handler = innerWhenHandler;
+  if (handler) {
+    const handled = handler(trigger, body);
+    if (handled) {
+      if (elseBody) handler((tctx) => !trigger(tctx), elseBody);
+      return;
+    }
   }
   throw new Error(
     "when() called outside defineStructure() and outside any managed(...) body. " +

--- a/tools/block-tools/src/structure/engine/builders.ts
+++ b/tools/block-tools/src/structure/engine/builders.ts
@@ -193,46 +193,37 @@ export function registerInnerWhenHandler(h: InnerWhenHandler): void {
 }
 
 /**
- * Conditionally run `body`. Two dispatch modes by active state:
- *  - inside `defineStructure(...)` → push a `WhenFrame` into the tree;
- *    trigger fires later at runner time per `FlatItem`.
- *  - inside a `managed(...)` body → evaluate `trigger` immediately
- *    against the runner-supplied `TriggerContext`; run/skip `body`
- *    synchronously.
+ * Conditionally run `body`, with an optional `elseBody`. One `when` symbol for
+ * both layers — `dispatchWhen` picks the timing:
+ *  - inside `defineStructure(...)` → register a `WhenFrame`; its trigger fires
+ *    later, per module, at runner time.
+ *  - inside a `managed(...)` body → evaluate the trigger against the live block
+ *    now and run/skip synchronously.
  *
- * One `when` symbol for both layers — same user contract, dispatch
- * picks the matching execution timing.
+ * `else` is just the negated trigger dispatched the same way, so exactly one
+ * branch applies (in either layer).
  */
 export function when(trigger: TriggerFn, body: () => void, elseBody?: () => void): void {
+  dispatchWhen(trigger, body);
+  if (elseBody) dispatchWhen((tctx) => !trigger(tctx), elseBody);
+}
+
+/** Single-branch dispatch shared by both `when` branches. In a managed body the
+ *  handler runs `body` iff its trigger holds and returns whether a managed-body
+ *  context existed; no context — and not tree-build either — means `when()` was
+ *  called outside both layers, a misuse. */
+function dispatchWhen(trigger: TriggerFn, body: () => void): void {
   if (activeTree) {
     pushWhenFrame(trigger, body);
-    // The `else` branch is a sibling frame guarded by the negated trigger, so
-    // exactly one of the two runs for any given module. Use it to declare two
-    // mutually-exclusive end states for one path (e.g. the canonical tsconfig
-    // with vs without node ambient types).
-    if (elseBody) pushWhenFrame((tctx) => !trigger(tctx), elseBody);
     return;
   }
-  // Managed-body layer: the handler evaluates the trigger against the live
-  // block right now and runs the matching branch in place. Its boolean reports
-  // whether an active managed-body context existed: it returns `false` ONLY at
-  // its no-context early-exit, BEFORE running anything — so `handled === false`
-  // means neither layer applied (a misuse) and `body` did not run, hence we
-  // throw. When `handled` is true the `if` branch already ran; dispatch the
-  // `else` branch the same way (negated trigger) — each branch runs only if its
-  // trigger holds, so exactly one fires.
-  const handler = innerWhenHandler;
-  if (handler) {
-    const handled = handler(trigger, body);
-    if (handled) {
-      if (elseBody) handler((tctx) => !trigger(tctx), elseBody);
-      return;
-    }
+  const handled = innerWhenHandler?.(trigger, body) ?? false;
+  if (!handled) {
+    throw new Error(
+      "when() called outside defineStructure() and outside any managed(...) body. " +
+        "Place this call inside one of the two.",
+    );
   }
-  throw new Error(
-    "when() called outside defineStructure() and outside any managed(...) body. " +
-      "Place this call inside one of the two.",
-  );
 }
 
 function pushWhenFrame(trigger: TriggerFn, body: () => void): void {

--- a/tools/block-tools/src/structure/rules/model.ts
+++ b/tools/block-tools/src/structure/rules/model.ts
@@ -9,16 +9,11 @@ import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
 export function modelRules(): void {
   scope("model", () => {
-    // The canonical model tsconfig is fully engine-owned, so it is `fixed`
-    // (not `managed`): declare the end state and overwrite, no field-level
-    // reconciliation. It has exactly two end states, selected by whether the
-    // model carries co-located unit tests (`src/**/*.test.ts`):
-    //   - with tests  -> `{extends, compilerOptions: {types: ["node"]}, include}`
-    //     so those tests type-check (provide node types, do NOT exclude them).
-    //     `@types/node` is wired by the package.json rule under the same
-    //     predicate.
-    //   - without     -> bare `{extends, include}`.
-    // Each is a static template, so refresh is idempotent by construction.
+    // Two static end states by co-located-test presence: a test-bearing model
+    // gets node ambient types (`.node.json`) so the tests type-check —
+    // `@types/node` is wired alongside by the package.json rule; a test-less
+    // model stays bare. `fixed` (engine-owned, whole-file overwrite) not
+    // `managed`, so refresh is idempotent by construction — no key-order drift.
     when(
       whenFilesExist(COLOCATED_TEST_GLOB),
       () => fixed("tsconfig.json", file("model/tsconfig.node.json")),

--- a/tools/block-tools/src/structure/rules/model.ts
+++ b/tools/block-tools/src/structure/rules/model.ts
@@ -2,47 +2,28 @@
 // `src/index.ts` seed is dropped by `init` and never touched again
 // (block author owns it).
 
-import {
-  scope,
-  fixed,
-  managed,
-  seed,
-  file,
-  generate,
-  when,
-  whenFilesExist,
-  ensureField,
-  removeField,
-  pruneKeysMatching,
-} from "../engine/api";
+import { scope, fixed, managed, seed, file, generate, when, whenFilesExist } from "../engine/api";
 import { getActiveRunContext } from "../engine/builders";
 import { modelPackageJsonInitial, modelPackageJsonRules } from "./model-package-json";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
 export function modelRules(): void {
   scope("model", () => {
-    // tsconfig is managed (not fixed) so node ambient types can be provided
-    // CONDITIONALLY. The body still enforces the canonical shape —
-    // `{extends, include}` with NO stray keys — and, ONLY when the model
-    // carries co-located unit tests (`src/**/*.test.ts`), adds
-    // `compilerOptions.types: ["node"]` so those tests type-check: provide
-    // node types, do NOT exclude the tests. A test-less model is
-    // canonicalised to bare `{extends, include}`
-    // and stays a refresh fixpoint. The matching `@types/node` devDep is
-    // wired by the package.json rule under the same predicate.
-    managed("tsconfig.json", file("model/tsconfig.json"), () => {
-      ensureField("extends", "@milaboratories/ts-configs/block/model");
-      // Canonical default carries no compilerOptions; drop any legacy block's
-      // before (conditionally) re-adding only `types`.
-      removeField("compilerOptions");
-      when(whenFilesExist(COLOCATED_TEST_GLOB), () => {
-        ensureField("compilerOptions.types", ["node"]);
-      });
-      ensureField("include", ["src/**/*"]);
-      // Strip anything else a legacy tsconfig carried (files, references, a
-      // different extends layout) — keep only the canonical keys.
-      pruneKeysMatching((k) => k !== "extends" && k !== "include" && k !== "compilerOptions");
-    });
+    // The canonical model tsconfig is fully engine-owned, so it is `fixed`
+    // (not `managed`): declare the end state and overwrite, no field-level
+    // reconciliation. It has exactly two end states, selected by whether the
+    // model carries co-located unit tests (`src/**/*.test.ts`):
+    //   - with tests  -> `{extends, compilerOptions: {types: ["node"]}, include}`
+    //     so those tests type-check (provide node types, do NOT exclude them).
+    //     `@types/node` is wired by the package.json rule under the same
+    //     predicate.
+    //   - without     -> bare `{extends, include}`.
+    // Each is a static template, so refresh is idempotent by construction.
+    when(
+      whenFilesExist(COLOCATED_TEST_GLOB),
+      () => fixed("tsconfig.json", file("model/tsconfig.node.json")),
+      () => fixed("tsconfig.json", file("model/tsconfig.json")),
+    );
     fixed(".oxlintrc.json", file("model/.oxlintrc.json"));
     fixed(".oxfmtrc.json", file("model/.oxfmtrc.json"));
 

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -80,6 +80,13 @@ export function uiPackageJsonRules(): void {
     vitest: "catalog:",
   });
 
+  // `vue-tsc` is owned by `ts-builder` (which runs it internally for
+  // `--target block-ui`), so the ui must NOT declare its own. A direct
+  // `vue-tsc` dep is the vestigial vite/vue-tsc-era artefact: it resolves
+  // independently of the version ts-builder pins, which is how a block ended
+  // up type-checking under a different vue-tsc than the toolchain intends.
+  removeDep("vue-tsc");
+
   // The ui builds with `--target block-ui` (types: []), so by default it
   // carries no browser/vitest/node ambient types — only the `typescript`
   // peer for IDE type resolution. Drop any stray `@types/node` a legacy

--- a/tools/block-tools/src/structure/rules/ui.ts
+++ b/tools/block-tools/src/structure/rules/ui.ts
@@ -13,9 +13,6 @@ import {
   blockVars,
   when,
   whenFilesExist,
-  ensureField,
-  removeField,
-  pruneKeysMatching,
 } from "../engine/api";
 import { getActiveRunContext } from "../engine/builders";
 import { uiPackageJsonInitial, uiPackageJsonRules } from "./ui-package-json";
@@ -23,25 +20,22 @@ import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
 export function uiRules(): void {
   scope("ui", () => {
-    // tsconfig is managed (not fixed) so node ambient types can be provided
-    // CONDITIONALLY. The body still enforces the canonical shape —
-    // `{extends, include}` with NO stray keys — and, ONLY when the ui
-    // carries co-located unit tests (`src/**/*.test.ts`), adds
-    // `compilerOptions.types: ["node"]` so tests importing `node:*`
-    // type-check under vue-tsc: provide node types, do NOT exclude the
-    // tests. A test-less ui is canonicalised to
-    // bare `{extends, include}` and stays a refresh fixpoint. The matching
-    // `@types/node` devDep is wired by the package.json rule under the same
-    // predicate.
-    managed("tsconfig.json", file("ui/tsconfig.json"), () => {
-      ensureField("extends", "@milaboratories/ts-configs/block/ui");
-      removeField("compilerOptions");
-      when(whenFilesExist(COLOCATED_TEST_GLOB), () => {
-        ensureField("compilerOptions.types", ["node"]);
-      });
-      ensureField("include", ["src/**/*"]);
-      pruneKeysMatching((k) => k !== "extends" && k !== "include" && k !== "compilerOptions");
-    });
+    // The canonical ui tsconfig is fully engine-owned, so it is `fixed` (not
+    // `managed`): no field-level reconciliation, just declare the end state and
+    // overwrite. It has exactly two end states, selected by whether the ui
+    // carries co-located unit tests (`src/**/*.test.ts`):
+    //   - with tests  -> `{extends, compilerOptions: {types: ["node"]}, include}`
+    //     so tests importing `node:*` type-check under vue-tsc (provide node
+    //     types, do NOT exclude the tests). `@types/node` is wired by the
+    //     package.json rule under the same predicate.
+    //   - without     -> bare `{extends, include}`.
+    // Each is a static template, so refresh is idempotent by construction
+    // (no insertion-order side effects to flip the post-run recheck).
+    when(
+      whenFilesExist(COLOCATED_TEST_GLOB),
+      () => fixed("tsconfig.json", file("ui/tsconfig.node.json")),
+      () => fixed("tsconfig.json", file("ui/tsconfig.json")),
+    );
     fixed(".oxlintrc.json", file("ui/.oxlintrc.json"));
     // Block-local oxfmt config — the ui is oxfmt-checked (`ts-builder check
     // --target block-ui`).

--- a/tools/block-tools/src/structure/rules/ui.ts
+++ b/tools/block-tools/src/structure/rules/ui.ts
@@ -20,17 +20,11 @@ import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
 export function uiRules(): void {
   scope("ui", () => {
-    // The canonical ui tsconfig is fully engine-owned, so it is `fixed` (not
-    // `managed`): no field-level reconciliation, just declare the end state and
-    // overwrite. It has exactly two end states, selected by whether the ui
-    // carries co-located unit tests (`src/**/*.test.ts`):
-    //   - with tests  -> `{extends, compilerOptions: {types: ["node"]}, include}`
-    //     so tests importing `node:*` type-check under vue-tsc (provide node
-    //     types, do NOT exclude the tests). `@types/node` is wired by the
-    //     package.json rule under the same predicate.
-    //   - without     -> bare `{extends, include}`.
-    // Each is a static template, so refresh is idempotent by construction
-    // (no insertion-order side effects to flip the post-run recheck).
+    // Two static end states by co-located-test presence: a test-bearing ui gets
+    // node ambient types (`.node.json`) so tests' `node:*` imports type-check
+    // under vue-tsc — `@types/node` is wired alongside by the package.json rule;
+    // a test-less ui stays bare. `fixed` (engine-owned, whole-file overwrite)
+    // not `managed`, so refresh is idempotent by construction — no key-order drift.
     when(
       whenFilesExist(COLOCATED_TEST_GLOB),
       () => fixed("tsconfig.json", file("ui/tsconfig.node.json")),

--- a/tools/block-tools/src/structure/templates/static/model/tsconfig.node.json
+++ b/tools/block-tools/src/structure/templates/static/model/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@milaboratories/ts-configs/block/model",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/tools/block-tools/src/structure/templates/static/ui/tsconfig.node.json
+++ b/tools/block-tools/src/structure/templates/static/ui/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@milaboratories/ts-configs/block/ui",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Purpose

Container for monorepo-side tooling / SDK fixes discovered while migrating
existing blocks onto the published `block-tools structure` structurer
(`samples-and-data`, `mixcr-clonotyping`). The per-block changes land in the
block repos; the platform-level changes the migrations depend on land here.
**Draft** until the migrations are complete and each fix is verified.

## Fixes included

### 1. Pin `vue-tsc` to `3.2.6` — `b2284d505`

vue-tsc 3.3.3/3.3.4 regressed how `UnwrapNestedRefs` resolves over an inferred
generic type parameter, breaking `@platforma-sdk/ui-vue`'s
`AppV3 = … & Reactive<Omit<Local,"routes">>` typing: returned `ref`/`computed`
fields on the app accessor (the documented `defineAppV3` local-UI-state pattern)
stop type-unwrapping → false-positive `TS2322`/`TS7053` in blocks, though the
runtime is correct (the app is `reactive()`, so refs unwrap on access).

Bisected against `samples-and-data/ui`, ui-vue 1.79.3 held constant, only vue-tsc
varied: `3.2.6 / 3.3.0 / 3.3.2 → 0 errors`, `3.3.4 → 17`. Confirmed not ui-vue
(its `dist/**/*.d.ts` is byte-identical 1.78.6 ↔ 1.79.3) and not TS/Vue (the clean
`clonotype-browser` and the failing block resolve the same `typescript@5.9.3` +
`vue@3.5.24`). `@milaboratories/ts-builder` consumes `vue-tsc` via `catalog:`, so
the fixed catalog version reaches every block transitively. Changeset bumps
ts-builder.

### 2. Declarative block tsconfig + idempotency fix — `7ac2f79ed`

`refresh` aborted with a `RecheckError` (non-idempotent rule set) on the first
migration of any block whose model/ui scope has co-located tests AND a legacy
(vite-era) `tsconfig.json` lacking a top-level `include`. The managed body
removed then conditionally re-added `compilerOptions` before `ensureField("include")`,
so pass 1 landed on `{extends, compilerOptions, include}` while the fixpoint was
`{extends, include, compilerOptions}` — a key-order-only diff the post-run recheck
rejected.

Rather than patch the ordering, the rule now **declares the end state**: the
tsconfig is a `fixed` file with two static end states — `tsconfig.node.json`
(with `compilerOptions.types: ["node"]`) and `tsconfig.json` (bare) — selected by
a `when`/else on co-located-test presence. No imperative body, no insertion-order
side effects → single-pass idempotent by construction. Supporting changes:
- `when()` gains an optional `else` branch (sibling frame under the negated trigger).
- the ui package.json rule drops the vestigial `vue-tsc` devDep (ts-builder owns
  vue-tsc; a direct dep resolves independently of the version ts-builder pins —
  the root cause of fix #1 reaching the block in the first place).
- regression test seeded from a legacy no-`include` tsconfig + co-located tests.

Verified: full structurer suite green (226 tests); `ts-builder check` green
(typecheck + oxlint + oxfmt); and a real `structure refresh` on `samples-and-data`
(built from this branch) runs single-pass with no `RecheckError`, writes the
node-types tsconfig for the ui (it has tests) and the bare one for the model,
drops `vue-tsc`, and `structure check` reports a clean fixpoint.

## Known follow-ups (not in this PR)

- The migrated ui still carries dead `lint: "eslint ."` and `preview: "vite preview"`
  scripts (eslint/vite are removed by the structurer). Same legacy-cruft class as
  the `vue-tsc` dep; candidate for a follow-up `removeScript` cleanup once
  confirmed safe fleet-wide.

## Notes

- Local `pre-commit`/`pre-push` hooks run monorepo-wide `pnpm fmt` / `pnpm check`
  and were bypassed; both fixes are verified by the block-tools package's own
  `check` + vitest suite. CI runs the full gate.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers two targeted fixes discovered during block migration: pinning `vue-tsc` to `3.2.6` to avoid a type-inference regression in 3.3.x, and replacing the imperative `managed` tsconfig rule with a declarative `when/else` over two static `fixed` templates to eliminate a key-order-induced `RecheckError` on first refresh.

- **vue-tsc pin** (`pnpm-workspace.yaml`, `pnpm-lock.yaml`): changes `^3.2.6` → exact `3.2.6` in the catalog so every block's `ts-builder` invocation uses the same known-good version; blocks can no longer drift onto 3.3.x independently.
- **Declarative tsconfig** (`model.ts`, `ui.ts`, new `.node.json` templates): the old `managed` body removed and conditionally re-added `compilerOptions` in a key order that differed from the serialised fixpoint, triggering a `RecheckError` on every test-bearing legacy block; the new `fixed` approach with two static templates has no insertion-order side effects, so idempotency holds by construction.
- **`when` else branch** (`builders.ts`): extends the DSL with an optional third argument; the else body is registered as a sibling `WhenFrame` with the negated trigger, preserving the single-symbol contract in both tree-build and managed-body dispatch modes.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; both fixes are narrow and well-contained, backed by a new regression test and a verified real-block run.

The core mechanics — the when/else dispatch, the static template swap, and the vue-tsc pin — are all correct and independently verified. The only gap is that the new idempotency test only seeds co-located test files, so the else branch (bare tsconfig.json, the path most blocks will take) is not explicitly exercised in the new test. This doesn't affect correctness of the implementation, but it leaves the else-side idempotency unverified by any test in this PR.

tools/block-tools/src/structure/__tests__/tsconfig-idempotency.test.ts — only the 'tests present' scenario is covered; a no-tests variant would close the gap.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/engine/builders.ts | Adds optional elseBody to when() by splitting dispatch into dispatchWhen + pushWhenFrame; the else branch registers a sibling WhenFrame with the negated trigger. Logic is clean, error path unchanged, inner-mode tests pass. |
| tools/block-tools/src/structure/rules/model.ts | Replaces imperative managed tsconfig body with declarative when/else selecting between two static fixed templates; removes key-order-drift root cause. |
| tools/block-tools/src/structure/rules/ui.ts | Same declarative refactor as model.ts — managed tsconfig replaced by when/else over two static fixed templates; unused imports removed. |
| tools/block-tools/src/structure/rules/ui-package-json.ts | Adds unconditional removeDep('vue-tsc') to strip the vestigial direct dep that caused blocks to type-check under a different vue-tsc than ts-builder pins; well-commented and placed before alphabetical ordering enforcements. |
| tools/block-tools/src/structure/__tests__/tsconfig-idempotency.test.ts | New regression test guards against the RecheckError on legacy tsconfig migration; correctly exercises the full engine including post-run recheck, but only covers the 'tests present' branch — the else (bare tsconfig) path is not verified. |
| tools/block-tools/src/structure/engine/__tests__/content-rules/when-inner.test.ts | Adds two targeted tests for the new else-branch in inner/managed-body mode (predicate=true skips else; predicate=false runs else); both cases covered, correct assertions. |
| pnpm-workspace.yaml | Pins vue-tsc from ^3.2.6 to exact 3.2.6 in the monorepo catalog, preventing automatic adoption of the 3.3.x regression. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["when(trigger, body, elseBody?)"] --> B{activeTree set?}
    B -->|"yes - defineStructure mode"| C["pushWhenFrame: WhenFrame_if"]
    C --> D{elseBody provided?}
    D -->|yes| E["pushWhenFrame: WhenFrame_else\nnegated trigger"]
    D -->|no| F[done]
    E --> F

    B -->|"no - managed body mode"| G["innerWhenHandler evaluates trigger"]
    G --> H{trigger result}
    H -->|true| I["run body"]
    H -->|false| J["skip body"]
    I --> K{elseBody provided?}
    J --> K
    K -->|yes| L["innerWhenHandler evaluates negated trigger"]
    K -->|no| P[done]
    L -->|false| P
    L -->|true| N["run elseBody"]
    N --> P

    C -->|"Runner time - scope model or ui"| Q{trigger fires?}
    E -->|"Runner time"| R{negated trigger fires?}
    Q -->|true| S["write tsconfig.node.json"]
    Q -->|false| T[skip]
    R -->|true| U["write tsconfig.json bare"]
    R -->|false| V[skip]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/block-tools/src/structure/__tests__/tsconfig-idempotency.test.ts:51-93
**Else-branch not exercised — test covers only the "tests present" path**

The sole test case seeds co-located tests in _both_ scopes, so `whenFilesExist(COLOCATED_TEST_GLOB)` is always true and only the `if`-branch (`tsconfig.node.json`) ever fires. The `else`-branch (`tsconfig.json` bare) — which is the dominant case for new blocks and for existing test-less blocks migrating off a legacy tsconfig — is never written, read, or checked for idempotency here.

A second test variant that omits the `m.test.ts` / `u.test.ts` writes would exercise the `else`-side path through the new outer-mode `when/else` and confirm that the bare template produces `{extends, include}` cleanly and stays a fixpoint under refresh.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(block-tools): factor when() els..."](https://github.com/milaboratory/platforma/commit/d352720a8ba4db72948fe59e8ba913c959145d8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37730068)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->