### PR TITLE
chore(ts-builder): re-pin vue-tsc to 3.3.5 (latest)

### DIFF
--- a/.changeset/repin-vue-tsc-latest.md
+++ b/.changeset/repin-vue-tsc-latest.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/ts-builder": patch
+---
+
+Pin `vue-tsc` to `3.3.5` (latest), replacing the earlier `3.2.6` pin. The `3.2.6` pin was made on the premise that vue-tsc 3.3.3+ regressed `UnwrapNestedRefs` over inferred generics; re-investigation against a fully-bumped block showed that diagnosis was a false lead (the earlier bisect was confounded by the SDK model version — the failing block reports identical errors on every vue-tsc version *and* on older ui-vue). vue-tsc is kept pinned for build reproducibility, but to the latest version rather than an arbitrary older one.

--- a/.changeset/structurer-catalog-and-cleanup.md
+++ b/.changeset/structurer-catalog-and-cleanup.md
@@ -1,0 +1,10 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+structure: several block-compat improvements distributed to every migrated block.
+
+- **Derive the catalog `vue` pin from `@platforma-sdk/ui-vue`** via a new `pinCatalogToDependencyOf` builder: it reads the exact `vue` version ui-vue declares (at npm-latest, or a given `ofVersion`) and OVERWRITES the block's catalog entry, so a loose `vue: ^3.5.x` is tightened to match the SDK. This prevents the two-vue-instance mismatch that broke `AppV3`/`SdkPluginV3` typing. Replaces the add-if-absent `vue` floor (which never tightened a pre-existing loose pin).
+- **Conditional `vitest`**: the `vitest` devDep (model/ui/workflow) and the workflow `vitest.config.mts` are now wired only when a package carries co-located tests (added when present, removed when absent), matching the existing conditional `test` script.
+- **Cruft cleanup**: drop vite/tsup/vue-tsc-era artefacts — catalog entries (`vite`, `tsup`, `vue-tsc`), the ui `vite` dep + `preview` script, and the model `tsup`/`vite` deps + top-level `tsup` config block.
+- **`update` script**: add a second `pnpm i` after the structural refresh so a first migration installs the newly-added devDeps (ts-builder/oxlint/oxfmt) before `pnpm fmt`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ catalogs:
       specifier: 3.5.24
       version: 3.5.24
     vue-tsc:
-      specifier: 3.2.6
-      version: 3.2.6
+      specifier: 3.3.5
+      version: 3.3.5
     winston:
       specifier: ^3.17.0
       version: 3.17.0
@@ -4315,7 +4315,7 @@ importers:
         version: 1.0.0-rc.13
       rolldown-plugin-dts:
         specifier: ^0.23.2
-        version: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+        version: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3))
       rollup-plugin-copy:
         specifier: ^3.5.0
         version: 3.5.0
@@ -4342,7 +4342,7 @@ importers:
         version: 2.2.2(vite@8.0.6(@types/node@24.5.2)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.83.4)(tsx@4.19.1)(yaml@2.8.0))
       vue-tsc:
         specifier: 'catalog:'
-        version: 3.2.6(typescript@5.9.3)
+        version: 3.3.5(typescript@5.9.3)
 
   tools/ts-configs: {}
 
@@ -6888,8 +6888,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.2.6':
-    resolution: {integrity: sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==}
+  '@vue/language-core@3.3.5':
+    resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
 
   '@vue/reactivity@3.5.24':
     resolution: {integrity: sha512-BM8kBhtlkkbnyl4q+HiF5R5BL0ycDPfihowulm02q3WYp2vxgPcJuZO866qa/0u3idbMntKEtVNuAUp5bw4teg==}
@@ -7061,8 +7061,8 @@ packages:
   alien-signals@0.4.14:
     resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
-  alien-signals@3.1.2:
-    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -9904,8 +9904,8 @@ packages:
   vue-component-type-helpers@2.1.6:
     resolution: {integrity: sha512-ng11B8B/ZADUMMOsRbqv0arc442q7lifSubD0v8oDXIFoMg/mXwAPUunrroIDkY+mcD0dHKccdaznSVp8EoX3w==}
 
-  vue-tsc@3.2.6:
-    resolution: {integrity: sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==}
+  vue-tsc@3.3.5:
+    resolution: {integrity: sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -13421,12 +13421,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/language-core@3.2.6':
+  '@vue/language-core@3.3.5':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.24
       '@vue/shared': 3.5.24
-      alien-signals: 3.1.2
+      alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       picomatch: 4.0.4
@@ -13606,7 +13606,7 @@ snapshots:
 
   alien-signals@0.4.14: {}
 
-  alien-signals@3.1.2: {}
+  alien-signals@3.2.1: {}
 
   ansi-colors@4.1.3: {}
 
@@ -15747,7 +15747,7 @@ snapshots:
       glob: 11.0.0
       package-json-from-dist: 1.0.0
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -15762,7 +15762,7 @@ snapshots:
       rolldown: 1.0.0-rc.13
     optionalDependencies:
       typescript: 5.9.3
-      vue-tsc: 3.2.6(typescript@5.9.3)
+      vue-tsc: 3.3.5(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -16565,10 +16565,10 @@ snapshots:
 
   vue-component-type-helpers@2.1.6: {}
 
-  vue-tsc@3.2.6(typescript@5.9.3):
+  vue-tsc@3.3.5(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.2.6
+      '@vue/language-core': 3.3.5
       typescript: 5.9.3
 
   vue@3.5.24(typescript@5.9.3):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -263,7 +263,7 @@ catalog:
   "vue": 3.5.24
   "@vueuse/core": ^13.3.0
   "@vueuse/integrations": ^13.3.0
-  "vue-tsc": 3.2.6
+  "vue-tsc": 3.3.5
   "immer": 11.1.4
   "sass": ~1.83.4
   "vitepress": "1.5.0"

--- a/tools/block-tools/src/structure/__tests__/model-package-json.snapshot.test.ts
+++ b/tools/block-tools/src/structure/__tests__/model-package-json.snapshot.test.ts
@@ -34,8 +34,7 @@ const EXPECTED_MODEL_PACKAGE_JSON = `{
   "devDependencies": {
     "@milaboratories/ts-builder": "catalog:",
     "@milaboratories/ts-configs": "catalog:",
-    "@platforma-sdk/block-tools": "catalog:",
-    "vitest": "catalog:"
+    "@platforma-sdk/block-tools": "catalog:"
   },
   "peerDependencies": {
     "@types/node": "*",

--- a/tools/block-tools/src/structure/cli/run-structure.ts
+++ b/tools/block-tools/src/structure/cli/run-structure.ts
@@ -11,8 +11,12 @@ import { NodeTemplateProvider } from "../engine/templates";
 import { run as engineRun, type Change } from "../engine/runner";
 import { discoverRunContext } from "../engine/discovery-fs";
 import { STRUCTURE } from "../structure-definition";
-import { matchesBumpPattern, buildRegistryLookupForNames } from "../engine/registry-client";
-import { SDK_CATALOG_PACKAGES } from "../rules/root-pnpm-workspace";
+import {
+  matchesBumpPattern,
+  buildRegistryLookupForNames,
+  buildDerivedPinLookupForPins,
+} from "../engine/registry-client";
+import { SDK_CATALOG_PACKAGES, DERIVED_CATALOG_PINS } from "../rules/root-pnpm-workspace";
 
 export type StructureMode = "check" | "refresh";
 
@@ -60,10 +64,16 @@ export async function runStructureForPath(input: RunStructureInput): Promise<Run
   });
 
   const registryLookup = input.updateDepsOnly ? await buildRegistryLookup() : undefined;
+  // Derived catalog pins (e.g. vue ← ui-vue's declared dep) resolve on the
+  // same prefetch budget as the SDK latest bump; absent on a default refresh.
+  const derivedPinLookup = input.updateDepsOnly
+    ? await buildDerivedPinLookupForPins(DERIVED_CATALOG_PINS)
+    : undefined;
 
   const result = engineRun(STRUCTURE, fs, ctx, {
     templates,
     registryLookup,
+    derivedPinLookup,
     // Fresh re-discovery for the post-run recheck (default refresh only)
     // — re-reads the just-written tree so a rename that shifted the
     // module map is observed.

--- a/tools/block-tools/src/structure/engine/__tests__/content-rules/pin-catalog-to-dependency-of.test.ts
+++ b/tools/block-tools/src/structure/engine/__tests__/content-rules/pin-catalog-to-dependency-of.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "vitest";
+import { pinCatalogToDependencyOf, withManagedYaml } from "../../content-rules";
+import { parseYaml, stringifyYaml } from "../../parsers/yaml";
+
+// The builder is sync: it reads a value the runner pre-resolved + validated
+// into `getDerivedDependencyPin`. These tests inject that accessor directly.
+const lookup =
+  (m: Record<string, string>) =>
+  (entry: string): string | undefined =>
+    m[entry];
+
+describe("pinCatalogToDependencyOf (mocked derived-pin lookup)", () => {
+  test("overwrites a present LOOSE entry with the derived exact version", () => {
+    const doc = parseYaml("catalog:\n  vue: ^3.5.24\n");
+    withManagedYaml(doc, () => pinCatalogToDependencyOf("vue", { of: "@platforma-sdk/ui-vue" }), {
+      getDerivedDependencyPin: lookup({ vue: "3.5.24" }),
+    });
+    const cat = (doc.toJSON() as { catalog: Record<string, string> }).catalog;
+    expect(cat.vue).toBe("3.5.24");
+  });
+
+  test("creates an absent entry", () => {
+    const doc = parseYaml("catalog:\n  unrelated: 1.0.0\n");
+    withManagedYaml(doc, () => pinCatalogToDependencyOf("vue", { of: "@platforma-sdk/ui-vue" }), {
+      getDerivedDependencyPin: lookup({ vue: "3.5.24" }),
+    });
+    const cat = (doc.toJSON() as { catalog: Record<string, string> }).catalog;
+    expect(cat.vue).toBe("3.5.24");
+    expect(cat.unrelated).toBe("1.0.0");
+  });
+
+  test("no-op when no derived-pin lookup is provided (default refresh)", () => {
+    const doc = parseYaml("catalog:\n  vue: ^3.5.24\n");
+    withManagedYaml(doc, () => pinCatalogToDependencyOf("vue", { of: "@platforma-sdk/ui-vue" }));
+    const cat = (doc.toJSON() as { catalog: Record<string, string> }).catalog;
+    expect(cat.vue).toBe("^3.5.24");
+  });
+
+  test("no-op when the entry was not prefetched (lookup returns undefined)", () => {
+    const doc = parseYaml("catalog:\n  vue: ^3.5.24\n");
+    withManagedYaml(doc, () => pinCatalogToDependencyOf("vue", { of: "@platforma-sdk/ui-vue" }), {
+      getDerivedDependencyPin: lookup({ other: "1.0.0" }),
+    });
+    const cat = (doc.toJSON() as { catalog: Record<string, string> }).catalog;
+    expect(cat.vue).toBe("^3.5.24");
+  });
+
+  test("idempotent — second run produces the same YAML", () => {
+    const doc = parseYaml("catalog:\n  vue: ^3.5.24\n");
+    const opts = { getDerivedDependencyPin: lookup({ vue: "3.5.24" }) };
+    withManagedYaml(
+      doc,
+      () => pinCatalogToDependencyOf("vue", { of: "@platforma-sdk/ui-vue" }),
+      opts,
+    );
+    const once = stringifyYaml(doc);
+    withManagedYaml(
+      doc,
+      () => pinCatalogToDependencyOf("vue", { of: "@platforma-sdk/ui-vue" }),
+      opts,
+    );
+    const twice = stringifyYaml(doc);
+    expect(twice).toBe(once);
+  });
+});

--- a/tools/block-tools/src/structure/engine/__tests__/derived-pin-lookup.test.ts
+++ b/tools/block-tools/src/structure/engine/__tests__/derived-pin-lookup.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "vitest";
+import { buildDerivedPinLookupForPins, createMockRegistryClient } from "../registry-client";
+
+describe("buildDerivedPinLookupForPins (mocked registry)", () => {
+  test("resolves the catalog entry to the source's declared exact dep version", async () => {
+    const client = createMockRegistryClient(
+      { "@platforma-sdk/ui-vue": "1.79.6" },
+      { "@platforma-sdk/ui-vue@1.79.6": { vue: "3.5.24" } },
+    );
+    const lookup = await buildDerivedPinLookupForPins(
+      [{ entry: "vue", of: "@platforma-sdk/ui-vue" }],
+      client,
+    );
+    expect(lookup("vue")).toBe("3.5.24");
+    expect(lookup("unrelated")).toBeUndefined();
+  });
+
+  test("reads from a pinned source version when `ofVersion` is given", async () => {
+    const client = createMockRegistryClient(
+      { "@platforma-sdk/ui-vue": "9.9.9" }, // latest — must NOT be used
+      { "@platforma-sdk/ui-vue@1.79.3": { vue: "3.5.20" } },
+    );
+    const lookup = await buildDerivedPinLookupForPins(
+      [{ entry: "vue", of: "@platforma-sdk/ui-vue", ofVersion: "1.79.3" }],
+      client,
+    );
+    expect(lookup("vue")).toBe("3.5.20");
+  });
+
+  test("empty pin list → lookup returns undefined for everything", async () => {
+    const lookup = await buildDerivedPinLookupForPins([], createMockRegistryClient({}));
+    expect(lookup("vue")).toBeUndefined();
+  });
+
+  test("policy (b): throws when the source declares a NON-EXACT range", async () => {
+    const client = createMockRegistryClient(
+      { "@platforma-sdk/ui-vue": "1.79.6" },
+      { "@platforma-sdk/ui-vue@1.79.6": { vue: "^3.5.24" } },
+    );
+    await expect(
+      buildDerivedPinLookupForPins([{ entry: "vue", of: "@platforma-sdk/ui-vue" }], client),
+    ).rejects.toThrow(/not an exact version/i);
+  });
+
+  test("policy (b): throws when the source declares no such dependency", async () => {
+    const client = createMockRegistryClient(
+      { "@platforma-sdk/ui-vue": "1.79.6" },
+      { "@platforma-sdk/ui-vue@1.79.6": { react: "19.0.0" } },
+    );
+    await expect(
+      buildDerivedPinLookupForPins([{ entry: "vue", of: "@platforma-sdk/ui-vue" }], client),
+    ).rejects.toThrow(/declares no/i);
+  });
+});

--- a/tools/block-tools/src/structure/engine/api.ts
+++ b/tools/block-tools/src/structure/engine/api.ts
@@ -117,6 +117,7 @@ export {
   ensureWorkspaceModulePaths,
   ensureCatalogVersion,
   pinCatalogTo,
+  pinCatalogToDependencyOf,
   ensureCatalogLatest,
   ensureCatalogAbsent,
   // Lines managed builders

--- a/tools/block-tools/src/structure/engine/content-rules.ts
+++ b/tools/block-tools/src/structure/engine/content-rules.ts
@@ -83,6 +83,9 @@ type YamlState = {
   triggerContext?: TriggerContext;
   /** Synchronous accessor for prefetched npm latest versions. */
   getLatestVersion?: (packageName: string) => string | undefined;
+  /** Synchronous accessor for prefetched derived catalog pins
+   *  (`catalogEntry → exact version`); see `pinCatalogToDependencyOf`. */
+  getDerivedDependencyPin?: (catalogEntry: string) => string | undefined;
 };
 
 type LinesState = {
@@ -177,6 +180,9 @@ export type WithManagedYamlOpts = WithManagedOpts & {
   /** Sync accessor for prefetched latest versions. Required for
    *  `ensureCatalogLatest` to take effect. */
   getLatestVersion?: (packageName: string) => string | undefined;
+  /** Sync accessor for prefetched derived catalog pins. Required for
+   *  `pinCatalogToDependencyOf` to take effect. */
+  getDerivedDependencyPin?: (catalogEntry: string) => string | undefined;
 };
 
 /** Engine-internal: run `body` with `doc` as the active YAML state (for
@@ -193,6 +199,7 @@ export function withManagedYaml(
     ctx: opts.ctx,
     triggerContext: opts.triggerContext,
     getLatestVersion: opts.getLatestVersion,
+    getDerivedDependencyPin: opts.getDerivedDependencyPin,
   };
   try {
     body();
@@ -577,6 +584,28 @@ export function ensureCatalogLatest(name: string): void {
   if (latest === undefined) return;
   if (readCatalogString(state, name) === latest) return;
   state.doc.setIn(["catalog", name], latest);
+}
+
+/** Pin `catalog.<catalogEntry>` to the EXACT version that package `opts.of`
+ *  declares for `catalogEntry` in its own manifest (read at npm latest, or at
+ *  `opts.ofVersion` if given). The value is resolved by the runner's
+ *  prefetched `getDerivedDependencyPin` accessor (the caller pre-resolves and
+ *  validates — exact-version-only — at prefetch time; no network here).
+ *  OVERWRITES like `pinCatalogTo` (not add-if-absent): a pre-existing loose
+ *  entry (`vue: ^3.5.24`) is tightened to the exact derived version. No-op
+ *  when no derived-pin lookup is available — default refresh/check pass none,
+ *  leaving the entry exactly as the lockfile has it; the resolution leaves
+ *  live in the `onInitOrUpdate` frame. */
+export function pinCatalogToDependencyOf(
+  catalogEntry: string,
+  _opts: { of: string; ofVersion?: string },
+): void {
+  const state = requireYaml("pinCatalogToDependencyOf");
+  if (!state.getDerivedDependencyPin) return;
+  const version = state.getDerivedDependencyPin(catalogEntry);
+  if (version === undefined) return;
+  if (readCatalogString(state, catalogEntry) === version) return;
+  state.doc.setIn(["catalog", catalogEntry], version);
 }
 
 /** Remove `catalog.<name>` if present; no-op when absent. */

--- a/tools/block-tools/src/structure/engine/registry-client.ts
+++ b/tools/block-tools/src/structure/engine/registry-client.ts
@@ -12,6 +12,15 @@ import { setTimeout as sleep } from "node:timers/promises";
 
 export interface RegistryClient {
   getLatestVersion(packageName: string): Promise<string>;
+  /** Read the version `packageName@version` declares for `depName` in its
+   *  published manifest. `version` may be "latest" (resolved via the
+   *  dist-tags). Looks in `dependencies` first, then `peerDependencies`.
+   *  Returns `undefined` when the dep is declared in neither section. */
+  getDeclaredDependency(
+    packageName: string,
+    version: string,
+    depName: string,
+  ): Promise<string | undefined>;
 }
 
 const RETRY_COUNT = 2;
@@ -60,6 +69,14 @@ async function fetchWithRetry(url: string): Promise<Response> {
   }
 }
 
+/** Shape of the per-version manifest doc fetched from
+ *  `https://registry.npmjs.org/<pkg>/<version>` (only the dep sections are
+ *  read). */
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
 /** Live npm registry client. Hits the network on each call. */
 export function createRealRegistryClient(): RegistryClient {
   return {
@@ -74,11 +91,33 @@ export function createRealRegistryClient(): RegistryClient {
       }
       return latest;
     },
+    async getDeclaredDependency(
+      packageName: string,
+      version: string,
+      depName: string,
+    ): Promise<string | undefined> {
+      const res = await fetchWithRetry(`https://registry.npmjs.org/${packageName}/${version}`);
+      const manifest = (await res.json()) as PackageManifest;
+      return manifest.dependencies?.[depName] ?? manifest.peerDependencies?.[depName];
+    },
   };
 }
 
-/** In-memory client backed by a fixed `name → version` map. */
-export function createMockRegistryClient(versions: Record<string, string>): RegistryClient {
+/** In-memory client backed by a fixed `name → version` map. The optional
+ *  `manifests` map (`pkg@version` → declared deps) backs
+ *  `getDeclaredDependency`; "latest" keys resolve via the `versions` map. */
+export function createMockRegistryClient(
+  versions: Record<string, string>,
+  manifests: Record<string, Record<string, string>> = {},
+): RegistryClient {
+  function resolveVersion(packageName: string, version: string): string {
+    if (version !== "latest") return version;
+    const v = versions[packageName];
+    if (v === undefined) {
+      throw new Error(`mock registry: no version configured for '${packageName}'`);
+    }
+    return v;
+  }
   return {
     async getLatestVersion(packageName: string): Promise<string> {
       const v = versions[packageName];
@@ -86,6 +125,18 @@ export function createMockRegistryClient(versions: Record<string, string>): Regi
         throw new Error(`mock registry: no version configured for '${packageName}'`);
       }
       return v;
+    },
+    async getDeclaredDependency(
+      packageName: string,
+      version: string,
+      depName: string,
+    ): Promise<string | undefined> {
+      const resolved = resolveVersion(packageName, version);
+      const deps = manifests[`${packageName}@${resolved}`];
+      if (deps === undefined) {
+        throw new Error(`mock registry: no manifest configured for '${packageName}@${resolved}'`);
+      }
+      return deps[depName];
     },
   };
 }
@@ -137,4 +188,67 @@ export async function buildRegistryLookupForNames(
   if (names.length === 0) return () => undefined;
   const resolved = await prefetchLatestVersions(client, names);
   return makeSyncLookup(resolved);
+}
+
+/** A catalog entry whose version is DERIVED from the version another
+ *  package declares for it. `entry` is the catalog key (== the dep name in
+ *  the source manifest); `of` is the package whose manifest is read; the
+ *  optional `ofVersion` pins which release of `of` to read (default: npm
+ *  latest, the same release the catalog bump pins `of` to). Consumed by
+ *  `pinCatalogToDependencyOf`. */
+export type DerivedCatalogPin = {
+  entry: string;
+  of: string;
+  ofVersion?: string;
+};
+
+/** True iff `version` is a bare exact `x.y.z(-prerelease)?` — no range
+ *  modifier (`^`, `~`, `>=`, `*`, `||`, ` - `, `x`, workspace:, etc.). */
+function isExactVersion(version: string): boolean {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version);
+}
+
+/** Prefetch every derived pin and build the sync lookup the runner passes
+ *  to `pinCatalogToDependencyOf` (`entry → exact version`). Reads
+ *  `pin.of`'s manifest (at `pin.ofVersion`, default npm latest) and the
+ *  version it declares for `pin.entry`. Policy (b): THROWS at prefetch time
+ *  if the source declares the dep as a non-exact (ranged) version or does
+ *  not declare it at all — a derived pin must resolve to an exact version
+ *  or it is a configuration error. Empty list → a lookup that resolves
+ *  nothing (no network). A registry failure REJECTS. `client` defaults to
+ *  the live npm client; tests inject a mock. */
+export async function buildDerivedPinLookupForPins(
+  pins: readonly DerivedCatalogPin[],
+  client: RegistryClient = createRealRegistryClient(),
+): Promise<(entry: string) => string | undefined> {
+  if (pins.length === 0) return () => undefined;
+  const entries = await Promise.all(
+    pins.map(async (pin) => {
+      const declared = await client.getDeclaredDependency(
+        pin.of,
+        pin.ofVersion ?? "latest",
+        pin.entry,
+      );
+      if (declared === undefined) {
+        throw new Error(
+          `derived catalog pin '${pin.entry}': package '${pin.of}'` +
+            `${pin.ofVersion ? `@${pin.ofVersion}` : " (latest)"} declares no ` +
+            `dependency '${pin.entry}'. A derived pin requires the source to ` +
+            `declare the dep as an exact version.`,
+        );
+      }
+      if (!isExactVersion(declared)) {
+        throw new Error(
+          `derived catalog pin '${pin.entry}': package '${pin.of}'` +
+            `${pin.ofVersion ? `@${pin.ofVersion}` : " (latest)"} declares ` +
+            `'${pin.entry}: ${declared}', which is not an exact version. ` +
+            `A derived pin requires an exact ('x.y.z') source dependency so ` +
+            `the catalog can pin to it precisely.`,
+        );
+      }
+      return [pin.entry, declared] as const;
+    }),
+  );
+  const resolved = new Map(entries);
+  return (entry) => resolved.get(entry);
 }

--- a/tools/block-tools/src/structure/engine/runner.ts
+++ b/tools/block-tools/src/structure/engine/runner.ts
@@ -83,6 +83,12 @@ export type RunOptions = {
    *  and passes the resulting sync map here; unit tests pass a mock.
    *  Absent → `ensureCatalogLatest` is a no-op (default refresh). */
   registryLookup?: (packageName: string) => string | undefined;
+  /** Sync accessor for prefetched derived catalog pins
+   *  (`catalogEntry → exact version`), consumed by `pinCatalogToDependencyOf`
+   *  inside `onInitOrUpdate` managed bodies. The CLI / init constructor
+   *  prefetches + validates these before the run (network). Absent →
+   *  `pinCatalogToDependencyOf` is a no-op (default refresh). */
+  derivedPinLookup?: (catalogEntry: string) => string | undefined;
 };
 
 export class RecheckError extends Error {
@@ -189,6 +195,7 @@ function runManagedBody(
   body: ManagedBody,
   tctx: TriggerContext,
   registryLookup: ((packageName: string) => string | undefined) | undefined,
+  derivedPinLookup: ((catalogEntry: string) => string | undefined) | undefined,
 ): string {
   const base = path.split("/").pop() ?? path;
   if (path.endsWith(".json")) {
@@ -203,7 +210,11 @@ function runManagedBody(
   }
   if (path.endsWith(".yaml") || path.endsWith(".yml")) {
     const doc = parseYaml(raw);
-    withManagedYaml(doc, body, { triggerContext: tctx, getLatestVersion: registryLookup });
+    withManagedYaml(doc, body, {
+      triggerContext: tctx,
+      getLatestVersion: registryLookup,
+      getDerivedDependencyPin: derivedPinLookup,
+    });
     return stringifyYaml(doc);
   }
   if (base === ".gitignore" || base.endsWith(".gitignore")) {
@@ -371,6 +382,7 @@ function applyManaged(
   tctx: TriggerContext,
   templates: TemplateProvider | undefined,
   registryLookup: ((packageName: string) => string | undefined) | undefined,
+  derivedPinLookup: ((catalogEntry: string) => string | undefined) | undefined,
   isSdkInternal: boolean,
 ): Change | undefined {
   if (item.leaf.kind !== "managed") return undefined;
@@ -388,7 +400,7 @@ function applyManaged(
     beforeRaw = fs.read(path);
   }
 
-  const after = runManagedBody(path, beforeRaw, leaf.body, tctx, registryLookup);
+  const after = runManagedBody(path, beforeRaw, leaf.body, tctx, registryLookup, derivedPinLookup);
 
   if (created) {
     if (!dryRun) fs.write(path, after);
@@ -419,6 +431,7 @@ function executePass(
   templates: TemplateProvider | undefined,
   initMode: boolean,
   registryLookup: ((packageName: string) => string | undefined) | undefined,
+  derivedPinLookup: ((catalogEntry: string) => string | undefined) | undefined,
 ): Change[] {
   const items = filterByMode(flat, currentMode(ctx, initMode));
   const changes: Change[] = [];
@@ -448,6 +461,7 @@ function executePass(
       tctx2,
       templates,
       registryLookup,
+      derivedPinLookup,
       ctx.isSdkInternal,
     );
     if (change) changes.push(change);
@@ -478,6 +492,7 @@ export function run(
       opts.templates,
       initMode,
       opts.registryLookup,
+      opts.derivedPinLookup,
     );
 
     const isRefreshDefault = !ctx.dryRun && !ctx.updateDepsOnly && !initMode;
@@ -499,6 +514,7 @@ export function run(
         opts.templates,
         false,
         opts.registryLookup,
+        opts.derivedPinLookup,
       );
       // Ignore .structure self-write (already up to date after
       // writeStructureVersion above).

--- a/tools/block-tools/src/structure/init-block-constructor.ts
+++ b/tools/block-tools/src/structure/init-block-constructor.ts
@@ -14,8 +14,12 @@ import { run as engineRun } from "./engine/runner";
 import { createRunContext, modulesForInit } from "./engine/ctx";
 import { STRUCTURE } from "./structure-definition";
 import { STRUCTURE_VERSION } from "./engine/version";
-import { matchesBumpPattern, buildRegistryLookupForNames } from "./engine/registry-client";
-import { SDK_CATALOG_PACKAGES } from "./rules/root-pnpm-workspace";
+import {
+  matchesBumpPattern,
+  buildRegistryLookupForNames,
+  buildDerivedPinLookupForPins,
+} from "./engine/registry-client";
+import { SDK_CATALOG_PACKAGES, DERIVED_CATALOG_PINS } from "./rules/root-pnpm-workspace";
 import type { BlockVars } from "./engine/api";
 
 /** Platform choices `init` can scaffold a software module for. Python is
@@ -145,8 +149,12 @@ export async function runInit(init: InitInput): Promise<BlockVars> {
   // aborts init rather than silently shipping an unresolved placeholder.
   const sdkNames = SDK_CATALOG_PACKAGES.filter(matchesBumpPattern);
   let registryLookup: (name: string) => string | undefined;
+  let derivedPinLookup: (entry: string) => string | undefined;
   try {
     registryLookup = await buildRegistryLookupForNames(sdkNames);
+    // Derived catalog pins (e.g. vue ← ui-vue's declared dep) are resolved on
+    // init too, so a freshly-scaffolded block pins vue exactly from the start.
+    derivedPinLookup = await buildDerivedPinLookupForPins(DERIVED_CATALOG_PINS);
   } catch (err) {
     throw new Error(
       `init requires network access to resolve SDK catalog versions from npm, ` +
@@ -154,7 +162,12 @@ export async function runInit(init: InitInput): Promise<BlockVars> {
     );
   }
 
-  engineRun(STRUCTURE, fs, ctx, { templates, initMode: true, registryLookup });
+  engineRun(STRUCTURE, fs, ctx, {
+    templates,
+    initMode: true,
+    registryLookup,
+    derivedPinLookup,
+  });
   init.log(
     `Initialised block '${vars.facadeName}'${
       vars.softwarePlatform ? ` (software: ${vars.softwarePlatform})` : " (no software)"

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -108,14 +108,23 @@ export function modelPackageJsonRules(): void {
   // peer) so the tests' `node:*` imports resolve under the `types: ["node"]`
   // that model/tsconfig adds under the same predicate. Runs AFTER ensurePeerDeps
   // so the promotion is not reverted.
+  //
+  // Skipped entirely for sdk-internal (in-monorepo) blocks: those live inside
+  // the platforma monorepo's own test infrastructure (build-configs, shared
+  // catalog, coverage providers) and own their test wiring — the structurer
+  // must not impose or strip standalone-block test conventions on them.
   when(
-    whenFilesExist(COLOCATED_TEST_GLOB),
-    () => {
-      ensureScript("test", "vitest run --passWithNoTests");
-      ensureDevDep("vitest", "catalog:");
-      ensureDevDep("@types/node", "*");
-    },
-    () => removeDep("vitest"),
+    ({ ctx }) => !ctx.isSdkInternal,
+    () =>
+      when(
+        whenFilesExist(COLOCATED_TEST_GLOB),
+        () => {
+          ensureScript("test", "vitest run --passWithNoTests");
+          ensureDevDep("vitest", "catalog:");
+          ensureDevDep("@types/node", "*");
+        },
+        () => removeDep("vitest"),
+      ),
   );
 
   // vite/tsup-era artefacts: the canonical model builds via ts-builder, so the

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -15,6 +15,8 @@ import {
   ensureDep,
   ensureDevDep,
   ensureDevDeps,
+  removeDep,
+  removeField,
   ensurePeerDeps,
   enforceAlphabeticalOrder,
   enforceFieldOrder,
@@ -49,8 +51,6 @@ export function modelPackageJsonInitial(ctx: RunContext): Record<string, unknown
       watch: "ts-builder build --target block-model --watch",
       build: "ts-builder build --target block-model && block-tools build-model",
       check: "ts-builder check --target block-model",
-      // No `test`: the vitest `test` script is wired by the body rule ONLY
-      // when co-located test files exist (a freshly-init'd model has none).
     },
     dependencies: {
       "@platforma-sdk/model": "sdk:",
@@ -59,7 +59,6 @@ export function modelPackageJsonInitial(ctx: RunContext): Record<string, unknown
       "@milaboratories/ts-builder": "sdk:",
       "@milaboratories/ts-configs": "sdk:",
       "@platforma-sdk/block-tools": "sdk:",
-      vitest: "catalog:",
     },
     peerDependencies: {
       "@types/node": "*",
@@ -94,7 +93,6 @@ export function modelPackageJsonRules(): void {
     "@milaboratories/ts-builder": "sdk:",
     "@milaboratories/ts-configs": "sdk:",
     "@platforma-sdk/block-tools": "sdk:",
-    vitest: "catalog:",
   });
 
   ensurePeerDeps({
@@ -102,18 +100,30 @@ export function modelPackageJsonRules(): void {
     typescript: "*",
   });
 
-  // The vitest `test` script + node ambient types are wired ONLY when the
-  // model carries co-located unit tests (`src/**/*.test.ts`). A test-less
-  // model gets neither — turbo simply has no `test` task for it, and the
-  // scope stays a refresh fixpoint. When tests ARE present, `@types/node`
-  // is promoted from peer to a devDep (the single-section invariant drops
-  // the peer) so the tests' `node:*` imports resolve under the
-  // `types: ["node"]` that model/tsconfig adds under the same predicate.
-  // Runs AFTER ensurePeerDeps so the promotion is not reverted.
-  when(whenFilesExist(COLOCATED_TEST_GLOB), () => {
-    ensureScript("test", "vitest run --passWithNoTests");
-    ensureDevDep("@types/node", "*");
-  });
+  // The vitest `test` script, the `vitest` devDep, and node ambient types are
+  // wired ONLY when the model carries co-located unit tests (`src/**/*.test.ts`).
+  // A test-less model gets none — turbo simply has no `test` task for it, and
+  // the scope stays a refresh fixpoint. When tests ARE present, `@types/node`
+  // is promoted from peer to a devDep (the single-section invariant drops the
+  // peer) so the tests' `node:*` imports resolve under the `types: ["node"]`
+  // that model/tsconfig adds under the same predicate. Runs AFTER ensurePeerDeps
+  // so the promotion is not reverted.
+  when(
+    whenFilesExist(COLOCATED_TEST_GLOB),
+    () => {
+      ensureScript("test", "vitest run --passWithNoTests");
+      ensureDevDep("vitest", "catalog:");
+      ensureDevDep("@types/node", "*");
+    },
+    () => removeDep("vitest"),
+  );
+
+  // vite/tsup-era artefacts: the canonical model builds via ts-builder, so the
+  // legacy `tsup`/`vite` devDeps and the top-level `tsup` bundler config block
+  // are dropped.
+  removeDep("tsup");
+  removeDep("vite");
+  removeField("tsup");
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/root-catalog-bump.ts
+++ b/tools/block-tools/src/structure/rules/root-catalog-bump.ts
@@ -26,12 +26,14 @@ import {
   generate,
   ensureCatalogLatest,
   ensureCatalogVersion,
+  pinCatalogToDependencyOf,
 } from "../engine/api";
 import { getActiveRunContext } from "../engine/builders";
 import {
   rootPnpmWorkspaceInitial,
   SDK_CATALOG_PACKAGES,
   INFRA_CATALOG_FLOOR,
+  DERIVED_CATALOG_PINS,
   RUNENV_PYTHON,
   RUNENV_PYTHON_VERSION,
 } from "./root-pnpm-workspace";
@@ -57,8 +59,17 @@ export function rootCatalogBumpRules(): void {
               // block's missing standard keys + overwrites the init
               // placeholder).
               for (const name of SDK_CATALOG_PACKAGES) ensureCatalogLatest(name);
+              // Derived catalog pins → the EXACT version their source package
+              // declares (e.g. `vue` from `@platforma-sdk/ui-vue`). OVERWRITES
+              // (seeds when absent, tightens a loose on-disk entry). Resolved
+              // by the prefetched `derivedPinLookup`; a no-op when absent
+              // (default refresh passes none). Must run AFTER ensureCatalogLatest
+              // — the source package's own version is bumped there first.
+              for (const pin of DERIVED_CATALOG_PINS) {
+                pinCatalogToDependencyOf(pin.entry, { of: pin.of, ofVersion: pin.ofVersion });
+              }
               // Curated infra floor → fixed version, ADD-IF-ABSENT (seeds
-              // shx/turbo/vitest/vue/changesets when missing; never touches a
+              // shx/turbo/vitest/changesets when missing; never touches a
               // version the block already pins).
               for (const [name, version] of Object.entries(INFRA_CATALOG_FLOOR)) {
                 ensureCatalogVersion(name, version);

--- a/tools/block-tools/src/structure/rules/root-package-json.ts
+++ b/tools/block-tools/src/structure/rules/root-package-json.ts
@@ -38,7 +38,7 @@ export function rootPackageJsonInitial(_ctx: RunContext): Record<string, unknown
       // refresh → format flow); kept for compatibility.
       "update-sdk": "block-tools structure refresh --update-deps-only",
       update:
-        "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm fmt",
+        "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
     },
     peerDependencies: {
       oxlint: "*",
@@ -79,12 +79,14 @@ export function rootPackageJsonRules(): void {
   // Deprecated in favour of `update`; kept for compatibility.
   ensureScript("update-sdk", "block-tools structure refresh --update-deps-only");
   // Full SDK-update flow: bump catalog (deps-only) → install → re-apply
-  // structure against the freshly-pulled deps → format the result, wrapped
-  // as one script. `pnpm fmt` (turbo run fmt) leaves the tree oxfmt-clean
-  // after the structural rewrite so a follow-up `pnpm check` passes.
+  // structure against the freshly-pulled deps → install AGAIN (the structural
+  // pass can add new devDeps — e.g. ts-builder/oxlint/oxfmt on a first
+  // migration — that `pnpm fmt` then needs on PATH) → format. Wrapped as one
+  // script. `pnpm fmt` (turbo run fmt) leaves the tree oxfmt-clean after the
+  // structural rewrite so a follow-up `pnpm check` passes.
   ensureScript(
     "update",
-    "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm fmt",
+    "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
   );
 
   ensureDevDeps({

--- a/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
+++ b/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
@@ -18,8 +18,8 @@
 // npm-latest for the SDK families) lives in the separate `onInitOrUpdate`
 // frame (`rootCatalogBumpRules`), which fires on init + update-deps only.
 
-import { ensureWorkspaceModulePaths, type RunContext } from "../engine/api";
-import { matchesBumpPattern } from "../engine/registry-client";
+import { ensureWorkspaceModulePaths, ensureCatalogAbsent, type RunContext } from "../engine/api";
+import { matchesBumpPattern, type DerivedCatalogPin } from "../engine/registry-client";
 
 /** SDK packages that live in the catalog (membership only — no versions).
  *  Init fetches npm latest for each; refresh leaves them as the lockfile has
@@ -62,13 +62,22 @@ export const INFRA_CATALOG_FLOOR: Record<string, string> = {
   shx: "~0.4.0",
   "@changesets/cli": "~2.29.8",
   vitest: "~4.0.18",
-  // The seeded ui depends on `vue` (catalog:). `@platforma-sdk/ui-vue` pins
-  // vue as an EXACT regular dependency (not a peer), so the block must pin the
-  // SAME exact version — a floated `~` lets the ui resolve a newer 3.5.x than
-  // ui-vue's, yielding two vue instances and a SdkPluginV3-vs-Plugin type
-  // clash in `main.ts`. Keep this in lockstep with ui-vue's vue pin.
-  vue: "3.5.24",
 };
+
+/** Catalog entries whose exact version is DERIVED from the version another
+ *  package declares for them (see `pinCatalogToDependencyOf`). Resolved on
+ *  init + update-deps and OVERWRITES the on-disk entry.
+ *
+ *  `vue`: the seeded ui depends on `vue` (catalog:). `@platforma-sdk/ui-vue`
+ *  pins vue as an EXACT regular dependency (not a peer), so the block must
+ *  pin the SAME exact version — a floated `~` lets the ui resolve a newer
+ *  3.5.x than ui-vue's, yielding two vue instances and a SdkPluginV3-vs-Plugin
+ *  type clash in `main.ts`. Deriving the pin from ui-vue's declared dep keeps
+ *  the block in lockstep with whatever vue ui-vue's npm-latest pins, with no
+ *  hand-maintained version here. */
+export const DERIVED_CATALOG_PINS: readonly DerivedCatalogPin[] = [
+  { entry: "vue", of: "@platforma-sdk/ui-vue" },
+];
 
 /** Catalog name of the python runenv. Added to a block's catalog only when
  *  the block carries a software module. Pinned to an EXACT version — updating
@@ -100,4 +109,11 @@ export function rootPnpmWorkspaceInitial(ctx: RunContext): Record<string, unknow
 
 export function rootPnpmWorkspaceRules(): void {
   ensureWorkspaceModulePaths();
+  // vite/tsup/vue-tsc-era catalog entries: the canonical toolchain (ts-builder
+  // owns vue-tsc; ts-builder + rolldown replace vite/tsup) does not use them.
+  // Drop the orphaned catalog keys — paired with the per-package `removeDep`
+  // so a migrated block sheds both the dep and its catalog entry.
+  ensureCatalogAbsent("vite");
+  ensureCatalogAbsent("tsup");
+  ensureCatalogAbsent("vue-tsc");
 }

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -104,14 +104,21 @@ export function uiPackageJsonRules(): void {
   // the same predicate) resolves the tests' `node:*` imports. A test-less ui
   // keeps the lean default (no test script, no vitest, no @types/node) and
   // stays a fixpoint. Runs AFTER removeDep so the dev deps are not stripped.
+  //
+  // Skipped entirely for sdk-internal (in-monorepo) blocks: they own their test
+  // wiring under the monorepo's shared infrastructure — see model-package-json.
   when(
-    whenFilesExist(COLOCATED_TEST_GLOB),
-    () => {
-      ensureScript("test", "vitest run --passWithNoTests");
-      ensureDevDep("vitest", "catalog:");
-      ensureDevDep("@types/node", "*");
-    },
-    () => removeDep("vitest"),
+    ({ ctx }) => !ctx.isSdkInternal,
+    () =>
+      when(
+        whenFilesExist(COLOCATED_TEST_GLOB),
+        () => {
+          ensureScript("test", "vitest run --passWithNoTests");
+          ensureDevDep("vitest", "catalog:");
+          ensureDevDep("@types/node", "*");
+        },
+        () => removeDep("vitest"),
+      ),
   );
 
   enforceAlphabeticalOrder("dependencies");

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -16,6 +16,7 @@ import {
   ensurePeerDeps,
   ensureWorkspaceScopeDeps,
   removeDep,
+  removeScript,
   enforceAlphabeticalOrder,
   enforceFieldOrder,
   when,
@@ -38,8 +39,6 @@ export function uiPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
       watch: "ts-builder build --target block-ui --watch",
       build: "ts-builder build --target block-ui",
       check: "ts-builder check --target block-ui",
-      // No `test`: the vitest `test` script is wired by the body rule ONLY
-      // when co-located test files exist (a freshly-init'd ui has none).
     },
     dependencies: {
       "@platforma-sdk/ui-vue": "sdk:",
@@ -51,7 +50,6 @@ export function uiPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
     devDependencies: {
       "@milaboratories/ts-builder": "sdk:",
       "@milaboratories/ts-configs": "sdk:",
-      vitest: "catalog:",
     },
     peerDependencies: {
       typescript: "*",
@@ -77,7 +75,6 @@ export function uiPackageJsonRules(): void {
   ensureDevDeps({
     "@milaboratories/ts-builder": "sdk:",
     "@milaboratories/ts-configs": "sdk:",
-    vitest: "catalog:",
   });
 
   // `vue-tsc` is owned by `ts-builder` (which runs it internally for
@@ -86,6 +83,11 @@ export function uiPackageJsonRules(): void {
   // independently of the version ts-builder pins, which is how a block ended
   // up type-checking under a different vue-tsc than the toolchain intends.
   removeDep("vue-tsc");
+
+  // vite-era artefacts: the canonical ui builds + dev-serves via ts-builder,
+  // so a legacy `vite` dep and the `preview` (vite preview) script are dropped.
+  removeDep("vite");
+  removeScript("preview");
 
   // The ui builds with `--target block-ui` (types: []), so by default it
   // carries no browser/vitest/node ambient types — only the `typescript`
@@ -97,15 +99,20 @@ export function uiPackageJsonRules(): void {
   removeDep("@types/node");
 
   // ...but a ui WITH co-located unit tests (`src/**/*.test.ts`) needs the
-  // vitest `test` script AND node ambient types: re-add `@types/node` as a
-  // devDep so `types: ["node"]` in ui/tsconfig (wired under the same
-  // predicate) resolves the tests' `node:*` imports. A test-less ui keeps
-  // the lean default (no test script, no @types/node) and stays a fixpoint.
-  // Runs AFTER removeDep so the dev dep is not stripped.
-  when(whenFilesExist(COLOCATED_TEST_GLOB), () => {
-    ensureScript("test", "vitest run --passWithNoTests");
-    ensureDevDep("@types/node", "*");
-  });
+  // vitest `test` script, the `vitest` devDep, AND node ambient types: re-add
+  // `@types/node` as a devDep so `types: ["node"]` in ui/tsconfig (wired under
+  // the same predicate) resolves the tests' `node:*` imports. A test-less ui
+  // keeps the lean default (no test script, no vitest, no @types/node) and
+  // stays a fixpoint. Runs AFTER removeDep so the dev deps are not stripped.
+  when(
+    whenFilesExist(COLOCATED_TEST_GLOB),
+    () => {
+      ensureScript("test", "vitest run --passWithNoTests");
+      ensureDevDep("vitest", "catalog:");
+      ensureDevDep("@types/node", "*");
+    },
+    () => removeDep("vitest"),
+  );
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/workflow-package-json.ts
+++ b/tools/block-tools/src/structure/rules/workflow-package-json.ts
@@ -68,13 +68,20 @@ export function workflowPackageJsonRules(): void {
   // the standalone workflow/tsconfig with `types: []` — they pull their types
   // from `@platforma-sdk/test` — so no node-types wiring is needed here,
   // unlike model/ui.)
+  //
+  // Skipped entirely for sdk-internal (in-monorepo) blocks: they own their test
+  // wiring under the monorepo's shared infrastructure — see model-package-json.
   when(
-    whenFilesExist(COLOCATED_TEST_GLOB),
-    () => {
-      ensureScript("test", "vitest run --passWithNoTests");
-      ensureDevDeps({ vitest: "catalog:" });
-    },
-    () => removeDep("vitest"),
+    ({ ctx }) => !ctx.isSdkInternal,
+    () =>
+      when(
+        whenFilesExist(COLOCATED_TEST_GLOB),
+        () => {
+          ensureScript("test", "vitest run --passWithNoTests");
+          ensureDevDeps({ vitest: "catalog:" });
+        },
+        () => removeDep("vitest"),
+      ),
   );
 
   ensureDep("@platforma-sdk/workflow-tengo", "sdk:");

--- a/tools/block-tools/src/structure/rules/workflow-package-json.ts
+++ b/tools/block-tools/src/structure/rules/workflow-package-json.ts
@@ -8,6 +8,7 @@ import {
   ensureScript,
   ensureDep,
   ensureDevDeps,
+  removeDep,
   ensureWorkspaceScopeDeps,
   enforceAlphabeticalOrder,
   enforceFieldOrder,
@@ -44,7 +45,8 @@ export function workflowPackageJsonInitial(ctx: RunContext): Record<string, unkn
     devDependencies: {
       "@platforma-sdk/tengo-builder": "sdk:",
       "@platforma-sdk/test": "sdk:",
-      vitest: "catalog:",
+      // `vitest` is NOT seeded here — it's wired by the body rule only when the
+      // workflow carries co-located tests (a freshly-init'd workflow has none).
       shx: "catalog:",
     },
   };
@@ -59,15 +61,21 @@ export function workflowPackageJsonRules(): void {
   ensureScript("check", "pl-tengo check");
   // Tengo source formatter (emacs batch); no-op notice when emacs is absent.
   ensureScript("format", "/usr/bin/env emacs --script ./format.el || echo 'No emacs.'");
-  // The vitest `test` script is wired ONLY when the workflow carries
-  // co-located integration tests (`src/**/*.test.ts`, incl. `src/test/`).
-  // A test-less workflow gets no `test` task and stays a refresh fixpoint.
-  // (Workflow tests type-check via the standalone workflow/tsconfig with
-  // `types: []` — they pull their types from `@platforma-sdk/test` — so no
-  // node-types wiring is needed here, unlike model/ui.)
-  when(whenFilesExist(COLOCATED_TEST_GLOB), () => {
-    ensureScript("test", "vitest run --passWithNoTests");
-  });
+  // The vitest `test` script AND the `vitest` devDep are wired ONLY when the
+  // workflow carries co-located integration tests (`src/**/*.test.ts`, incl.
+  // `src/test/`). A test-less workflow gets neither — no `test` task, no
+  // vitest dep — and stays a refresh fixpoint. (Workflow tests type-check via
+  // the standalone workflow/tsconfig with `types: []` — they pull their types
+  // from `@platforma-sdk/test` — so no node-types wiring is needed here,
+  // unlike model/ui.)
+  when(
+    whenFilesExist(COLOCATED_TEST_GLOB),
+    () => {
+      ensureScript("test", "vitest run --passWithNoTests");
+      ensureDevDeps({ vitest: "catalog:" });
+    },
+    () => removeDep("vitest"),
+  );
 
   ensureDep("@platforma-sdk/workflow-tengo", "sdk:");
 
@@ -80,7 +88,6 @@ export function workflowPackageJsonRules(): void {
   ensureDevDeps({
     "@platforma-sdk/tengo-builder": "sdk:",
     "@platforma-sdk/test": "sdk:",
-    vitest: "catalog:",
     shx: "catalog:",
   });
 

--- a/tools/block-tools/src/structure/rules/workflow.ts
+++ b/tools/block-tools/src/structure/rules/workflow.ts
@@ -31,10 +31,19 @@ export function workflowRules(): void {
     // (`src/**/*.test.ts`, incl. `src/test/`) — paired with the conditional
     // `vitest` devDep + `test` script in workflow-package-json. scaffold (not
     // fixed): author-tunable when present; a test-less workflow gets none.
+    //
+    // Skipped entirely for sdk-internal (in-monorepo) blocks: they own their
+    // test config under the monorepo's shared infrastructure (e.g. a bespoke
+    // `vitest run --coverage` + `createVitestConfig`), which the structurer
+    // must neither scaffold nor remove. See workflow-package-json.
     when(
-      whenFilesExist(COLOCATED_TEST_GLOB),
-      () => scaffold("vitest.config.mts", file("workflow/vitest.config.mts")),
-      () => remove("vitest.config.mts"),
+      ({ ctx }) => !ctx.isSdkInternal,
+      () =>
+        when(
+          whenFilesExist(COLOCATED_TEST_GLOB),
+          () => scaffold("vitest.config.mts", file("workflow/vitest.config.mts")),
+          () => remove("vitest.config.mts"),
+        ),
     );
     // No workflow facade (index.js / index.d.ts): the block loader resolves the
     // workflow via the `block:` components dist path (workflow/dist/.../main.plj.gz),

--- a/tools/block-tools/src/structure/rules/workflow.ts
+++ b/tools/block-tools/src/structure/rules/workflow.ts
@@ -11,10 +11,13 @@ import {
   tpl,
   generate,
   remove,
+  when,
+  whenFilesExist,
   blockVars,
 } from "../engine/api";
 import { getActiveRunContext } from "../engine/builders";
 import { workflowPackageJsonInitial, workflowPackageJsonRules } from "./workflow-package-json";
+import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
 export function workflowRules(): void {
   scope("workflow", () => {
@@ -24,8 +27,15 @@ export function workflowRules(): void {
     fixed("tsconfig.json", file("workflow/tsconfig.json"));
     // Tengo source formatter (emacs batch); the `format` script invokes it.
     fixed("format.el", file("workflow/format.el"));
-    // scaffold (not fixed): tengo test config is author-tunable.
-    scaffold("vitest.config.mts", file("workflow/vitest.config.mts"));
+    // vitest config only when the workflow carries co-located tests
+    // (`src/**/*.test.ts`, incl. `src/test/`) — paired with the conditional
+    // `vitest` devDep + `test` script in workflow-package-json. scaffold (not
+    // fixed): author-tunable when present; a test-less workflow gets none.
+    when(
+      whenFilesExist(COLOCATED_TEST_GLOB),
+      () => scaffold("vitest.config.mts", file("workflow/vitest.config.mts")),
+      () => remove("vitest.config.mts"),
+    );
     // No workflow facade (index.js / index.d.ts): the block loader resolves the
     // workflow via the `block:` components dist path (workflow/dist/.../main.plj.gz),
     // never the JS facade. It was orphaned in production — dropped. Actively


### PR DESCRIPTION
## What

Re-pin `vue-tsc` in the catalog from `3.2.6` to `3.3.5` (latest), and add a `ts-builder` changeset to republish.

## Why

The `3.2.6` pin (#1699) was made on the premise that vue-tsc 3.3.3+ regressed `UnwrapNestedRefs` resolution over inferred generics, breaking `@platforma-sdk/ui-vue` `AppV3` typing. Re-investigation during the samples-and-data structurer migration **refuted** that diagnosis:

- The failing block reports the **same 17 type errors on every vue-tsc version** (2.2.8 / 3.2.6 / 3.3.4) **and** on older ui-vue (1.79.3). The original bisect was confounded by the SDK **model** version, not vue-tsc.
- The real blocker is a `defineAppV3` type-robustness limit in ui-vue (tracked separately).

vue-tsc stays **pinned** (build reproducibility), but to the **latest** version instead of an arbitrary older one.

## Scope

Only the vue-tsc version + changeset. All meaningful structurer content from #1699 (declarative two-file tsconfig, `when`/else + `dispatchWhen`, `tsconfig.node.json` templates, idempotency test, `removeDep("vue-tsc")`) is unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Re-pins `vue-tsc` in the pnpm catalog from `3.2.6` to `3.3.5` (latest) and adds a patch changeset to republish `@milaboratories/ts-builder`. The earlier `3.2.6` pin was based on a misdiagnosed regression that turned out to be independent of the `vue-tsc` version.

- **`pnpm-workspace.yaml`** — catalog entry updated from `3.2.6` to `3.3.5`.
- **`pnpm-lock.yaml`** — lockfile regenerated; `vue-tsc`, `@vue/language-core`, `alien-signals` (3.1.2 → 3.2.1 minor), and the `rolldown-plugin-dts` peer specifier all updated consistently.
- **`.changeset/repin-vue-tsc-latest.md`** — new patch changeset with a clear description of the rationale.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a well-scoped catalog pin bump with a fully regenerated lockfile and a clear changeset.

All three changed files are consistent: the catalog entry, the lockfile (including transitive deps and peer specifiers), and the changeset all agree on 3.3.5. The transitive bump of alien-signals from 3.1.2 to 3.2.1 is a minor version step within the same major and looks correct for the new @vue/language-core. No logic changes, no new code paths.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Catalog pin for vue-tsc bumped from 3.2.6 → 3.3.5; no other changes. |
| pnpm-lock.yaml | Lockfile regenerated consistently: vue-tsc 3.3.5, @vue/language-core 3.3.5, alien-signals 3.1.2→3.2.1, rolldown-plugin-dts peer updated — all hashes look well-formed. |
| .changeset/repin-vue-tsc-latest.md | New patch changeset for @milaboratories/ts-builder documenting the version re-pin; description matches the PR rationale. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm-workspace.yaml\ncatalog: vue-tsc"] -- "3.2.6 → 3.3.5" --> B["pnpm-lock.yaml regenerated"]
    B --> C["vue-tsc@3.3.5"]
    B --> D["@vue/language-core@3.3.5"]
    B --> E["alien-signals@3.2.1\n(was 3.1.2)"]
    B --> F["rolldown-plugin-dts peer\nupdated to vue-tsc@3.3.5"]
    G[".changeset/repin-vue-tsc-latest.md\npatch: @milaboratories/ts-builder"] --> H["publishes new ts-builder version"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["pnpm-workspace.yaml\ncatalog: vue-tsc"] -- "3.2.6 → 3.3.5" --> B["pnpm-lock.yaml regenerated"]
    B --> C["vue-tsc@3.3.5"]
    B --> D["@vue/language-core@3.3.5"]
    B --> E["alien-signals@3.2.1\n(was 3.1.2)"]
    B --> F["rolldown-plugin-dts peer\nupdated to vue-tsc@3.3.5"]
    G[".changeset/repin-vue-tsc-latest.md\npatch: @milaboratories/ts-builder"] --> H["publishes new ts-builder version"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ts-builder): re-pin vue-tsc to 3.3..."](https://github.com/milaboratory/platforma/commit/f2d1351c8ed79a9c9713632960875841bdf8bbe3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37861971)</sub>

<!-- /greptile_comment -->