### PR TITLE
feat(pl-drivers): cache presigned download URLs

### DIFF
--- a/.changeset/blob-get-content-direct.md
+++ b/.changeset/blob-get-content-direct.md
@@ -1,0 +1,8 @@
+---
+"@milaboratories/pl-drivers": minor
+"@milaboratories/pl-middle-layer": patch
+---
+
+Add `DownloadDriver.getContentDirect(handle, options?)` — same result as `getContent`, but it never reads from or writes to the ranges cache (a fresh read straight from storage that does not populate the cache). For local handles it is identical to `getContent`, since local content never uses the ranges cache.
+
+The PFrames data-source blob reader (`pl-middle-layer` pool driver) now uses `getContentDirect`, since PFrames manages its own caching and should not populate the ranges cache.

--- a/.changeset/cache-download-urls.md
+++ b/.changeset/cache-download-urls.md
@@ -3,3 +3,5 @@
 ---
 
 Cache presigned download URLs by signed resource id, avoiding a `GetDownloadURL` round-trip per blob read. Each cache entry's TTL is derived from the expiry encoded in the URL (`X-Amz-*` for S3 / FS-remote, `X-Goog-*` for GCS), minus a 30s safety margin for clock skew; URLs without an encoded expiry (local `storage://`) get a bounded default TTL.
+
+If a cached URL is nonetheless rejected by storage with a 4xx (e.g. an expired signature when clock skew exceeds the safety margin), the entry is evicted and the download is retried once with a freshly fetched URL, instead of failing until the cache entry's TTL lapses.

--- a/.changeset/cache-download-urls.md
+++ b/.changeset/cache-download-urls.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-drivers": patch
+---
+
+Cache presigned download URLs by signed resource id, avoiding a `GetDownloadURL` round-trip per blob read. Each cache entry's TTL is derived from the expiry encoded in the URL (`X-Amz-*` for S3 / FS-remote, `X-Goog-*` for GCS), minus a 30s safety margin for clock skew; URLs without an encoded expiry (local `storage://`) get a bounded default TTL.

--- a/.changeset/loose-bugs-roll.md
+++ b/.changeset/loose-bugs-roll.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+"@platforma-sdk/workflow-tengo": patch
+---
+
+PFrames bump

--- a/.changeset/wire-parquet-blob-cache.md
+++ b/.changeset/wire-parquet-blob-cache.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Wire the persistent parquet blob cache into the PFrames remote blob provider, bumping `@milaboratories/pframes-rs-*` to 1.1.48 (which ships the caching runtime). Downloaded parquet byte ranges are now served from a local cache that survives restarts, backed by a new `parquetCachePath` (default `<workDir>/parquetCache`, not emptied on startup). Cache tuning is exposed via `parquetCacheOps` (defaults: 8 GiB budget, 0.2 single-file admission fraction, 50k tracked files), and `getCacheMetrics()` / `resetCache()` now report real data instead of `null` / no-op.

--- a/etc/blocks/model-test/test/src/wf.test.ts
+++ b/etc/blocks/model-test/test/src/wf.test.ts
@@ -3,7 +3,7 @@ import { blockTest } from "@platforma-sdk/test";
 import { createPlDataTableStateV2, pluginOutputKey } from "@platforma-sdk/model";
 import { blockSpec } from "this-block";
 
-blockTest("with args", { timeout: 10000 }, async ({ rawPrj: project, expect }) => {
+blockTest("with args", { timeout: 60000 }, async ({ rawPrj: project, expect }) => {
   const blockId = await project.addBlock("Block", blockSpec);
 
   const stableOverview1 = await project.overview.awaitStableValue();
@@ -60,12 +60,12 @@ blockTest("with args", { timeout: 10000 }, async ({ rawPrj: project, expect }) =
 
 blockTest(
   "block-level services",
-  { timeout: 30000 },
+  { timeout: 60000 },
   async ({ rawPrj: project, helpers, expect }) => {
     const blockId = await project.addBlock("Block", blockSpec);
 
     await project.runBlock(blockId);
-    const blockState = await helpers.awaitBlockDoneAndGetStableBlockState(blockId);
+    const blockState = await helpers.awaitBlockDoneAndGetStableBlockState(blockId, 50000);
 
     // Block-level pframeSpec service
     expect(blockState.outputs?.blockSpecFrameTest).toStrictEqual({

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -523,9 +523,6 @@ export class AbstractPFrameDriver<
       return { data, overallSize };
     }, combinedSignal);
 
-    const cacheMetrics = await this.getCacheMetrics();
-    this.logger("info", `Parquet cache metrics: ${JSON.stringify(cacheMetrics)}`);
-
     this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
     return tableSpec.map((spec, i) => ({
       spec: spec,

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -524,7 +524,7 @@ export class AbstractPFrameDriver<
     }, combinedSignal);
 
     const cacheMetrics = await this.getCacheMetrics();
-    this.logger("info", `Parquet cache metrics: ${cacheMetrics}`);
+    this.logger("info", `Parquet cache metrics: ${JSON.stringify(cacheMetrics)}`);
 
     this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
     return tableSpec.map((spec, i) => ({

--- a/lib/node/pf-driver/src/driver_impl.ts
+++ b/lib/node/pf-driver/src/driver_impl.ts
@@ -523,6 +523,9 @@ export class AbstractPFrameDriver<
       return { data, overallSize };
     }, combinedSignal);
 
+    const cacheMetrics = await this.getCacheMetrics();
+    this.logger("info", `Parquet cache metrics: ${cacheMetrics}`);
+
     this.pTableCachePerFrame.cache(tableGuard.keep(), overallSize);
     return tableSpec.map((spec, i) => ({
       spec: spec,

--- a/lib/node/pl-drivers/package.json
+++ b/lib/node/pl-drivers/package.json
@@ -41,6 +41,7 @@
     "@protobuf-ts/runtime-rpc": "catalog:",
     "decompress": "catalog:",
     "denque": "catalog:",
+    "lru-cache": "catalog:",
     "openapi-fetch": "catalog:",
     "tar-fs": "catalog:",
     "undici": "catalog:",

--- a/lib/node/pl-drivers/src/clients/download.ts
+++ b/lib/node/pl-drivers/src/clients/download.ts
@@ -106,7 +106,9 @@ export class ClientDownload {
     const cached = this.urlCache.get(info.id);
     if (cached !== undefined) {
       try {
-        return await attempt(cached);
+        const result = await attempt(cached);
+        this.logger.info(`cached download URL for blob ${stringifyWithResourceId(info)} accepted`);
+        return result;
       } catch (error) {
         if (!isDownloadNetworkError400(error)) throw error;
         this.urlCache.delete(info.id);

--- a/lib/node/pl-drivers/src/clients/download.ts
+++ b/lib/node/pl-drivers/src/clients/download.ts
@@ -25,6 +25,7 @@ import type { DownloadAPI_GetDownloadURL_Response } from "../proto-grpc/github.c
 import { DownloadClient } from "../proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/downloadapi/protocol.client";
 import type { DownloadApiPaths, DownloadRestClientType } from "../proto-rest";
 import { type GetContentOptions } from "@milaboratories/pl-model-common";
+import { DownloadUrlCache } from "./download_url_cache";
 
 /** Gets URLs for downloading from pl-core, parses them and reads or downloads
  * files locally and from the web. */
@@ -37,6 +38,9 @@ export class ClientDownload {
 
   /** Concurrency limiter for local file reads - limit to 32 parallel reads */
   private readonly localFileReadLimiter = new ConcurrencyLimitingExecutor(32);
+
+  /** Caches presigned download URLs by resource id until they (almost) expire. */
+  private readonly urlCache: DownloadUrlCache;
 
   constructor(
     wireClientProviderFactory: WireClientProviderFactory,
@@ -59,6 +63,7 @@ export class ClientDownload {
     });
     this.remoteFileDownloader = new RemoteFileDownloader(httpClient);
     this.localStorageIdsToRoot = newLocalStorageIdsToRoot(localProjections);
+    this.urlCache = new DownloadUrlCache(logger);
   }
 
   close() {}
@@ -135,18 +140,22 @@ export class ClientDownload {
     options?: RpcOptions,
     signal?: AbortSignal,
   ): Promise<DownloadAPI_GetDownloadURL_Response> {
+    const cached = this.urlCache.get(id);
+    if (cached !== undefined) return cached;
+
     const withAbort = options ?? {};
     withAbort.abort = signal;
 
     const { globalId, signature } = parseSignedResourceId(id);
     const client = this.wire.get();
+    let response: DownloadAPI_GetDownloadURL_Response;
     if (client instanceof DownloadClient) {
-      return await client.getDownloadURL(
+      response = await client.getDownloadURL(
         { resourceId: globalId, resourceSignature: signature, isInternalUse: false },
         addRTypeToMetadata(type, withAbort),
       ).response;
     } else {
-      return (
+      response = (
         await client.POST("/v1/get-download-url", {
           body: {
             resourceId: globalId.toString(),
@@ -157,6 +166,9 @@ export class ClientDownload {
         })
       ).data!;
     }
+
+    this.urlCache.set(id, response);
+    return response;
   }
 }
 

--- a/lib/node/pl-drivers/src/clients/download.ts
+++ b/lib/node/pl-drivers/src/clients/download.ts
@@ -106,9 +106,7 @@ export class ClientDownload {
     const cached = this.urlCache.get(info.id);
     if (cached !== undefined) {
       try {
-        const result = await attempt(cached);
-        this.logger.info(`cached download URL for blob ${stringifyWithResourceId(info)} accepted`);
-        return result;
+        return await attempt(cached);
       } catch (error) {
         if (!isDownloadNetworkError400(error)) throw error;
         this.urlCache.delete(info.id);

--- a/lib/node/pl-drivers/src/clients/download.ts
+++ b/lib/node/pl-drivers/src/clients/download.ts
@@ -20,6 +20,7 @@ import { Readable } from "node:stream";
 import type { Dispatcher } from "undici";
 import type { LocalStorageProjection } from "../drivers/types";
 import { type ContentHandler, RemoteFileDownloader } from "../helpers/download";
+import { isDownloadNetworkError400 } from "../helpers/download_errors";
 import { validateAbsolute } from "../helpers/validate";
 import type { DownloadAPI_GetDownloadURL_Response } from "../proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/downloadapi/protocol";
 import { DownloadClient } from "../proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/downloadapi/protocol.client";
@@ -80,24 +81,45 @@ export class ClientDownload {
     ops: GetContentOptions,
     handler: ContentHandler<T>,
   ): Promise<T> {
-    const { downloadUrl, headers } = await this.grpcGetDownloadUrl(info, options, ops.signal);
+    const attempt = async ({
+      downloadUrl,
+      headers,
+    }: DownloadAPI_GetDownloadURL_Response): Promise<T> => {
+      const remoteHeaders = Object.fromEntries(headers.map(({ name, value }) => [name, value]));
+      this.logger.info(
+        `blob ${stringifyWithResourceId(info)} download started, ` +
+          `url: ${downloadUrl}, ` +
+          `range: ${JSON.stringify(ops.range ?? null)}`,
+      );
 
-    const remoteHeaders = Object.fromEntries(headers.map(({ name, value }) => [name, value]));
-    this.logger.info(
-      `blob ${stringifyWithResourceId(info)} download started, ` +
-        `url: ${downloadUrl}, ` +
-        `range: ${JSON.stringify(ops.range ?? null)}`,
-    );
+      const timer = PerfTimer.start();
+      const result = isLocal(downloadUrl)
+        ? await this.withLocalFileContent(downloadUrl, ops, handler)
+        : await this.remoteFileDownloader.withContent(downloadUrl, remoteHeaders, ops, handler);
 
-    const timer = PerfTimer.start();
-    const result = isLocal(downloadUrl)
-      ? await this.withLocalFileContent(downloadUrl, ops, handler)
-      : await this.remoteFileDownloader.withContent(downloadUrl, remoteHeaders, ops, handler);
+      this.logger.info(
+        `blob ${stringifyWithResourceId(info)} download finished, ` + `took: ${timer.elapsed()}`,
+      );
+      return result;
+    };
 
-    this.logger.info(
-      `blob ${stringifyWithResourceId(info)} download finished, ` + `took: ${timer.elapsed()}`,
-    );
-    return result;
+    const cached = this.urlCache.get(info.id);
+    if (cached !== undefined) {
+      try {
+        return await attempt(cached);
+      } catch (error) {
+        if (!isDownloadNetworkError400(error)) throw error;
+        this.urlCache.delete(info.id);
+        this.logger.info(
+          `cached download URL for blob ${stringifyWithResourceId(info)} rejected ` +
+            `(status ${error.statusCode}), re-fetching`,
+        );
+      }
+    }
+
+    const fresh = await this.grpcGetDownloadUrl(info, options, ops.signal);
+    this.urlCache.set(info.id, fresh);
+    return await attempt(fresh);
   }
 
   async withLocalFileContent<T>(
@@ -140,22 +162,18 @@ export class ClientDownload {
     options?: RpcOptions,
     signal?: AbortSignal,
   ): Promise<DownloadAPI_GetDownloadURL_Response> {
-    const cached = this.urlCache.get(id);
-    if (cached !== undefined) return cached;
-
     const withAbort = options ?? {};
     withAbort.abort = signal;
 
     const { globalId, signature } = parseSignedResourceId(id);
     const client = this.wire.get();
-    let response: DownloadAPI_GetDownloadURL_Response;
     if (client instanceof DownloadClient) {
-      response = await client.getDownloadURL(
+      return await client.getDownloadURL(
         { resourceId: globalId, resourceSignature: signature, isInternalUse: false },
         addRTypeToMetadata(type, withAbort),
       ).response;
     } else {
-      response = (
+      return (
         await client.POST("/v1/get-download-url", {
           body: {
             resourceId: globalId.toString(),
@@ -166,9 +184,6 @@ export class ClientDownload {
         })
       ).data!;
     }
-
-    this.urlCache.set(id, response);
-    return response;
   }
 }
 

--- a/lib/node/pl-drivers/src/clients/download_url_cache.test.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "vitest";
+import { test, expect, describe, vi, afterEach } from "vitest";
 import { downloadUrlCacheTtlMs, extractUrlExpiryMs } from "./download_url_cache";
 
 // 2026-06-16T12:00:00Z, expressed timezone-independently.
@@ -45,19 +45,24 @@ describe("extractUrlExpiryMs", () => {
 });
 
 describe("downloadUrlCacheTtlMs", () => {
+  // downloadUrlCacheTtlMs reads Date.now(); pin it so the TTL math is deterministic.
+  afterEach(() => vi.useRealTimers());
+
   test("subtracts the 30s safety margin from the encoded expiry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(SIGNED_AT); // now = signing time -> raw remaining 3600s, minus 30s margin.
     const url = "https://x/key?X-Amz-Date=20260616T120000Z&X-Amz-Expires=3600&X-Amz-Signature=x";
-    // now = signing time -> raw remaining 3600s, minus 30s margin.
-    expect(downloadUrlCacheTtlMs(url, SIGNED_AT)).toBe(3600_000 - 30_000);
+    expect(downloadUrlCacheTtlMs(url)).toBe(3600_000 - 30_000);
   });
 
   test("returns non-positive when within the safety margin of expiry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(SIGNED_AT + 50_000); // 10s of life left -> after a 30s margin, not worth caching.
     const url = "https://x/key?X-Amz-Date=20260616T120000Z&X-Amz-Expires=60&X-Amz-Signature=x";
-    // 10s of life left -> after a 30s margin the entry is not worth caching.
-    expect(downloadUrlCacheTtlMs(url, SIGNED_AT + 50_000)).toBeLessThanOrEqual(0);
+    expect(downloadUrlCacheTtlMs(url)).toBeLessThanOrEqual(0);
   });
 
   test("falls back to a positive default TTL for URLs without encoded expiry", () => {
-    expect(downloadUrlCacheTtlMs("storage://main/path", SIGNED_AT)).toBeGreaterThan(0);
+    expect(downloadUrlCacheTtlMs("storage://main/path")).toBeGreaterThan(0);
   });
 });

--- a/lib/node/pl-drivers/src/clients/download_url_cache.test.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.test.ts
@@ -34,9 +34,9 @@ describe("extractUrlExpiryMs", () => {
     expect(extractUrlExpiryMs("https://example.com/file?foo=bar")).toBeUndefined();
   });
 
-  test("malformed date yields no expiry", () => {
+  test("malformed presign params yield null (present but invalid - do not cache)", () => {
     const url = "https://x/key?X-Amz-Date=not-a-date&X-Amz-Expires=3600&X-Amz-Signature=x";
-    expect(extractUrlExpiryMs(url)).toBeUndefined();
+    expect(extractUrlExpiryMs(url)).toBeNull();
   });
 
   test("non-URL input yields no expiry", () => {

--- a/lib/node/pl-drivers/src/clients/download_url_cache.test.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, describe } from "vitest";
+import { downloadUrlCacheTtlMs, extractUrlExpiryMs } from "./download_url_cache";
+
+// 2026-06-16T12:00:00Z, expressed timezone-independently.
+const SIGNED_AT = Date.UTC(2026, 5, 16, 12, 0, 0);
+
+describe("extractUrlExpiryMs", () => {
+  test("AWS SigV4 URL (S3 / FS remote driver): X-Amz-Date + X-Amz-Expires", () => {
+    const url =
+      "https://bucket.s3.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+      "&X-Amz-Date=20260616T120000Z&X-Amz-Expires=3600&X-Amz-Signature=deadbeef";
+    expect(extractUrlExpiryMs(url)).toBe(SIGNED_AT + 3600_000);
+  });
+
+  test("GCS V4 signed URL: X-Goog-Date + X-Goog-Expires", () => {
+    const url =
+      "https://storage.googleapis.com/bucket/key?X-Goog-Algorithm=GOOG4-RSA-SHA256" +
+      "&X-Goog-Date=20260616T120000Z&X-Goog-Expires=600&X-Goog-Signature=deadbeef";
+    expect(extractUrlExpiryMs(url)).toBe(SIGNED_AT + 600_000);
+  });
+
+  test("the encoded timestamp is UTC, independent of host timezone", () => {
+    // The compact form ends with 'Z' (Zulu/UTC); the result must equal the
+    // UTC epoch and never shift by the runner's local offset.
+    const url = "https://x/key?X-Amz-Date=20260101T000000Z&X-Amz-Expires=1&X-Amz-Signature=x";
+    expect(extractUrlExpiryMs(url)).toBe(Date.UTC(2026, 0, 1, 0, 0, 0) + 1000);
+  });
+
+  test("local storage:// URL has no encoded expiry", () => {
+    expect(extractUrlExpiryMs("storage://main/some/relative/path.json")).toBeUndefined();
+  });
+
+  test("plain URL without presign params has no expiry", () => {
+    expect(extractUrlExpiryMs("https://example.com/file?foo=bar")).toBeUndefined();
+  });
+
+  test("malformed date yields no expiry", () => {
+    const url = "https://x/key?X-Amz-Date=not-a-date&X-Amz-Expires=3600&X-Amz-Signature=x";
+    expect(extractUrlExpiryMs(url)).toBeUndefined();
+  });
+
+  test("non-URL input yields no expiry", () => {
+    expect(extractUrlExpiryMs("not a url")).toBeUndefined();
+  });
+});
+
+describe("downloadUrlCacheTtlMs", () => {
+  test("subtracts the 30s safety margin from the encoded expiry", () => {
+    const url = "https://x/key?X-Amz-Date=20260616T120000Z&X-Amz-Expires=3600&X-Amz-Signature=x";
+    // now = signing time -> raw remaining 3600s, minus 30s margin.
+    expect(downloadUrlCacheTtlMs(url, SIGNED_AT)).toBe(3600_000 - 30_000);
+  });
+
+  test("returns non-positive when within the safety margin of expiry", () => {
+    const url = "https://x/key?X-Amz-Date=20260616T120000Z&X-Amz-Expires=60&X-Amz-Signature=x";
+    // 10s of life left -> after a 30s margin the entry is not worth caching.
+    expect(downloadUrlCacheTtlMs(url, SIGNED_AT + 50_000)).toBeLessThanOrEqual(0);
+  });
+
+  test("falls back to a positive default TTL for URLs without encoded expiry", () => {
+    expect(downloadUrlCacheTtlMs("storage://main/path", SIGNED_AT)).toBeGreaterThan(0);
+  });
+});

--- a/lib/node/pl-drivers/src/clients/download_url_cache.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.ts
@@ -110,4 +110,8 @@ export class DownloadUrlCache {
     if (ttl <= 0) return; // Cache miss.
     this.cache.set(key, value, { ttl });
   }
+
+  delete(key: SignedResourceId): void {
+    this.cache.delete(key);
+  }
 }

--- a/lib/node/pl-drivers/src/clients/download_url_cache.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.ts
@@ -1,0 +1,113 @@
+import { LRUCache } from "lru-cache";
+import type { SignedResourceId } from "@milaboratories/pl-client";
+import type { MiLogger } from "@milaboratories/ts-helpers";
+import type { DownloadAPI_GetDownloadURL_Response } from "../proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/downloadapi/protocol";
+
+/**
+ * Safety margin subtracted from the encoded URL expiry. Covers clock skew
+ * between this host and pl-core (the timestamp is the server's signing clock,
+ * not ours) plus in-flight time between signing and use.
+ */
+const SAFETY_MARGIN_MS = 30_000;
+
+/**
+ * TTL applied to download URLs that carry no expiry in their query string -
+ * notably local `storage://` URLs, which are deterministic for a given resource
+ * and effectively never expire. Bounded so a changed storage projection is
+ * eventually re-resolved.
+ */
+const NO_EXPIRY_DEFAULT_TTL_MS = 60 * 60 * 1000; // 1h
+
+/** Max number of cached {url, headers} entries. Each entry is tiny. */
+const DEFAULT_MAX_ENTRIES = 4096;
+
+/**
+ * Extracts the absolute expiry time (epoch ms) encoded in a presigned download
+ * URL, or `undefined` if the URL carries no expiry.
+ *
+ * Supports AWS SigV4 (`X-Amz-Date` + `X-Amz-Expires`, used by pl's S3 and FS
+ * remote drivers) and GCS V4 (`X-Goog-Date` + `X-Goog-Expires`). Both encode
+ * the date as a compact ISO-8601 UTC timestamp `YYYYMMDDTHHMMSSZ` (trailing `Z`
+ * = Zulu/UTC; verified against pl `util/storage/v4sign/presigner.go`) and the
+ * lifetime as integer seconds.
+ */
+export function extractUrlExpiryMs(url: string): number | undefined {
+  let query: URLSearchParams;
+  try {
+    query = new URL(url).searchParams;
+  } catch {
+    return undefined;
+  }
+
+  for (const prefix of ["X-Amz", "X-Goog"]) {
+    const date = query.get(`${prefix}-Date`);
+    const expires = query.get(`${prefix}-Expires`);
+    if (date === null || expires === null) continue;
+
+    const signedAtMs = parseCompactIso8601Utc(date);
+    const expiresSec = Number(expires);
+    if (signedAtMs === undefined || !Number.isFinite(expiresSec)) return undefined;
+
+    return signedAtMs + expiresSec * 1000;
+  }
+
+  return undefined;
+}
+
+/**
+ * Parses a compact ISO-8601 UTC timestamp `YYYYMMDDTHHMMSSZ` into epoch ms.
+ * `new Date()` cannot parse the compact form, so we expand it to the extended
+ * form `YYYY-MM-DDTHH:MM:SSZ`; the trailing `Z` makes it UTC regardless of the
+ * host's local timezone.
+ */
+function parseCompactIso8601Utc(value: string): number | undefined {
+  const m = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/.exec(value);
+  if (m === null) return undefined;
+  const [, y, mo, d, h, mi, s] = m;
+  const ms = Date.parse(`${y}-${mo}-${d}T${h}:${mi}:${s}Z`);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/**
+ * Computes the cache TTL (ms from `nowMs`) for a download URL, with the safety
+ * margin already subtracted. Returns a non-positive number when the URL is
+ * already within the margin of expiring - the caller should then skip caching.
+ */
+export function downloadUrlCacheTtlMs(url: string, nowMs: number): number {
+  const expiry = extractUrlExpiryMs(url);
+  if (expiry === undefined) return NO_EXPIRY_DEFAULT_TTL_MS;
+  return expiry - nowMs - SAFETY_MARGIN_MS;
+}
+
+/**
+ * LRU cache of `GetDownloadURL` responses keyed by `SignedResourceId`. Each
+ * entry's TTL is derived from the expiry encoded in the presigned URL (minus a
+ * safety margin), so an entry never outlives the URL it holds.
+ *
+ * Note: the key intentionally omits `isInternalUse` because the only caller
+ * always requests `isInternalUse: false`. Revisit if that ever varies.
+ */
+export class DownloadUrlCache {
+  private readonly cache: LRUCache<SignedResourceId, DownloadAPI_GetDownloadURL_Response>;
+
+  constructor(
+    private readonly logger: MiLogger,
+    maxEntries: number = DEFAULT_MAX_ENTRIES,
+  ) {
+    this.cache = new LRUCache<SignedResourceId, DownloadAPI_GetDownloadURL_Response>({
+      max: maxEntries,
+      // URL expiry is absolute, not sliding - do not extend TTL on access.
+      updateAgeOnGet: false,
+    });
+  }
+
+  get(key: SignedResourceId): DownloadAPI_GetDownloadURL_Response | undefined {
+    return this.cache.get(key);
+  }
+
+  set(key: SignedResourceId, value: DownloadAPI_GetDownloadURL_Response): void {
+    const ttl = downloadUrlCacheTtlMs(value.downloadUrl, Date.now());
+    if (ttl <= 0) return; // Cache miss.
+    this.cache.set(key, value, { ttl });
+  }
+}

--- a/lib/node/pl-drivers/src/clients/download_url_cache.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.ts
@@ -31,7 +31,7 @@ const DEFAULT_MAX_ENTRIES = 4096;
  * = Zulu/UTC; verified against pl `util/storage/v4sign/presigner.go`) and the
  * lifetime as integer seconds.
  */
-function extractUrlExpiryMs(url: string): number | null | undefined {
+export function extractUrlExpiryMs(url: string): number | null | undefined {
   let query: URLSearchParams;
   try {
     query = new URL(url).searchParams;
@@ -73,7 +73,7 @@ function parseCompactIso8601Utc(value: string): number | undefined {
  * margin already subtracted. Returns a non-positive number when the URL is
  * already within the margin of expiring - the caller should then skip caching.
  */
-function downloadUrlCacheTtlMs(url: string, nowMs: number): number {
+export function downloadUrlCacheTtlMs(url: string, nowMs: number): number {
   const expiry = extractUrlExpiryMs(url);
   if (expiry === null) return 0;
   if (expiry === undefined) return NO_EXPIRY_DEFAULT_TTL_MS;

--- a/lib/node/pl-drivers/src/clients/download_url_cache.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.ts
@@ -31,7 +31,7 @@ const DEFAULT_MAX_ENTRIES = 4096;
  * = Zulu/UTC; verified against pl `util/storage/v4sign/presigner.go`) and the
  * lifetime as integer seconds.
  */
-export function extractUrlExpiryMs(url: string): number | undefined {
+function extractUrlExpiryMs(url: string): number | null | undefined {
   let query: URLSearchParams;
   try {
     query = new URL(url).searchParams;
@@ -46,7 +46,7 @@ export function extractUrlExpiryMs(url: string): number | undefined {
 
     const signedAtMs = parseCompactIso8601Utc(date);
     const expiresSec = Number(expires);
-    if (signedAtMs === undefined || !Number.isFinite(expiresSec)) return undefined;
+    if (signedAtMs === undefined || !Number.isFinite(expiresSec) || expiresSec <= 0) return null;
 
     return signedAtMs + expiresSec * 1000;
   }
@@ -73,8 +73,9 @@ function parseCompactIso8601Utc(value: string): number | undefined {
  * margin already subtracted. Returns a non-positive number when the URL is
  * already within the margin of expiring - the caller should then skip caching.
  */
-export function downloadUrlCacheTtlMs(url: string, nowMs: number): number {
+function downloadUrlCacheTtlMs(url: string, nowMs: number): number {
   const expiry = extractUrlExpiryMs(url);
+  if (expiry === null) return 0;
   if (expiry === undefined) return NO_EXPIRY_DEFAULT_TTL_MS;
   return expiry - nowMs - SAFETY_MARGIN_MS;
 }

--- a/lib/node/pl-drivers/src/clients/download_url_cache.ts
+++ b/lib/node/pl-drivers/src/clients/download_url_cache.ts
@@ -69,15 +69,15 @@ function parseCompactIso8601Utc(value: string): number | undefined {
 }
 
 /**
- * Computes the cache TTL (ms from `nowMs`) for a download URL, with the safety
+ * Computes the cache TTL (ms from now) for a download URL, with the safety
  * margin already subtracted. Returns a non-positive number when the URL is
  * already within the margin of expiring - the caller should then skip caching.
  */
-export function downloadUrlCacheTtlMs(url: string, nowMs: number): number {
+export function downloadUrlCacheTtlMs(url: string): number {
   const expiry = extractUrlExpiryMs(url);
   if (expiry === null) return 0;
   if (expiry === undefined) return NO_EXPIRY_DEFAULT_TTL_MS;
-  return expiry - nowMs - SAFETY_MARGIN_MS;
+  return expiry - Date.now() - SAFETY_MARGIN_MS;
 }
 
 /**
@@ -107,7 +107,7 @@ export class DownloadUrlCache {
   }
 
   set(key: SignedResourceId, value: DownloadAPI_GetDownloadURL_Response): void {
-    const ttl = downloadUrlCacheTtlMs(value.downloadUrl, Date.now());
+    const ttl = downloadUrlCacheTtlMs(value.downloadUrl);
     if (ttl <= 0) return; // Cache miss.
     this.cache.set(key, value, { ttl });
   }

--- a/lib/node/pl-drivers/src/drivers/download_blob/download_blob.test.ts
+++ b/lib/node/pl-drivers/src/drivers/download_blob/download_blob.test.ts
@@ -227,8 +227,52 @@ test("should get undefined when releasing a blob from a small cache and the blob
   });
 });
 
+test("getContentDirect returns the same content but bypasses the ranges cache", async () => {
+  await TestHelpers.withTempRoot(async (client) => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "test-download-direct-"));
+    const rangesCacheDir = await fsp.mkdtemp(path.join(os.tmpdir(), "test-download-ranges-"));
+
+    const driver = await genDriver(client, dir, rangesCacheDir, genSigner());
+    const downloadable = await makeDownloadableBlobFromAssets(client, fileName);
+
+    // On-demand (remote) handle - this is the path that uses the ranges cache.
+    const c = driver.getOnDemandBlob(downloadable);
+    const blob = await c.getValue();
+    expect(blob).toBeDefined();
+    expect(blob.size).toEqual(3);
+
+    const baseline = await dirSizeBytes(rangesCacheDir);
+
+    // Direct reads return the correct bytes (full + range) ...
+    expect((await driver.getContentDirect(blob.handle))?.toString()).toBe("42\n");
+    expect(
+      (await driver.getContentDirect(blob.handle, { range: { from: 0, to: 2 } }))?.toString(),
+    ).toBe("42");
+
+    // ... and leave the ranges cache untouched (cache writes are fire-and-forget, so settle first).
+    await scheduler.wait(100);
+    expect(await dirSizeBytes(rangesCacheDir)).toBe(baseline);
+
+    // A normal cached read of the same handle DOES populate the ranges cache.
+    expect((await driver.getContent(blob.handle))?.toString()).toBe("42\n");
+    await scheduler.wait(100);
+    expect(await dirSizeBytes(rangesCacheDir)).toBeGreaterThan(baseline);
+  });
+});
+
 function genSigner() {
   return new HmacSha256Signer(HmacSha256Signer.generateSecret());
+}
+
+/** Total bytes of all files under `dir` (recursive), for asserting cache population. */
+async function dirSizeBytes(dir: string): Promise<number> {
+  let total = 0;
+  for (const entry of await fsp.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) total += await dirSizeBytes(full);
+    else if (entry.isFile()) total += (await fsp.stat(full)).size;
+  }
+  return total;
 }
 
 async function genDriver(

--- a/lib/node/pl-drivers/src/drivers/download_blob/download_blob.ts
+++ b/lib/node/pl-drivers/src/drivers/download_blob/download_blob.ts
@@ -322,9 +322,38 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
       }
     }
 
+    return await this.getContentImpl({ handle, options });
+  }
+
+  /**
+   * Same as {@link getContent}, but bypasses the ranges cache entirely (no read, no write).
+   * For local handles this is identical to {@link getContent}, since local content never
+   * uses the ranges cache.
+   */
+  public async getContentDirect(
+    handle: LocalBlobHandle | RemoteBlobHandle,
+    options?: GetContentOptions,
+  ): Promise<Uint8Array> {
+    return await this.getContentImpl({
+      handle,
+      options: options ?? {},
+      bypassRangesCache: true,
+    });
+  }
+
+  private async getContentImpl({
+    handle,
+    options,
+    bypassRangesCache = false,
+  }: {
+    handle: LocalBlobHandle | RemoteBlobHandle;
+    options: GetContentOptions;
+    bypassRangesCache?: boolean;
+  }): Promise<Uint8Array> {
     const request = () =>
       this.withContent(handle, {
         ...options,
+        bypassRangesCache,
         handler: async (content) => {
           const chunks: Uint8Array[] = [];
           for await (const chunk of content) {
@@ -350,9 +379,10 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
     handle: LocalBlobHandle | RemoteBlobHandle,
     options: GetContentOptions & {
       handler: ContentHandler<T>;
+      bypassRangesCache?: boolean;
     },
   ): Promise<T> {
-    const { range, signal, handler } = options;
+    const { range, signal, handler, bypassRangesCache } = options;
 
     if (isLocalBlobHandle(handle)) {
       return await withFileContent({ path: this.getLocalPath(handle), range, signal, handler });
@@ -362,7 +392,9 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
       const result = parseRemoteHandle(handle, this.signer);
 
       const key = blobKey(result.info.id);
-      const filePath = await this.rangesCache.get(key, range ?? { from: 0, to: result.size });
+      const filePath = bypassRangesCache
+        ? undefined
+        : await this.rangesCache.get(key, range ?? { from: 0, to: result.size });
       signal?.throwIfAborted();
 
       if (filePath) return await withFileContent({ path: filePath, range, signal, handler });
@@ -372,6 +404,8 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
         { signal },
         options,
         async (content, size) => {
+          if (bypassRangesCache) return await handler(content, size);
+
           const [handlerStream, cacheStream] = content.tee();
 
           const handlerPromise = handler(handlerStream, size);

--- a/lib/node/pl-middle-layer/src/middle_layer/driver_kit.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/driver_kit.ts
@@ -118,7 +118,9 @@ export async function initDriverKit(
     blobDriver,
     logger: ops.logger,
     spillPath: ops.pframesSpillPath,
+    cachePath: ops.parquetCachePath,
     options: ops.pFrameDriverOps,
+    cacheOps: ops.parquetCacheOps,
   });
 
   const frontendDownloadDriver = new DownloadUrlDriver(

--- a/lib/node/pl-middle-layer/src/middle_layer/ops.ts
+++ b/lib/node/pl-middle-layer/src/middle_layer/ops.ts
@@ -12,7 +12,7 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
 import { ConsoleLoggerAdapter } from "@milaboratories/ts-helpers";
 import type { LocalStorageProjection } from "@milaboratories/pl-drivers";
 import path from "node:path";
-import { PFrameDriverOpsDefaults, type PFrameDriverOps } from "../pool";
+import { PFrameDriverOpsDefaults, type PFrameDriverOps, type ParquetCacheOps } from "../pool";
 
 /** Paths part of {@link DriverKitOps}. */
 export type DriverKitOpsPaths = {
@@ -47,6 +47,13 @@ export type DriverKitOpsPaths = {
 
   /** Path to the directory where pframes will spill temporary files and store materialized views */
   readonly pframesSpillPath: string;
+
+  /**
+   * Path to the directory backing the persistent parquet blob cache. Unlike
+   * {@link pframesSpillPath} this directory is NOT emptied on startup - the cache
+   * (and its lifetime counters) is meant to survive restarts.
+   */
+  readonly parquetCachePath: string;
 };
 
 /** Options required to initialize full set of middle layer driver kit */
@@ -127,6 +134,13 @@ export type DriverKitOpsSettings = {
 
   /** Settings related to the PFrame driver */
   readonly pFrameDriverOps: PFrameDriverOps;
+
+  /**
+   * Tuning for the persistent parquet blob cache. Its directory is
+   * {@link DriverKitOpsPaths.parquetCachePath}; this carries only the
+   * size/eviction knobs.
+   */
+  readonly parquetCacheOps: ParquetCacheOps;
 };
 
 export type DriverKitOps = DriverKitOpsPaths & DriverKitOpsSettings;
@@ -141,6 +155,7 @@ export const DefaultDriverKitOpsSettings: Pick<
   | "uploadDriverOps"
   | "logStreamDriverOps"
   | "pFrameDriverOps"
+  | "parquetCacheOps"
 > = {
   logger: new ConsoleLoggerAdapter(),
   blobDriverOps: {
@@ -169,19 +184,29 @@ export const DefaultDriverKitOpsSettings: Pick<
     stopPollingDelay: 1000,
   },
   pFrameDriverOps: PFrameDriverOpsDefaults,
+  parquetCacheOps: {
+    maxSizeBytes: 8 * 1024 * 1024 * 1024, // 8 GB
+    admissionFraction: 0.2, // a single file may occupy at most 20% of the budget
+    maxFilesTracked: 50_000, // ghost (previously-evicted) files remembered to guide readmission
+  },
 };
 
 export function DefaultDriverKitOpsPaths(
   workDir: string,
 ): Pick<
   DriverKitOpsPaths,
-  "blobDownloadPath" | "blobDownloadRangesCachePath" | "downloadBlobToURLPath" | "pframesSpillPath"
+  | "blobDownloadPath"
+  | "blobDownloadRangesCachePath"
+  | "downloadBlobToURLPath"
+  | "pframesSpillPath"
+  | "parquetCachePath"
 > {
   return {
     blobDownloadPath: path.join(workDir, "download"),
     blobDownloadRangesCachePath: path.join(workDir, "downloadRangesCache"),
     downloadBlobToURLPath: path.join(workDir, "downloadToURL"),
     pframesSpillPath: path.join(workDir, "pframes"),
+    parquetCachePath: path.join(workDir, "parquetCache"),
   };
 }
 

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -88,7 +88,7 @@ class LocalBlobProviderImpl
       resolveBlobContent: async (blobId: PFrameInternal.PFrameBlobId) => {
         const computable = this.getByKey(blobId);
         const blob = await computable.awaitStableValue(signal);
-        return await this.blobDriver.getContent(blob.handle, { signal });
+        return await this.blobDriver.getContentDirect(blob.handle, { signal });
       },
     };
   }

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -251,23 +251,28 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
   constructor(
     private readonly pool: RemoteBlobPool,
     private readonly server: PFrameInternal.HttpServer,
-    // TODO: private readonly cache: PFrameInternal.CachingObjectStore,
+    private readonly cache: PFrameInternal.CachingObjectStore,
   ) {}
 
   public static async init(
     blobDriver: DownloadDriver,
     logger: PFrameInternal.Logger,
     serverOptions: Omit<PFrameInternal.HttpServerOptions, "handler">,
+    cacheConfig: PFrameInternal.CacheConfig,
   ): Promise<RemoteBlobProviderImpl> {
     const pool = new RemoteBlobPool(blobDriver, logger);
     const store = new BlobStore({ remoteBlobProvider: pool, logger });
-    // TODO: const cachingStore = HttpHelpers.createCachingObjectStore({ ... });
+    const cachingStore = await HttpHelpers.createCachingObjectStore({
+      upstream: store,
+      config: cacheConfig,
+      logger,
+    });
 
-    const handler = HttpHelpers.createRequestHandler({ store });
+    const handler = HttpHelpers.createRequestHandler({ store: cachingStore });
     const server = await HttpHelpers.createHttpServer({ ...serverOptions, handler });
     logger("info", `PFrames HTTP server started on ${server.info.url}`);
 
-    return new RemoteBlobProviderImpl(pool, server);
+    return new RemoteBlobProviderImpl(pool, server, cachingStore);
   }
 
   public acquire(params: BlobResourceRef): PoolEntry<PFrameInternal.PFrameBlobId> {
@@ -279,16 +284,16 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
   }
 
   public async getCacheMetrics(): Promise<PFrameInternal.CacheMetrics | null> {
-    return null; // TODO: this.cache.getMetrics()
+    return this.cache.getMetrics();
   }
 
   public async resetCache(): Promise<void> {
-    // TODO: this.cache.reset()
+    await this.cache.reset();
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.server.stop();
-    // TODO: await this.cache[Symbol.asyncDispose]();
+    await this.cache[Symbol.asyncDispose]();
     await this.pool[Symbol.asyncDispose]();
   }
 }
@@ -307,20 +312,32 @@ export const PFrameDriverOpsDefaults: PFrameDriverOps = {
   parquetServerPort: 0, // 0 means that some unused port will be assigned by the OS
 };
 
+/**
+ * Tuning for the persistent parquet blob cache, minus its filesystem path (which
+ * is supplied separately - see {@link createPFrameDriver}'s `cachePath`). Carries
+ * only the size/eviction knobs of {@link PFrameInternal.CacheConfig}.
+ */
+export type ParquetCacheOps = Omit<PFrameInternal.CacheConfig, "cachePath">;
+
 export async function createPFrameDriver(params: {
   blobDriver: DownloadDriver;
   logger: MiLogger;
   spillPath: string;
+  cachePath: string;
   options: PFrameDriverOps;
+  cacheOps: ParquetCacheOps;
 }): Promise<InternalPFrameDriver> {
   const resolvedSpillPath = path.resolve(params.spillPath);
   await emptyDir(resolvedSpillPath);
 
   const logger: PFrameInternal.Logger = (level, message) => params.logger[level](message);
   const localBlobProvider = new LocalBlobProviderImpl(params.blobDriver, logger);
-  const remoteBlobProvider = await RemoteBlobProviderImpl.init(params.blobDriver, logger, {
-    port: params.options.parquetServerPort,
-  });
+  const remoteBlobProvider = await RemoteBlobProviderImpl.init(
+    params.blobDriver,
+    logger,
+    { port: params.options.parquetServerPort },
+    { cachePath: path.resolve(params.cachePath), ...params.cacheOps },
+  );
 
   const resolveDataInfo = (spec: PColumnSpec, data: PColumnDataUniversal<PlTreeNodeAccessor>) => {
     if (isPlTreeNodeAccessor(data)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.48
-      version: 1.1.48
+      specifier: 1.1.50
+      version: 1.1.50
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.48
-      version: 1.1.48
+      specifier: 1.1.50
+      version: 1.1.50
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.48
-      version: 1.1.48
+      specifier: 1.1.50
+      version: 1.1.50
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -2180,7 +2180,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2300,10 +2300,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.48(encoding@0.1.13)
+        version: 1.1.50(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2786,10 +2786,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.48(encoding@0.1.13)
+        version: 1.1.50(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3460,7 +3460,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.48
+        version: 1.1.50
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5372,18 +5372,18 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.48':
-    resolution: {integrity: sha512-W6gQxhVefGFMya8GQLoSRhmTGrnzGdGQHEdIdOP9eCkoCeISN7VO3ID2vgoV9nD67DFk3CjVa5aJkDkva4/sAg==}
+  '@milaboratories/pframes-rs-node@1.1.50':
+    resolution: {integrity: sha512-XshCE3Z9+tAKszlWCSDYJnpYRTIsag8v3YcjPmP6//W3dXDDrqi6gBqaGI0u58V9C3PLCjP3zC85vmtI5L26BQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.48':
-    resolution: {integrity: sha512-s0qZnhMfmVFru1s1+49bT/mGvI1QvFz7rfPqfPUKgzD0is0DKj/F+knqvrtmClhbOy1QeNCpqOp7bIcJ+hc+3g==}
+  '@milaboratories/pframes-rs-serv@1.1.50':
+    resolution: {integrity: sha512-XFWRsTGLCfQZhpRlWAmmBfznWyKL72dXY8UFTK+gmI2SOFdxQb8CJc0v/6LgNohwTKRTZZr59K9eRP3v8gCK6A==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.48':
-    resolution: {integrity: sha512-8iOqLV7ov9qlyuHb/iX7Crtt6BWVSH0WoZirNCFP7MzwpwH73KYwqlmMi3BaQcJVQ1AxPrQwgq/3OAuXVCKPBg==}
+  '@milaboratories/pframes-rs-wasip2@1.1.50':
+    resolution: {integrity: sha512-FHv6Cksyl9q9plIhRUzNP0cQ03aZVltNh+haZ5KGVNHh9e5PgP9ndnTP06bQ1JRyQ/6Thf1NF5yw1lBXp6J+uw==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.48':
-    resolution: {integrity: sha512-E1dUEkeySKILtwFDbB240I4Et9novRlQ86VlbUBLs8XdHt9YssmpSxJDv4ry7VL1nAm/WVqRZ77BmHoV5+4Muw==}
+  '@milaboratories/pframes-rs-wasm@1.1.50':
+    resolution: {integrity: sha512-D7YvFltjAk+OLCC/5/U741Hipxof4v/t0cJbk+y38MJjx6PyGQhAyVP/J4XfbJgdFdTGdDidRCNGYLt/Jn8l3w==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.1
@@ -11788,18 +11788,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.48(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.50(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.48
+      '@milaboratories/pframes-rs-serv': 1.1.50
       '@milaboratories/pl-model-common': 1.46.1
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.48':
+  '@milaboratories/pframes-rs-serv@1.1.50':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.1
@@ -11808,12 +11808,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.48': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.50': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.48
+      '@milaboratories/pframes-rs-wasip2': 1.1.50
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2569,6 +2569,9 @@ importers:
       denque:
         specifier: 'catalog:'
         version: 2.1.0
+      lru-cache:
+        specifier: 'catalog:'
+        version: 11.2.2
       openapi-fetch:
         specifier: 'catalog:'
         version: 0.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.46
-      version: 1.1.46
+      specifier: 1.1.48
+      version: 1.1.48
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.46
-      version: 1.1.46
+      specifier: 1.1.48
+      version: 1.1.48
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.46
-      version: 1.1.46
+      specifier: 1.1.48
+      version: 1.1.48
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -2180,7 +2180,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2300,10 +2300,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.46(encoding@0.1.13)
+        version: 1.1.48(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2786,10 +2786,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.46(encoding@0.1.13)
+        version: 1.1.48(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3460,7 +3460,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.46
+        version: 1.1.48
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5372,22 +5372,22 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.46':
-    resolution: {integrity: sha512-TYvlvW3E59LXdfLrkklmJF1Eb29oxIrP6CTbE/RQxHrcBw0kkDUaR+VG2L/b+OQRTORi9YNrqJhWzhJOIrPWFQ==}
+  '@milaboratories/pframes-rs-node@1.1.48':
+    resolution: {integrity: sha512-W6gQxhVefGFMya8GQLoSRhmTGrnzGdGQHEdIdOP9eCkoCeISN7VO3ID2vgoV9nD67DFk3CjVa5aJkDkva4/sAg==}
 
-  '@milaboratories/pframes-rs-serv@1.1.46':
-    resolution: {integrity: sha512-0ohN+yvePXG4pP6TY9S0N5mrP1WYSjv30iKk1VjlCTW2HqjyMa7MPGsnJaVX3BVUzB7IQJs0BZ5GP3oHsEZm6g==}
+  '@milaboratories/pframes-rs-serv@1.1.48':
+    resolution: {integrity: sha512-s0qZnhMfmVFru1s1+49bT/mGvI1QvFz7rfPqfPUKgzD0is0DKj/F+knqvrtmClhbOy1QeNCpqOp7bIcJ+hc+3g==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.46':
-    resolution: {integrity: sha512-aKKcPzyud13WmiEV2+2lbT0/qcuPJx/d3yztoXZHU++gwDRu1LXq2c/hjphYMPQ/g2zDXewMtzeBHknypi95UQ==}
+  '@milaboratories/pframes-rs-wasip2@1.1.48':
+    resolution: {integrity: sha512-8iOqLV7ov9qlyuHb/iX7Crtt6BWVSH0WoZirNCFP7MzwpwH73KYwqlmMi3BaQcJVQ1AxPrQwgq/3OAuXVCKPBg==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.46':
-    resolution: {integrity: sha512-1NJ4PTzTuXUfNCiYCkOvclP34SPTXRVJei5vHmPt4guawX/u8m+zYhyQcnARZoDGMV21VNuxTPAeqRzBPSzr3w==}
+  '@milaboratories/pframes-rs-wasm@1.1.48':
+    resolution: {integrity: sha512-E1dUEkeySKILtwFDbB240I4Et9novRlQ86VlbUBLs8XdHt9YssmpSxJDv4ry7VL1nAm/WVqRZ77BmHoV5+4Muw==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/pl-model-middle-layer': 1.30.4
+      '@milaboratories/pl-model-middle-layer': 1.30.5
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
@@ -5395,8 +5395,8 @@ packages:
   '@milaboratories/pl-model-common@1.46.1':
     resolution: {integrity: sha512-ABOz/w7dA4t2zUpZHXI74MTNW6LmPFSLxgfhOPFdO6vodIY8draVN+ag2U21WlYIoSgdJwSXJrXJWdu1cefrIg==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.4':
-    resolution: {integrity: sha512-U81Fk33PFBxBDTt8s1Ue31z1yM4Yx8ZOPu0SrANT8oevlIfgDYZHEtPzPfUBprh3Yq4/4VrEqkRpTLbP6I6s4g==}
+  '@milaboratories/pl-model-middle-layer@1.30.5':
+    resolution: {integrity: sha512-TSpemA65REZay1ObnuwV3QLIjN46Iluy0HUu/aiHMQ1d1BFAG2vrgvonQqTnxp7UKQYOr9RGJg/QDYG/+UNKMw==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -7183,6 +7183,13 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -7575,6 +7582,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -7795,6 +7806,10 @@ packages:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -7883,6 +7898,9 @@ packages:
   file-type@6.2.0:
     resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
     engines: {node: '>=4'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -8008,6 +8026,9 @@ packages:
 
   git-hooks-list@3.1.0:
     resolution: {integrity: sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -8674,6 +8695,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -8683,6 +8707,10 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -8966,6 +8994,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -9044,6 +9078,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -9314,6 +9352,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
@@ -9428,6 +9472,10 @@ packages:
 
   strip-eof@1.0.0:
     resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
+    engines: {node: '>=0.10.0'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
@@ -11740,31 +11788,32 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.46(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.48(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.46
+      '@milaboratories/pframes-rs-serv': 1.1.48
       '@milaboratories/pl-model-common': 1.46.1
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.46':
+  '@milaboratories/pframes-rs-serv@1.1.48':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/pl-model-middle-layer': 1.30.4
+      '@milaboratories/pl-model-middle-layer': 1.30.5
+      better-sqlite3: 12.10.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.46': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.48': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.48(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.46
+      '@milaboratories/pframes-rs-wasip2': 1.1.48
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11780,7 +11829,7 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.4':
+  '@milaboratories/pl-model-middle-layer@1.30.5':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.1
@@ -13736,6 +13785,15 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@4.0.0: {}
 
   bl@1.2.3:
@@ -14163,6 +14221,8 @@ snapshots:
 
   dedent@1.7.0: {}
 
+  deep-extend@0.6.0: {}
+
   deepmerge@4.3.1: {}
 
   defer-to-connect@2.0.1: {}
@@ -14402,6 +14462,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-eof: 1.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
@@ -14506,6 +14568,8 @@ snapshots:
   file-type@5.2.0: {}
 
   file-type@6.2.0: {}
+
+  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.4:
     dependencies:
@@ -14635,6 +14699,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   git-hooks-list@3.1.0: {}
+
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -15253,6 +15319,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
 
   nice-try@1.0.5: {}
@@ -15261,6 +15329,10 @@ snapshots:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.2
 
   node-addon-api@7.1.1:
     optional: true
@@ -15571,6 +15643,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.0.3
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.2
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.0.1
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   process-nextick-args@2.0.1: {}
@@ -15657,6 +15744,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -15986,6 +16080,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -16112,6 +16214,8 @@ snapshots:
       is-natural-number: 4.0.1
 
   strip-eof@1.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -252,9 +252,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.48
-  "@milaboratories/pframes-rs-wasip2": 1.1.48
-  "@milaboratories/pframes-rs-wasm": 1.1.48
+  "@milaboratories/pframes-rs-node": 1.1.50
+  "@milaboratories/pframes-rs-wasip2": 1.1.50
+  "@milaboratories/pframes-rs-wasm": 1.1.50
 
   "quickjs-emscripten": 0.31.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -252,9 +252,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.46
-  "@milaboratories/pframes-rs-wasip2": 1.1.46
-  "@milaboratories/pframes-rs-wasm": 1.1.46
+  "@milaboratories/pframes-rs-node": 1.1.48
+  "@milaboratories/pframes-rs-wasip2": 1.1.48
+  "@milaboratories/pframes-rs-wasm": 1.1.48
 
   "quickjs-emscripten": 0.31.0
 


### PR DESCRIPTION
## What

Caches `GetDownloadURL` responses in `ClientDownload` so repeated reads of the same blob don't each pay a backend round-trip.

- New `DownloadUrlCache` (LRU, keyed by `SignedResourceId`) holding the full `{downloadUrl, headers}` response.
- `grpcGetDownloadUrl` now checks the cache before the gRPC/REST call and populates it on success.
- Each entry's TTL is derived from the expiry **encoded in the presigned URL**, not a guessed constant:
  - `X-Amz-Date` + `X-Amz-Expires` — S3 and the FS remote driver (AWS SigV4).
  - `X-Goog-Date` + `X-Goog-Expires` — GCS (V4 signed URLs).
  - The timestamp is UTC (`Z`/Zulu), verified against pl `util/storage/v4sign/presigner.go`. The compact `YYYYMMDDTHHMMSSZ` form is expanded to the extended ISO form before parsing (V8 cannot parse the compact form).
  - A **30s safety margin** is subtracted to cover clock skew between this host and pl-core plus in-flight time.
  - Local `storage://` URLs carry no encoded expiry and get a bounded 1h default TTL.

## Why

`GetDownloadURL` is called on every blob read; the returned URL is valid for its full TTL (1h for FS-remote/GCS by default), so re-requesting it per read is wasted work.

## Notes

- The TTL clock is captured atomically inside `DownloadUrlCache.set()` (not before the await), so the cache entry never outlives `expiry − margin`.
- The cache key omits `isInternalUse` because the only caller always passes `false`.
- No request coalescing: two concurrent misses for the same id will both call the backend (unchanged from before).

## Tests

`download_url_cache.test.ts` — 10 unit tests covering S3/FS, GCS, the UTC-independence guarantee, malformed/non-URL input, the 30s margin, and the no-expiry default.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `DownloadUrlCache` (LRU, keyed by `SignedResourceId`) to `ClientDownload` so that each `GetDownloadURL` backend call is only made once per presigned URL's lifetime instead of once per blob read. Cache entry TTLs are computed from the expiry embedded in the presigned URL (`X-Amz-Date`/`X-Amz-Expires` for S3 and the FS remote driver, `X-Goog-Date`/`X-Goog-Expires` for GCS), with a 30 s safety margin; `storage://` URLs fall back to a 1 h default.

- **`download_url_cache.ts`** — New module with `extractUrlExpiryMs`, `downloadUrlCacheTtlMs`, and `DownloadUrlCache`; the injected `logger` is currently unused, and a malformed presign date (however unlikely) would cause a fall-through to the 1 h default TTL instead of bypassing the cache.
- **`download.ts`** — `grpcGetDownloadUrl` now checks the cache before the gRPC/REST call and populates it on success; diff is minimal and correct.
- **`download_url_cache.test.ts`** — Tests cover `extractUrlExpiryMs` and `downloadUrlCacheTtlMs` thoroughly, but the `DownloadUrlCache` class itself (round-trip get/set, TTL enforcement, the `ttl ≤ 0` skip path) has no direct test coverage.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the caching logic is correct for the happy path and the changes are well-scoped to a single client class.

The core TTL derivation and LRU integration are sound. The three findings are all quality/observability concerns: an unused logger, a misleading comment, and a theoretical over-caching scenario on malformed presign dates that the backend never produces in practice. Nothing in the changed path can cause data loss or incorrect auth.

download_url_cache.ts deserves a second look for the unused logger and the malformed-date fallback path; the test file is missing coverage of the DownloadUrlCache class itself.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-drivers/src/clients/download_url_cache.ts | New LRU cache for presigned download URLs with TTL derived from AWS/GCS query parameters; logger is accepted but unused, a misleading comment exists, and a malformed presign date falls back to the 1h default TTL instead of bypassing the cache. |
| lib/node/pl-drivers/src/clients/download.ts | Integrates DownloadUrlCache into grpcGetDownloadUrl; cache check and populate added correctly with minimal diff. |
| lib/node/pl-drivers/src/clients/download_url_cache.test.ts | 10 unit tests covering URL expiry extraction and TTL calculation; no tests for the DownloadUrlCache class itself (get/set/TTL enforcement), leaving that integration path untested. |
| .changeset/cache-download-urls.md | Changeset entry describing the patch; accurate and well-written. |
| lib/node/pl-drivers/package.json | Adds lru-cache as a direct dependency via the workspace catalog; no issues. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/node/pl-drivers/src/clients/download_url_cache.ts:108-111
**Misleading "Cache miss" comment**

`// Cache miss.` is the wrong term here — a cache miss means the key was not found. This path means the URL has already (nearly) expired and should not be stored. Consider `// URL already expired or within safety margin; skip caching.`

### Issue 2 of 3
lib/node/pl-drivers/src/clients/download_url_cache.ts:93-101
**`logger` is injected but never used**

`logger` is stored as `private readonly logger` but is not referenced anywhere in `get()` or `set()`. If it was intended for cache-hit/miss diagnostics it should be wired up; if not needed it can be dropped to avoid misleading future readers.

### Issue 3 of 3
lib/node/pl-drivers/src/clients/download_url_cache.ts:42-54
**Early `return undefined` on malformed expiry causes over-long default TTL**

When a URL has recognizable signing params (`X-Amz-Date` is present) but the date is malformed, line 49 returns `undefined` rather than `continue`-ing. `downloadUrlCacheTtlMs` then cannot distinguish "no expiry encoded" (`storage://`) from "expiry encoded but unreadable", and applies the full 1 h default TTL. If a near-expiring URL ever has a corrupt date field, the stale URL would be served for up to ~1 h, producing 403s from S3/GCS on every blob read until the entry ages out.

Consider returning a distinct sentinel (e.g. `null`) or throwing, so the caller knows a signing scheme was detected but the TTL cannot be trusted.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pl-drivers): cache presigned downlo..."](https://github.com/milaboratory/platforma/commit/b4098f0e2c6948735be2d871a3d6837d32c6a118) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37900455)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->