### PR TITLE
fix(workflow-tengo): mkDir no longer creates a literal ["name"] directory

### DIFF
--- a/.changeset/milab-6460-workdir-mkdir-spread.md
+++ b/.changeset/milab-6460-workdir-mkdir-spread.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Fix workdir/exec builder `mkDir` creating a literal `["name"]` directory instead of `name`

--- a/sdk/workflow-tengo/src/workdir/dirs.lib.tengo
+++ b/sdk/workflow-tengo/src/workdir/dirs.lib.tengo
@@ -1,0 +1,28 @@
+/**
+ * Helpers for collecting the directories that must be created inside a workdir.
+ */
+
+ll := import(":ll")
+sets := import(":sets")
+path := import(":path")
+
+/**
+ * Adds `dir` and every intermediate parent directory to `set`.
+ *
+ * path.getBasenameDirs returns all nested parent paths of `dir`
+ * (e.g. "a/b/c" => ["a", "a/b", "a/b/c"]; "embeddings" => ["embeddings"]).
+ * The spread is required: sets.add is variadic, so without it the whole
+ * slice would be stored as a single key and serialize to a literal
+ * directory name like ["embeddings"].
+ *
+ * @param set: set<string> - the directory set to extend.
+ * @param dir: string - the directory path to register.
+ * @return set<string> - `set` with `dir` and all of its parents added.
+ */
+addNestedDirs := func(set, dir) {
+	return sets.add(set, path.getBasenameDirs(dir)...)
+}
+
+export ll.toStrict({
+	addNestedDirs: addNestedDirs
+})

--- a/sdk/workflow-tengo/src/workdir/dirs.test.tengo
+++ b/sdk/workflow-tengo/src/workdir/dirs.test.tengo
@@ -1,0 +1,26 @@
+test := import(":test")
+sets := import(":sets")
+dirs := import(":workdir.dirs")
+
+TestAddNestedDirs_single := func() {
+	test.isEqual(
+		["embeddings"],
+		sets.toSlice(dirs.addNestedDirs({}, "embeddings"))
+	)
+}
+
+TestAddNestedDirs_nested := func() {
+	test.isEqual(
+		["a", "a/b", "a/b/c"],
+		sets.toSlice(dirs.addNestedDirs({}, "a/b/c"))
+	)
+}
+
+TestAddNestedDirs_accumulatesAndDedupesParents := func() {
+	set := dirs.addNestedDirs({}, "a/b")
+	set = dirs.addNestedDirs(set, "a/c")
+	test.isEqual(
+		["a", "a/b", "a/c"],
+		sets.toSlice(set)
+	)
+}

--- a/sdk/workflow-tengo/src/workdir/index.lib.tengo
+++ b/sdk/workflow-tengo/src/workdir/index.lib.tengo
@@ -328,6 +328,7 @@ _fill := func() {
 		 * @param dir: string - the path of the directory.
 		 */
 		mkDir: func(dir) {
+			validation.assertType(dir, "string")
 			dirs = workdirDirs.addNestedDirs(dirs, dir)
 			return self
 		},

--- a/sdk/workflow-tengo/src/workdir/index.lib.tengo
+++ b/sdk/workflow-tengo/src/workdir/index.lib.tengo
@@ -16,6 +16,7 @@ oop := import(":oop")
 sets := import(":sets")
 slices := import(":slices")
 path := import(":path")
+workdirDirs := import(":workdir.dirs")
 render := import(":render")
 maps := import(":maps")
 
@@ -327,7 +328,7 @@ _fill := func() {
 		 * @param dir: string - the path of the directory.
 		 */
 		mkDir: func(dir) {
-			sets.add(dirs, path.getBasenameDirs(dir))
+			dirs = workdirDirs.addNestedDirs(dirs, dir)
 			return self
 		},
 

--- a/tests/workflow-tengo/src/exec/workdir/mkdir.test.ts
+++ b/tests/workflow-tengo/src/exec/workdir/mkdir.test.ts
@@ -1,0 +1,43 @@
+import { tplTest } from "@platforma-sdk/test";
+
+/**
+ * MILAB-6460: exec/workdir builder mkDir must create real nested directories,
+ * not a single directory literally named ["embeddings"] / ["a", "a/b", "a/b/c"].
+ *
+ * The template creates "embeddings" and "a/b/c" via mkDir, then prints
+ * ok:<dir> / missing:<dir> for each expected directory plus a top-level listing.
+ */
+tplTest.concurrent(
+  "exec.builder.mkDir creates real nested directories (MILAB-6460)",
+  async ({ helper, expect }) => {
+    const result = await helper.renderTemplate(
+      false,
+      "exec.workdir.mkdir",
+      ["dirs"],
+      () => ({}),
+    );
+
+    const listing = await result
+      .computeOutput("dirs", (a) => a?.getDataAsString())
+      .awaitStableValue();
+
+    expect(listing).toBeTypeOf("string");
+
+    const lines = (listing as string)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    // Every path component exists as its own directory.
+    expect(lines).toContain("ok:embeddings");
+    expect(lines).toContain("ok:a");
+    expect(lines).toContain("ok:a/b");
+    expect(lines).toContain("ok:a/b/c");
+
+    // None of the expected directories are missing ...
+    expect(listing).not.toMatch(/missing:/);
+    // ... and no directory was created with the bug's bracketed literal name.
+    expect(listing).not.toContain("[");
+    expect(listing).not.toContain("]");
+  },
+);

--- a/tests/workflow-tengo/src/exec/workdir/mkdir.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/workdir/mkdir.tpl.tengo
@@ -1,0 +1,31 @@
+/**
+ * MILAB-6460: exec/workdir builder mkDir must create real nested directories.
+ *
+ * Creates "embeddings" and "a/b/c" via exec.builder().mkDir, then checks each
+ * expected directory exists and lists the workdir top level. On the buggy
+ * (pre-fix) builder, mkDir created a single directory literally named
+ * ["embeddings"] / ["a", "a/b", "a/b/c"], so the existence checks report
+ * "missing:" and the listing contains bracket characters.
+ */
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+
+self.defineOutputs(["dirs"])
+
+self.body(func(inputs) {
+	run := exec.builder().
+		cpu(1).ram("50Mi").
+		mkDir("embeddings").
+		mkDir("a/b/c").
+		cmd("/usr/bin/env").
+		arg("bash").
+		arg("-c").
+		arg("for d in embeddings a a/b a/b/c; do if [ -d $d ]; then echo ok:$d; else echo missing:$d; fi; done; echo ---top---; ls -A").
+		saveStdoutContent().
+		run()
+
+	return {
+		dirs: run.getStdoutContent()
+	}
+})


### PR DESCRIPTION
MILAB-6460

- `mkDir` passed the `path.getBasenameDirs` slice to the variadic `sets.add` without `...`, so the whole `[]string` became one set key and serialized to a literal dir name like `["embeddings"]`.
- Fix: add the spread; extracted into `workdir.dirs.addNestedDirs` so the logic is unit-testable without a render context, `mkDir` delegates to it.
- Unit tests (`dirs.test.tengo`): `mkDir("embeddings")` -> `embeddings`; `mkDir("a/b/c")` -> `a`, `a/b`, `a/b/c`; parent dedup across calls. Verified failing on the pre-fix code.
- E2E test (`tests/workflow-tengo/.../exec/workdir/mkdir`): creates the dirs on a real backend and asserts they exist under plain names (validated in CI).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a bug in `mkDir` where `path.getBasenameDirs(dir)` was passed to the variadic `sets.add` without the spread operator (`...`), causing the entire `[]string` to be stored as a single map key and serialized into a literal directory name like `["embeddings"]`.

- **Core fix** (`dirs.lib.tengo`, `index.lib.tengo`): extracts `addNestedDirs` with the correct `sets.add(set, slice...)` spread, and updates `mkDir` to delegate to it with proper `dirs =` reassignment.
- **Unit tests** (`dirs.test.tengo`): cover single-component, nested (`a/b/c`), and cross-call deduplication cases; `sets.toSlice` sorts results so assertions are deterministic.
- **E2E test** (`mkdir.test.ts` + `mkdir.tpl.tengo`): validates real directory creation on a backend and explicitly guards against the bracketed regression with `not.toContain("[")` checks.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a focused one-line bug fix backed by both unit and E2E tests, and the existing `_addDirs` method confirms the correct spread pattern was already understood elsewhere in the codebase.

The root cause (missing `...` spread on a variadic call) is well understood, the fix is minimal and correct, and the new tests directly reproduce the pre-fix failure mode. No unrelated behavior is touched.

The only file worth a second glance is `index.lib.tengo` — specifically the `_addDirs` method, which uses the same `sets.add` pattern without capturing the return value, making it slightly inconsistent with the updated `mkDir`.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/workdir/dirs.lib.tengo | New helper extracting addNestedDirs; correctly applies the spread operator to sets.add, making the fix unit-testable in isolation. |
| sdk/workflow-tengo/src/workdir/index.lib.tengo | mkDir now delegates to addNestedDirs and correctly reassigns dirs; _addDirs (used by writeFile) already had the spread and is unaffected. |
| sdk/workflow-tengo/src/workdir/dirs.test.tengo | Unit tests cover single dir, nested dir, and cross-call deduplication; sets.toSlice sorts results so assertions are deterministic. |
| tests/workflow-tengo/src/exec/workdir/mkdir.test.ts | E2E test verifies real directory creation on a backend and guards against the bracketed-name regression with explicit not.toContain("[") checks. |
| tests/workflow-tengo/src/exec/workdir/mkdir.tpl.tengo | Template creates "embeddings" and "a/b/c" via mkDir and uses a bash loop to report ok:/missing: for each expected subdirectory. |
| .changeset/milab-6460-workdir-mkdir-spread.md | Changeset correctly categorizes the fix as a patch for @platforma-sdk/workflow-tengo. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["mkDir(dir) called"] --> B["workdirDirs.addNestedDirs(dirs, dir)"]
    B --> C["path.getBasenameDirs(dir)"]
    C --> D["Returns []string e.g. ['a', 'a/b', 'a/b/c']"]
    D --> E["sets.add(set, slice...) — spread applied"]
    E --> F["Each path component added as individual set key"]
    F --> G["dirs = updated set (reassigned)"]
    G --> H["return self (builder chain)"]

    subgraph BUG["Pre-fix behavior"]
        B1["sets.add(dirs, path.getBasenameDirs(dir))"]
        B1 --> B2["Entire []string stored as one key"]
        B2 --> B3["Creates literal dir named ['embeddings']"]
    end

    subgraph FIX["Post-fix behavior"]
        F1["sets.add(set, path.getBasenameDirs(dir)...)"]
        F1 --> F2["Each string added as its own key"]
        F2 --> F3["Creates dirs: embeddings, a, a/b, a/b/c"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["mkDir(dir) called"] --> B["workdirDirs.addNestedDirs(dirs, dir)"]
    B --> C["path.getBasenameDirs(dir)"]
    C --> D["Returns []string e.g. ['a', 'a/b', 'a/b/c']"]
    D --> E["sets.add(set, slice...) — spread applied"]
    E --> F["Each path component added as individual set key"]
    F --> G["dirs = updated set (reassigned)"]
    G --> H["return self (builder chain)"]

    subgraph BUG["Pre-fix behavior"]
        B1["sets.add(dirs, path.getBasenameDirs(dir))"]
        B1 --> B2["Entire []string stored as one key"]
        B2 --> B3["Creates literal dir named ['embeddings']"]
    end

    subgraph FIX["Post-fix behavior"]
        F1["sets.add(set, path.getBasenameDirs(dir)...)"]
        F1 --> F2["Each string added as its own key"]
        F2 --> F3["Creates dirs: embeddings, a, a/b, a/b/c"]
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/workflow-tengo/src/workdir/index.lib.tengo`, line 152-155 ([link](https://github.com/milaboratory/platforma/blob/cb6821983fa9c6f92ebc81a2e77022203ae0cd9f/sdk/workflow-tengo/src/workdir/index.lib.tengo#L152-L155)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> For consistency with the new `mkDir` pattern, `_addDirs` could also capture the return value. `sets.add` mutates the map in-place and returns the same object, so this is not a functional bug today — but if `sets.add` were ever changed to return a new set (as the `dirs = ...` pattern in `mkDir` now implies is the safe idiom), `_addDirs` would silently stop working.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/workflow-tengo/src/workdir/index.lib.tengo
   Line: 152-155

   Comment:
   For consistency with the new `mkDir` pattern, `_addDirs` could also capture the return value. `sets.add` mutates the map in-place and returns the same object, so this is not a functional bug today — but if `sets.add` were ever changed to return a new set (as the `dirs = ...` pattern in `mkDir` now implies is the safe idiom), `_addDirs` would silently stop working.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20sdk%2Fworkflow-tengo%2Fsrc%2Fworkdir%2Findex.lib.tengo%0ALine%3A%20152-155%0A%0AComment%3A%0AFor%20consistency%20with%20the%20new%20%60mkDir%60%20pattern%2C%20%60_addDirs%60%20could%20also%20capture%20the%20return%20value.%20%60sets.add%60%20mutates%20the%20map%20in-place%20and%20returns%20the%20same%20object%2C%20so%20this%20is%20not%20a%20functional%20bug%20today%20%E2%80%94%20but%20if%20%60sets.add%60%20were%20ever%20changed%20to%20return%20a%20new%20set%20%28as%20the%20%60dirs%20%3D%20...%60%20pattern%20in%20%60mkDir%60%20now%20implies%20is%20the%20safe%20idiom%29%2C%20%60_addDirs%60%20would%20silently%20stop%20working.%0A%0A%60%60%60suggestion%0A%09%09_addDirs%3A%20func%28fileName%29%20%7B%0A%09%09%09newDirs%20%3A%3D%20self._getAllDirs%28fileName%29%0A%09%09%09dirs%20%3D%20sets.add%28dirs%2C%20newDirs...%29%0A%09%09%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=milaboratory%2Fplatforma&pr=1703&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asdk%2Fworkflow-tengo%2Fsrc%2Fworkdir%2Findex.lib.tengo%3A152-155%0AFor%20consistency%20with%20the%20new%20%60mkDir%60%20pattern%2C%20%60_addDirs%60%20could%20also%20capture%20the%20return%20value.%20%60sets.add%60%20mutates%20the%20map%20in-place%20and%20returns%20the%20same%20object%2C%20so%20this%20is%20not%20a%20functional%20bug%20today%20%E2%80%94%20but%20if%20%60sets.add%60%20were%20ever%20changed%20to%20return%20a%20new%20set%20%28as%20the%20%60dirs%20%3D%20...%60%20pattern%20in%20%60mkDir%60%20now%20implies%20is%20the%20safe%20idiom%29%2C%20%60_addDirs%60%20would%20silently%20stop%20working.%0A%0A%60%60%60suggestion%0A%09%09_addDirs%3A%20func%28fileName%29%20%7B%0A%09%09%09newDirs%20%3A%3D%20self._getAllDirs%28fileName%29%0A%09%09%09dirs%20%3D%20sets.add%28dirs%2C%20newDirs...%29%0A%09%09%7D%2C%0A%60%60%60%0A%0A&repo=milaboratory%2Fplatforma&pr=1703&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/workflow-tengo/src/workdir/index.lib.tengo:152-155
For consistency with the new `mkDir` pattern, `_addDirs` could also capture the return value. `sets.add` mutates the map in-place and returns the same object, so this is not a functional bug today — but if `sets.add` were ever changed to return a new set (as the `dirs = ...` pattern in `mkDir` now implies is the safe idiom), `_addDirs` would silently stop working.

```suggestion
		_addDirs: func(fileName) {
			newDirs := self._getAllDirs(fileName)
			dirs = sets.add(dirs, newDirs...)
		},
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflow-tengo): mkDir no longer cre..."](https://github.com/milaboratory/platforma/commit/cb6821983fa9c6f92ebc81a2e77022203ae0cd9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38128802)</sub>

<!-- /greptile_comment -->