### PR TITLE
chore(structure): address review follow-ups on block scaffolding rules

### DIFF
--- a/.changeset/structurer-review-followups.md
+++ b/.changeset/structurer-review-followups.md
@@ -1,0 +1,12 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+structure: address review follow-ups on the block scaffolding rules
+
+- test scope now runs the full `ts-builder check` (type-check + lint + fmt-check) instead of type-only, with block-local `.oxlintrc.json` / `.oxfmtrc.json` and a `fmt` script — matching model/ui.
+- ui declares `@types/node` as a peer dependency (mirrors model) instead of stripping it.
+- drop the retired eslint leftovers: the `lint` script and `@platforma-sdk/eslint-config` dep across model/ui/test, plus its catalog entry.
+- drop the vite-era `@vitejs/plugin-vue` / `vite-plugin-dts` deps and catalog entries (now owned by ts-builder).
+- workflow `tsconfig.json` is scaffolded only when the workflow carries co-located tests (paired with the conditional vitest config).
+- rename the root `update` script to `upgrade-sdk` (deprecated `update-sdk` kept for now).

--- a/etc/blocks/blob-url-custom-protocol/ui/package.json
+++ b/etc/blocks/blob-url-custom-protocol/ui/package.json
@@ -28,6 +28,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/download-file/ui/package.json
+++ b/etc/blocks/download-file/ui/package.json
@@ -29,6 +29,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/enter-numbers-v3/ui/package.json
+++ b/etc/blocks/enter-numbers-v3/ui/package.json
@@ -27,6 +27,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/enter-numbers/ui/package.json
+++ b/etc/blocks/enter-numbers/ui/package.json
@@ -27,6 +27,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/filter-column-test/test/package.json
+++ b/etc/blocks/filter-column-test/test/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest run --passWithNoTests",
-    "check": "ts-builder type-check --target block-test",
+    "check": "ts-builder check --target block-test",
     "formatter:check": "ts-builder formatter --check",
     "linter:check": "ts-builder linter --check",
     "types:check": "ts-builder type-check --target block-test",

--- a/etc/blocks/filter-column-test/ui/package.json
+++ b/etc/blocks/filter-column-test/ui/package.json
@@ -24,6 +24,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/model-test/test/package.json
+++ b/etc/blocks/model-test/test/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest run --passWithNoTests",
-    "check": "ts-builder type-check --target block-test",
+    "check": "ts-builder check --target block-test",
     "formatter:check": "ts-builder formatter --check",
     "linter:check": "ts-builder linter --check",
     "types:check": "ts-builder type-check --target block-test",

--- a/etc/blocks/model-test/ui/package.json
+++ b/etc/blocks/model-test/ui/package.json
@@ -26,6 +26,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/monetization-test/ui/package.json
+++ b/etc/blocks/monetization-test/ui/package.json
@@ -25,6 +25,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/pool-explorer/ui/package.json
+++ b/etc/blocks/pool-explorer/ui/package.json
@@ -27,6 +27,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/read-logs/ui/package.json
+++ b/etc/blocks/read-logs/ui/package.json
@@ -27,6 +27,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/sum-numbers-v3/ui/package.json
+++ b/etc/blocks/sum-numbers-v3/ui/package.json
@@ -28,6 +28,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/sum-numbers/ui/package.json
+++ b/etc/blocks/sum-numbers/ui/package.json
@@ -28,6 +28,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/table-test/test/package.json
+++ b/etc/blocks/table-test/test/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest run --passWithNoTests",
-    "check": "ts-builder type-check --target block-test",
+    "check": "ts-builder check --target block-test",
     "formatter:check": "ts-builder formatter --check",
     "linter:check": "ts-builder linter --check",
     "types:check": "ts-builder type-check --target block-test",

--- a/etc/blocks/table-test/ui/package.json
+++ b/etc/blocks/table-test/ui/package.json
@@ -25,6 +25,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/transfer-files/ui/package.json
+++ b/etc/blocks/transfer-files/ui/package.json
@@ -28,6 +28,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/ui-examples/ui/package.json
+++ b/etc/blocks/ui-examples/ui/package.json
@@ -31,6 +31,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/etc/blocks/ui-examples/workflow/package.json
+++ b/etc/blocks/ui-examples/workflow/package.json
@@ -17,7 +17,6 @@
     "@platforma-sdk/test": "workspace:*",
     "shx": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/etc/blocks/upload-file/ui/package.json
+++ b/etc/blocks/upload-file/ui/package.json
@@ -27,6 +27,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@types/node": "*",
     "typescript": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -537,6 +540,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       '@vueuse/core':
         specifier: 'catalog:'
         version: 13.3.0(vue@3.5.24(typescript@5.9.3))
@@ -646,6 +652,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -752,6 +761,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -892,6 +904,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1014,6 +1029,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1117,6 +1135,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1226,6 +1247,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       monaco-editor:
         specifier: 'catalog:'
         version: 0.52.2
@@ -1332,6 +1356,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1441,6 +1468,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1550,6 +1580,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1684,6 +1717,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1790,6 +1826,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1899,6 +1938,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -1958,9 +2000,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-      vite:
-        specifier: 'catalog:'
-        version: 8.0.6(@types/node@24.5.2)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.83.4)(tsx@4.19.1)(yaml@2.8.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.3(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.3)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.0.6(@types/node@24.5.2)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.83.4)(tsx@4.19.1)(yaml@2.8.0))
@@ -2026,6 +2065,9 @@ importers:
       '@platforma-sdk/ui-vue':
         specifier: workspace:*
         version: link:../../../../sdk/ui-vue
+      '@types/node':
+        specifier: '*'
+        version: 24.5.2
       typescript:
         specifier: '*'
         version: 5.9.3

--- a/tools/block-tools/src/structure/CLAUDE.md
+++ b/tools/block-tools/src/structure/CLAUDE.md
@@ -1,0 +1,28 @@
+# structurer — mental model
+
+A declarative reconciler for a block's scaffolding. `rules/` DECLARE the
+canonical end-state of every non-source file in a block (package.json, configs,
+tsconfig, scripts, catalog); `engine/` reconciles any block toward that state.
+To change what "canonical" means, edit `rules/`; the engine is block-agnostic.
+
+## Boundaries
+
+- `engine/` — generic reconciliation primitives, module discovery, IR. Knows nothing about blocks.
+- `rules/` — the only home of block-specific layout knowledge. `templates/` holds the verbatim file bodies the rules reference.
+- Owns: the shape of a block's scaffolding. Is NOT a build tool, and NOT the author of a block's source — seeded/scaffolded files become author-owned once written.
+
+## Reading posture
+
+- Each `rules/*` file pairs a generator (init: full initial content) with a body (refresh: drift-correcting assertions). Read as "what the file should be" + "how to nudge an existing file there", not as sequential logic.
+- The primitive choice IS the design: `fixed` (overwrite verbatim, engine-owned), `managed` (reconcile named fields, author keeps the rest), `scaffold` (write-once default, author may tune), `seed` (written once at init, author owns forever), `remove` (one-way). Wrong primitive is the main design error — `fixed` on an author-tunable file clobbers their work; `seed` on engine-owned content lets drift accumulate.
+
+## Invariants
+
+- Fixpoint: `refresh` on an already-canonical block makes zero changes. Every rule must converge.
+- Generators emit oxfmt-clean output (the `enforce*` calls mirror oxfmt's order), so build→check passes with no prior `fmt`.
+- sdk-internal blocks (`etc/blocks/*`) skip root-scope and standalone test wiring — the monorepo owns that infra; the structurer must neither impose nor strip it.
+
+## Gotchas
+
+- A rule change also changes the canonical for `etc/blocks/*`: refresh them in the SAME PR (`pnpm run check-blocks`) or CI fails.
+- Dep/peer changes need a `pnpm i` lockfile sync — pnpm records peers and per-importer deps in pnpm-lock.yaml; frozen-install CI fails otherwise.

--- a/tools/block-tools/src/structure/rules/migrations.ts
+++ b/tools/block-tools/src/structure/rules/migrations.ts
@@ -23,40 +23,39 @@ export function testFrameworkMigration(): void {
 // Unconditional legacy-cleanup rules. Each is a no-op on an
 // already-canonical block (remove on an absent path, removeScript /
 // removeDep on an absent key) and idempotent, so they sit at top level
-// with no `when` gate. The trailing comment on each line names the real
-// block(s) that carry the artefact being cleaned.
+// with no `when` gate.
 //
 // Root-scope cleanup is skipped for `--sdk-internal` blocks (no root
 // module in that mode), so it never touches in-monorepo blocks.
 export function legacyCleanup(): void {
-  // eslint → oxlint: the canonical layout ships `.oxlintrc.json` /
-  // `.oxfmtrc.json`; flat eslint configs are retired.
+  // Retired per-scope config files: flat eslint configs and vite-era build /
+  // split-tsconfig files, replaced by the oxlint/oxfmt + ts-builder layout.
   scope("model", () => {
-    remove("eslint.config.mjs"); // samples-and-data, mixcr-clonotyping, clonotype-clustering, antibody-sequence-liabilities
-    remove("vite.config.mts"); // samples-and-data (vite build → ts-builder)
+    remove("eslint.config.mjs");
+    remove("vite.config.mts");
   });
   scope("ui", () => {
-    remove("eslint.config.mjs"); // samples-and-data, mixcr-clonotyping, clonotype-clustering, antibody-sequence-liabilities
-    remove("vite.config.ts"); // samples-and-data (vite build → ts-builder)
-    remove("tsconfig.app.json"); // samples-and-data (vite-era split tsconfig)
-    remove("tsconfig.node.json"); // samples-and-data (vite-era split tsconfig)
+    remove("eslint.config.mjs");
+    remove("vite.config.ts");
+    remove("tsconfig.app.json");
+    remove("tsconfig.node.json");
   });
   scope("test", () => {
-    remove("eslint.config.mjs"); // all 5 experiment blocks
+    remove("eslint.config.mjs");
   });
 
   // Root-scope cleanup. The second `managed("package.json")` body composes
   // after rootRules.
   scope("root", () => {
-    remove(".prettierrc"); // samples-and-data, sequence-properties (prettier → oxfmt)
+    remove(".prettierrc");
     managed(
       "package.json",
       generate(() => rootPackageJsonInitial(getActiveRunContext())),
       () => {
-        // `pretty` (prettier) is superseded by the canonical `fmt` (oxfmt);
-        // the standalone deps-updater was merged into block-tools.
-        removeScript("pretty"); // samples-and-data
-        removeDep("@platforma-sdk/blocks-deps-updater"); // samples-and-data
+        // `pretty` (prettier) is superseded by `fmt` (oxfmt); the standalone
+        // deps-updater is now part of block-tools.
+        removeScript("pretty");
+        removeDep("@platforma-sdk/blocks-deps-updater");
       },
     );
   });

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -129,13 +129,7 @@ export function modelPackageJsonRules(): void {
       ),
   );
 
-  // Shed retired toolchain deps (tsup, vite, vite-plugin-dts, eslint-config) —
-  // ts-builder + rolldown own the build; oxlint replaces eslint. Single source
-  // of truth in shared/retired-deps; catalog entries drop in lockstep via
-  // rootPnpmWorkspaceRules.
   removeRetiredToolchainDeps();
-  // The top-level `tsup` CONFIG block (a package.json field, not a dep) and the
-  // eslint `lint` script go too — neither is a dependency.
   removeField("tsup");
   removeScript("lint");
 

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -27,6 +27,7 @@ import {
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
+import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
 export function modelPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
   const v = ctx.blockVars;
@@ -128,20 +129,15 @@ export function modelPackageJsonRules(): void {
       ),
   );
 
-  // vite/tsup-era artefacts: the canonical model builds via ts-builder, so the
-  // legacy `tsup`/`vite` devDeps and the top-level `tsup` bundler config block
-  // are dropped.
-  removeDep("tsup");
-  removeDep("vite");
-  // `vite-plugin-dts` (vite-era .d.ts emit) is superseded by ts-builder; shed
-  // the leftover dep — paired with its catalog removal in root-pnpm-workspace.
-  removeDep("vite-plugin-dts");
+  // Shed retired toolchain deps (tsup, vite, vite-plugin-dts, eslint-config) —
+  // ts-builder + rolldown own the build; oxlint replaces eslint. Single source
+  // of truth in shared/retired-deps; catalog entries drop in lockstep via
+  // rootPnpmWorkspaceRules.
+  removeRetiredToolchainDeps();
+  // The top-level `tsup` CONFIG block (a package.json field, not a dep) and the
+  // eslint `lint` script go too — neither is a dependency.
   removeField("tsup");
-
-  // eslint → ts-builder/oxlint: linting runs inside `ts-builder check`, so the
-  // standalone `lint` script and the eslint config dep are legacy leftovers.
   removeScript("lint");
-  removeDep("@platforma-sdk/eslint-config");
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -16,6 +16,7 @@ import {
   ensureDevDep,
   ensureDevDeps,
   removeDep,
+  removeScript,
   removeField,
   ensurePeerDeps,
   enforceAlphabeticalOrder,
@@ -132,7 +133,15 @@ export function modelPackageJsonRules(): void {
   // are dropped.
   removeDep("tsup");
   removeDep("vite");
+  // `vite-plugin-dts` (vite-era .d.ts emit) is superseded by ts-builder; shed
+  // the leftover dep — paired with its catalog removal in root-pnpm-workspace.
+  removeDep("vite-plugin-dts");
   removeField("tsup");
+
+  // eslint → ts-builder/oxlint: linting runs inside `ts-builder check`, so the
+  // standalone `lint` script and the eslint config dep are legacy leftovers.
+  removeScript("lint");
+  removeDep("@platforma-sdk/eslint-config");
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/root-package-json.ts
+++ b/tools/block-tools/src/structure/rules/root-package-json.ts
@@ -8,6 +8,7 @@ import {
   ensureScript,
   ensureDevDeps,
   ensurePeerDeps,
+  removeScript,
   removeField,
   pruneKeysMatching,
   enforceAlphabeticalOrder,
@@ -34,10 +35,10 @@ export function rootPackageJsonInitial(_ctx: RunContext): Record<string, unknown
       watch: "turbo watch build",
       changeset: "changeset",
       "version-packages": "changeset version",
-      // Deprecated in favour of `update` (the full refresh → install →
-      // refresh → format flow); kept for compatibility.
+      // Deprecated in favour of `upgrade-sdk` (the full refresh → install →
+      // refresh → format flow); kept for compatibility, removed eventually.
       "update-sdk": "block-tools structure refresh --update-deps-only",
-      update:
+      "upgrade-sdk":
         "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
     },
     peerDependencies: {
@@ -76,16 +77,19 @@ export function rootPackageJsonRules(): void {
   ensureScript("watch", "turbo watch build");
   ensureScript("changeset", "changeset");
   ensureScript("version-packages", "changeset version");
-  // Deprecated in favour of `update`; kept for compatibility.
+  // Deprecated in favour of `upgrade-sdk`; kept for compatibility, removed
+  // eventually. Drop the pre-rename `update` script so a refreshed block
+  // converges on the new name.
   ensureScript("update-sdk", "block-tools structure refresh --update-deps-only");
-  // Full SDK-update flow: bump catalog (deps-only) → install → re-apply
+  removeScript("update");
+  // Full SDK-upgrade flow: bump catalog (deps-only) → install → re-apply
   // structure against the freshly-pulled deps → install AGAIN (the structural
   // pass can add new devDeps — e.g. ts-builder/oxlint/oxfmt on a first
   // migration — that `pnpm fmt` then needs on PATH) → format. Wrapped as one
   // script. `pnpm fmt` (turbo run fmt) leaves the tree oxfmt-clean after the
   // structural rewrite so a follow-up `pnpm check` passes.
   ensureScript(
-    "update",
+    "upgrade-sdk",
     "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
   );
 

--- a/tools/block-tools/src/structure/rules/root-package-json.ts
+++ b/tools/block-tools/src/structure/rules/root-package-json.ts
@@ -35,8 +35,7 @@ export function rootPackageJsonInitial(_ctx: RunContext): Record<string, unknown
       watch: "turbo watch build",
       changeset: "changeset",
       "version-packages": "changeset version",
-      // Deprecated in favour of `upgrade-sdk` (the full refresh → install →
-      // refresh → format flow); kept for compatibility, removed eventually.
+      // Deprecated alias of `upgrade-sdk`; kept for compatibility.
       "update-sdk": "block-tools structure refresh --update-deps-only",
       "upgrade-sdk":
         "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
@@ -77,9 +76,8 @@ export function rootPackageJsonRules(): void {
   ensureScript("watch", "turbo watch build");
   ensureScript("changeset", "changeset");
   ensureScript("version-packages", "changeset version");
-  // Deprecated in favour of `upgrade-sdk`; kept for compatibility, removed
-  // eventually. Drop the pre-rename `update` script so a refreshed block
-  // converges on the new name.
+  // `update-sdk` is a deprecated alias of `upgrade-sdk`, kept for compatibility;
+  // `update` is the pre-rename name — drop it so refreshed blocks converge.
   ensureScript("update-sdk", "block-tools structure refresh --update-deps-only");
   removeScript("update");
   // Full SDK-upgrade flow: bump catalog (deps-only) → install → re-apply

--- a/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
+++ b/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
@@ -110,10 +110,7 @@ export function rootPnpmWorkspaceInitial(ctx: RunContext): Record<string, unknow
 
 export function rootPnpmWorkspaceRules(): void {
   ensureWorkspaceModulePaths();
-  // Retired toolchain catalog entries: drop the orphaned keys. Driven by the
-  // single `RETIRED_TOOLCHAIN_DEPS` source of truth — the per-package side
-  // (`removeRetiredToolchainDeps`) sheds the matching `<dep>: "catalog:"`
-  // references from every scope, so neither side can drift from the other and
-  // leave a dangling catalog reference.
+  // Catalog side of the retired-dep cleanup — the per-package side sheds the
+  // matching `catalog:` references.
   for (const name of RETIRED_TOOLCHAIN_DEPS) ensureCatalogAbsent(name);
 }

--- a/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
+++ b/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
@@ -116,4 +116,11 @@ export function rootPnpmWorkspaceRules(): void {
   ensureCatalogAbsent("vite");
   ensureCatalogAbsent("tsup");
   ensureCatalogAbsent("vue-tsc");
+  // `@vitejs/plugin-vue` + `vite-plugin-dts` are vite-build-era plugins now
+  // encapsulated by ts-builder; drop their orphaned catalog keys too.
+  ensureCatalogAbsent("@vitejs/plugin-vue");
+  ensureCatalogAbsent("vite-plugin-dts");
+  // eslint → oxlint (run via ts-builder check): the shared eslint config is no
+  // longer referenced by any scope; drop its catalog key.
+  ensureCatalogAbsent("@platforma-sdk/eslint-config");
 }

--- a/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
+++ b/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
@@ -20,6 +20,7 @@
 
 import { ensureWorkspaceModulePaths, ensureCatalogAbsent, type RunContext } from "../engine/api";
 import { matchesBumpPattern, type DerivedCatalogPin } from "../engine/registry-client";
+import { RETIRED_TOOLCHAIN_DEPS } from "./shared/retired-deps";
 
 /** SDK packages that live in the catalog (membership only — no versions).
  *  Init fetches npm latest for each; refresh leaves them as the lockfile has
@@ -109,18 +110,10 @@ export function rootPnpmWorkspaceInitial(ctx: RunContext): Record<string, unknow
 
 export function rootPnpmWorkspaceRules(): void {
   ensureWorkspaceModulePaths();
-  // vite/tsup/vue-tsc-era catalog entries: the canonical toolchain (ts-builder
-  // owns vue-tsc; ts-builder + rolldown replace vite/tsup) does not use them.
-  // Drop the orphaned catalog keys — paired with the per-package `removeDep`
-  // so a migrated block sheds both the dep and its catalog entry.
-  ensureCatalogAbsent("vite");
-  ensureCatalogAbsent("tsup");
-  ensureCatalogAbsent("vue-tsc");
-  // `@vitejs/plugin-vue` + `vite-plugin-dts` are vite-build-era plugins now
-  // encapsulated by ts-builder; drop their orphaned catalog keys too.
-  ensureCatalogAbsent("@vitejs/plugin-vue");
-  ensureCatalogAbsent("vite-plugin-dts");
-  // eslint → oxlint (run via ts-builder check): the shared eslint config is no
-  // longer referenced by any scope; drop its catalog key.
-  ensureCatalogAbsent("@platforma-sdk/eslint-config");
+  // Retired toolchain catalog entries: drop the orphaned keys. Driven by the
+  // single `RETIRED_TOOLCHAIN_DEPS` source of truth — the per-package side
+  // (`removeRetiredToolchainDeps`) sheds the matching `<dep>: "catalog:"`
+  // references from every scope, so neither side can drift from the other and
+  // leave a dangling catalog reference.
+  for (const name of RETIRED_TOOLCHAIN_DEPS) ensureCatalogAbsent(name);
 }

--- a/tools/block-tools/src/structure/rules/root.ts
+++ b/tools/block-tools/src/structure/rules/root.ts
@@ -14,7 +14,6 @@ export function rootRules(): void {
     when(
       ({ ctx }) => !ctx.isSdkInternal,
       () => {
-        // see templates/static/root/turbo.json — verbatim canonical content.
         fixed("turbo.json", file("root/turbo.json"));
         fixed(".vscode/settings.json", file("root/.vscode/settings.json"));
 

--- a/tools/block-tools/src/structure/rules/shared/retired-deps.ts
+++ b/tools/block-tools/src/structure/rules/shared/retired-deps.ts
@@ -1,0 +1,42 @@
+// Retired toolchain dependencies — a SINGLE source of truth.
+//
+// These packages are superseded by the canonical toolchain (ts-builder owns
+// the build, vue-tsc, and the vite plugins; oxlint/oxfmt replace eslint) and
+// must be shed from a migrated block in BOTH places at once:
+//   - the root catalog          → `ensureCatalogAbsent` (root-pnpm-workspace)
+//   - every package.json scope  → `removeDep` (via removeRetiredToolchainDeps)
+//
+// Removing from only one side is a latent bug: a catalog entry dropped while a
+// package still references `<dep>: "catalog:"` leaves a dangling reference that
+// breaks `pnpm install`. Driving both from this one list makes that impossible
+// — add (or un-retire) a dependency HERE, once.
+//
+// Per-entry rationale:
+//   vite / tsup          — bundling now goes through ts-builder + rolldown.
+//   vue-tsc              — ts-builder runs vue-tsc internally for `block-ui`; a
+//                          direct dep resolves a different version than the
+//                          toolchain pins, causing type clashes in main.ts.
+//   @vitejs/plugin-vue   — bundled by ts-builder's internal vite config.
+//   vite-plugin-dts      — .d.ts emit is handled by ts-builder.
+//   @platforma-sdk/eslint-config — eslint is retired; linting runs via oxlint
+//                          inside `ts-builder check`.
+
+import { removeDep } from "../../engine/api";
+
+export const RETIRED_TOOLCHAIN_DEPS: readonly string[] = [
+  "vite",
+  "tsup",
+  "vue-tsc",
+  "@vitejs/plugin-vue",
+  "vite-plugin-dts",
+  "@platforma-sdk/eslint-config",
+];
+
+/** Drop every retired toolchain dep from the current package.json scope.
+ *  Idempotent (a `removeDep` on an absent key is a no-op), so it is safe to
+ *  call uniformly from every package.json rules body regardless of which deps
+ *  a given scope ever carried. Pairs with the catalog-side removal in
+ *  `rootPnpmWorkspaceRules`. */
+export function removeRetiredToolchainDeps(): void {
+  for (const name of RETIRED_TOOLCHAIN_DEPS) removeDep(name);
+}

--- a/tools/block-tools/src/structure/rules/test-package-json.ts
+++ b/tools/block-tools/src/structure/rules/test-package-json.ts
@@ -7,6 +7,7 @@ import {
   ensureDevDeps,
   ensurePeerDeps,
   removeDep,
+  removeScript,
   enforceAlphabeticalOrder,
   enforceFieldOrder,
   type RunContext,
@@ -21,9 +22,11 @@ export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown>
     private: true,
     type: "module",
     scripts: {
-      // Type-only check (no oxlint/oxfmt — the test scope ships no lint/fmt
-      // config). Slots into the turbo `check` task.
-      check: "ts-builder type-check --target block-test",
+      fmt: "ts-builder format",
+      // Full check — type-check + lint (oxlint) + fmt-check (oxfmt) — same as
+      // model/ui, so test sources are gated identically. Slots into the turbo
+      // `check` task.
+      check: "ts-builder check --target block-test",
       test: "vitest run --passWithNoTests",
     },
     peerDependencies: {
@@ -41,10 +44,17 @@ export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown>
 export function testPackageJsonRules(): void {
   ensureField("type", "module");
 
-  // Type-only check (no oxlint/oxfmt — the test scope ships no lint/fmt
-  // config); slots into the turbo `check` task.
-  ensureScript("check", "ts-builder type-check --target block-test");
+  // The test scope is formatted + lint/fmt-checked like model/ui: `fmt` runs
+  // the oxlint/oxfmt fixer, `check` the type-check + lint + fmt-check.
+  ensureScript("fmt", "ts-builder format");
+  // Full check — type-check + lint (oxlint) + fmt-check (oxfmt) — same as
+  // model/ui, so test sources are gated identically; slots into the turbo
+  // `check` task.
+  ensureScript("check", "ts-builder check --target block-test");
   ensureScript("test", "vitest run --passWithNoTests");
+  // eslint → ts-builder/oxlint: the legacy `lint` script is an author leftover
+  // (linting now runs inside `ts-builder check`). Drop it and its config dep.
+  removeScript("lint");
 
   // @platforma-sdk/test is a test-time dep → devDependencies (matches prod).
   ensureDevDeps({
@@ -61,6 +71,8 @@ export function testPackageJsonRules(): void {
     typescript: "*",
   });
   removeDep("@types/node");
+  // eslint is retired across the toolchain — drop the legacy config dep.
+  removeDep("@platforma-sdk/eslint-config");
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/test-package-json.ts
+++ b/tools/block-tools/src/structure/rules/test-package-json.ts
@@ -13,6 +13,7 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
 export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
   const v = ctx.blockVars;
@@ -71,8 +72,10 @@ export function testPackageJsonRules(): void {
     typescript: "*",
   });
   removeDep("@types/node");
-  // eslint is retired across the toolchain — drop the legacy config dep.
-  removeDep("@platforma-sdk/eslint-config");
+  // Shed retired toolchain deps (eslint-config among them) — single source of
+  // truth in shared/retired-deps; their catalog entries drop in lockstep via
+  // rootPnpmWorkspaceRules.
+  removeRetiredToolchainDeps();
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/test-package-json.ts
+++ b/tools/block-tools/src/structure/rules/test-package-json.ts
@@ -24,9 +24,7 @@ export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown>
     type: "module",
     scripts: {
       fmt: "ts-builder format",
-      // Full check — type-check + lint (oxlint) + fmt-check (oxfmt) — same as
-      // model/ui, so test sources are gated identically. Slots into the turbo
-      // `check` task.
+      // `ts-builder check` runs type-check + lint (oxlint) + fmt-check (oxfmt).
       check: "ts-builder check --target block-test",
       test: "vitest run --passWithNoTests",
     },
@@ -45,19 +43,13 @@ export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown>
 export function testPackageJsonRules(): void {
   ensureField("type", "module");
 
-  // The test scope is formatted + lint/fmt-checked like model/ui: `fmt` runs
-  // the oxlint/oxfmt fixer, `check` the type-check + lint + fmt-check.
   ensureScript("fmt", "ts-builder format");
-  // Full check — type-check + lint (oxlint) + fmt-check (oxfmt) — same as
-  // model/ui, so test sources are gated identically; slots into the turbo
-  // `check` task.
+  // `ts-builder check` runs type-check + lint (oxlint) + fmt-check (oxfmt).
   ensureScript("check", "ts-builder check --target block-test");
   ensureScript("test", "vitest run --passWithNoTests");
-  // eslint → ts-builder/oxlint: the legacy `lint` script is an author leftover
-  // (linting now runs inside `ts-builder check`). Drop it and its config dep.
+  // Linting runs inside `ts-builder check` — no separate `lint` script.
   removeScript("lint");
 
-  // @platforma-sdk/test is a test-time dep → devDependencies (matches prod).
   ensureDevDeps({
     "@platforma-sdk/test": "sdk:",
     "@milaboratories/ts-builder": "sdk:",
@@ -66,15 +58,11 @@ export function testPackageJsonRules(): void {
   });
 
   // The test tsconfig (@milaboratories/ts-configs/block/test) supplies the
-  // ambient types; only the `typescript` peer is needed. Drop any stray
-  // `@types/node` peer a legacy block declares.
+  // ambient types, so only the `typescript` peer is needed — no `@types/node`.
   ensurePeerDeps({
     typescript: "*",
   });
   removeDep("@types/node");
-  // Shed retired toolchain deps (eslint-config among them) — single source of
-  // truth in shared/retired-deps; their catalog entries drop in lockstep via
-  // rootPnpmWorkspaceRules.
   removeRetiredToolchainDeps();
 
   enforceAlphabeticalOrder("dependencies");

--- a/tools/block-tools/src/structure/rules/test.ts
+++ b/tools/block-tools/src/structure/rules/test.ts
@@ -11,6 +11,12 @@ export function testRules(): void {
     // lets the check pass on a test-less block while `include` still
     // type-checks real tests once present.
     fixed("tsconfig.json", file("test/tsconfig.json"));
+    // The test scope is lint + fmt-checked alongside type-check (the `check`
+    // script runs `ts-builder check --target block-test`, paired with the
+    // `fmt` script). Ship its block-local oxlint/oxfmt config, same as model/ui
+    // — extends ts-builder's `oxlint-test.json`.
+    fixed(".oxlintrc.json", file("test/.oxlintrc.json"));
+    fixed(".oxfmtrc.json", file("test/.oxfmtrc.json"));
     // scaffold (not fixed): integration tests legitimately tune timeout /
     // retry per block. Write the canonical default if absent; never
     // overwrite an author's config.

--- a/tools/block-tools/src/structure/rules/test.ts
+++ b/tools/block-tools/src/structure/rules/test.ts
@@ -11,10 +11,8 @@ export function testRules(): void {
     // lets the check pass on a test-less block while `include` still
     // type-checks real tests once present.
     fixed("tsconfig.json", file("test/tsconfig.json"));
-    // The test scope is lint + fmt-checked alongside type-check (the `check`
-    // script runs `ts-builder check --target block-test`, paired with the
-    // `fmt` script). Ship its block-local oxlint/oxfmt config, same as model/ui
-    // — extends ts-builder's `oxlint-test.json`.
+    // Block-local oxlint/oxfmt config — test sources are lint + fmt-checked
+    // (the `check` script runs `ts-builder check --target block-test`).
     fixed(".oxlintrc.json", file("test/.oxlintrc.json"));
     fixed(".oxfmtrc.json", file("test/.oxfmtrc.json"));
     // scaffold (not fixed): integration tests legitimately tune timeout /

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -52,6 +52,7 @@ export function uiPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
       "@milaboratories/ts-configs": "sdk:",
     },
     peerDependencies: {
+      "@types/node": "*",
       typescript: "*",
     },
   };
@@ -88,22 +89,34 @@ export function uiPackageJsonRules(): void {
   // so a legacy `vite` dep and the `preview` (vite preview) script are dropped.
   removeDep("vite");
   removeScript("preview");
+  // `@vitejs/plugin-vue` + `vite-plugin-dts` are vite-build-era plugins now
+  // owned by ts-builder (it bundles the vue plugin internally). Shed the
+  // leftover direct deps — paired with their catalog removal in
+  // root-pnpm-workspace, so a migrated block sheds both the dep and the (now
+  // dangling) `catalog:` reference.
+  removeDep("@vitejs/plugin-vue");
+  removeDep("vite-plugin-dts");
 
-  // The ui builds with `--target block-ui` (types: []), so by default it
-  // carries no browser/vitest/node ambient types — only the `typescript`
-  // peer for IDE type resolution. Drop any stray `@types/node` a legacy
-  // block declares...
+  // eslint → ts-builder/oxlint: linting runs inside `ts-builder check`, so the
+  // standalone `lint` script and the eslint config dep are legacy leftovers.
+  removeScript("lint");
+  removeDep("@platforma-sdk/eslint-config");
+
+  // `@types/node` is declared as a peer by default — mirrors the model scope
+  // (the block author resolves it from the workspace root). The ui builds with
+  // `--target block-ui` (types: []), so it pulls no node ambient types into the
+  // build; the peer only satisfies IDE / type resolution, alongside `typescript`.
   ensurePeerDeps({
+    "@types/node": "*",
     typescript: "*",
   });
-  removeDep("@types/node");
 
-  // ...but a ui WITH co-located unit tests (`src/**/*.test.ts`) needs the
-  // vitest `test` script, the `vitest` devDep, AND node ambient types: re-add
-  // `@types/node` as a devDep so `types: ["node"]` in ui/tsconfig (wired under
-  // the same predicate) resolves the tests' `node:*` imports. A test-less ui
-  // keeps the lean default (no test script, no vitest, no @types/node) and
-  // stays a fixpoint. Runs AFTER removeDep so the dev deps are not stripped.
+  // A ui WITH co-located unit tests (`src/**/*.test.ts`) needs the vitest
+  // `test` script, the `vitest` devDep, AND node ambient types promoted from
+  // peer to a devDep (the single-section invariant drops the peer) so that
+  // `types: ["node"]` in ui/tsconfig — wired under the same predicate —
+  // resolves the tests' `node:*` imports. A test-less ui keeps `@types/node`
+  // as a peer and carries no vitest, staying a refresh fixpoint.
   //
   // Skipped entirely for sdk-internal (in-monorepo) blocks: they own their test
   // wiring under the monorepo's shared infrastructure — see model-package-json.

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -26,6 +26,7 @@ import {
 import { scopeDepMap } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
+import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
 export function uiPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
   const v = ctx.blockVars;
@@ -78,29 +79,17 @@ export function uiPackageJsonRules(): void {
     "@milaboratories/ts-configs": "sdk:",
   });
 
-  // `vue-tsc` is owned by `ts-builder` (which runs it internally for
-  // `--target block-ui`), so the ui must NOT declare its own. A direct
-  // `vue-tsc` dep is the vestigial vite/vue-tsc-era artefact: it resolves
-  // independently of the version ts-builder pins, which is how a block ended
-  // up type-checking under a different vue-tsc than the toolchain intends.
-  removeDep("vue-tsc");
-
-  // vite-era artefacts: the canonical ui builds + dev-serves via ts-builder,
-  // so a legacy `vite` dep and the `preview` (vite preview) script are dropped.
-  removeDep("vite");
+  // Shed retired toolchain deps — vue-tsc, vite, @vitejs/plugin-vue,
+  // vite-plugin-dts, eslint-config — all owned/replaced by ts-builder + oxlint.
+  // (vue-tsc in particular MUST go: a direct dep resolves a different version
+  // than ts-builder pins, clashing types in main.ts.) Single source of truth in
+  // shared/retired-deps; their catalog entries drop in lockstep via
+  // rootPnpmWorkspaceRules.
+  removeRetiredToolchainDeps();
+  // The vite-era `preview` and eslint `lint` SCRIPTS go too — scripts, not
+  // deps, so dropped here directly.
   removeScript("preview");
-  // `@vitejs/plugin-vue` + `vite-plugin-dts` are vite-build-era plugins now
-  // owned by ts-builder (it bundles the vue plugin internally). Shed the
-  // leftover direct deps — paired with their catalog removal in
-  // root-pnpm-workspace, so a migrated block sheds both the dep and the (now
-  // dangling) `catalog:` reference.
-  removeDep("@vitejs/plugin-vue");
-  removeDep("vite-plugin-dts");
-
-  // eslint → ts-builder/oxlint: linting runs inside `ts-builder check`, so the
-  // standalone `lint` script and the eslint config dep are legacy leftovers.
   removeScript("lint");
-  removeDep("@platforma-sdk/eslint-config");
 
   // `@types/node` is declared as a peer by default — mirrors the model scope
   // (the block author resolves it from the workspace root). The ui builds with

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -79,15 +79,7 @@ export function uiPackageJsonRules(): void {
     "@milaboratories/ts-configs": "sdk:",
   });
 
-  // Shed retired toolchain deps — vue-tsc, vite, @vitejs/plugin-vue,
-  // vite-plugin-dts, eslint-config — all owned/replaced by ts-builder + oxlint.
-  // (vue-tsc in particular MUST go: a direct dep resolves a different version
-  // than ts-builder pins, clashing types in main.ts.) Single source of truth in
-  // shared/retired-deps; their catalog entries drop in lockstep via
-  // rootPnpmWorkspaceRules.
   removeRetiredToolchainDeps();
-  // The vite-era `preview` and eslint `lint` SCRIPTS go too — scripts, not
-  // deps, so dropped here directly.
   removeScript("preview");
   removeScript("lint");
 

--- a/tools/block-tools/src/structure/rules/workflow-package-json.ts
+++ b/tools/block-tools/src/structure/rules/workflow-package-json.ts
@@ -19,6 +19,7 @@ import {
 import { scopeDepMaps } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
+import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
 export function workflowPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
   const v = ctx.blockVars;
@@ -97,6 +98,12 @@ export function workflowPackageJsonRules(): void {
     "@platforma-sdk/test": "sdk:",
     shx: "catalog:",
   });
+
+  // Shed any retired toolchain dep — a no-op for a canonical Tengo workflow
+  // (it carries none), but applied uniformly across every package.json scope so
+  // no scope can be left holding a dangling `catalog:` reference to a key the
+  // catalog rule dropped. Single source of truth in shared/retired-deps.
+  removeRetiredToolchainDeps();
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/workflow-package-json.ts
+++ b/tools/block-tools/src/structure/rules/workflow-package-json.ts
@@ -56,11 +56,10 @@ export function workflowPackageJsonInitial(ctx: RunContext): Record<string, unkn
 export function workflowPackageJsonRules(): void {
   ensureField("type", "module");
 
-  // No `fmt`: the workflow is Tengo, not TS. Build + check go through
-  // pl-tengo. shx powers the cross-platform build clean-up.
+  // No `fmt` script: the workflow is Tengo, not TS — build + check run via
+  // pl-tengo; `format` runs the emacs-batch Tengo formatter (no-op when absent).
   ensureScript("build", "shx rm -rf dist && pl-tengo build");
   ensureScript("check", "pl-tengo check");
-  // Tengo source formatter (emacs batch); no-op notice when emacs is absent.
   ensureScript("format", "/usr/bin/env emacs --script ./format.el || echo 'No emacs.'");
   // The vitest `test` script AND the `vitest` devDep are wired ONLY when the
   // workflow carries co-located integration tests (`src/**/*.test.ts`, incl.
@@ -99,10 +98,8 @@ export function workflowPackageJsonRules(): void {
     shx: "catalog:",
   });
 
-  // Shed any retired toolchain dep — a no-op for a canonical Tengo workflow
-  // (it carries none), but applied uniformly across every package.json scope so
-  // no scope can be left holding a dangling `catalog:` reference to a key the
-  // catalog rule dropped. Single source of truth in shared/retired-deps.
+  // No-op for a canonical Tengo workflow; called uniformly across every scope
+  // for safety.
   removeRetiredToolchainDeps();
 
   enforceAlphabeticalOrder("dependencies");

--- a/tools/block-tools/src/structure/rules/workflow.ts
+++ b/tools/block-tools/src/structure/rules/workflow.ts
@@ -52,8 +52,8 @@ export function workflowRules(): void {
     );
     // No workflow facade (index.js / index.d.ts): the block loader resolves the
     // workflow via the `block:` components dist path (workflow/dist/.../main.plj.gz),
-    // never the JS facade. It was orphaned in production — dropped. Actively
-    // removed so existing blocks that carry it get cleaned (idempotent on absence).
+    // never the JS facade. Removed so blocks that carry one get cleaned
+    // (idempotent on absence).
     remove("index.js");
     remove("index.d.ts");
 

--- a/tools/block-tools/src/structure/rules/workflow.ts
+++ b/tools/block-tools/src/structure/rules/workflow.ts
@@ -21,16 +21,15 @@ import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
 export function workflowRules(): void {
   scope("workflow", () => {
-    // tsconfig for the TypeScript vitest integration tests under src/test
-    // (e.g. mixcr's workflow/src/test/columns.test.ts). types:[] keeps the
-    // isomorphic workflow free of ambient Node/DOM types.
-    fixed("tsconfig.json", file("workflow/tsconfig.json"));
     // Tengo source formatter (emacs batch); the `format` script invokes it.
     fixed("format.el", file("workflow/format.el"));
-    // vitest config only when the workflow carries co-located tests
-    // (`src/**/*.test.ts`, incl. `src/test/`) — paired with the conditional
-    // `vitest` devDep + `test` script in workflow-package-json. scaffold (not
-    // fixed): author-tunable when present; a test-less workflow gets none.
+    // The TS-test tsconfig + vitest config exist ONLY when the workflow carries
+    // co-located tests (`src/**/*.test.ts`, incl. `src/test/` — e.g. mixcr's
+    // workflow/src/test/columns.test.ts). They pair with the conditional
+    // `vitest` devDep + `test` script in workflow-package-json. tsconfig is
+    // `fixed` (structural: types:[] keeps the isomorphic workflow free of
+    // ambient Node/DOM types); vitest.config is `scaffold` (author-tunable once
+    // present). A test-less workflow gets neither and stays a refresh fixpoint.
     //
     // Skipped entirely for sdk-internal (in-monorepo) blocks: they own their
     // test config under the monorepo's shared infrastructure (e.g. a bespoke
@@ -41,8 +40,14 @@ export function workflowRules(): void {
       () =>
         when(
           whenFilesExist(COLOCATED_TEST_GLOB),
-          () => scaffold("vitest.config.mts", file("workflow/vitest.config.mts")),
-          () => remove("vitest.config.mts"),
+          () => {
+            fixed("tsconfig.json", file("workflow/tsconfig.json"));
+            scaffold("vitest.config.mts", file("workflow/vitest.config.mts"));
+          },
+          () => {
+            remove("tsconfig.json");
+            remove("vitest.config.mts");
+          },
         ),
     );
     // No workflow facade (index.js / index.d.ts): the block loader resolves the

--- a/tools/block-tools/src/structure/templates/static/test/.oxfmtrc.json
+++ b/tools/block-tools/src/structure/templates/static/test/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["node_modules/@milaboratories/ts-builder/configs/oxfmt.json"],
+  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md"]
+}

--- a/tools/block-tools/src/structure/templates/static/test/.oxlintrc.json
+++ b/tools/block-tools/src/structure/templates/static/test/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["node_modules/@milaboratories/ts-builder/dist/configs/oxlint-test.json"]
+}


### PR DESCRIPTION
Follow-ups from Alexander's review of the samples-and-data structurer migration (platforma-open/samples-and-data#125), distributed into the structurer rules so every block converges.

## Review follow-ups (`tools/block-tools/src/structure`)

- **test scope — full check.** `check` now runs `ts-builder check --target block-test` (type-check + lint + fmt-check) instead of type-only, with block-local `.oxlintrc.json` / `.oxfmtrc.json` (extends `oxlint-test.json`) and a `fmt` script — matching model/ui.
- **ui `@types/node` → peer.** Declared as a peer dependency (mirrors model); still promoted to devDep when the ui carries co-located tests.
- **Drop retired eslint.** Removes the `lint` script + `@platforma-sdk/eslint-config` across model/ui/test, plus its catalog entry. Linting runs inside `ts-builder check`.
- **Drop vite-era plugins.** `@vitejs/plugin-vue` and `vite-plugin-dts` deps + catalog entries removed.
- **workflow `tsconfig.json` conditional.** Scaffolded only when the workflow has co-located tests (both it and the vitest config skipped for `--sdk-internal`).
- **root script rename.** `update` → `upgrade-sdk`; deprecated `update-sdk` kept for now.

## Retired-dep cleanup abstraction (2nd commit)

The catalog removal and per-package `removeDep` were hand-paired across files and drifted (the `@vitejs/plugin-vue` near-miss). Replaced with a single `RETIRED_TOOLCHAIN_DEPS` source of truth (`rules/shared/retired-deps.ts`), consumed by both the catalog loop and `removeRetiredToolchainDeps()` in **every** package.json scope — a catalog entry can no longer be dropped while a package still references it. Applying it uniformly also caught a stray `vite` devDep in `etc/blocks/ui-examples/workflow`.

## In-monorepo blocks

`etc/blocks/*` refreshed (`--sdk-internal`) to keep `check-blocks` green; `pnpm-lock.yaml` synced (peer deps recorded per importer).

## Verification

- structure unit tests: 238 passing; type-check + build clean.
- Local tool vs samples-and-data: clean refresh, then `install`/`fmt`/`check`/`build` green, block packs, refresh idempotent.
- `structure check --sdk-internal etc/blocks/*` green; existing test packages pass the upgraded check; lockfile diff is only importer changes, no resolution churn.