### PR TITLE
feat(block-tools): manage block CI workflows in the structurer

### DIFF
--- a/.changeset/structurer-ci-workflows.md
+++ b/.changeset/structurer-ci-workflows.md
@@ -1,0 +1,11 @@
+---
+"@platforma-sdk/block-tools": minor
+---
+
+structurer: manage the block CI workflows (`.github/workflows/build.yaml` and
+`mark-stable.yaml`) as engine-owned (`fixed`) scaffold files, generated from
+the block's short name. Brings the shared-CI pin (`@v4`) and job wiring under
+central management so `refresh` keeps every block's workflow in sync; the only
+per-block bits are derived (`app-name`, `app-name-slug`), with `team-id` and
+the `test` toggle as shared constants. Standalone blocks only — `--sdk-internal`
+blocks are unaffected.

--- a/.changeset/structurer-managed-body-ctx.md
+++ b/.changeset/structurer-managed-body-ctx.md
@@ -1,0 +1,9 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+structurer: `managed(path, initial, body)` bodies now receive the active
+`RunContext` as an argument (`(ctx) => …`), matching `generate`/`tpl`/`when`.
+Rule code no longer reaches for the module-global `getActiveRunContext()` —
+every execution-level lambda gets `ctx` by argument. Internal refactor; no
+change to generated block output.

--- a/tools/block-tools/.oxfmtrc.json
+++ b/tools/block-tools/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "extends": ["node_modules/@milaboratories/ts-builder/configs/oxfmt.json"],
-  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md"]
+  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md", "src/structure/templates/text/workflows"]
 }

--- a/tools/block-tools/src/structure/CLAUDE.md
+++ b/tools/block-tools/src/structure/CLAUDE.md
@@ -15,12 +15,14 @@ To change what "canonical" means, edit `rules/`; the engine is block-agnostic.
 
 - Each `rules/*` file pairs a generator (init: full initial content) with a body (refresh: drift-correcting assertions). Read as "what the file should be" + "how to nudge an existing file there", not as sequential logic.
 - The primitive choice IS the design: `fixed` (overwrite verbatim, engine-owned), `managed` (reconcile named fields, author keeps the rest), `scaffold` (write-once default, author may tune), `seed` (written once at init, author owns forever), `remove` (one-way). Wrong primitive is the main design error — `fixed` on an author-tunable file clobbers their work; `seed` on engine-owned content lets drift accumulate.
+- Two layers. Calls inside `defineStructure` (`scope`/`fixed`/`managed`/`seed`/`when`-framing) run once at tree-build time to DECLARE the tree — there is no block and no `ctx` yet. The lambdas the engine runs later, per block — trigger predicates, `generate`/`tpl` producers, and `managed` bodies — are the EXECUTION layer, where per-block values are computed.
 
 ## Invariants
 
 - Fixpoint: `refresh` on an already-canonical block makes zero changes. Every rule must converge.
 - Generators emit oxfmt-clean output (the `enforce*` calls mirror oxfmt's order), so build→check passes with no prior `fmt`.
 - sdk-internal blocks (`etc/blocks/*`) skip root-scope and standalone test wiring — the monorepo owns that infra; the structurer must neither impose nor strip it.
+- Every execution-level lambda receives `ctx` by argument (trigger predicates get the richer `TriggerContext`; `generate`/`tpl`/`managed` bodies get `RunContext`); none reaches for it ambiently. `getActiveRunContext()`/`blockVars()` are engine-internal plumbing, not the rule-author surface.
 
 ## Gotchas
 

--- a/tools/block-tools/src/structure/CLAUDE.md
+++ b/tools/block-tools/src/structure/CLAUDE.md
@@ -22,7 +22,7 @@ To change what "canonical" means, edit `rules/`; the engine is block-agnostic.
 - Fixpoint: `refresh` on an already-canonical block makes zero changes. Every rule must converge.
 - Generators emit oxfmt-clean output (the `enforce*` calls mirror oxfmt's order), so build→check passes with no prior `fmt`.
 - sdk-internal blocks (`etc/blocks/*`) skip root-scope and standalone test wiring — the monorepo owns that infra; the structurer must neither impose nor strip it.
-- Every execution-level lambda receives `ctx` by argument (trigger predicates get the richer `TriggerContext`; `generate`/`tpl`/`managed` bodies get `RunContext`); none reaches for it ambiently. `getActiveRunContext()`/`blockVars()` are engine-internal plumbing, not the rule-author surface.
+- Rule code never reaches for `ctx` ambiently — `getActiveRunContext()`/`blockVars()` are engine-internal plumbing. A lambda that needs block identity takes `ctx` by argument (triggers get the richer `TriggerContext`, the rest `RunContext`); a `managed` body that doesn't take it relies on the builders it calls, which resolve `ctx` themselves.
 
 ## Gotchas
 

--- a/tools/block-tools/src/structure/__tests__/discovery-shortname.test.ts
+++ b/tools/block-tools/src/structure/__tests__/discovery-shortname.test.ts
@@ -1,0 +1,50 @@
+// DISCOVERY derives BlockVars from the block-scope module's package name.
+// This structurer names that package `<facade>.block`, while the root
+// package carries no `name` — so on refresh/check the `.block` suffix would
+// leak into `shortName` unless discovery strips it (see discovery-fs.ts).
+// These tests pin both shapes: the structurer-shaped block (suffix stripped)
+// and a legacy block whose block package IS the bare facade (nothing to
+// strip).
+
+import { describe, test, expect } from "vitest";
+import type { BlockVars } from "../engine/api";
+import { simulateInit } from "../engine/testing";
+import { discoverRunContext } from "../engine/discovery-fs";
+import { MemoryFileSystem } from "../engine/fs/memory";
+
+describe("DISCOVERY: shortName from the block package name", () => {
+  test("strips the trailing .block for a <facade>.block-shaped block", () => {
+    const vars: BlockVars = {
+      facadeName: "@platforma-open/test-org.demo",
+      baseName: "test-org.demo",
+      npmOrg: "@platforma-open",
+      orgScope: "test-org",
+      shortName: "demo",
+    };
+    // simulateInit runs the real init then RE-DISCOVERS from the written FS,
+    // so this is the genuine refresh/check derivation path.
+    const { ctx } = simulateInit({ vars });
+    // Sanity: the block package really is named `<facade>.block` on disk.
+    const blockMod = ctx.modules.find((m) => m.scope === "block");
+    expect(blockMod?.name).toBe("@platforma-open/test-org.demo.block");
+    expect(ctx.blockVars.shortName).toBe("demo");
+  });
+
+  test("keeps the real shortName for a legacy bare-facade block package", () => {
+    const fs = new MemoryFileSystem({
+      "pnpm-workspace.yaml": "packages:\n  - block\n",
+      // Nameless root — the standalone shape; classified `root` by path.
+      "package.json": "{}",
+      // Legacy block package: name IS the bare facade, no `.block` suffix.
+      "block/package.json": JSON.stringify({
+        name: "@platforma-open/test-org.legacy",
+        files: ["index.d.ts", "index.js"],
+        dependencies: { "@platforma-sdk/block-tools": "*" },
+      }),
+    });
+    const ctx = discoverRunContext({ fs, isSdkInternal: false });
+    const blockMod = ctx.modules.find((m) => m.scope === "block");
+    expect(blockMod?.name).toBe("@platforma-open/test-org.legacy");
+    expect(ctx.blockVars.shortName).toBe("legacy");
+  });
+});

--- a/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
+++ b/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
@@ -1,0 +1,68 @@
+// Root CI workflow files (`rules/root-ci.ts`) — `fixed`, generated from the
+// block's short name. These rules are `!isSdkInternal`, so the `etc/blocks`
+// check-blocks run never exercises them; this is their only coverage.
+//
+// Asserts: init writes both workflows with derived identity (app-name /
+// app-name-slug) + shared constants (team-id, the `@v4` pins, test: true);
+// the files are idempotent (init → check zero diff); and `--sdk-internal`
+// blocks get neither file.
+
+import { describe, test, expect } from "vitest";
+import type { BlockVars, RunContext } from "../engine/api";
+import { STRUCTURE } from "../structure-definition";
+import { run as engineRun } from "../engine/runner";
+import { defaultTemplateProvider, simulateInit } from "../engine/testing";
+
+const TEMPLATES = defaultTemplateProvider();
+
+const VARS: BlockVars = {
+  facadeName: "@platforma-open/milaboratories.mixcr-clonotyping-2",
+  baseName: "milaboratories.mixcr-clonotyping-2",
+  npmOrg: "@platforma-open",
+  orgScope: "milaboratories",
+  shortName: "mixcr-clonotyping-2",
+};
+
+const BUILD = ".github/workflows/build.yaml";
+const MARK_STABLE = ".github/workflows/mark-stable.yaml";
+
+describe("root CI workflows (fixed, generated)", () => {
+  test("init writes both workflows with derived identity + shared constants", () => {
+    const { fs } = simulateInit({ vars: VARS });
+
+    const build = fs.read(BUILD);
+    // Derived identity from the short name.
+    expect(build).toContain("app-name: 'Block: Mixcr Clonotyping 2'");
+    expect(build).toContain("app-name-slug: 'block-mixcr-clonotyping-2'");
+    // Shared constants.
+    expect(build).toContain("team-id: 'ciplopen'");
+    expect(build).toContain("test: true");
+    // The reusable-workflow pins — the whole point of engine-owning the file.
+    expect(build).toContain(
+      "uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4",
+    );
+    expect(build).toContain("uses: milaboratory/github-ci/actions/context/init@v4");
+    // `${{ ... }}` GitHub expressions survive `tpl` substitution untouched.
+    expect(build).toContain("${{ toJSON(secrets.NPMJS_TOKEN) }}");
+
+    const markStable = fs.read(MARK_STABLE);
+    expect(markStable).toContain("app-name: 'Block: Mixcr Clonotyping 2 - Mark Stable'");
+    expect(markStable).toContain(
+      "uses: milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4",
+    );
+  });
+
+  test("init → check is zero-diff for the workflow files (fixed idempotency)", () => {
+    const { fs, ctx } = simulateInit({ vars: VARS });
+    const checkCtx: RunContext = { ...ctx, dryRun: true };
+    const result = engineRun(STRUCTURE, fs, checkCtx, { templates: TEMPLATES });
+    const ciChanges = result.changes.filter((c) => c.path === BUILD || c.path === MARK_STABLE);
+    expect(ciChanges).toEqual([]);
+  });
+
+  test("sdk-internal blocks get neither workflow file", () => {
+    const { fs } = simulateInit({ vars: VARS, isSdkInternal: true });
+    expect(fs.exists(BUILD)).toBe(false);
+    expect(fs.exists(MARK_STABLE)).toBe(false);
+  });
+});

--- a/tools/block-tools/src/structure/engine/builders.ts
+++ b/tools/block-tools/src/structure/engine/builders.ts
@@ -327,18 +327,19 @@ export function text(value: string): ContentForm {
 }
 
 /** Content form: a text template (the structurer's `text/` templates) with
- *  `${var}` placeholders substituted from `vars`. */
+ *  `${var}` placeholders substituted from `vars`. When `vars` is a function it
+ *  receives the active {@link RunContext} at resolve time. */
 export function tpl(
   path: string,
-  vars: Record<string, string> | (() => Record<string, string>),
+  vars: Record<string, string> | ((ctx: RunContext) => Record<string, string>),
 ): ContentForm {
   return { kind: "tpl", path, vars };
 }
 
-/** Content form: content computed at run time. The return value is serialised
- *  as JSON / YAML by the target file's extension, or used verbatim if it is
- *  already a string. */
-export function generate(fn: () => unknown): ContentForm {
+/** Content form: content computed at run time from the active
+ *  {@link RunContext}. The return value is serialised as JSON / YAML by the
+ *  target file's extension, or used verbatim if it is already a string. */
+export function generate(fn: (ctx: RunContext) => unknown): ContentForm {
   return { kind: "generate", fn };
 }
 

--- a/tools/block-tools/src/structure/engine/content-rules.ts
+++ b/tools/block-tools/src/structure/engine/content-rules.ts
@@ -13,7 +13,7 @@
 
 import { registerInnerWhenHandler, tryGetActiveRunContext } from "./builders";
 import type { RunContext, Scope } from "./api";
-import type { TriggerContext, TriggerFn } from "./ir";
+import type { ManagedBody, TriggerContext, TriggerFn } from "./ir";
 import {
   deleteAtPath,
   getAtPath,
@@ -163,13 +163,13 @@ export type WithManagedOpts = {
  *  the runner calls this for managed `.json` files. */
 export function withManagedBody(
   obj: JsonObject,
-  body: () => void,
+  body: ManagedBody,
   opts: WithManagedOpts = {},
 ): JsonObject {
   if (active) throw new Error("Nested managed(...) body — engine bug.");
   active = { kind: "json", obj, ctx: opts.ctx, triggerContext: opts.triggerContext };
   try {
-    body();
+    body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext);
     return obj;
   } finally {
     active = undefined;
@@ -189,7 +189,7 @@ export type WithManagedYamlOpts = WithManagedOpts & {
  *  `pnpm-workspace.yaml`); returns the mutated document. Exported for tests. */
 export function withManagedYaml(
   doc: YamlDocument,
-  body: () => void,
+  body: ManagedBody,
   opts: WithManagedYamlOpts = {},
 ): YamlDocument {
   if (active) throw new Error("Nested managed(...) body — engine bug.");
@@ -202,7 +202,7 @@ export function withManagedYaml(
     getDerivedDependencyPin: opts.getDerivedDependencyPin,
   };
   try {
-    body();
+    body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext);
     return doc;
   } finally {
     active = undefined;
@@ -213,7 +213,7 @@ export function withManagedYaml(
  *  (for `.gitignore`); returns the mutated lines. Exported for tests. */
 export function withManagedLines(
   lines: string[],
-  body: () => void,
+  body: ManagedBody,
   opts: WithManagedOpts = {},
 ): string[] {
   if (active) throw new Error("Nested managed(...) body — engine bug.");
@@ -224,7 +224,7 @@ export function withManagedLines(
     triggerContext: opts.triggerContext,
   };
   try {
-    body();
+    body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext);
     return lines;
   } finally {
     active = undefined;

--- a/tools/block-tools/src/structure/engine/discovery-fs.ts
+++ b/tools/block-tools/src/structure/engine/discovery-fs.ts
@@ -196,7 +196,15 @@ export function discoverRunContext(input: DiscoverInput): RunContext {
       `Could not find a 'block' (or root-as-block) package to derive BlockVars from.`,
     );
   }
-  const blockVars = parseBlockVars(blockMod.name);
+  // This structurer names the block package `<facade>.block`
+  // (block-package-json.ts). The root package carries no `name`, so DISCOVERY
+  // derives BlockVars from the block module — whose `.block` suffix would
+  // otherwise leak into `shortName` on refresh/check (but not init, which is
+  // fed the facade directly). Strip it so `shortName` is the real short name
+  // everywhere. No-op for legacy blocks whose block package IS the bare facade
+  // and for the root-as-block fallback.
+  const facadeName = blockMod.name.replace(/\.block$/, "");
+  const blockVars = parseBlockVars(facadeName);
 
   return createRunContext({
     isSdkInternal,

--- a/tools/block-tools/src/structure/engine/ir.ts
+++ b/tools/block-tools/src/structure/engine/ir.ts
@@ -52,8 +52,11 @@ export type ContentForm =
   // only `seed` / `scaffold` consume it (via fs.writeBinary).
   | { kind: "binary"; path: string };
 
-/** Builder-body for a `managed` file (the content-rules lambda). */
-export type ManagedBody = () => void;
+/** Builder-body for a `managed` file (the content-rules lambda). Receives the
+ *  active `RunContext` — the same object triggers see as `tctx.ctx` and that
+ *  `generate`/`tpl` lambdas receive — so the body reads block identity via its
+ *  argument rather than the module-global `getActiveRunContext()`. */
+export type ManagedBody = (ctx: RunContext) => void;
 
 // --- Leaf primitives ---
 

--- a/tools/block-tools/src/structure/engine/ir.ts
+++ b/tools/block-tools/src/structure/engine/ir.ts
@@ -37,14 +37,16 @@ export type TriggerContext = {
 export type TriggerFn = (tctx: TriggerContext) => boolean;
 
 /** Content forms — what to write into a file when creating it.
- *  `tpl.vars` may be a record or a thunk returning a record; the latter
- *  lets rule authors call `blockVars()` lazily at resolve time. */
-export type TplVarsLike = Record<string, string> | (() => Record<string, string>);
+ *  `tpl.vars` and `generate.fn` may be functions; when they are, the
+ *  resolver calls them with the active `RunContext` (the same object
+ *  triggers see as `tctx.ctx`), so lambdas read block identity via their
+ *  argument rather than the module-global `getActiveRunContext()`. */
+export type TplVarsLike = Record<string, string> | ((ctx: RunContext) => Record<string, string>);
 export type ContentForm =
   | { kind: "file"; path: string }
   | { kind: "text"; value: string }
   | { kind: "tpl"; path: string; vars: TplVarsLike }
-  | { kind: "generate"; fn: () => unknown }
+  | { kind: "generate"; fn: (ctx: RunContext) => unknown }
   // A binary static asset (e.g. a logo PNG) copied verbatim from the
   // template tree. Carried as raw bytes, never decoded to a string —
   // only `seed` / `scaffold` consume it (via fs.writeBinary).

--- a/tools/block-tools/src/structure/engine/runner.ts
+++ b/tools/block-tools/src/structure/engine/runner.ts
@@ -110,7 +110,7 @@ function resolveContent(
   form: ContentForm,
   filePath: string,
   templates: TemplateProvider | undefined,
-  isSdkInternal: boolean,
+  ctx: RunContext,
 ): string {
   switch (form.kind) {
     case "text":
@@ -132,15 +132,15 @@ function resolveContent(
         );
       }
       const raw = templates.textRead(form.path);
-      const vars = typeof form.vars === "function" ? form.vars() : form.vars;
+      const vars = typeof form.vars === "function" ? form.vars(ctx) : form.vars;
       return substituteVars(raw, vars);
     }
     case "generate": {
-      const value = form.fn();
+      const value = form.fn(ctx);
       if (filePath.endsWith(".json")) {
         // Resolve `sdk:` sentinels in the generated dep sections so the
         // initial content matches what the body rules re-assert.
-        resolveSdkSentinelsInJson(value, isSdkInternal);
+        resolveSdkSentinelsInJson(value, ctx.isSdkInternal);
         // package.json stays fully expanded (oxfmt's package.json shape);
         // every other .json collapses to oxfmt's generic-file shape.
         return stringifyJson(value, { collapse: !filePath.endsWith("package.json") });
@@ -170,7 +170,7 @@ function writeLeafContent(
   resolvedPath: string,
   form: ContentForm,
   templates: TemplateProvider | undefined,
-  isSdkInternal: boolean,
+  ctx: RunContext,
 ): void {
   if (form.kind === "binary") {
     if (!templates) {
@@ -182,7 +182,7 @@ function writeLeafContent(
     fs.writeBinary(resolvedPath, templates.staticReadBinary(form.path));
     return;
   }
-  fs.write(resolvedPath, resolveContent(form, resolvedPath, templates, isSdkInternal));
+  fs.write(resolvedPath, resolveContent(form, resolvedPath, templates, ctx));
 }
 
 /** Dispatch managed-body parse → mutate → serialize by file extension /
@@ -292,11 +292,11 @@ function applyStructural(
   dryRun: boolean,
   templates: TemplateProvider | undefined,
   initMode: boolean,
-  isSdkInternal: boolean,
+  ctx: RunContext,
 ): Change | undefined {
   const leaf = item.leaf;
   if (leaf.kind === "fixed") {
-    const desired = resolveContent(leaf.content, item.resolvedPath, templates, isSdkInternal);
+    const desired = resolveContent(leaf.content, item.resolvedPath, templates, ctx);
     const exists = fs.exists(item.resolvedPath);
     if (!exists) {
       if (!dryRun) fs.write(item.resolvedPath, desired);
@@ -320,7 +320,7 @@ function applyStructural(
   if (leaf.kind === "scaffold") {
     if (fs.exists(item.resolvedPath)) return undefined;
     if (!dryRun) {
-      writeLeafContent(fs, item.resolvedPath, leaf.initial, templates, isSdkInternal);
+      writeLeafContent(fs, item.resolvedPath, leaf.initial, templates, ctx);
     }
     return {
       scope: item.scope,
@@ -338,7 +338,7 @@ function applyStructural(
     if (!initMode) return undefined;
     if (fs.exists(item.resolvedPath)) return undefined;
     if (!dryRun) {
-      writeLeafContent(fs, item.resolvedPath, leaf.initial, templates, isSdkInternal);
+      writeLeafContent(fs, item.resolvedPath, leaf.initial, templates, ctx);
     }
     return {
       scope: item.scope,
@@ -383,7 +383,7 @@ function applyManaged(
   templates: TemplateProvider | undefined,
   registryLookup: ((packageName: string) => string | undefined) | undefined,
   derivedPinLookup: ((catalogEntry: string) => string | undefined) | undefined,
-  isSdkInternal: boolean,
+  ctx: RunContext,
 ): Change | undefined {
   if (item.leaf.kind !== "managed") return undefined;
   const leaf = item.leaf;
@@ -394,7 +394,7 @@ function applyManaged(
   let created = false;
 
   if (!exists) {
-    beforeRaw = resolveContent(leaf.initial, path, templates, isSdkInternal);
+    beforeRaw = resolveContent(leaf.initial, path, templates, ctx);
     created = true;
   } else {
     beforeRaw = fs.read(path);
@@ -443,7 +443,7 @@ function executePass(
     if (item.leaf.kind === "managed") continue;
     const tctx1 = buildTriggerCtx(snap1, ctx, item.modulePath);
     if (!passesTriggers(item, tctx1)) continue;
-    const change = applyStructural(item, fs, dryRun, templates, initMode, ctx.isSdkInternal);
+    const change = applyStructural(item, fs, dryRun, templates, initMode, ctx);
     if (change) changes.push(change);
   }
 
@@ -462,7 +462,7 @@ function executePass(
       templates,
       registryLookup,
       derivedPinLookup,
-      ctx.isSdkInternal,
+      ctx,
     );
     if (change) changes.push(change);
   }

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -12,7 +12,6 @@ import {
   enforceFieldOrder,
   type RunContext,
 } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { findModules, scopeDepMap } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
 
@@ -111,7 +110,7 @@ export function blockPackageJsonInitial(ctx: RunContext): Record<string, unknown
   };
 }
 
-export function blockPackageJsonRules(): void {
+export function blockPackageJsonRules(ctx: RunContext): void {
   // type:"module" intentionally omitted: the facade's index.js is the
   // CommonJS dev-block descriptor (module.exports / __dirname); ESM would
   // break it. The facade has no TS sources to compile.
@@ -146,7 +145,7 @@ export function blockPackageJsonRules(): void {
   // it in sync on refresh. `block.meta` is deliberately NOT touched here: it
   // is an author-owned seed (set once in the init package.json), so refresh
   // must never overwrite the author's title / description / logo.
-  ensureField("block.components", blockComponents(getActiveRunContext()));
+  ensureField("block.components", blockComponents(ctx));
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/block.ts
+++ b/tools/block-tools/src/structure/rules/block.ts
@@ -20,8 +20,8 @@ export function blockRules(): void {
     managed(
       "package.json",
       generate((ctx) => blockPackageJsonInitial(ctx)),
-      () => {
-        blockPackageJsonRules();
+      (ctx) => {
+        blockPackageJsonRules(ctx);
       },
     );
   });

--- a/tools/block-tools/src/structure/rules/block.ts
+++ b/tools/block-tools/src/structure/rules/block.ts
@@ -2,7 +2,6 @@
 // Workspace-scope deps in the body resolve from ctx.modules.
 
 import { scope, fixed, managed, seed, file, binaryFile, generate } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { blockPackageJsonInitial, blockPackageJsonRules } from "./block-package-json";
 
 export function blockRules(): void {
@@ -20,7 +19,7 @@ export function blockRules(): void {
 
     managed(
       "package.json",
-      generate(() => blockPackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => blockPackageJsonInitial(ctx)),
       () => {
         blockPackageJsonRules();
       },

--- a/tools/block-tools/src/structure/rules/migrations.ts
+++ b/tools/block-tools/src/structure/rules/migrations.ts
@@ -12,7 +12,6 @@
 //    keys/paths). Each line is a one-way decision: every block converges.
 
 import { scope, remove, managed, generate, removeScript, removeDep } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { rootPackageJsonInitial } from "./root-package-json";
 
 export function testFrameworkMigration(): void {
@@ -50,7 +49,7 @@ export function legacyCleanup(): void {
     remove(".prettierrc");
     managed(
       "package.json",
-      generate(() => rootPackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => rootPackageJsonInitial(ctx)),
       () => {
         // `pretty` (prettier) is superseded by `fmt` (oxfmt); the standalone
         // deps-updater is now part of block-tools.

--- a/tools/block-tools/src/structure/rules/model.ts
+++ b/tools/block-tools/src/structure/rules/model.ts
@@ -3,7 +3,6 @@
 // (block author owns it).
 
 import { scope, fixed, managed, seed, file, generate, when, whenFilesExist } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { modelPackageJsonInitial, modelPackageJsonRules } from "./model-package-json";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
@@ -32,7 +31,7 @@ export function modelRules(): void {
 
     managed(
       "package.json",
-      generate(() => modelPackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => modelPackageJsonInitial(ctx)),
       () => {
         modelPackageJsonRules();
       },

--- a/tools/block-tools/src/structure/rules/root-catalog-bump.ts
+++ b/tools/block-tools/src/structure/rules/root-catalog-bump.ts
@@ -53,7 +53,7 @@ export function rootCatalogBumpRules(): void {
           // generator.
           managed(
             "pnpm-workspace.yaml",
-            generate(() => rootPnpmWorkspaceInitial(getActiveRunContext())),
+            generate((ctx) => rootPnpmWorkspaceInitial(ctx)),
             () => {
               // SDK families → npm latest, ADD-IF-ABSENT (seeds a migrated
               // block's missing standard keys + overwrites the init

--- a/tools/block-tools/src/structure/rules/root-catalog-bump.ts
+++ b/tools/block-tools/src/structure/rules/root-catalog-bump.ts
@@ -28,7 +28,6 @@ import {
   ensureCatalogVersion,
   pinCatalogToDependencyOf,
 } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import {
   rootPnpmWorkspaceInitial,
   SDK_CATALOG_PACKAGES,
@@ -54,7 +53,7 @@ export function rootCatalogBumpRules(): void {
           managed(
             "pnpm-workspace.yaml",
             generate((ctx) => rootPnpmWorkspaceInitial(ctx)),
-            () => {
+            (ctx) => {
               // SDK families → npm latest, ADD-IF-ABSENT (seeds a migrated
               // block's missing standard keys + overwrites the init
               // placeholder).
@@ -76,7 +75,7 @@ export function rootCatalogBumpRules(): void {
               }
               // The python runenv pin is relevant only to software-bearing
               // blocks; seed it add-if-absent when one is present.
-              if (getActiveRunContext().modules.some((m) => m.scope === "software")) {
+              if (ctx.modules.some((m) => m.scope === "software")) {
                 ensureCatalogVersion(RUNENV_PYTHON, RUNENV_PYTHON_VERSION);
               }
             },

--- a/tools/block-tools/src/structure/rules/root-ci.ts
+++ b/tools/block-tools/src/structure/rules/root-ci.ts
@@ -1,0 +1,55 @@
+// Root-scope CI workflows — the block's GitHub Actions `build.yaml` and
+// `mark-stable.yaml`. Engine-OWNED (`fixed`): rewritten verbatim on every
+// refresh, generated from the block's identity (short name); everything else
+// is a constant baked into the templates.
+//
+// Why fixed, not managed: previously each block carried a hand-copied
+// workflow pinning the shared reusable workflow at `@v4` (a moving branch),
+// so a breaking shared-CI change was absorbed silently and per-block edits
+// drifted. Engine-owning the file makes the pin + job wiring centrally
+// refreshable; the only per-block bits are derived (app-name, slug), so
+// nothing author-tunable is clobbered.
+//
+// Standalone blocks only — `--sdk-internal` blocks (`etc/blocks/*`) carry no
+// per-block workflow (the monorepo owns their CI), hence the
+// `when(!isSdkInternal)` guard, matching the rest of the root scope.
+
+import { scope, when, fixed, tpl } from "../engine/api";
+
+/** Readable default CI label from a short name (`mixcr-clonotyping-2` →
+ *  `Mixcr Clonotyping 2`). Dash/underscore words, title-cased. Human-curated
+ *  casing (e.g. `MiXCR`) is not recoverable from the slug — this is a
+ *  generated label, not the marketing name. */
+function humanizeShortName(shortName: string): string {
+  return shortName
+    .split(/[-_]+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export function rootCiRules(): void {
+  scope("root", () => {
+    when(
+      ({ ctx }) => !ctx.isSdkInternal,
+      () => {
+        fixed(
+          ".github/workflows/build.yaml",
+          tpl("workflows/build.tpl.yaml", (ctx) => {
+            const shortName = ctx.blockVars.shortName;
+            return {
+              appName: `Block: ${humanizeShortName(shortName)}`,
+              appNameSlug: `block-${shortName}`,
+            };
+          }),
+        );
+        fixed(
+          ".github/workflows/mark-stable.yaml",
+          tpl("workflows/mark-stable.tpl.yaml", (ctx) => ({
+            appName: `Block: ${humanizeShortName(ctx.blockVars.shortName)} - Mark Stable`,
+          })),
+        );
+      },
+    );
+  });
+}

--- a/tools/block-tools/src/structure/rules/root.ts
+++ b/tools/block-tools/src/structure/rules/root.ts
@@ -4,7 +4,6 @@
 // `when(({ ctx }) => !ctx.isSdkInternal, ...)` wrapper.
 
 import { scope, when, fixed, managed, file, generate } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { rootPackageJsonInitial, rootPackageJsonRules } from "./root-package-json";
 import { rootPnpmWorkspaceInitial, rootPnpmWorkspaceRules } from "./root-pnpm-workspace";
 import { rootGitignoreRules } from "./root-gitignore";
@@ -19,7 +18,7 @@ export function rootRules(): void {
 
         managed(
           "package.json",
-          generate(() => rootPackageJsonInitial(getActiveRunContext())),
+          generate((ctx) => rootPackageJsonInitial(ctx)),
           () => {
             rootPackageJsonRules();
           },
@@ -27,7 +26,7 @@ export function rootRules(): void {
 
         managed(
           "pnpm-workspace.yaml",
-          generate(() => rootPnpmWorkspaceInitial(getActiveRunContext())),
+          generate((ctx) => rootPnpmWorkspaceInitial(ctx)),
           () => {
             rootPnpmWorkspaceRules();
           },

--- a/tools/block-tools/src/structure/rules/software.ts
+++ b/tools/block-tools/src/structure/rules/software.ts
@@ -6,7 +6,6 @@
 // `init` and never touched again — the block author owns them.
 
 import { scope, managed, seed, generate, text } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { softwarePackageJsonInitial, softwarePackageJsonRules } from "./software-package-json";
 
 const MAIN_PY_SEED = `import sys
@@ -24,7 +23,7 @@ export function softwareRules(): void {
 
     managed(
       "package.json",
-      generate(() => softwarePackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => softwarePackageJsonInitial(ctx)),
       () => {
         softwarePackageJsonRules();
       },

--- a/tools/block-tools/src/structure/rules/test.ts
+++ b/tools/block-tools/src/structure/rules/test.ts
@@ -1,7 +1,6 @@
 // Test-scope rules.
 
 import { scope, fixed, managed, scaffold, seed, file, text, generate } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { testPackageJsonInitial, testPackageJsonRules } from "./test-package-json";
 
 export function testRules(): void {
@@ -35,7 +34,7 @@ export function testRules(): void {
 
     managed(
       "package.json",
-      generate(() => testPackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => testPackageJsonInitial(ctx)),
       () => {
         testPackageJsonRules();
       },

--- a/tools/block-tools/src/structure/rules/ui.ts
+++ b/tools/block-tools/src/structure/rules/ui.ts
@@ -10,11 +10,9 @@ import {
   file,
   tpl,
   generate,
-  blockVars,
   when,
   whenFilesExist,
 } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { uiPackageJsonInitial, uiPackageJsonRules } from "./ui-package-json";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
@@ -45,16 +43,16 @@ export function uiRules(): void {
     seed("src/main.ts", file("ui/src/main.ts"));
     seed(
       "src/app.ts",
-      tpl("ui/src/app.tpl.ts", () => ({ modelPkg: `${blockVars().facadeName}.model` })),
+      tpl("ui/src/app.tpl.ts", (ctx) => ({ modelPkg: `${ctx.blockVars.facadeName}.model` })),
     );
     seed(
       "src/MainPage.vue",
-      tpl("ui/src/MainPage.tpl.vue", () => ({ shortName: blockVars().shortName })),
+      tpl("ui/src/MainPage.tpl.vue", (ctx) => ({ shortName: ctx.blockVars.shortName })),
     );
 
     managed(
       "package.json",
-      generate(() => uiPackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => uiPackageJsonInitial(ctx)),
       () => {
         uiPackageJsonRules();
       },

--- a/tools/block-tools/src/structure/rules/workflow.ts
+++ b/tools/block-tools/src/structure/rules/workflow.ts
@@ -13,9 +13,7 @@ import {
   remove,
   when,
   whenFilesExist,
-  blockVars,
 } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { workflowPackageJsonInitial, workflowPackageJsonRules } from "./workflow-package-json";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 
@@ -59,14 +57,14 @@ export function workflowRules(): void {
 
     seed(
       "src/main.tpl.tengo",
-      tpl("workflow/src/main.tpl.tengo", () => ({
-        shortName: blockVars().shortName,
+      tpl("workflow/src/main.tpl.tengo", (ctx) => ({
+        shortName: ctx.blockVars.shortName,
       })),
     );
 
     managed(
       "package.json",
-      generate(() => workflowPackageJsonInitial(getActiveRunContext())),
+      generate((ctx) => workflowPackageJsonInitial(ctx)),
       () => {
         workflowPackageJsonRules();
       },

--- a/tools/block-tools/src/structure/structure-definition.ts
+++ b/tools/block-tools/src/structure/structure-definition.ts
@@ -5,6 +5,7 @@
 
 import { defineStructure } from "./engine/api";
 import { rootRules } from "./rules/root";
+import { rootCiRules } from "./rules/root-ci";
 import { blockRules } from "./rules/block";
 import { modelRules } from "./rules/model";
 import { uiRules } from "./rules/ui";
@@ -16,6 +17,7 @@ import { rootCatalogBumpRules } from "./rules/root-catalog-bump";
 
 export const STRUCTURE = defineStructure(() => {
   rootRules();
+  rootCiRules();
   blockRules();
   modelRules();
   uiRules();

--- a/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
@@ -1,0 +1,67 @@
+name: Build, Test and Release Platforma Block
+on:
+  merge_group:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch: {}
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: milaboratory/github-ci/actions/context/init@v4
+        with:
+          version-canonize: false
+          branch-versioning: main
+  run:
+    needs:
+      - init
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    with:
+      app-name: '${appName}'
+      app-name-slug: '${appNameSlug}'
+      node-version: '20.x'
+      build-script-name: 'build'
+      pnpm-recursive-build: false
+
+      test: true
+      test-script-name: 'test'
+      pnpm-recursive-tests: false
+      team-id: 'ciplopen'
+
+      publish-to-public: 'true'
+      package-path: 'block'
+      create-tag: 'true'
+
+      npmrc-config: |
+        {
+          "registries": {
+            "https://registry.npmjs.org/": {
+              "scopes": ["milaboratories", "platforma-sdk", "platforma-open"],
+              "tokenVar": "NPMJS_TOKEN"
+            }
+          }
+        }
+    secrets:
+      env: |
+        { "PL_LICENSE": ${{ toJSON(secrets.MI_LICENSE) }},
+          "MI_LICENSE": ${{ toJSON(secrets.MI_LICENSE) }},
+          "NPMJS_TOKEN": ${{ toJSON(secrets.NPMJS_TOKEN) }},
+          "PL_CI_TEST_USER": ${{ toJSON(secrets.PL_CI_TEST_USER) }},
+          "PL_CI_TEST_PASSWORD": ${{ toJSON(secrets.PL_CI_TEST_PASSWORD) }},
+
+          "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
+          "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
+          "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
+          "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
+          "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }
+
+      SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      GH_ZEN_APP_ID: ${{ secrets.GH_ZEN_APP_ID }}
+      GH_ZEN_APP_PRIVATE_KEY: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}

--- a/tools/block-tools/src/structure/templates/text/workflows/mark-stable.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/mark-stable.tpl.yaml
@@ -1,0 +1,34 @@
+name: Mark Platforma Block as Stable
+on:
+  workflow_dispatch: {}
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: milaboratory/github-ci/actions/context/init@v4
+        with:
+          version-canonize: false
+          branch-versioning: main
+  run:
+    needs:
+      - init
+    uses: milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4
+    with:
+      app-name: '${appName}'
+      node-version: '20.x'
+      npmrc-config: |
+        {
+          "registries": {
+            "https://registry.npmjs.org/": {
+              "scopes": ["milaboratories", "platforma-sdk", "platforma-open"],
+              "tokenVar": "NPMJS_TOKEN"
+            }
+          }
+        }
+    secrets:
+      env: |
+        { "NPMJS_TOKEN": ${{ toJSON(secrets.NPMJS_TOKEN) }},
+          "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }} }
+
+      SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## What

Brings the block CI workflows under structurer management as engine-owned (`fixed`) scaffold files, generated from the block's short name:

- `.github/workflows/build.yaml` and `mark-stable.yaml` are now generated and kept in sync on `refresh`.
- The shared reusable-workflow pin (`@v4`) and job wiring are centrally managed instead of hand-copied per block — which is how blocks silently absorbed a breaking shared-CI change and drifted.
- Per-block bits are derived: `app-name` (humanized short name), `app-name-slug` (`block-<shortName>`). `team-id` (`ciplopen`), `test: true`, and the `@v4` pin are constants baked into the templates.
- Standalone blocks only — sdk-internal blocks (`etc/blocks/*`) get neither file (`when(!isSdkInternal)`).

## Engine cleanups (enabling the above)

- `tpl()`/`generate()` content lambdas now receive the active `RunContext` as an argument (consistent with `when()` triggers) instead of reaching for a module-global. All 16 call sites migrated.
- Discovery derived `blockVars.shortName` with a stray `.block` suffix on refresh (the block package is named `<facade>.block`); now stripped so `ctx.blockVars` is correct on init and refresh alike.

## Notes

- Workflow `.tpl.yaml` templates are excluded from oxfmt (verbatim payloads).
- `@v4` is intentionally left as-is; pinning to an immutable ref is a separate shared-CI decision.
- On rollout (`refresh` per block), `app-name-slug` normalizes to `block-<shortName>` — this changes the release-artifact filename for ~14 blocks whose current slug differs (some are typo fixes, some deliberate). Worth a look before mass-refresh.

## Test

243 structure tests pass (incl. init→check parity, new `root-ci-workflows` and `discovery-shortname` tests); `pnpm check` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings the per-block GitHub Actions CI workflows (`build.yaml`, `mark-stable.yaml`) under structurer engine ownership as `fixed` scaffold files, and cleans up the `generate()`/`tpl()` content-lambda API so lambdas receive `RunContext` as an explicit argument instead of pulling from a module-global.

- **CI workflow generation** (`root-ci.ts`, `build.tpl.yaml`, `mark-stable.tpl.yaml`): Two new `fixed` files are generated from the block's `shortName` on every `refresh`; `app-name` and `app-name-slug` are derived, all other fields (pin `@v4`, `team-id`, secrets wiring) are constants baked into the templates. Standalone blocks only — `--sdk-internal` blocks are excluded via the existing `when(!isSdkInternal)` guard.
- **`generate()`/`tpl()` lambda migration** (16 call sites): The lambdas now receive `(ctx: RunContext)` directly; `getActiveRunContext()` is retained only where it is the correct tool — inside managed-body lambdas, which do not receive `RunContext` as a direct argument.
- **Discovery bug fix** (`discovery-fs.ts`): On `refresh`/`check`, the block-scope package name `<facade>.block` would previously leak the `.block` suffix into `blockVars.shortName`; stripping it makes `shortName` consistent between `init` and `refresh`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge; the engine refactor is mechanical and well-covered by 243 tests including the new init→check parity assertions.

The generate/tpl lambda migration is a clean, thoroughly tested mechanical refactor. The discovery fix and CI workflow generation are new, well-tested features. The one gap is that the `.block` suffix strip in discovery-fs.ts would throw for a legacy block whose shortName happens to be "block" — but such a block is extraordinarily unlikely to exist in the ecosystem, making this a very low-probability regression.

tools/block-tools/src/structure/engine/discovery-fs.ts and its companion test tools/block-tools/src/structure/__tests__/discovery-shortname.test.ts — the edge case of a legacy block with shortName "block" is untested.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/engine/discovery-fs.ts | Adds .block suffix stripping when deriving BlockVars from the block-scope package name on refresh/check. Correctly handles the structurer-shaped <facade>.block package name and is a no-op for bare-facade legacy blocks — except for the untested edge case where a legacy block's shortName is literally "block". |
| tools/block-tools/src/structure/rules/root-ci.ts | New rule file registering fixed CI workflow files (.github/workflows/build.yaml and mark-stable.yaml) for standalone (non-sdk-internal) blocks. Correctly gated behind when(!isSdkInternal), uses tpl() with ctx-receiving lambdas, and humanizes the shortName consistently. |
| tools/block-tools/src/structure/engine/runner.ts | Propagates full RunContext to resolveContent/writeLeafContent/applyStructural/applyManaged instead of extracting isSdkInternal, enabling tpl/generate lambdas to receive ctx directly. Clean mechanical refactor with no logic changes. |
| tools/block-tools/src/structure/engine/builders.ts | Updates tpl() and generate() signatures to accept (ctx: RunContext) callbacks. getActiveRunContext() and blockVars() are preserved for managed-body use cases that cannot receive ctx as a direct argument. |
| tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml | New CI build workflow template. Uses ${appName}/${appNameSlug} placeholders for per-block identity; ${{ ... }} GitHub expressions are unaffected by substituteVars (double-brace pattern is excluded by the regex). Verified by test assertions. |
| tools/block-tools/src/structure/templates/text/workflows/mark-stable.tpl.yaml | New mark-stable workflow template. Only substitutes ${appName}; simpler than build.yaml. Consistent structure with the build template. |
| tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts | New test covering CI workflow generation, content correctness, fixed idempotency (init→check zero-diff), and sdk-internal exclusion. Good coverage of the happy path and the guard condition. |
| tools/block-tools/src/structure/__tests__/discovery-shortname.test.ts | Tests the .block suffix stripping for a structurer-shaped block and the no-op path for a legacy block. Missing coverage for the edge case where a legacy block's shortName is "block". |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[engine.run / DISCOVERY] --> B[discoverRunContext]
    B --> C{blockMod.name ends with .block?}
    C -- yes --> D[Strip .block suffix]
    C -- no --> E[Name unchanged - legacy bare-facade]
    D --> F[parseBlockVars - blockVars.shortName]
    E --> F
    F --> G[RunContext with correct shortName]
    G --> H[engine.run with tpl/generate ctx lambdas]
    H --> I{isSdkInternal?}
    I -- no --> J[rootCiRules fired]
    I -- yes --> K[Skip CI workflow files]
    J --> L[tpl lambda receives ctx - Derives appName and appNameSlug]
    L --> M[substituteVars replaces placeholders - Leaves GitHub expressions untouched]
    M --> O[fixed files written on every refresh]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[engine.run / DISCOVERY] --> B[discoverRunContext]
    B --> C{blockMod.name ends with .block?}
    C -- yes --> D[Strip .block suffix]
    C -- no --> E[Name unchanged - legacy bare-facade]
    D --> F[parseBlockVars - blockVars.shortName]
    E --> F
    F --> G[RunContext with correct shortName]
    G --> H[engine.run with tpl/generate ctx lambdas]
    H --> I{isSdkInternal?}
    I -- no --> J[rootCiRules fired]
    I -- yes --> K[Skip CI workflow files]
    J --> L[tpl lambda receives ctx - Derives appName and appNameSlug]
    L --> M[substituteVars replaces placeholders - Leaves GitHub expressions untouched]
    M --> O[fixed files written on every refresh]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fblock-tools%2Fsrc%2Fstructure%2Fengine%2Fdiscovery-fs.ts%3A204-207%0A**Suffix%20strip%20clobbers%20legacy%20block%20whose%20shortName%20is%20%22block%22**%0A%0A%60%2F%5C.block%24%2F%60%20strips%20the%20suffix%20from%20the%20bare-facade%20package%20name%20of%20a%20legacy%20block%20named%20%60%40org%2Fscope.block%60%20%28shortName%20%3D%20%22block%22%29%2C%20reducing%20it%20to%20%60%40org%2Fscope%60%20%E2%80%94%20a%20package%20string%20with%20no%20dot%20in%20the%20base%20name%2C%20so%20%60parseBlockVars%60%20immediately%20throws%20%60%22base%20name%20'scope'%20has%20no%20'.'%20separating%20org-scope%20from%20short-name.%22%60%20on%20refresh.%20A%20structurer-shaped%20block%20is%20unaffected%20%28its%20block%20package%20is%20%60%40org%2Fscope.block.block%60%2C%20strip%20%E2%86%92%20%60%40org%2Fscope.block%60%20is%20correct%29%2C%20but%20the%20legacy%20path%20is%20broken%20for%20this%20specific%20name.%20A%20test%20covering%20%60shortName%20%3D%20%22block%22%60%20with%20the%20legacy%20shape%20is%20missing%20from%20%60discovery-shortname.test.ts%60.%0A%0A&repo=milaboratory%2Fplatforma&pr=1705&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/block-tools/src/structure/engine/discovery-fs.ts:204-207
**Suffix strip clobbers legacy block whose shortName is "block"**

`/\.block$/` strips the suffix from the bare-facade package name of a legacy block named `@org/scope.block` (shortName = "block"), reducing it to `@org/scope` — a package string with no dot in the base name, so `parseBlockVars` immediately throws `"base name 'scope' has no '.' separating org-scope from short-name."` on refresh. A structurer-shaped block is unaffected (its block package is `@org/scope.block.block`, strip → `@org/scope.block` is correct), but the legacy path is broken for this specific name. A test covering `shortName = "block"` with the legacy shape is missing from `discovery-shortname.test.ts`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(block-tools): manage block CI workf..."](https://github.com/milaboratory/platforma/commit/10944e87541ce86527e54b809dcbc217378e7be7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38355427)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->