### PR TITLE
refactor(block-tools): pass RunContext to managed bodies + document the two layers

### DIFF
--- a/.changeset/structurer-managed-body-ctx.md
+++ b/.changeset/structurer-managed-body-ctx.md
@@ -1,0 +1,9 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+structurer: `managed(path, initial, body)` bodies now receive the active
+`RunContext` as an argument (`(ctx) => …`), matching `generate`/`tpl`/`when`.
+Rule code no longer reaches for the module-global `getActiveRunContext()` —
+every execution-level lambda gets `ctx` by argument. Internal refactor; no
+change to generated block output.

--- a/tools/block-tools/src/structure/CLAUDE.md
+++ b/tools/block-tools/src/structure/CLAUDE.md
@@ -15,12 +15,14 @@ To change what "canonical" means, edit `rules/`; the engine is block-agnostic.
 
 - Each `rules/*` file pairs a generator (init: full initial content) with a body (refresh: drift-correcting assertions). Read as "what the file should be" + "how to nudge an existing file there", not as sequential logic.
 - The primitive choice IS the design: `fixed` (overwrite verbatim, engine-owned), `managed` (reconcile named fields, author keeps the rest), `scaffold` (write-once default, author may tune), `seed` (written once at init, author owns forever), `remove` (one-way). Wrong primitive is the main design error — `fixed` on an author-tunable file clobbers their work; `seed` on engine-owned content lets drift accumulate.
+- Two layers. Calls inside `defineStructure` (`scope`/`fixed`/`managed`/`seed`/`when`-framing) run once at tree-build time to DECLARE the tree — there is no block and no `ctx` yet. The lambdas the engine runs later, per block — trigger predicates, `generate`/`tpl` producers, and `managed` bodies — are the EXECUTION layer, where per-block values are computed.
 
 ## Invariants
 
 - Fixpoint: `refresh` on an already-canonical block makes zero changes. Every rule must converge.
 - Generators emit oxfmt-clean output (the `enforce*` calls mirror oxfmt's order), so build→check passes with no prior `fmt`.
 - sdk-internal blocks (`etc/blocks/*`) skip root-scope and standalone test wiring — the monorepo owns that infra; the structurer must neither impose nor strip it.
+- Every execution-level lambda receives `ctx` by argument (trigger predicates get the richer `TriggerContext`; `generate`/`tpl`/`managed` bodies get `RunContext`); none reaches for it ambiently. `getActiveRunContext()`/`blockVars()` are engine-internal plumbing, not the rule-author surface.
 
 ## Gotchas
 

--- a/tools/block-tools/src/structure/engine/content-rules.ts
+++ b/tools/block-tools/src/structure/engine/content-rules.ts
@@ -13,7 +13,7 @@
 
 import { registerInnerWhenHandler, tryGetActiveRunContext } from "./builders";
 import type { RunContext, Scope } from "./api";
-import type { TriggerContext, TriggerFn } from "./ir";
+import type { ManagedBody, TriggerContext, TriggerFn } from "./ir";
 import {
   deleteAtPath,
   getAtPath,
@@ -163,13 +163,13 @@ export type WithManagedOpts = {
  *  the runner calls this for managed `.json` files. */
 export function withManagedBody(
   obj: JsonObject,
-  body: () => void,
+  body: ManagedBody,
   opts: WithManagedOpts = {},
 ): JsonObject {
   if (active) throw new Error("Nested managed(...) body — engine bug.");
   active = { kind: "json", obj, ctx: opts.ctx, triggerContext: opts.triggerContext };
   try {
-    body();
+    body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext);
     return obj;
   } finally {
     active = undefined;
@@ -189,7 +189,7 @@ export type WithManagedYamlOpts = WithManagedOpts & {
  *  `pnpm-workspace.yaml`); returns the mutated document. Exported for tests. */
 export function withManagedYaml(
   doc: YamlDocument,
-  body: () => void,
+  body: ManagedBody,
   opts: WithManagedYamlOpts = {},
 ): YamlDocument {
   if (active) throw new Error("Nested managed(...) body — engine bug.");
@@ -202,7 +202,7 @@ export function withManagedYaml(
     getDerivedDependencyPin: opts.getDerivedDependencyPin,
   };
   try {
-    body();
+    body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext);
     return doc;
   } finally {
     active = undefined;
@@ -213,7 +213,7 @@ export function withManagedYaml(
  *  (for `.gitignore`); returns the mutated lines. Exported for tests. */
 export function withManagedLines(
   lines: string[],
-  body: () => void,
+  body: ManagedBody,
   opts: WithManagedOpts = {},
 ): string[] {
   if (active) throw new Error("Nested managed(...) body — engine bug.");
@@ -224,7 +224,7 @@ export function withManagedLines(
     triggerContext: opts.triggerContext,
   };
   try {
-    body();
+    body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext);
     return lines;
   } finally {
     active = undefined;

--- a/tools/block-tools/src/structure/engine/ir.ts
+++ b/tools/block-tools/src/structure/engine/ir.ts
@@ -52,8 +52,11 @@ export type ContentForm =
   // only `seed` / `scaffold` consume it (via fs.writeBinary).
   | { kind: "binary"; path: string };
 
-/** Builder-body for a `managed` file (the content-rules lambda). */
-export type ManagedBody = () => void;
+/** Builder-body for a `managed` file (the content-rules lambda). Receives the
+ *  active `RunContext` — the same object triggers see as `tctx.ctx` and that
+ *  `generate`/`tpl` lambdas receive — so the body reads block identity via its
+ *  argument rather than the module-global `getActiveRunContext()`. */
+export type ManagedBody = (ctx: RunContext) => void;
 
 // --- Leaf primitives ---
 

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -12,7 +12,6 @@ import {
   enforceFieldOrder,
   type RunContext,
 } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import { findModules, scopeDepMap } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
 
@@ -111,7 +110,7 @@ export function blockPackageJsonInitial(ctx: RunContext): Record<string, unknown
   };
 }
 
-export function blockPackageJsonRules(): void {
+export function blockPackageJsonRules(ctx: RunContext): void {
   // type:"module" intentionally omitted: the facade's index.js is the
   // CommonJS dev-block descriptor (module.exports / __dirname); ESM would
   // break it. The facade has no TS sources to compile.
@@ -146,7 +145,7 @@ export function blockPackageJsonRules(): void {
   // it in sync on refresh. `block.meta` is deliberately NOT touched here: it
   // is an author-owned seed (set once in the init package.json), so refresh
   // must never overwrite the author's title / description / logo.
-  ensureField("block.components", blockComponents(getActiveRunContext()));
+  ensureField("block.components", blockComponents(ctx));
 
   enforceAlphabeticalOrder("dependencies");
   enforceAlphabeticalOrder("devDependencies");

--- a/tools/block-tools/src/structure/rules/block.ts
+++ b/tools/block-tools/src/structure/rules/block.ts
@@ -20,8 +20,8 @@ export function blockRules(): void {
     managed(
       "package.json",
       generate((ctx) => blockPackageJsonInitial(ctx)),
-      () => {
-        blockPackageJsonRules();
+      (ctx) => {
+        blockPackageJsonRules(ctx);
       },
     );
   });

--- a/tools/block-tools/src/structure/rules/root-catalog-bump.ts
+++ b/tools/block-tools/src/structure/rules/root-catalog-bump.ts
@@ -28,7 +28,6 @@ import {
   ensureCatalogVersion,
   pinCatalogToDependencyOf,
 } from "../engine/api";
-import { getActiveRunContext } from "../engine/builders";
 import {
   rootPnpmWorkspaceInitial,
   SDK_CATALOG_PACKAGES,
@@ -54,7 +53,7 @@ export function rootCatalogBumpRules(): void {
           managed(
             "pnpm-workspace.yaml",
             generate((ctx) => rootPnpmWorkspaceInitial(ctx)),
-            () => {
+            (ctx) => {
               // SDK families → npm latest, ADD-IF-ABSENT (seeds a migrated
               // block's missing standard keys + overwrites the init
               // placeholder).
@@ -76,7 +75,7 @@ export function rootCatalogBumpRules(): void {
               }
               // The python runenv pin is relevant only to software-bearing
               // blocks; seed it add-if-absent when one is present.
-              if (getActiveRunContext().modules.some((m) => m.scope === "software")) {
+              if (ctx.modules.some((m) => m.scope === "software")) {
                 ensureCatalogVersion(RUNENV_PYTHON, RUNENV_PYTHON_VERSION);
               }
             },


### PR DESCRIPTION
Stacked on #1705 (base = `feat/structurer-ci-scaffold`). Completes the "every execution-level lambda receives `ctx` by argument" theme that #1705 started for `generate`/`tpl`.

## What

- `ManagedBody` becomes `(ctx: RunContext) => void`, so `managed(path, initial, body)` bodies receive `ctx` the same way `generate`/`tpl` producers and `when` triggers do. The three `withManaged*` wrappers pass it through (derived from the trigger context they already carry — no runner change).
- The two rule bodies that actually read run state now use the body's `ctx` arg instead of the module-global `getActiveRunContext()`:
  - `root-catalog-bump.ts` — the software-module check.
  - `block-package-json.ts` — `block.components` derivation.
- `getActiveRunContext()` / `blockVars()` are now **absent from `rules/` entirely** — they remain exported as engine-internal plumbing (content-rule builders resolve ctx through them under the hood).

## Mental model (structurer `CLAUDE.md`)

Documents the composition-vs-execution split:
- **Composition layer** — calls inside `defineStructure` build the tree at load time; no block, no `ctx`.
- **Execution layer** — trigger predicates, `generate`/`tpl` producers, and `managed` bodies run per block and each receive `ctx` by argument.

Plus an invariant: no execution lambda reaches for the run context ambiently.

## Scope note

The ~15 ctx-free `managed` bodies are untouched (`() => void` is assignable to `(ctx) => void`). This homogenizes the **rule-author surface**; it does not remove the module-global internally (a larger separate refactor).

## Test

243 structure tests pass; `pnpm check` clean. No change to generated block output.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the "execution lambdas receive `ctx` by argument" theme by extending it to `managed` bodies. `ManagedBody` is widened from `() => void` to `(ctx: RunContext) => void`, the three `withManaged*` engine wrappers thread the context through, and the two rule files that actually read block state (`block-package-json.ts`, `root-catalog-bump.ts`) are migrated from the module-global `getActiveRunContext()` to the body's `ctx` parameter.

- **`ManagedBody` type change** (`ir.ts`): signature widened to `(ctx: RunContext) => void`; the ~15 ctx-free bodies remain assignable unchanged (TypeScript parameter-count compatibility), so no call-sites break.
- **Engine wrappers updated** (`content-rules.ts`): `withManagedBody`, `withManagedYaml`, and `withManagedLines` now call `body((opts.ctx ?? opts.triggerContext?.ctx) as RunContext)`, deriving ctx from whichever option the caller provides.
- **Rule files cleaned up** (`block-package-json.ts`, `root-catalog-bump.ts`): `getActiveRunContext()` removed; `ctx.modules` is now accessed via the body argument, making the ambient-context footprint in `rules/` zero.

**Key Terms**

| Term | Definition | Change |
|---|---|---|
| `ManagedBody` | The content-rules lambda stored on a `ManagedItem` and executed by the runner to reconcile a managed file. | Widened from `() => void` → `(ctx: RunContext) => void`. |
| `RunContext` | Per-block execution context carrying `modules`, `isSdkInternal`, `blockVars`, etc. | Now passed explicitly as the argument to every `ManagedBody`. |
| `withManagedBody` / `withManagedYaml` / `withManagedLines` | Engine-internal wrappers that establish active state so content-rule builders can mutate the file. | Now forward `ctx` to the body; sourced from `opts.ctx ?? opts.triggerContext?.ctx`. |
| `blockPackageJsonRules` | Drift-correcting body for the block's `package.json`; re-asserts `block.components`, scripts, deps. | Signature changed from `(): void` to `(ctx: RunContext): void`; no longer uses `getActiveRunContext()`. |
| `getActiveRunContext` | Module-global accessor for the run context set by `withRunContext`. | Removed from all `rules/` files; retained as engine-internal plumbing used by `ctxOrThrow`. |
| `TriggerContext` | Richer per-leaf execution context wrapping `RunContext` and adding FS-snapshot predicates. | Unchanged; its inner `.ctx` is now the source when `opts.ctx` is absent in the wrappers. |

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is an internal refactor with no impact on generated block output, confirmed by 243 passing structure tests and a clean pnpm check.

All production paths always supply either `opts.ctx` or `opts.triggerContext`, so the `as RunContext` cast in the three engine wrappers is safe today. The cast does, however, hide the `undefined` case from TypeScript, meaning a future test that wires a ctx-using body without supplying either option will get an opaque `TypeError` rather than a descriptive error. The two rule files that needed the context have been correctly updated, and the ~15 ctx-free bodies are structurally unaffected.

tools/block-tools/src/structure/engine/content-rules.ts — the three `as RunContext` casts on lines 172, 205, and 227 are the only spots worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/engine/ir.ts | ManagedBody type widened from `() => void` to `(ctx: RunContext) => void`; existing zero-arg lambdas remain assignable due to TS parameter-count compatibility. |
| tools/block-tools/src/structure/engine/content-rules.ts | All three withManaged* wrappers now pass `(opts.ctx ?? opts.triggerContext?.ctx) as RunContext` to the body; the `as RunContext` cast hides the undefined case and may produce opaque TypeErrors in future tests lacking ctx. |
| tools/block-tools/src/structure/rules/block-package-json.ts | blockPackageJsonRules signature changed to accept explicit ctx; getActiveRunContext() import removed; `block.components` derivation now uses the argument directly. |
| tools/block-tools/src/structure/rules/block.ts | Managed body for package.json updated to thread ctx through to blockPackageJsonRules(ctx); no logic change. |
| tools/block-tools/src/structure/rules/root-catalog-bump.ts | Software-module check migrated from getActiveRunContext() to the body's ctx argument; getActiveRunContext() import removed. |
| tools/block-tools/src/structure/CLAUDE.md | Documents the composition vs. execution two-layer model and the new invariant that every execution lambda receives ctx by argument. |
| .changeset/structurer-managed-body-ctx.md | Patch-level changeset correctly describing the ManagedBody signature change and its scope. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Runner
    participant withManagedBody
    participant ManagedBody
    participant ContentRuleBuilders

    Runner->>withManagedBody: "withManagedBody(obj, body, { ctx, triggerContext })"
    withManagedBody->>withManagedBody: "active = { kind:json, obj, ctx, triggerContext }"
    withManagedBody->>ManagedBody: body(opts.ctx ?? triggerContext?.ctx)
    ManagedBody->>ContentRuleBuilders: ensureField(block.components, blockComponents(ctx))
    ContentRuleBuilders->>withManagedBody: reads active state (via requireJson)
    ContentRuleBuilders-->>ManagedBody: mutation applied
    ManagedBody-->>withManagedBody: returns
    withManagedBody->>withManagedBody: "active = undefined"
    withManagedBody-->>Runner: mutated obj
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Runner
    participant withManagedBody
    participant ManagedBody
    participant ContentRuleBuilders

    Runner->>withManagedBody: "withManagedBody(obj, body, { ctx, triggerContext })"
    withManagedBody->>withManagedBody: "active = { kind:json, obj, ctx, triggerContext }"
    withManagedBody->>ManagedBody: body(opts.ctx ?? triggerContext?.ctx)
    ManagedBody->>ContentRuleBuilders: ensureField(block.components, blockComponents(ctx))
    ContentRuleBuilders->>withManagedBody: reads active state (via requireJson)
    ContentRuleBuilders-->>ManagedBody: mutation applied
    ManagedBody-->>withManagedBody: returns
    withManagedBody->>withManagedBody: "active = undefined"
    withManagedBody-->>Runner: mutated obj
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fblock-tools%2Fsrc%2Fstructure%2Fengine%2Fcontent-rules.ts%3A172%0A**%60as%20RunContext%60%20silences%20a%20potential%20undefined-ctx%20diagnostic**%0A%0A%60opts.ctx%20%3F%3F%20opts.triggerContext%3F.ctx%60%20is%20typed%20%60RunContext%20%7C%20undefined%60%3B%20the%20cast%20passes%20%60undefined%60%20to%20the%20body%20unchecked%20when%20neither%20option%20is%20supplied.%20For%20the%20~15%20ctx-free%20bodies%20that%20ignore%20their%20argument%20this%20is%20harmless%2C%20but%20any%20future%20test%20that%20passes%20a%20ctx-using%20body%20to%20%60withManagedBody%60%2F%60withManagedYaml%60%2F%60withManagedLines%60%20without%20setting%20%60opts.ctx%60%20or%20%60opts.triggerContext%60%20will%20receive%20a%20%60TypeError%3A%20Cannot%20read%20properties%20of%20undefined%60%20rather%20than%20the%20descriptive%20message%20%60ctxOrThrow%60%20would%20have%20produced.%20The%20same%20pattern%20repeats%20on%20the%20two%20parallel%20callsites%20%28lines%20205%2C%20227%29.%0A%0A&repo=milaboratory%2Fplatforma&pr=1706&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/block-tools/src/structure/engine/content-rules.ts:172
**`as RunContext` silences a potential undefined-ctx diagnostic**

`opts.ctx ?? opts.triggerContext?.ctx` is typed `RunContext | undefined`; the cast passes `undefined` to the body unchecked when neither option is supplied. For the ~15 ctx-free bodies that ignore their argument this is harmless, but any future test that passes a ctx-using body to `withManagedBody`/`withManagedYaml`/`withManagedLines` without setting `opts.ctx` or `opts.triggerContext` will receive a `TypeError: Cannot read properties of undefined` rather than the descriptive message `ctxOrThrow` would have produced. The same pattern repeats on the two parallel callsites (lines 205, 227).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(block-tools): pass RunContext t..."](https://github.com/milaboratory/platforma/commit/cf7b5c4b8139e8ecba7f2678e22bd06e2791f8b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38361967)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->