### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/dry-owls-grow.md
+++ b/.changeset/dry-owls-grow.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+---
+
+PFrames bump

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.49
+polars-pf==1.1.51
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.43
+polars-pf==1.1.49
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^4.0.37
       version: 4.0.37
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.10.3
-      version: 1.10.3
+      specifier: 1.10.4
+      version: 1.10.4
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -3135,7 +3135,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.3
+        version: 1.10.4
       '@platforma-sdk/package-builder':
         specifier: workspace:*
         version: link:../../../tools/package-builder
@@ -3144,7 +3144,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.3
+        version: 1.10.4
       '@platforma-sdk/package-builder':
         specifier: 'workspace:'
         version: link:../../tools/package-builder
@@ -4156,7 +4156,7 @@ importers:
         version: link:../ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.3
+        version: 1.10.4
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
@@ -5897,8 +5897,8 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-clustering@0.1.1':
     resolution: {integrity: sha512-hnr1tf0dwoqTyjtUVZcwQm13O0V8kz4jCUz+yvOgdvWMrbg4o/h1KbghtM8HivI+tRoowc629QJWdy0bc7inQA==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.4':
-    resolution: {integrity: sha512-Yo47x/rm/FF8x/7q2o7TXdAS7pEWqBd/+aHnQzgNAF0DYljzln99mq1L4lMrQx08SJBGrh84ZtgQl/weTzWSIw==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.5':
+    resolution: {integrity: sha512-cuGk6NMBocvNePoMTnDW4z8eIF5RQdDcgwuPHg9atW9/veOOp02p5jk0EwxmnbMSVV0yDwRMd+0crQAQqW9bCA==}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-humanness@0.2.0':
     resolution: {integrity: sha512-YjKFPXe+caABLre5oZTwAxFHvVCEb5K8rVTEIUBhFYMtfLipVIix0LXi6LxWoOYdhoEeKgIc4zlWFDKs1xaEoQ==}
@@ -5906,11 +5906,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0':
     resolution: {integrity: sha512-nEM4eEj7pFT6yi+P5028qtgK5v9A9H0XdVHDtrKX7xW5Jipc1RIliOEU3gzaH0E7UAzPFQGSqShlwakRcGXwdQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.6.0':
-    resolution: {integrity: sha512-SHCS1PevyL1mEo1G7eCzrkkulVQKPQYrOfLYvmKob2wPdxp8I68AiSzSx3pC4L0ctzuWK/yAM5GVlZqF4uZg9Q==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.7.0':
+    resolution: {integrity: sha512-nChTh2Fk9KW1yLfqDb1Bb1BBDQRNoZZ2jRMLH76wEa3l0g1ZHG52wCkwzXz6fztvru0Em52PH4KdENp4hUTNMw==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.5':
-    resolution: {integrity: sha512-oNkt0u8fgZACcL3XmAu4v0tDGnTSc3qRQs07U8OFX+paQk7qH4ckt0psLGN1iHDKZ3Gw3nlgel0D6Lst02WahQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.6':
+    resolution: {integrity: sha512-NAacPe2uFxf5zqDAa70bblP4ZicvA52lVyzhV7IzlyeEIClAsGatLbitMnRghc2TepwYhQY4EbvElkKDFaSSGw==}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0':
     resolution: {integrity: sha512-CSLEjBYUdHDf66QAfgQ9jo+MoW63Wr0ygdIncJE2siO2jMUzYCqgCNd8bMjaMfZa3YBC9bHca3Cjxbp4VYc54A==}
@@ -5918,11 +5918,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0':
     resolution: {integrity: sha512-Z9OIHbWfq0OsTUvmJIK6HBm8qLIli5xxHlGsiNx012YU69snwgi2edioMjUQ1vr5eWPA/9+Xs8Ih9z+aWbmUpQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.17':
-    resolution: {integrity: sha512-dMZyTsNxEpFVxR6vANxGCQEm7dEkyB8APEmodjWHJfe1sqwWy2liWajJkjLfQ4g/T15UU3yle04zq++u3O/ahQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.18':
+    resolution: {integrity: sha512-Nz4KqZrwDfNb4/VxM9LhkRy6Ksw5kTDk7csQ+i2Sj1gWh8JC0QIQf9oAStc9L4YHBB/AczVsncG4uQiXRBAIUg==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.3':
-    resolution: {integrity: sha512-ArdWMYMk4hkc8likdmI6h2sv0Eh3RV4mYkXeLn/WZFU/WpLYxv+eKKNeeTcQjov0AP8VkqN1cwhMCfqcv+UudA==}
+  '@platforma-open/milaboratories.runenv-python-3@1.10.4':
+    resolution: {integrity: sha512-ixL/dPvTuHOzuEhsn9LoS6jOg4K+NeYXKUzcaUKDRFJglPnezL5uD9YJTq8PKBjRWjqKneJV/wtGGnj+uVYmPg==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -12221,32 +12221,32 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-clustering@0.1.1': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.4': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.5': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-humanness@0.2.0': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.6.0': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.7.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.5': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.6': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.17': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.18': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.3':
+  '@platforma-open/milaboratories.runenv-python-3@1.10.4':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.17
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.18
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
-      '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.4
+      '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5
       '@platforma-open/milaboratories.runenv-python-3.12.10-humanness': 0.2.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-parapred': 1.1.0
-      '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.6.0
-      '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.5
+      '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.7.0
+      '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.6
       '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': 1.1.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': 0.1.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^4.0.37
       version: 4.0.37
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.10.4
-      version: 1.10.4
+      specifier: 1.10.5
+      version: 1.10.5
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -3135,7 +3135,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.4
+        version: 1.10.5
       '@platforma-sdk/package-builder':
         specifier: workspace:*
         version: link:../../../tools/package-builder
@@ -3144,7 +3144,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.4
+        version: 1.10.5
       '@platforma-sdk/package-builder':
         specifier: 'workspace:'
         version: link:../../tools/package-builder
@@ -4156,7 +4156,7 @@ importers:
         version: link:../ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.4
+        version: 1.10.5
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
@@ -5918,11 +5918,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0':
     resolution: {integrity: sha512-Z9OIHbWfq0OsTUvmJIK6HBm8qLIli5xxHlGsiNx012YU69snwgi2edioMjUQ1vr5eWPA/9+Xs8Ih9z+aWbmUpQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.18':
-    resolution: {integrity: sha512-Nz4KqZrwDfNb4/VxM9LhkRy6Ksw5kTDk7csQ+i2Sj1gWh8JC0QIQf9oAStc9L4YHBB/AczVsncG4uQiXRBAIUg==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.19':
+    resolution: {integrity: sha512-8cqWtBASMmq9lAxD9Mz8PNiki8xYR/h7huW5+pGj07q8r+cxeCGuqP1T+sFgzU4aZ9Cr+xxIqQ2w8DiSWpox9A==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.4':
-    resolution: {integrity: sha512-ixL/dPvTuHOzuEhsn9LoS6jOg4K+NeYXKUzcaUKDRFJglPnezL5uD9YJTq8PKBjRWjqKneJV/wtGGnj+uVYmPg==}
+  '@platforma-open/milaboratories.runenv-python-3@1.10.5':
+    resolution: {integrity: sha512-Wd/LLjQ4XJI8LGxRj9eqKHhQQui4iAUXQI+BdWXHLqFEECUsuGpqXj27xOrojpsnzg9H0j9/QBUmApCMoZa32A==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -12235,11 +12235,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.18': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.19': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.4':
+  '@platforma-open/milaboratories.runenv-python-3@1.10.5':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.18
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.19
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -297,7 +297,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.1.1
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.10.3
+  "@platforma-open/milaboratories.runenv-python-3": 1.10.4
 
   "shx": ^0.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -297,7 +297,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.1.1
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.10.4
+  "@platforma-open/milaboratories.runenv-python-3": 1.10.5
 
   "shx": ^0.4.0
 

--- a/tests/workflow-tengo/src/exec/workdir/mkdir.test.ts
+++ b/tests/workflow-tengo/src/exec/workdir/mkdir.test.ts
@@ -10,12 +10,7 @@ import { tplTest } from "@platforma-sdk/test";
 tplTest.concurrent(
   "exec.builder.mkDir creates real nested directories (MILAB-6460)",
   async ({ helper, expect }) => {
-    const result = await helper.renderTemplate(
-      false,
-      "exec.workdir.mkdir",
-      ["dirs"],
-      () => ({}),
-    );
+    const result = await helper.renderTemplate(false, "exec.workdir.mkdir", ["dirs"], () => ({}));
 
     const listing = await result
       .computeOutput("dirs", (a) => a?.getDataAsString())


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the PFrames Python library (`polars-pf`) from `1.1.43` to `1.1.49` within the ptabler software package, and upgrades the associated Python 3 runtime environment (`runenv-python-3`) from `1.10.3` to `1.10.4` along with several of its sub-environment packages.

- **`polars-pf`** (PFrames): The core change — bumped `1.1.43 → 1.1.49` in `lib/ptabler/software/src/requirements.txt`. This is the Polars-based PFrames data-frame integration used by ptabler.
- **`@platforma-open/milaboratories.runenv-python-3`**: Bumped `1.10.3 → 1.10.4` in `pnpm-workspace.yaml` and the lockfile, pulling in updated sub-environments (`runenv-python-3.12.10` `1.3.17 → 1.3.18`, `h5ad` `1.1.4 → 1.1.5`, `rapids` `1.6.0 → 1.7.0`, `sccoda` `1.3.5 → 1.3.6`).
- **`tests/workflow-tengo/src/exec/workdir/mkdir.test.ts`**: Cosmetic reformatting only — a multi-line `renderTemplate` call was collapsed to a single line with no functional change.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Routine dependency bump with no logic changes; safe to merge.

All changes are version bumps to pinned Python dependencies (polars-pf 1.1.43→1.1.49) and the Python 3 runtime environment bundle, plus a cosmetic test-file reformat. The changeset correctly marks the ptabler package as a patch release. No application logic, API contracts, or data-flow paths are modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ptabler/software/src/requirements.txt | Bumps polars-pf (PFrames) from 1.1.43 to 1.1.49; all other pinned dependencies are unchanged. |
| pnpm-workspace.yaml | Updates the catalog pin for @platforma-open/milaboratories.runenv-python-3 from 1.10.3 to 1.10.4. |
| pnpm-lock.yaml | Lockfile updated to reflect runenv-python-3 1.10.4 and its sub-environment bumps (h5ad, rapids, sccoda, python-3.12.10 base); all other entries are unchanged. |
| .changeset/dry-owls-grow.md | New changeset file marking a patch release for @platforma-open/milaboratories.software-ptabler. |
| tests/workflow-tengo/src/exec/workdir/mkdir.test.ts | Cosmetic-only reformatting: multi-line renderTemplate call collapsed to a single line; no logic change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@platforma-open/milaboratories.software-ptabler\n(patch release)"] --> B["lib/ptabler/software/src/requirements.txt\npolars-pf 1.1.43 → 1.1.49"]
    A --> C["@platforma-open/milaboratories.runenv-python-3\n1.10.3 → 1.10.4"]
    C --> D["runenv-python-3.12.10\n1.3.17 → 1.3.18"]
    C --> E["runenv-python-3.12.10-h5ad\n1.1.4 → 1.1.5"]
    C --> F["runenv-python-3.12.10-rapids\n1.6.0 → 1.7.0"]
    C --> G["runenv-python-3.12.10-sccoda\n1.3.5 → 1.3.6"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["@platforma-open/milaboratories.software-ptabler\n(patch release)"] --> B["lib/ptabler/software/src/requirements.txt\npolars-pf 1.1.43 → 1.1.49"]
    A --> C["@platforma-open/milaboratories.runenv-python-3\n1.10.3 → 1.10.4"]
    C --> D["runenv-python-3.12.10\n1.3.17 → 1.3.18"]
    C --> E["runenv-python-3.12.10-h5ad\n1.1.4 → 1.1.5"]
    C --> F["runenv-python-3.12.10-rapids\n1.6.0 → 1.7.0"]
    C --> G["runenv-python-3.12.10-sccoda\n1.3.5 → 1.3.6"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/milaboratory/platforma/commit/9abbfd54d2944e3e8765734afece4ee590381ff6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38370985)</sub>

<!-- /greptile_comment -->