### PR TITLE
MILAB-6463: select graph PFrame columns via the discover engine

### DIFF
--- a/.changeset/milab-6463-graph-pframe-discover.md
+++ b/.changeset/milab-6463-graph-pframe-discover.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Fix "axes sets are disjoint" errors in graph PFrames. `getRelatedColumns` now gates its candidate columns through the spec-driver discover engine, dropping result-pool columns that share only a low-cardinality context axis (e.g. `pl7.app/sampleId`) with the block but are otherwise a disconnected column universe.

--- a/sdk/model/src/pframe_utils/columns.ts
+++ b/sdk/model/src/pframe_utils/columns.ts
@@ -1,4 +1,10 @@
-import type { PColumn, PColumnSpec, PColumnLazy, PFrameDef } from "@milaboratories/pl-model-common";
+import type {
+  PColumn,
+  PColumnSpec,
+  PColumnLazy,
+  PFrameDef,
+  PObjectId,
+} from "@milaboratories/pl-model-common";
 import {
   getNormalizedAxesList,
   getAxisId,
@@ -11,6 +17,8 @@ import type { AxesVault } from "./axes";
 import { enrichCompatible, getAvailableWithLinkersAxes } from "./axes";
 import type { RenderCtxBase, PColumnDataUniversal } from "../render";
 import { PColumnCollection } from "../render";
+import { ColumnCollectionBuilder } from "../columns";
+import { collectCtxColumnSnapshotProviders } from "../columns/ctx_column_sources";
 
 export function getAllRelatedColumns<A, U>(
   ctx: RenderCtxBase<A, U>,
@@ -137,8 +145,42 @@ export function getRelatedColumns<A, U>(
 
   const compatible = [...compatibleWithoutLabels, ...compatibleLabels];
 
+  // Drop result-pool columns that share an axis with the block but cannot join it.
+  const integrableIds = discoverIntegrableColumnIds(ctx, rootColumns);
+  const rootIds = new Set(rootColumns.map((c) => c.id));
+  const connected = compatible.filter(
+    (c) => rootIds.has(c.id) || isLinkerColumn(c.spec) || (integrableIds?.has(c.id) ?? true),
+  );
+
   // additional columns are duplicates with extra fields in domains for compatibility if there are ones with partial match
-  const extendedColumns = enrichCompatible(blockAxes, compatible);
+  const extendedColumns = enrichCompatible(blockAxes, connected);
 
   return extendedColumns;
+}
+
+/** Column ids that discovery confirms integrate with the block, or `undefined` when it can't decide. */
+function discoverIntegrableColumnIds<A, U>(
+  ctx: RenderCtxBase<A, U>,
+  rootColumns: PColumn<PColumnDataUniversal>[],
+): Set<PObjectId> | undefined {
+  const anchorSpecs = Array.from(
+    new Map(rootColumns.map((c) => [canonicalizeJson(c.spec), c.spec])).values(),
+  );
+  if (anchorSpecs.length === 0) return undefined;
+
+  try {
+    const collection = new ColumnCollectionBuilder()
+      .addSources(collectCtxColumnSnapshotProviders(ctx))
+      .build({
+        allowPartialColumnList: true,
+        anchors: Object.fromEntries(anchorSpecs.map((spec, i) => [`anchor_${i}`, spec])),
+      });
+    try {
+      return new Set(collection.findColumns({ mode: "enrichment" }).map((m) => m.column.id));
+    } finally {
+      collection.dispose();
+    }
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Problem

`getRelatedColumns` (used by `createPFrameForGraphs`, which builds the PFrame behind every block's graphs) selected related result-pool columns with a partial-axis-match heuristic. A column that shared a single low-cardinality **context** axis with the block (e.g. `pl7.app/sampleId`) was admitted, and its *other*, foreign axis was then seeded into the candidate set — dragging in an entire disconnected column universe. The resulting PFrame fails on join with `SpecError … some of axes sets are disjoint`.

Concretely, in `clonotype-space` an IG-anchored graph PFrame pulled in a redefined-clonotype universe (a sibling block's columns sharing only `sampleId`), and the multi-sequence-alignment join crashed.

## Fix

Decide column membership with the spec-driver **discover engine** (`ColumnCollectionBuilder`, `enrichment` mode) instead of the JS heuristic:

- A candidate is kept only if discovery **integrates** it with the block's columns through linkers — `enrichment` mode rejects a hit that would introduce a floating/disconnected axis.
- Block columns (anchors) always stay.
- Linkers stay only when they connect to the block axis universe (a linker reaching a different universe would itself leave the join disjoint).
- When discovery is unavailable (no anchors, or it throws), the selection is **conservative** — block columns + connected linkers only — rather than keeping all candidates, which would re-admit disjoint universes. With no anchors this yields an essentially empty result, matching prior behavior.

Column assembly (`enrichCompatible`) is unchanged; only the *selection* step changed.

## Behavior verified (clonotype-space, all input anchors)

- **IG** — graph PFrame contains only the IG universe (+ connected linkers); alignment renders.
- **Redefined (IG / VDJRegion aa)** — redefined-only universe, no disconnected linkers; alignment returns rows (previously the disjoint `SpecError`).
- **TCRAB** — empty, which is correct: this dataset has no TCR clonotypes (Beta/Alpha = 0 rows at the MiXCR source). The previous heuristic masked this by leaking in unrelated data.

## Known deviations from the previous heuristic (documented inline, for follow-up)

These are inherent to selecting via discover while still assembling with `enrichCompatible`, and are noted as code comments in `getRelatedColumns`:

1. Discover qualifications / linker paths are not applied at assembly; included columns are still qualified by `enrichCompatible`'s `blockAxes` heuristic, so a hit needing a non-trivial qualification to integrate may not be qualified.
2. Label columns no longer get the looser "some axis matches" rule they had — they pass through the same discover verdict, so loosely-reachable axis-label columns may be dropped.
3. Columns reachable only via a non-anchor intermediate column (the old `allAxes` "hanging" set) are not rediscovered — discovery anchors on `rootColumns` only.
4. Discovery runs one anchor per distinct `rootColumn` spec; very large block column sets may stress the spec-driver (QuickJS) deadline.

## Scope / testing note

`createPFrameForGraphs` runs for every block's graphs. This was verified end-to-end on `clonotype-space` across all three anchors; it should go through the monorepo test suite before merge given the broad reach.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a disjoint-axis `SpecError` in `createPFrameForGraphs` by replacing a loose JS heuristic in `getRelatedColumns` with the spec-driver discover engine (`enrichment` mode). The old heuristic admitted result-pool columns that shared any single axis with the block, which could drag in entire disconnected universes; the new path only accepts columns that the discover engine can integrate without leaving a floating axis.

- **Column selection rewritten**: `candidates` now contains all predicate-matching result-pool columns, and membership is decided by `AnchoredColumnCollection.findColumns({ mode: "enrichment" })`; root columns (anchors) and linkers that share an axis with the block are unconditionally kept.
- **Conservative fallback**: when the discover engine is unavailable or throws (e.g. anchor specs not in ctx sources, QuickJS deadline exceeded on large sets), `integrableIds` is left `undefined` and only block columns + directly-connected linkers are returned — rather than re-admitting the full candidate set.
- **Known deviations documented inline**: label columns, columns reachable only via intermediate non-anchor columns, and linker-connectivity checks still use the old JS heuristic paths, flagged for follow-up.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core fix is sound and verified end-to-end on clonotype-space, but the outer catch silently suppresses all discover-engine errors — including the QuickJS deadline explicitly called out as a risk for large column sets — which could produce unexpectedly empty graphs in production with no diagnostic trail.

The silent catch on a code path with a known stress trigger (large block column sets hitting QuickJS deadline) is the main concern: the graph silently loses enrichment columns and nothing surfaces to the operator. Combined with the potential ID-namespace mismatch and the still-heuristic linker path, the change needs the logging gap addressed and a broader test run before it can be considered fully safe.

sdk/model/src/pframe_utils/columns.ts — specifically the bare catch block around the discover-engine call and the linker-connectivity check.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/pframe_utils/columns.ts | Replaces the JS axis-heuristic in `getRelatedColumns` with the spec-driver discover engine (enrichment mode) for candidate filtering; linkers still use a JS heuristic; silent catch on discover failure has no logging; potential PObjectId namespace mismatch between integrableIds and candidates. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getRelatedColumns called
rootColumns + predicate] --> B[Build blockAxes
from rootColumns axes]
    B --> C[Collect linkerColumns
matching predicate]
    C --> D[getAvailableWithLinkersAxes
expand blockAxes with
connected linker axes]
    D --> E[Fetch candidates
columns.getColumns predicate]
    E --> F{anchorSpecs
non-empty?}
    F -- No --> G[integrableIds = undefined]
    F -- Yes --> H[ColumnCollectionBuilder
.addSources ctx
.build with anchors]
    H -- throws --> G
    H -- ok --> I[collection.findColumns
mode: enrichment]
    I -- throws --> G
    I -- ok --> J[integrableIds = Set of discovered IDs
collection.dispose]
    G --> K[Filter candidates]
    J --> K
    K --> L{rootIds.has c.id?}
    L -- Yes --> M[include]
    L -- No --> N{isLinkerColumn?}
    N -- Yes --> O{linkerConnectsToBlock?
JS heuristic on blockAxes}
    O -- Yes --> M
    O -- No --> P[exclude]
    N -- No --> Q{integrableIds?.has c.id}
    Q -- true --> M
    Q -- false/undefined --> P
    M --> R[enrichCompatible
assemble final PFrameDef]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getRelatedColumns called
rootColumns + predicate] --> B[Build blockAxes
from rootColumns axes]
    B --> C[Collect linkerColumns
matching predicate]
    C --> D[getAvailableWithLinkersAxes
expand blockAxes with
connected linker axes]
    D --> E[Fetch candidates
columns.getColumns predicate]
    E --> F{anchorSpecs
non-empty?}
    F -- No --> G[integrableIds = undefined]
    F -- Yes --> H[ColumnCollectionBuilder
.addSources ctx
.build with anchors]
    H -- throws --> G
    H -- ok --> I[collection.findColumns
mode: enrichment]
    I -- throws --> G
    I -- ok --> J[integrableIds = Set of discovered IDs
collection.dispose]
    G --> K[Filter candidates]
    J --> K
    K --> L{rootIds.has c.id?}
    L -- Yes --> M[include]
    L -- No --> N{isLinkerColumn?}
    N -- Yes --> O{linkerConnectsToBlock?
JS heuristic on blockAxes}
    O -- Yes --> M
    O -- No --> P[exclude]
    N -- No --> Q{integrableIds?.has c.id}
    Q -- true --> M
    Q -- false/undefined --> P
    M --> R[enrichCompatible
assemble final PFrameDef]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asdk%2Fmodel%2Fsrc%2Fpframe_utils%2Fcolumns.ts%3A129-131%0A**Silent%20catch%20discards%20all%20discover-engine%20errors%20without%20logging**%0A%0AThe%20bare%20%60catch%60%20swallows%20every%20exception%20%E2%80%94%20including%20the%20QuickJS%20deadline%20that%20the%20PR%20description%20explicitly%20flags%20as%20a%20known%20risk%20for%20large%20block-column%20sets.%20When%20that%20happens%2C%20%60integrableIds%60%20stays%20%60undefined%60%2C%20the%20function%20returns%20only%20block%20columns%20%2B%20connected%20linkers%2C%20and%20graphs%20silently%20become%20empty%20or%20partial.%20There%20is%20no%20way%20for%20an%20operator%20or%20developer%20to%20know%20whether%20the%20conservative%20fallback%20fired%20due%20to%20a%20legitimate%20%22no%20anchors%22%20condition%20or%20due%20to%20a%20spec-driver%20crash%2Ftimeout.%20Adding%20at%20least%20a%20%60console.warn%60%20%28or%20the%20project's%20standard%20logger%29%20with%20the%20caught%20error%20and%20the%20number%20of%20anchor%20specs%20would%20make%20production%20incidents%20diagnosable%20without%20changing%20the%20fallback%20behaviour.%0A%0A%23%23%23%20Issue%202%20of%203%0Asdk%2Fmodel%2Fsrc%2Fpframe_utils%2Fcolumns.ts%3A141-143%0A**Linker%20inclusion%20still%20uses%20JS%20axis-match%20heuristic%2C%20not%20the%20discover%20engine**%0A%0A%60linkerConnectsToBlock%60%20admits%20any%20linker%20that%20shares%20at%20least%20one%20axis%20with%20the%20expanded%20%60blockAxes%60%20%28root-column%20axes%20%2B%20axes%20reachable%20via%20already-connected%20linkers%29.%20This%20is%20the%20same%20%22some%20axis%20overlaps%22%20heuristic%20that%20the%20PR%20replaces%20for%20regular%20result-pool%20columns.%20A%20linker%20that%20shares%20only%20a%20low-cardinality%20context%20axis%20%28e.g.%20%60pl7.app%2FsampleId%60%29%20with%20the%20block%20would%20pass%2C%20and%20its%20foreign%20axes%20are%20already%20baked%20into%20%60blockAxes%60%20via%20%60getAvailableWithLinkersAxes%60%20%E2%80%94%20so%20a%20chained%20linker%20bridging%20a%20disconnected%20universe%20could%20still%20slip%20in.%20The%20PR%20acknowledges%20this%20as%20a%20known%20deviation%3B%20this%20comment%20surfaces%20it%20for%20the%20follow-up%20ticket%2C%20since%20the%20discover-engine%20path%20in%20%60findColumns%28%7B%20mode%3A%20%22enrichment%22%20%7D%29%60%20would%20reject%20such%20a%20linker%20outright.%0A%0A%23%23%23%20Issue%203%20of%203%0Asdk%2Fmodel%2Fsrc%2Fpframe_utils%2Fcolumns.ts%3A113-132%0A**%60integrableIds%60%20uses%20outputs-priority%20IDs%3B%20%60candidates%60%20uses%20result-pool%20IDs**%0A%0A%60collectCtxColumnSnapshotProviders%60%20deduplicates%20by%20%60NativePObjectId%60%20and%20keeps%20the%20first-source%20%28%60outputs%60%29%20%60PObjectId%60%20when%20the%20same%20column%20appears%20in%20both%20%60ctx.outputs%60%20and%20%60ctx.resultPool%60%20%28the%20%60ctx_column_sources.ts%60%20comment%20calls%20this%20out%20explicitly%29.%20%60candidates%60%2C%20however%2C%20comes%20from%20%60columns.getColumns%28...%29%60%20which%20is%20sourced%20exclusively%20from%20%60ctx.resultPool%60%20%E2%80%94%20and%20therefore%20carries%20the%20result-pool%20%60PObjectId%60.%20For%20any%20non-root%20column%20whose%20outputs%20ID%20differs%20from%20its%20result-pool%20ID%2C%20%60integrableIds.has%28c.id%29%60%20will%20be%20%60false%60%2C%20and%20the%20column%20is%20silently%20excluded%20even%20though%20the%20discover%20engine%20accepted%20it.%20Root%20columns%20are%20safe%20because%20of%20the%20%60rootIds.has%28c.id%29%60%20guard%2C%20but%20result-pool%20columns%20also%20exposed%20via%20the%20block's%20prerun%20output%20could%20be%20affected.%20Sourcing%20%60candidates%60%20from%20the%20same%20provider%20set%20as%20%60collectCtxColumnSnapshotProviders%60%2C%20or%20cross-mapping%20by%20spec's%20native%20ID%2C%20would%20close%20this%20gap.%0A%0A&repo=milaboratory%2Fplatforma&pr=1708&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
sdk/model/src/pframe_utils/columns.ts:129-131
**Silent catch discards all discover-engine errors without logging**

The bare `catch` swallows every exception — including the QuickJS deadline that the PR description explicitly flags as a known risk for large block-column sets. When that happens, `integrableIds` stays `undefined`, the function returns only block columns + connected linkers, and graphs silently become empty or partial. There is no way for an operator or developer to know whether the conservative fallback fired due to a legitimate "no anchors" condition or due to a spec-driver crash/timeout. Adding at least a `console.warn` (or the project's standard logger) with the caught error and the number of anchor specs would make production incidents diagnosable without changing the fallback behaviour.

### Issue 2 of 3
sdk/model/src/pframe_utils/columns.ts:141-143
**Linker inclusion still uses JS axis-match heuristic, not the discover engine**

`linkerConnectsToBlock` admits any linker that shares at least one axis with the expanded `blockAxes` (root-column axes + axes reachable via already-connected linkers). This is the same "some axis overlaps" heuristic that the PR replaces for regular result-pool columns. A linker that shares only a low-cardinality context axis (e.g. `pl7.app/sampleId`) with the block would pass, and its foreign axes are already baked into `blockAxes` via `getAvailableWithLinkersAxes` — so a chained linker bridging a disconnected universe could still slip in. The PR acknowledges this as a known deviation; this comment surfaces it for the follow-up ticket, since the discover-engine path in `findColumns({ mode: "enrichment" })` would reject such a linker outright.

### Issue 3 of 3
sdk/model/src/pframe_utils/columns.ts:113-132
**`integrableIds` uses outputs-priority IDs; `candidates` uses result-pool IDs**

`collectCtxColumnSnapshotProviders` deduplicates by `NativePObjectId` and keeps the first-source (`outputs`) `PObjectId` when the same column appears in both `ctx.outputs` and `ctx.resultPool` (the `ctx_column_sources.ts` comment calls this out explicitly). `candidates`, however, comes from `columns.getColumns(...)` which is sourced exclusively from `ctx.resultPool` — and therefore carries the result-pool `PObjectId`. For any non-root column whose outputs ID differs from its result-pool ID, `integrableIds.has(c.id)` will be `false`, and the column is silently excluded even though the discover engine accepted it. Root columns are safe because of the `rootIds.has(c.id)` guard, but result-pool columns also exposed via the block's prerun output could be affected. Sourcing `candidates` from the same provider set as `collectCtxColumnSnapshotProviders`, or cross-mapping by spec's native ID, would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6463: select graph PFrame columns ..."](https://github.com/milaboratory/platforma/commit/321a634f7087a14037a6f4f52edf4dfd1b5c7d8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38422457)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->