### PR TITLE
feat: add bytesMissed cache counter and blob download driver metrics

### DIFF
--- a/.changeset/blob-driver-metrics.md
+++ b/.changeset/blob-driver-metrics.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-model-common": patch
+"@milaboratories/pl-drivers": patch
+---
+
+Add `BlobDriverMetrics` and `DownloadDriver.getMetrics()`: uncached (sparse-cache-bypass) request volume, live in-flight download gauges, and presigned-URL cache efficiency (hits / misses / stale hits / fetch latency).

--- a/.changeset/cache-missed-bytes.md
+++ b/.changeset/cache-missed-bytes.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+---
+
+Add `bytesMissed` to cache counters: bytes requested by clients that were not cached, for measuring read-ahead amplification against `bytesFetched`.

--- a/.changeset/plugin-handshake-symbol-for.md
+++ b/.changeset/plugin-handshake-symbol-for.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Make the plugin↔block handshake symbol (`CREATE_PLUGIN_MODEL`) a global registry symbol (`Symbol.for`) instead of a unique `Symbol(...)`, so it stays identical across multiple copies of `@platforma-sdk/model` in one process. Fixes `instance[CREATE_PLUGIN_MODEL] is not a function` when a block registers a plugin defined in a separate package (e.g. `@milaboratories/graph-maker`) — the plugin instance and the consuming block could otherwise resolve different module copies (bundled vs externalized in `block-tools build-model`, pnpm peer-hash duplicates) and the handshake would miss.

--- a/lib/model/common/src/drivers/blob.ts
+++ b/lib/model/common/src/drivers/blob.ts
@@ -77,3 +77,27 @@ export interface BlobDriver {
    */
   getContent(handle: LocalBlobHandle | RemoteBlobHandle, range?: RangeBytes): Promise<Uint8Array>;
 }
+
+/**
+ * Operational metrics of the blob download driver.
+ */
+export type BlobDriverMetrics = {
+  /** Downloads that bypassed the ranges (sparse) cache. Counted when issued, so failed downloads still count. */
+  uncachedRequests: number;
+  /** Bytes actually streamed off the wire on the uncached path. */
+  uncachedRequestBytes: number;
+  /** Currently active remote downloads. */
+  downloadsInFlight: number;
+  /** Sum of known sizes of active downloads — progress-bar denominator. */
+  inFlightBytesTotal: number;
+  /** Sum of bytes received so far across active downloads — progress-bar numerator. */
+  inFlightBytesReceived: number;
+  /** Cached presigned URL was used and the download started successfully (one gRPC sign call avoided). */
+  presignedUrlCacheHits: number;
+  /** No cached presigned URL; a fresh one was fetched. */
+  presignedUrlCacheMisses: number;
+  /** Cached presigned URL was rejected (HTTP 400) and re-fetched — signals the TTL safety margin is too loose. */
+  presignedUrlStaleHits: number;
+  /** Total latency of presigned-URL fetch calls (misses + stale hits); divide by their count for the mean cost a hit avoids. */
+  presignedUrlRequestSumLatencyMs: number;
+};

--- a/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
@@ -191,7 +191,12 @@ export type CacheCounters = {
   misses: number;
   /** Bytes served from cache */
   bytesServed: number;
-  /** Bytes downloaded from upstream on misses */
+  /**
+   * Bytes requested by clients that were not cached; compare with {@link bytesFetched} for read-ahead
+   * amplification. Optional until producers (serv) emit it; treat absent as not-yet-reported.
+   */
+  bytesMissed?: number;
+  /** Bytes downloaded from upstream on misses, including read-ahead and read-behind */
   bytesFetched: number;
   /** Bytes evicted to keep the cache within its total size budget, @see CacheConfig.maxSizeBytes */
   bytesEvictedByBudget: number;

--- a/lib/node/pl-drivers/src/clients/download.ts
+++ b/lib/node/pl-drivers/src/clients/download.ts
@@ -25,8 +25,11 @@ import { validateAbsolute } from "../helpers/validate";
 import type { DownloadAPI_GetDownloadURL_Response } from "../proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/downloadapi/protocol";
 import { DownloadClient } from "../proto-grpc/github.com/milaboratory/pl/controllers/shared/grpc/downloadapi/protocol.client";
 import type { DownloadApiPaths, DownloadRestClientType } from "../proto-rest";
-import { type GetContentOptions } from "@milaboratories/pl-model-common";
+import { type GetContentOptions, type BlobDriverMetrics } from "@milaboratories/pl-model-common";
 import { DownloadUrlCache } from "./download_url_cache";
+
+/** Subset of {@link BlobDriverMetrics} owned by the download client (presigned cache + in-flight downloads). */
+type ClientDownloadMetrics = Omit<BlobDriverMetrics, "uncachedRequests" | "uncachedRequestBytes">;
 
 /** Gets URLs for downloading from pl-core, parses them and reads or downloads
  * files locally and from the web. */
@@ -42,6 +45,13 @@ export class ClientDownload {
 
   /** Caches presigned download URLs by resource id until they (almost) expire. */
   private readonly urlCache: DownloadUrlCache;
+
+  /** Active remote downloads; in-flight gauges are summed over this set on read. */
+  private readonly inFlight = new Set<{ size: number; received: number }>();
+  private presignedUrlCacheHits = 0;
+  private presignedUrlCacheMisses = 0;
+  private presignedUrlStaleHits = 0;
+  private presignedUrlRequestSumLatencyMs = 0;
 
   constructor(
     wireClientProviderFactory: WireClientProviderFactory,
@@ -95,7 +105,7 @@ export class ClientDownload {
       const timer = PerfTimer.start();
       const result = isLocal(downloadUrl)
         ? await this.withLocalFileContent(downloadUrl, ops, handler)
-        : await this.remoteFileDownloader.withContent(downloadUrl, remoteHeaders, ops, handler);
+        : await this.withTrackedRemoteContent(downloadUrl, remoteHeaders, ops, handler);
 
       this.logger.info(
         `blob ${stringifyWithResourceId(info)} download finished, ` + `took: ${timer.elapsed()}`,
@@ -106,20 +116,78 @@ export class ClientDownload {
     const cached = this.urlCache.get(info.id);
     if (cached !== undefined) {
       try {
-        return await attempt(cached);
+        const result = await attempt(cached);
+        this.presignedUrlCacheHits++;
+        return result;
       } catch (error) {
         if (!isDownloadNetworkError400(error)) throw error;
         this.urlCache.delete(info.id);
+        this.presignedUrlStaleHits++;
         this.logger.info(
           `cached download URL for blob ${stringifyWithResourceId(info)} rejected ` +
             `(status ${error.statusCode}), re-fetching`,
         );
       }
+    } else {
+      this.presignedUrlCacheMisses++;
     }
 
+    const urlFetchStartMs = performance.now();
     const fresh = await this.grpcGetDownloadUrl(info, options, ops.signal);
+    this.presignedUrlRequestSumLatencyMs += performance.now() - urlFetchStartMs;
     this.urlCache.set(info.id, fresh);
     return await attempt(fresh);
+  }
+
+  /** Download-client-owned slice of {@link BlobDriverMetrics}: presigned-URL cache + in-flight downloads. */
+  metrics(): ClientDownloadMetrics {
+    let inFlightBytesTotal = 0;
+    let inFlightBytesReceived = 0;
+    for (const rec of this.inFlight) {
+      inFlightBytesTotal += rec.size;
+      inFlightBytesReceived += rec.received;
+    }
+    return {
+      downloadsInFlight: this.inFlight.size,
+      inFlightBytesTotal,
+      inFlightBytesReceived,
+      presignedUrlCacheHits: this.presignedUrlCacheHits,
+      presignedUrlCacheMisses: this.presignedUrlCacheMisses,
+      presignedUrlStaleHits: this.presignedUrlStaleHits,
+      presignedUrlRequestSumLatencyMs: this.presignedUrlRequestSumLatencyMs,
+    };
+  }
+
+  /** Wraps a remote download so it appears in the in-flight gauges and its received bytes are counted live. */
+  private async withTrackedRemoteContent<T>(
+    url: string,
+    headers: Record<string, string>,
+    ops: GetContentOptions,
+    handler: ContentHandler<T>,
+  ): Promise<T> {
+    const rec = { size: 0, received: 0 };
+    this.inFlight.add(rec);
+    try {
+      return await this.remoteFileDownloader.withContent(
+        url,
+        headers,
+        ops,
+        async (content, size) => {
+          rec.size = size;
+          const counted = content.pipeThrough(
+            new TransformStream<Uint8Array, Uint8Array>({
+              transform: (chunk, controller) => {
+                rec.received += chunk.byteLength;
+                controller.enqueue(chunk);
+              },
+            }),
+          );
+          return await handler(counted, size);
+        },
+      );
+    } finally {
+      this.inFlight.delete(rec);
+    }
   }
 
   async withLocalFileContent<T>(

--- a/lib/node/pl-drivers/src/drivers/download_blob/download_blob.ts
+++ b/lib/node/pl-drivers/src/drivers/download_blob/download_blob.ts
@@ -9,6 +9,7 @@ import {
 import type {
   AnyLogHandle,
   BlobDriver,
+  BlobDriverMetrics,
   ContentHandler,
   GetContentOptions,
   LocalBlobHandle,
@@ -100,6 +101,10 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
   private idToProgressLog: Map<string, LastLinesGetter> = new Map();
 
   private readonly saveDir: string;
+
+  /** Downloads that bypassed the ranges cache; counted when issued. */
+  private uncachedRequests = 0;
+  private uncachedRequestBytes = 0;
 
   constructor(
     private readonly logger: MiLogger,
@@ -341,6 +346,18 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
     });
   }
 
+  /**
+   * Operational metrics for a monitoring panel. Serv cache metrics are reported separately
+   * (different owner) — the panel composes both.
+   */
+  public getMetrics(): BlobDriverMetrics {
+    return {
+      uncachedRequests: this.uncachedRequests,
+      uncachedRequestBytes: this.uncachedRequestBytes,
+      ...this.clientDownload.metrics(),
+    };
+  }
+
   private async getContentImpl({
     handle,
     options,
@@ -399,12 +416,24 @@ export class DownloadDriver implements BlobDriver, AsyncDisposable {
 
       if (filePath) return await withFileContent({ path: filePath, range, signal, handler });
 
+      if (bypassRangesCache) this.uncachedRequests++;
+
       return await this.clientDownload.withBlobContent(
         result.info,
         { signal },
         options,
         async (content, size) => {
-          if (bypassRangesCache) return await handler(content, size);
+          if (bypassRangesCache) {
+            const counted = content.pipeThrough(
+              new TransformStream<Uint8Array, Uint8Array>({
+                transform: (chunk, controller) => {
+                  this.uncachedRequestBytes += chunk.byteLength;
+                  controller.enqueue(chunk);
+                },
+              }),
+            );
+            return await handler(counted, size);
+          }
 
           const [handlerStream, cacheStream] = content.tee();
 

--- a/sdk/model/src/plugin_model.ts
+++ b/sdk/model/src/plugin_model.ts
@@ -47,8 +47,9 @@ type PluginOutputFns<
   [K in keyof Outputs]: PluginOutputFn<Data, Params, ModelServices, UiServices, Outputs[K]>;
 };
 
-/** Symbol for internal plugin model creation — not accessible to external consumers */
-export const CREATE_PLUGIN_MODEL = Symbol("createPluginModel");
+/** Internal plugin↔block handshake. `Symbol.for` (not `Symbol`) so it stays
+ * identical across multiple `@platforma-sdk/model` copies in one process. */
+export const CREATE_PLUGIN_MODEL = Symbol.for("@platforma-sdk/model:createPluginModel");
 
 /** Sentinel for PluginInstance without transferAt — no transfer possible. */
 const NO_TRANSFER_VERSION = "";


### PR DESCRIPTION
## What

Two related observability additions for blob caching/downloading:

### 1. `bytesMissed` on the serv cache counters (`CacheCounters`)
Bytes requested by clients that were **not** cached. Compared with `bytesFetched` (downloaded incl. read-ahead/behind), the ratio `bytesFetched / bytesMissed` is read-ahead amplification — the signal for tuning the read-ahead window. Optional for now so producers typed against the published model stay assignable; serv emits it later.

### 2. `BlobDriverMetrics` + `DownloadDriver.getMetrics()`
- **uncached volume** — count + bytes streamed on the sparse-cache-bypass path
- **live in-flight gauges** — active downloads, total/received bytes (progress-bar denominator/numerator), summed from a live set of per-download records
- **presigned-URL cache efficiency** — hits, misses, stale hits (cached URL 400'd → refetch; flags a too-loose TTL margin), and summed fetch latency (mean cost a hit avoids)

Reported **separately** from the serv cache metrics — different owners and release cadences — so a monitoring panel composes both rather than one nesting the other. `RemoteBlobProviderImpl` untouched.

## Notes
- Patch changesets included for all three packages.
- `uncachedRequestBytes` counts bytes actually streamed off the wire, not nominal request size.