### PR TITLE
chore: bump pframes-rs to 1.1.52

### DIFF
--- a/.changeset/pframes-rs-1-1-52.md
+++ b/.changeset/pframes-rs-1-1-52.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/pl-model-middle-layer": patch
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+"@milaboratories/pl-middle-layer": patch
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Bump `@milaboratories/pframes-rs-*` to 1.1.52, which now populates `bytesMissed` in the serv cache counters. Make `bytesMissed` required on `CacheCounters` accordingly.

--- a/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts
@@ -193,9 +193,9 @@ export type CacheCounters = {
   bytesServed: number;
   /**
    * Bytes requested by clients that were not cached; compare with {@link bytesFetched} for read-ahead
-   * amplification. Optional until producers (serv) emit it; treat absent as not-yet-reported.
+   * amplification.
    */
-  bytesMissed?: number;
+  bytesMissed: number;
   /** Bytes downloaded from upstream on misses, including read-ahead and read-behind */
   bytesFetched: number;
   /** Bytes evicted to keep the cache within its total size budget, @see CacheConfig.maxSizeBytes */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.50
-      version: 1.1.50
+      specifier: 1.1.52
+      version: 1.1.52
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.50
-      version: 1.1.50
+      specifier: 1.1.52
+      version: 1.1.52
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.50
-      version: 1.1.50
+      specifier: 1.1.52
+      version: 1.1.52
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -2222,7 +2222,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2342,10 +2342,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.50(encoding@0.1.13)
+        version: 1.1.52(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -2828,10 +2828,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.50(encoding@0.1.13)
+        version: 1.1.52(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3502,7 +3502,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.50
+        version: 1.1.52
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5414,31 +5414,31 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.50':
-    resolution: {integrity: sha512-XshCE3Z9+tAKszlWCSDYJnpYRTIsag8v3YcjPmP6//W3dXDDrqi6gBqaGI0u58V9C3PLCjP3zC85vmtI5L26BQ==}
+  '@milaboratories/pframes-rs-node@1.1.52':
+    resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
 
-  '@milaboratories/pframes-rs-serv@1.1.50':
-    resolution: {integrity: sha512-XFWRsTGLCfQZhpRlWAmmBfznWyKL72dXY8UFTK+gmI2SOFdxQb8CJc0v/6LgNohwTKRTZZr59K9eRP3v8gCK6A==}
+  '@milaboratories/pframes-rs-serv@1.1.52':
+    resolution: {integrity: sha512-yVfcyLztgj5UAffj30se5G4MwxkIOFVWPHY1tZZ8zLhQQzx95R/e1toAqq3FLV7y6kpJovwmLusbefgKw9Ejcg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.50':
-    resolution: {integrity: sha512-FHv6Cksyl9q9plIhRUzNP0cQ03aZVltNh+haZ5KGVNHh9e5PgP9ndnTP06bQ1JRyQ/6Thf1NF5yw1lBXp6J+uw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.52':
+    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.50':
-    resolution: {integrity: sha512-D7YvFltjAk+OLCC/5/U741Hipxof4v/t0cJbk+y38MJjx6PyGQhAyVP/J4XfbJgdFdTGdDidRCNGYLt/Jn8l3w==}
+  '@milaboratories/pframes-rs-wasm@1.1.52':
+    resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/pl-model-middle-layer': 1.30.5
+      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-middle-layer': 1.30.7
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-model-common@1.46.1':
-    resolution: {integrity: sha512-ABOz/w7dA4t2zUpZHXI74MTNW6LmPFSLxgfhOPFdO6vodIY8draVN+ag2U21WlYIoSgdJwSXJrXJWdu1cefrIg==}
+  '@milaboratories/pl-model-common@1.46.2':
+    resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.5':
-    resolution: {integrity: sha512-TSpemA65REZay1ObnuwV3QLIjN46Iluy0HUu/aiHMQ1d1BFAG2vrgvonQqTnxp7UKQYOr9RGJg/QDYG/+UNKMw==}
+  '@milaboratories/pl-model-middle-layer@1.30.7':
+    resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
@@ -11830,32 +11830,32 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.50(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.52(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.50
-      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pframes-rs-serv': 1.1.52
+      '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.50':
+  '@milaboratories/pframes-rs-serv@1.1.52':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/pl-model-middle-layer': 1.30.5
+      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-middle-layer': 1.30.7
       better-sqlite3: 12.10.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.50': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.50
+      '@milaboratories/pframes-rs-wasip2': 1.1.52
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11864,17 +11864,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.1':
+  '@milaboratories/pl-model-common@1.46.2':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.5':
+  '@milaboratories/pl-model-middle-layer@1.30.7':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-common': 1.46.2
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -252,9 +252,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.50
-  "@milaboratories/pframes-rs-wasip2": 1.1.50
-  "@milaboratories/pframes-rs-wasm": 1.1.50
+  "@milaboratories/pframes-rs-node": 1.1.52
+  "@milaboratories/pframes-rs-wasip2": 1.1.52
+  "@milaboratories/pframes-rs-wasm": 1.1.52
 
   "quickjs-emscripten": 0.31.0
 


### PR DESCRIPTION
Bumps `@milaboratories/pframes-rs-*` to 1.1.52. The only change in this release is that serv now populates `bytesMissed` in the cache counters.

- Bump `pframes-rs-{node,wasip2,wasm}` 1.1.50 → 1.1.52 in the workspace catalog.
- Make `bytesMissed` required on `CacheCounters` (it was optional pending a producer that emits it).

`REQUIRES_PFRAMES_VERSION` is left unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps `@milaboratories/pframes-rs-{node,wasip2,wasm}` from 1.1.50 to 1.1.52 in the workspace catalog and updates the lock file accordingly. The only behavioral change in the new release is that the `serv` process now always populates `bytesMissed` in its cache counters, so the TypeScript type for `CacheCounters` is updated to reflect that guarantee.

- **`pnpm-workspace.yaml` / `pnpm-lock.yaml`**: Catalog pins and resolved hashes updated for all three pframes-rs flavors (node, wasip2, wasm) plus their co-versioned peer deps (`pl-model-common` 1.46.2, `pl-model-middle-layer` 1.30.7).
- **`CacheCounters.bytesMissed`** (`http_helpers.ts`): Changed from `bytesMissed?: number` to `bytesMissed: number`; the field is now always emitted by pframes-rs 1.1.52, so the optional marker was no longer accurate.
- **`REQUIRES_PFRAMES_VERSION`** intentionally left at its prior value — this is a purely additive reporting improvement and does not require desktop apps to upgrade.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Straightforward dependency bump with a matching type tightening; no logic changes, no breaking API surface.

All changes are mechanical: version strings in the catalog and lock file, integrity hashes, and one TypeScript field made non-optional to match what the new library version now always emits. The `bytesMissed` field had no callers constructing `CacheCounters` objects manually (values come straight from the pframes-rs library), so the optional→required change carries no runtime risk. `REQUIRES_PFRAMES_VERSION` is intentionally unchanged and the PR description explains why.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/pframes-rs-1-1-52.md | New changeset entry describing the pframes-rs bump and the bytesMissed schema change; correctly lists all affected workspace packages. |
| lib/model/middle-layer/src/pframe/internal_api/http_helpers.ts | Promotes bytesMissed on CacheCounters from optional to required, matching the new pframes-rs 1.1.52 behavior that always emits the field. |
| pnpm-workspace.yaml | Bumps the catalog pins for pframes-rs-{node,wasip2,wasm} from 1.1.50 to 1.1.52; no other changes. |
| pnpm-lock.yaml | Lock file updated to reflect new package resolutions and integrity hashes for pframes-rs 1.1.52 and its updated peer deps (pl-model-common 1.46.2, pl-model-middle-layer 1.30.7). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Desktop App
    participant Driver as PFrameDriver
    participant Serv as pframes-rs-serv (1.1.52)
    participant Cache as CachingObjectStore

    App->>Driver: getCacheMetrics()
    Driver->>Cache: getMetrics()
    Cache->>Serv: HTTP /metrics (internal API)
    Serv-->>Cache: CacheMetrics JSON (bytesMissed now always present)
    Cache-->>Driver: "CacheMetrics { lifetime: CacheCounters, session: CacheCounters }"
    note over Cache,Driver: CacheCounters.bytesMissed: number (required, was optional)
    Driver-->>App: "CacheMetrics | null"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Desktop App
    participant Driver as PFrameDriver
    participant Serv as pframes-rs-serv (1.1.52)
    participant Cache as CachingObjectStore

    App->>Driver: getCacheMetrics()
    Driver->>Cache: getMetrics()
    Cache->>Serv: HTTP /metrics (internal API)
    Serv-->>Cache: CacheMetrics JSON (bytesMissed now always present)
    Cache-->>Driver: "CacheMetrics { lifetime: CacheCounters, session: CacheCounters }"
    note over Cache,Driver: CacheCounters.bytesMissed: number (required, was optional)
    Driver-->>App: "CacheMetrics | null"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump pframes-rs to 1.1.52, make b..."](https://github.com/milaboratory/platforma/commit/3a4036d274c4f4c8192333ccecbc0c7052941a4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39223638)</sub>

<!-- /greptile_comment -->