### PR TITLE
fix: drop redundant axis sort from PFrame export (fixes OOM on large frames)

### DIFF
--- a/.changeset/pframe-export-drop-redundant-sort.md
+++ b/.changeset/pframe-export-drop-redundant-sort.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/workflow-tengo": patch
+---
+
+Drop the redundant axis sort from the PFrame export paths (`xsv.exportFrame`, `tableBuilder.build()`). The `read_frame` source is already sorted by its full axis tuple (the PFrame primary key) per the pframes-rs PTable contract, so the extra `sort` step only added a pipeline-breaker. Because the Polars source is a non-spillable io-source generator, that sort materialized the whole frame in memory and OOMed on large exports (billions of rows). Removing it makes these exports stream with bounded memory; output order is unchanged (`select`/`save` preserve row order, and the unique axis key leaves no ties).

--- a/sdk/workflow-tengo/src/pframes/build-table.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/build-table.tpl.tengo
@@ -285,7 +285,6 @@ self.body(func(inputs) {
 		axisLabel: axisLabel,
 		columnLabel: columnLabel
 	})
-	sortSelectors := selectors.sortSelectors
 	columnSelectors := selectors.columnSelectors
 
 	wf := pt.workflow()
@@ -293,8 +292,8 @@ self.body(func(inputs) {
 	if !is_undefined(inputs.mem) { wf.mem(inputs.mem) }
 	if !is_undefined(inputs.cacheInputs) { wf.cacheInputs(inputs.cacheInputs) }
 
+	// read_frame output is already sorted by axes (PFrame PTable contract).
 	wf.frame(frameInput).
-		sort(sortSelectors).
 		select(columnSelectors...).
 		save(resultFile)
 

--- a/sdk/workflow-tengo/src/pframes/export-util.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/export-util.lib.tengo
@@ -1,9 +1,9 @@
 /**
- * Shared helpers for templates that export a list of resolved PColumns to a
- * flat table via pt (sort + axes + value columns + save).
- *
- * Consumers: `:pframes.xsv-export-pframe`, `:pframes.build-table`.
- */
+* Shared helpers for templates that export a list of resolved PColumns to a
+* flat table via pt (sort + axes + value columns + save).
+*
+* Consumers: `:pframes.xsv-export-pframe`, `:pframes.build-table`.
+*/
 
 ll := import(":ll")
 slices := import(":slices")
@@ -12,38 +12,37 @@ pSpec := import(":pframes.spec")
 pt := import(":pt")
 
 /**
- * Builds pt sort and column selectors for exporting resolved columns.
- *
- * Deduplicates axes across columns by distilling each axis (strips annotations
- * and non-discriminative domains via pSpec.createSpecDistiller) and canonically
- * encoding the result. Then produces:
- *   - sortSelectors  — axis selectors for deterministic row ordering
- *   - columnSelectors — axis selectors aliased with labels, followed by
- *                       per-column selectors aliased with headers
- *
- * Label uniqueness is always enforced: if two axes/columns resolve to the
- * same label, the helper panics. Callers must supply their own labeling
- * policy via the two callbacks.
- *
- * @param rawColumns: [{frameKey: string, spec: PColumnSpec, ...}]
- *   frameKey — pFrame column key, used in `pt.col(frameKey)` selectors.
- *              Must match the id used when building the pFrame.
- *   spec     — PColumnSpec, used for axis distillation and label derivation.
- *              Additional fields (e.g. header, headerPrefix) are read only by
- *              the caller-provided `columnLabel` callback.
- *
- * @param opts: {
- *     axisLabel: func(originalAxisSpec) -> string
- *       Derives label for an axis. Receives the ORIGINAL axis spec with its
- *       annotations intact (distillation strips annotations). Called once
- *       per unique axis — identity determined by canonical encoding of the
- *       distilled axis, but the label source is the raw spec.
- *     columnLabel: func(rawColumn) -> string
- *       Derives header for a column. Called once per rawColumns entry.
- *   }
- *
- * @return { sortSelectors, columnSelectors }
- */
+* Builds pt column selectors for exporting resolved columns.
+*
+* Deduplicates axes across columns by distilling each axis (strips annotations
+* and non-discriminative domains via pSpec.createSpecDistiller) and canonically
+* encoding the result. Then produces:
+*   - columnSelectors — axis selectors aliased with labels, followed by
+*                       per-column selectors aliased with headers
+*
+* Label uniqueness is always enforced: if two axes/columns resolve to the
+* same label, the helper panics. Callers must supply their own labeling
+* policy via the two callbacks.
+*
+* @param rawColumns: [{frameKey: string, spec: PColumnSpec, ...}]
+*   frameKey — pFrame column key, used in `pt.col(frameKey)` selectors.
+*              Must match the id used when building the pFrame.
+*   spec     — PColumnSpec, used for axis distillation and label derivation.
+*              Additional fields (e.g. header, headerPrefix) are read only by
+*              the caller-provided `columnLabel` callback.
+*
+* @param opts: {
+*     axisLabel: func(originalAxisSpec) -> string
+*       Derives label for an axis. Receives the ORIGINAL axis spec with its
+*       annotations intact (distillation strips annotations). Called once
+*       per unique axis — identity determined by canonical encoding of the
+*       distilled axis, but the label source is the raw spec.
+*     columnLabel: func(rawColumn) -> string
+*       Derives header for a column. Called once per rawColumns entry.
+*   }
+*
+* @return { columnSelectors }
+*/
 buildExportSelectors := func(rawColumns, opts) {
 	axisLabel := opts.axisLabel
 	columnLabel := opts.columnLabel
@@ -88,12 +87,9 @@ buildExportSelectors := func(rawColumns, opts) {
 		}
 	}
 
-	// Build sort + column selectors. Axes first (sort order = output order),
-	// then value columns.
-	sortSelectors := []
+	// Build column selectors: axes first (= output order), then value columns.
 	columnSelectors := []
 	for ua in uniqueAxes {
-		sortSelectors = append(sortSelectors, pt.axis(ua.spec))
 		columnSelectors = append(columnSelectors, pt.axis(ua.spec).alias(ua.label))
 	}
 	for column in rawColumns {
@@ -103,7 +99,6 @@ buildExportSelectors := func(rawColumns, opts) {
 	}
 
 	return {
-		sortSelectors: sortSelectors,
 		columnSelectors: columnSelectors
 	}
 }

--- a/sdk/workflow-tengo/src/pframes/export-util.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/export-util.lib.tengo
@@ -1,6 +1,6 @@
 /**
 * Shared helpers for templates that export a list of resolved PColumns to a
-* flat table via pt (sort + axes + value columns + save).
+* flat table via pt (axes + value columns + save).
 *
 * Consumers: `:pframes.xsv-export-pframe`, `:pframes.build-table`.
 */

--- a/sdk/workflow-tengo/src/pframes/xsv-export-pframe.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/xsv-export-pframe.tpl.tengo
@@ -11,16 +11,16 @@ self := import(":tpl.light")
 self.defineOutputs(["result"])
 
 self.body(func(inputs) {
-    pf := inputs.pf
-    xsvType := inputs.xsvType
-    params := inputs.params
+	pf := inputs.pf
+	xsvType := inputs.xsvType
+	params := inputs.params
 
-    queue := inputs.queue
-    cpu := inputs.cpu
-    mem := inputs.mem
-    inputCache := inputs.inputCache
-    
-    resultFile := "result." + xsvType
+	queue := inputs.queue
+	cpu := inputs.cpu
+	mem := inputs.mem
+	inputCache := inputs.inputCache
+
+	resultFile := "result." + xsvType
 
 	columnEntries := []
 	rawColumns := []
@@ -58,7 +58,6 @@ self.body(func(inputs) {
 		axisLabel: getLabel,
 		columnLabel: func(c) { return getLabel(c.spec) }
 	})
-	sortSelectors := selectors.sortSelectors
 	columnSelectors := selectors.columnSelectors
 
 	wf := pt.workflow()
@@ -82,14 +81,14 @@ self.body(func(inputs) {
 	if !is_undefined(inputCache) {
 		wf.cacheInputs(inputCache)
 	}
+	// read_frame output is already sorted by axes (PFrame PTable contract).
 	wf.frame(frameInput).
-		sort(sortSelectors).
 		select(numericSelector, stringSelector).
 		select(columnSelectors...).
 		save(resultFile)
 
 	result := wf.run()
-    return {
-        result: result.getFile(resultFile)
-    }
+	return {
+		result: result.getFile(resultFile)
+	}
 })


### PR DESCRIPTION
## Problem

`xsv.exportFrame(..., \"parquet\")` (and `tableBuilder.build()`) OOM on large PFrames. Observed on a ~2.1 billion-row embedding matrix export: the worker is killed, output file is 0 bytes.

The generated ptabler workflow is `read_frame → sort(axes) → select → select → write_parquet`. The only pipeline-breaker is the `sort`. Because the Polars source (`pframe_source`) is a `register_io_source` Python generator, the streaming engine cannot spill the sort out-of-core — it materializes the whole frame in memory and OOMs. (`write_frame` already sidesteps this by sorting via DuckDB; the flat-file export path never got that treatment and doesn't need it.)

## Why the sort is redundant

`read_frame`'s output is **already sorted by axes ascending**: pframes-rs materializes every PTable sorted by its full axis tuple (`plan.rs:into_table` default; multi-column joins inherit it via `into_table_plan`). That axis tuple is the PFrame **primary key**, so the sort key is unique — no ties, stability is irrelevant. The export's first-seen axis order matches `read_frame`'s because both derive from the same insertion-ordered column arrays, and `select`/`save` preserve row order.

## Change

- Remove `.sort(sortSelectors)` from `xsv-export-pframe.tpl.tengo` and `build-table.tpl.tengo`.
- Drop the now-unused `sortSelectors` from `buildExportSelectors`.

Output bytes are unchanged; these exports now stream with bounded memory.

## Note

`src/` changed — rebuild `@platforma-sdk/workflow-tengo` to regenerate `dist/`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the redundant `.sort(sortSelectors)` step from the two PFrame flat-file export pipelines (`xsv.exportFrame` / `tableBuilder.build()`). Because `read_frame` already emits rows sorted by the full axis tuple (the PFrame PTable contract in pframes-rs), the downstream sort was a pure pipeline-breaker: Polars' non-spillable `register_io_source` generator had to materialise the entire frame in memory, causing OOM at ~2 billion rows.

- **`export-util.lib.tengo`**: `buildExportSelectors` no longer builds or returns `sortSelectors`; the axis-sort loop is dropped and the return map is reduced to `{ columnSelectors }` only.
- **`build-table.tpl.tengo` / `xsv-export-pframe.tpl.tengo`**: `.sort(sortSelectors)` removed from the `pt` workflow chain in both templates; a comment citing the PFrame PTable sort contract is added in each.
- **`xsv-export-pframe.tpl.tengo`**: Also fixes indentation (mixed spaces → consistent tabs in the template body).

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change removes a proven pipeline-breaker without altering output content or row order, relying on the well-established PFrame PTable sort contract.

The only finding is a single stale word ("sort") left in the file-level docblock of export-util.lib.tengo; every functional change is correct and tightly scoped. The PFrame PTable sort guarantee (pframes-rs materialises PTables sorted by their full axis tuple) is cited in both changed templates and the changeset, and write_frame already depended on the same contract. Output order is preserved by select/save.

No files require special attention. All four changed files are straightforward and internally consistent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/pframes/export-util.lib.tengo | Removed sortSelectors from buildExportSelectors: the axis-sort loop and the returned sortSelectors key are dropped; the function now returns only columnSelectors. File-level docblock still mentions "sort" (stale, minor). |
| sdk/workflow-tengo/src/pframes/build-table.tpl.tengo | Removes .sort(sortSelectors) from the pt workflow chain in tableBuilder.build(); adds a comment explaining the PFrame PTable sort contract. Change is correct and well-scoped. |
| sdk/workflow-tengo/src/pframes/xsv-export-pframe.tpl.tengo | Removes .sort(sortSelectors) from the pt workflow chain in xsv.exportFrame; also fixes indentation (tabs replacing leading spaces). Change is correct and well-scoped. |
| .changeset/pframe-export-drop-redundant-sort.md | Accurate patch-level changeset entry; describes the PTable sort contract and why removing the sort fixes the OOM. No issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant pframes_rs as pframes-rs (PTable)
    participant read_frame as read_frame step
    participant select as select step(s)
    participant save as save (parquet/csv)

    note over pframes_rs,read_frame: PTable contract: rows sorted by full axis tuple
    pframes_rs->>read_frame: rows (axis-sorted, streaming)
    note over read_frame: BEFORE: .sort(sortSelectors) inserted here<br/>→ Polars io-source cannot spill → OOM
    read_frame->>select: rows (already axis-sorted)
    select->>save: projected rows (order preserved)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant pframes_rs as pframes-rs (PTable)
    participant read_frame as read_frame step
    participant select as select step(s)
    participant save as save (parquet/csv)

    note over pframes_rs,read_frame: PTable contract: rows sorted by full axis tuple
    pframes_rs->>read_frame: rows (axis-sorted, streaming)
    note over read_frame: BEFORE: .sort(sortSelectors) inserted here<br/>→ Polars io-source cannot spill → OOM
    read_frame->>select: rows (already axis-sorted)
    select->>save: projected rows (order preserved)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asdk%2Fworkflow-tengo%2Fsrc%2Fpframes%2Fexport-util.lib.tengo%3A3%0AThe%20file-level%20docblock%20still%20says%20%22sort%20%2B%20axes%20%2B%20value%20columns%20%2B%20save%22%20after%20the%20sort%20step%20has%20been%20removed.%20This%20makes%20the%20header%20description%20stale.%0A%0A%60%60%60suggestion%0A*%20flat%20table%20via%20pt%20%28axes%20%2B%20value%20columns%20%2B%20save%29.%0A%60%60%60%0A%0A&repo=milaboratory%2Fplatforma&pr=1711&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/workflow-tengo/src/pframes/export-util.lib.tengo:3
The file-level docblock still says "sort + axes + value columns + save" after the sort step has been removed. This makes the header description stale.

```suggestion
* flat table via pt (axes + value columns + save).
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: drop redundant axis sort from PFram..."](https://github.com/milaboratory/platforma/commit/907f87c1058a96de7b71f8fdee103a23e38fdc60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39241255)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->