### PR TITLE
Fix type error in PFrames driver

### DIFF
--- a/.changeset/mighty-toys-go.md
+++ b/.changeset/mighty-toys-go.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Fix type error in PFrames driver

--- a/lib/node/pl-middle-layer/src/pool/driver.ts
+++ b/lib/node/pl-middle-layer/src/pool/driver.ts
@@ -262,11 +262,11 @@ class RemoteBlobProviderImpl implements RemoteBlobProvider<BlobResourceRef> {
   ): Promise<RemoteBlobProviderImpl> {
     const pool = new RemoteBlobPool(blobDriver, logger);
     const store = new BlobStore({ remoteBlobProvider: pool, logger });
-    const cachingStore = await HttpHelpers.createCachingObjectStore({
+    const cachingStore = (await HttpHelpers.createCachingObjectStore({
       upstream: store,
       config: cacheConfig,
       logger,
-    });
+    })) as PFrameInternal.CachingObjectStore; // TODO: remove cast after next PFrames release
 
     const handler = HttpHelpers.createRequestHandler({ store: cachingStore });
     const server = await HttpHelpers.createHttpServer({ ...serverOptions, handler });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a temporary type cast to fix a TypeScript compilation error in the PFrames driver, where the return type of `HttpHelpers.createCachingObjectStore` from `@milaboratories/pframes-rs-node` no longer structurally matches `PFrameInternal.CachingObjectStore` from `@milaboratories/pl-model-middle-layer`.

- **`driver.ts`**: Wraps `await HttpHelpers.createCachingObjectStore(...)` in parentheses and appends `as PFrameInternal.CachingObjectStore`, with a `// TODO: remove cast after next PFrames release` comment to track removal once the upstream package updates its declarations.
- **`.changeset/mighty-toys-go.md`**: Registers the change as a patch release for `@milaboratories/pl-middle-layer`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is type-only with no behavioral impact at runtime, and the TODO comment clearly tracks the technical debt to remove the cast.

The cast works around a type declaration mismatch between @milaboratories/pframes-rs-node and @milaboratories/pl-model-middle-layer. At runtime the object returned by createCachingObjectStore does implement the CachingObjectStore interface (all three call sites — createRequestHandler, getMetrics, and [Symbol.asyncDispose] — will behave correctly). The cast is unchecked, so if the upstream package ever diverges structurally from CachingObjectStore and the TODO is forgotten, failures would surface at runtime rather than compile time.

No files require special attention. driver.ts is the only substantive change, and it is narrow and self-contained.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/pool/driver.ts | Adds a temporary `as PFrameInternal.CachingObjectStore` cast with a TODO comment to resolve a type mismatch between the NAPI module's return type and the expected interface; no behavioral change at runtime. |
| .changeset/mighty-toys-go.md | Changeset entry for a patch release of @milaboratories/pl-middle-layer; correctly scoped as patch since this is a type-only fix with no API change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant RemoteBlobProviderImpl
    participant HttpHelpers as HttpHelpers (pframes-rs-node)
    participant BlobStore
    participant CachingObjectStore as CachingObjectStore (cast)

    Caller->>RemoteBlobProviderImpl: init(blobDriver, logger, serverOptions, cacheConfig)
    RemoteBlobProviderImpl->>BlobStore: "new BlobStore({ remoteBlobProvider: pool, logger })"
    RemoteBlobProviderImpl->>HttpHelpers: "createCachingObjectStore({ upstream: store, config, logger })"
    HttpHelpers-->>RemoteBlobProviderImpl: "Promise<unknown type>"
    Note over RemoteBlobProviderImpl: cast as PFrameInternal.CachingObjectStore
    RemoteBlobProviderImpl->>HttpHelpers: "createRequestHandler({ store: cachingStore })"
    HttpHelpers-->>RemoteBlobProviderImpl: RequestListener (handler)
    RemoteBlobProviderImpl->>HttpHelpers: "createHttpServer({ ...serverOptions, handler })"
    HttpHelpers-->>RemoteBlobProviderImpl: HttpServer
    RemoteBlobProviderImpl-->>Caller: new RemoteBlobProviderImpl(pool, server, cachingStore)

    Caller->>RemoteBlobProviderImpl: getCacheMetrics()
    RemoteBlobProviderImpl->>CachingObjectStore: getMetrics()
    CachingObjectStore-->>RemoteBlobProviderImpl: CacheMetrics
    RemoteBlobProviderImpl-->>Caller: "Promise<CacheMetrics | null>"

    Caller->>RemoteBlobProviderImpl: [Symbol.asyncDispose]()
    RemoteBlobProviderImpl->>HttpHelpers: server.stop()
    RemoteBlobProviderImpl->>CachingObjectStore: [Symbol.asyncDispose]()
    RemoteBlobProviderImpl->>RemoteBlobProviderImpl: pool[Symbol.asyncDispose]()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant RemoteBlobProviderImpl
    participant HttpHelpers as HttpHelpers (pframes-rs-node)
    participant BlobStore
    participant CachingObjectStore as CachingObjectStore (cast)

    Caller->>RemoteBlobProviderImpl: init(blobDriver, logger, serverOptions, cacheConfig)
    RemoteBlobProviderImpl->>BlobStore: "new BlobStore({ remoteBlobProvider: pool, logger })"
    RemoteBlobProviderImpl->>HttpHelpers: "createCachingObjectStore({ upstream: store, config, logger })"
    HttpHelpers-->>RemoteBlobProviderImpl: "Promise<unknown type>"
    Note over RemoteBlobProviderImpl: cast as PFrameInternal.CachingObjectStore
    RemoteBlobProviderImpl->>HttpHelpers: "createRequestHandler({ store: cachingStore })"
    HttpHelpers-->>RemoteBlobProviderImpl: RequestListener (handler)
    RemoteBlobProviderImpl->>HttpHelpers: "createHttpServer({ ...serverOptions, handler })"
    HttpHelpers-->>RemoteBlobProviderImpl: HttpServer
    RemoteBlobProviderImpl-->>Caller: new RemoteBlobProviderImpl(pool, server, cachingStore)

    Caller->>RemoteBlobProviderImpl: getCacheMetrics()
    RemoteBlobProviderImpl->>CachingObjectStore: getMetrics()
    CachingObjectStore-->>RemoteBlobProviderImpl: CacheMetrics
    RemoteBlobProviderImpl-->>Caller: "Promise<CacheMetrics | null>"

    Caller->>RemoteBlobProviderImpl: [Symbol.asyncDispose]()
    RemoteBlobProviderImpl->>HttpHelpers: server.stop()
    RemoteBlobProviderImpl->>CachingObjectStore: [Symbol.asyncDispose]()
    RemoteBlobProviderImpl->>RemoteBlobProviderImpl: pool[Symbol.asyncDispose]()
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix type error in PFrames driver"](https://github.com/milaboratory/platforma/commit/c73159fc1f02f022a99f6ef0f3c05838e8f8305f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39291507)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->