### PR TITLE
ci: run CI on Hetzner k3s runners (hz-ubuntu-dind) + RGW caches

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: Cache pnpm store (S3/RGW)
       if: inputs.cache-s3-access-key != ''
-      uses: milaboratory/github-ci/actions/node/cache-pnpm-s3@feat/hz-s3-cache-actions
+      uses: milaboratory/github-ci/actions/node/cache-pnpm-s3@v4
       with:
         access-key: ${{ inputs.cache-s3-access-key }}
         secret-key: ${{ inputs.cache-s3-secret-key }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,6 +28,33 @@ inputs:
     description: 'Turbo team ID (controls cache directory)'
     required: false
     default: 'ci-010101'
+  # --- S3/RGW caches (self-hosted hz runners). When the cache-s3 keys are set,
+  #     the pnpm store is cached in RGW (node/cache-pnpm-s3, use-fallback->GitHub)
+  #     instead of actions/cache. Turbo S3 env points the remote cache at RGW.
+  cache-s3-access-key:
+    description: 'S3/RGW access key for the pnpm cache. Empty = GitHub actions/cache.'
+    required: false
+    default: ''
+  cache-s3-secret-key:
+    description: 'S3/RGW secret key for the pnpm cache.'
+    required: false
+    default: ''
+  turbo-s3-endpoint:
+    description: 'S3 endpoint URL for the Turbo remote cache (RGW). Empty = AWS default.'
+    required: false
+    default: ''
+  turbo-s3-region:
+    description: 'S3 region for the Turbo remote cache.'
+    required: false
+    default: ''
+  turbo-s3-access-key:
+    description: 'S3 access key for the Turbo remote cache (RGW).'
+    required: false
+    default: ''
+  turbo-s3-secret-key:
+    description: 'S3 secret key for the Turbo remote cache (RGW).'
+    required: false
+    default: ''
   quay-username:
     description: 'Quay.io username for Docker login'
     required: false
@@ -54,12 +81,20 @@ runs:
       shell: bash
       run: echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
-    - name: Cache pnpm store
+    - name: Cache pnpm store (GitHub)
+      if: inputs.cache-s3-access-key == ''
       uses: actions/cache@v4
       with:
         path: ${{ steps.pnpm-cache.outputs.store-path }}
         key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: pnpm-store-${{ runner.os }}-
+
+    - name: Cache pnpm store (S3/RGW)
+      if: inputs.cache-s3-access-key != ''
+      uses: milaboratory/github-ci/actions/node/cache-pnpm-s3@feat/hz-s3-cache-actions
+      with:
+        access-key: ${{ inputs.cache-s3-access-key }}
+        secret-key: ${{ inputs.cache-s3-secret-key }}
 
     - name: Configure AWS credentials
       if: inputs.aws-iam-role != ''
@@ -94,6 +129,15 @@ runs:
     - name: Setup Turbo S3 remote cache
       if: inputs.turbo-s3-bucket != ''
       uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4
+      env:
+        # Scoped to THIS step only. NEVER set AWS_ENDPOINT_URL globally — it would
+        # redirect aws-cli/ECR image pulls to RGW and break them. The turbo cache
+        # server (ducktors/turborepo-remote-cache) reads these S3_* vars.
+        S3_ACCESS_KEY: ${{ inputs.turbo-s3-access-key }}
+        S3_SECRET_KEY: ${{ inputs.turbo-s3-secret-key }}
+        S3_REGION: ${{ inputs.turbo-s3-region }}
+        S3_ENDPOINT: ${{ inputs.turbo-s3-endpoint }}
+        S3_USE_PATH_STYLE: 'true'
       with:
         storage-provider: 's3'
         storage-path: ${{ inputs.turbo-s3-bucket }}

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -13,7 +13,9 @@ env:
 
 jobs:
   test:
-    runs-on: dev-pl-sdk
+    # hz self-hosted DinD runner — this job runs pl-compose (docker compose up a
+    # Platforma backend), so it needs a real Docker daemon.
+    runs-on: hz-ubuntu-dind
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -32,7 +34,15 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
           github-token: ${{ steps.app-token.outputs.token }}
           aws-iam-role: ${{ secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
-          turbo-s3-bucket: ${{ secrets.AWS_CI_TURBOREPO_S3_BUCKET }}
+          # Caches → RGW: turbo to ci-turbo-cache, pnpm to ci-actions-cache (both
+          # use-fallback → GitHub). Shared org secrets/vars (selected to platforma).
+          turbo-s3-bucket: ${{ vars.HZ_CI_TURBO_S3_BUCKET }}
+          turbo-s3-endpoint: https://${{ vars.HZ_CI_TURBO_S3_ENDPOINT }}
+          turbo-s3-region: ${{ vars.HZ_CI_TURBO_S3_REGION }}
+          turbo-s3-access-key: ${{ secrets.HZ_CI_TURBO_S3_ACCESS_KEY }}
+          turbo-s3-secret-key: ${{ secrets.HZ_CI_TURBO_S3_SECRET_KEY }}
+          cache-s3-access-key: ${{ secrets.HZ_CI_CACHE_S3_ACCESS_KEY }}
+          cache-s3-secret-key: ${{ secrets.HZ_CI_CACHE_S3_SECRET_KEY }}
           quay-username: ${{ secrets.QUAY_USERNAME }}
           quay-robot-token: ${{ secrets.QUAY_ROBOT_TOKEN }}
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,7 @@ jobs:
   # 5. Publish
   # ──────────────────────────────────────────────
   publish:
-    runs-on: dev-pl-sdk
+    runs-on: hz-ubuntu-dind
     needs: [init, check-pnpm-consistency, test, check-changesets]
     if: ${{ !failure() && !cancelled() && needs.check-changesets.outputs.has-pending == 'true' }}
     steps:
@@ -79,7 +79,15 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
           github-token: ${{ steps.app-token.outputs.token }}
           aws-iam-role: ${{ secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
-          turbo-s3-bucket: ${{ secrets.AWS_CI_TURBOREPO_S3_BUCKET }}
+          # Caches → RGW: turbo to ci-turbo-cache, pnpm to ci-actions-cache (both
+          # use-fallback → GitHub). Shared org secrets/vars (selected to platforma).
+          turbo-s3-bucket: ${{ vars.HZ_CI_TURBO_S3_BUCKET }}
+          turbo-s3-endpoint: https://${{ vars.HZ_CI_TURBO_S3_ENDPOINT }}
+          turbo-s3-region: ${{ vars.HZ_CI_TURBO_S3_REGION }}
+          turbo-s3-access-key: ${{ secrets.HZ_CI_TURBO_S3_ACCESS_KEY }}
+          turbo-s3-secret-key: ${{ secrets.HZ_CI_TURBO_S3_SECRET_KEY }}
+          cache-s3-access-key: ${{ secrets.HZ_CI_CACHE_S3_ACCESS_KEY }}
+          cache-s3-secret-key: ${{ secrets.HZ_CI_CACHE_S3_SECRET_KEY }}
           quay-username: ${{ secrets.QUAY_USERNAME }}
           quay-robot-token: ${{ secrets.QUAY_ROBOT_TOKEN }}
 


### PR DESCRIPTION
## What

Switches platforma CI to the self-hosted **Hetzner k3s ARC runners** (`hz-ubuntu-dind`) with **RGW-backed caches**:

- **pnpm store** → `node/cache-pnpm-s3` (bucket `ci-actions-cache`)
- **turbo** → `turborepo/cache-s3` (bucket `ci-turbo-cache`)

Both use `use-fallback: true`, so a cache miss/endpoint hiccup falls back to the GitHub-hosted cache (non-fatal).

## Details

- Runs on the org-level `hz-ubuntu-dind` ARC runners (in-cluster on the hz fleet).
- Cache actions are pinned to the **released `@v4`** github-ci line (the S3 cache-s3 siblings were promoted via `github-ci#189`). Endpoint `s3.hz.platforma.bio`, region `us-east-1`, path-style.
- Credentials come from the org secrets `HZ_CI_CACHE_S3_*` / `HZ_CI_TURBO_S3_*` (scoped to this repo); buckets are GitOps-managed RGW `ObjectBucketClaim`s on the hz cluster.

## Status

CI is **green** on `hz-ubuntu-dind` against the released `@v4` actions (latest run passed). The RGW caches are confirmed populating (cache hits on re-runs).

Ready for review/merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates CI from `dev-pl-sdk` self-hosted runners to Hetzner k3s ARC (`hz-ubuntu-dind`) runners and introduces RGW-backed S3 caches for both the pnpm store and Turbo remote cache, with `use-fallback: true` so cache misses/endpoint issues gracefully fall back to GitHub-hosted cache.

- **Runner change**: Both `test` and `publish` jobs switch from `dev-pl-sdk` to `hz-ubuntu-dind` across `_test.yaml` and `main.yaml`.
- **Dual-cache S3 path**: `setup/action.yml` gains six new inputs (`cache-s3-*` and `turbo-s3-*`) to route pnpm store to `node/cache-pnpm-s3@v4` (RGW `ci-actions-cache` bucket) and configure the Turbo remote cache via step-scoped `S3_*` env vars against `ci-turbo-cache`.
- **Credential wiring**: RGW credentials come from org-level `HZ_CI_CACHE_S3_*` secrets and `HZ_CI_TURBO_S3_*` secrets/vars, replacing the old `AWS_CI_TURBOREPO_S3_BUCKET` secret.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; runner migration and RGW cache wiring are straightforward infrastructure changes confirmed working by a green CI run with observed cache hits.

The changes are CI-infrastructure only: runner label swap and new S3/RGW cache inputs. The design is intentional and well-commented. Two minor design gaps were noted — S3_USE_PATH_STYLE being unconditional regardless of whether a custom endpoint is present, and the pnpm cache step not exposing bucket/endpoint/region as overridable inputs — but neither affects current behaviour.

setup/action.yml deserves a second look for the unconditional S3_USE_PATH_STYLE flag and the hardcoded pnpm cache endpoint/bucket defaults; the workflow files are straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/setup/action.yml | Adds six new inputs and a conditional S3/RGW pnpm cache step; extends turbo cache step with step-scoped S3_* env vars. S3_USE_PATH_STYLE is always set when turbo-s3-bucket is non-empty, even when no custom endpoint is provided. |
| .github/workflows/_test.yaml | Switches runner to hz-ubuntu-dind and wires all HZ_CI_* secrets/vars for RGW caches. Mirrors main.yaml publish job configuration correctly. |
| .github/workflows/main.yaml | Switches publish job runner to hz-ubuntu-dind and wires HZ_CI_* secrets/vars identically to _test.yaml; no logic changes to publish flow itself. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Runner as hz-ubuntu-dind Runner
    participant RGW as RGW S3 Cache
    participant GHCache as GitHub Cache (fallback)
    participant AWS as AWS (OIDC / ECR)

    GH->>Runner: Dispatch job (test / publish)
    Runner->>Runner: checkout + setup Node.js + pnpm

    alt cache-s3-access-key is empty
        Runner->>GHCache: "actions/cache@v4 restore pnpm store"
        GHCache-->>Runner: HIT / MISS
    else cache-s3-access-key is set
        Runner->>RGW: "cache-pnpm-s3@v4 restore (ci-actions-cache bucket)"
        RGW-->>Runner: HIT / MISS
        note over Runner,GHCache: use-fallback=true on S3 error
    end

    Runner->>AWS: configure-aws-credentials (OIDC)
    Runner->>Runner: "turborepo/cache-s3@v4 starts background cache server"
    note over Runner,RGW: S3_ENDPOINT + S3_USE_PATH_STYLE=true (RGW path-style)

    Runner->>RGW: Turbo remote cache reads (ci-turbo-cache bucket)
    Runner->>Runner: pnpm install + build + test / publish
    Runner->>RGW: Turbo remote cache writes (ci-turbo-cache bucket)
    Runner->>RGW: "cache-pnpm-s3@v4 save pnpm store"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Runner as hz-ubuntu-dind Runner
    participant RGW as RGW S3 Cache
    participant GHCache as GitHub Cache (fallback)
    participant AWS as AWS (OIDC / ECR)

    GH->>Runner: Dispatch job (test / publish)
    Runner->>Runner: checkout + setup Node.js + pnpm

    alt cache-s3-access-key is empty
        Runner->>GHCache: "actions/cache@v4 restore pnpm store"
        GHCache-->>Runner: HIT / MISS
    else cache-s3-access-key is set
        Runner->>RGW: "cache-pnpm-s3@v4 restore (ci-actions-cache bucket)"
        RGW-->>Runner: HIT / MISS
        note over Runner,GHCache: use-fallback=true on S3 error
    end

    Runner->>AWS: configure-aws-credentials (OIDC)
    Runner->>Runner: "turborepo/cache-s3@v4 starts background cache server"
    note over Runner,RGW: S3_ENDPOINT + S3_USE_PATH_STYLE=true (RGW path-style)

    Runner->>RGW: Turbo remote cache reads (ci-turbo-cache bucket)
    Runner->>Runner: pnpm install + build + test / publish
    Runner->>RGW: Turbo remote cache writes (ci-turbo-cache bucket)
    Runner->>RGW: "cache-pnpm-s3@v4 save pnpm store"
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fsetup%2Faction.yml%3A136-140%0A%60S3_USE_PATH_STYLE%3A%20'true'%60%20is%20applied%20unconditionally%20whenever%20%60turbo-s3-bucket%60%20is%20set%2C%20even%20when%20%60turbo-s3-endpoint%60%20is%20empty%20%28i.e.%20pointing%20at%20standard%20AWS%20S3%29.%20AWS%20has%20deprecated%20path-style%20addressing%20for%20S3%20buckets%2C%20so%20forcing%20it%20without%20a%20custom%20endpoint%20could%20cause%20unexpected%20failures%20if%20this%20action%20is%20ever%20called%20with%20a%20plain%20AWS%20bucket%20and%20no%20RGW%20endpoint.%20Consider%20guarding%20the%20flag%20on%20the%20endpoint%20input%20being%20non-empty.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20S3_ACCESS_KEY%3A%20%24%7B%7B%20inputs.turbo-s3-access-key%20%7D%7D%0A%20%20%20%20%20%20%20%20S3_SECRET_KEY%3A%20%24%7B%7B%20inputs.turbo-s3-secret-key%20%7D%7D%0A%20%20%20%20%20%20%20%20S3_REGION%3A%20%24%7B%7B%20inputs.turbo-s3-region%20%7D%7D%0A%20%20%20%20%20%20%20%20S3_ENDPOINT%3A%20%24%7B%7B%20inputs.turbo-s3-endpoint%20%7D%7D%0A%20%20%20%20%20%20%20%20S3_USE_PATH_STYLE%3A%20%24%7B%7B%20inputs.turbo-s3-endpoint%20!%3D%20''%20%26%26%20'true'%20%7C%7C%20'false'%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Factions%2Fsetup%2Faction.yml%3A92-97%0A**pnpm%20S3%20cache%3A%20endpoint%2Fbucket%2Fregion%20not%20passthrough-configurable**%0A%0AThe%20%60cache-pnpm-s3%60%20call%20only%20forwards%20%60access-key%60%20and%20%60secret-key%60%3B%20the%20%60endpoint%60%20%28default%20%60s3.hz.platforma.bio%60%29%2C%20%60bucket%60%20%28default%20%60ci-actions-cache%60%29%2C%20and%20%60region%60%20%28default%20%60us-east-1%60%29%20are%20hardcoded%20inside%20the%20%5Baction%5D%28https%3A%2F%2Fgithub.com%2Fmilaboratory%2Fgithub-ci%2Fblob%2FHEAD%2Factions%2Fnode%2Fcache-pnpm-s3%2Faction.yaml%29.%20Any%20future%20caller%20of%20%60setup%2Faction.yml%60%20that%20needs%20a%20different%20RGW%20bucket%20or%20endpoint%20has%20no%20override%20path%20%E2%80%94%20they%20would%20need%20to%20modify%20the%20child%20action's%20defaults.%20Adding%20optional%20passthrough%20inputs%20%28%60cache-s3-endpoint%60%2C%20%60cache-s3-bucket%60%2C%20%60cache-s3-region%60%29%20here%20would%20keep%20the%20interface%20consistent%20with%20the%20turbo%20inputs%20and%20make%20reuse%20easier.%0A%0A&repo=milaboratory%2Fplatforma&pr=1713&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/actions/setup/action.yml:136-140
`S3_USE_PATH_STYLE: 'true'` is applied unconditionally whenever `turbo-s3-bucket` is set, even when `turbo-s3-endpoint` is empty (i.e. pointing at standard AWS S3). AWS has deprecated path-style addressing for S3 buckets, so forcing it without a custom endpoint could cause unexpected failures if this action is ever called with a plain AWS bucket and no RGW endpoint. Consider guarding the flag on the endpoint input being non-empty.

```suggestion
        S3_ACCESS_KEY: ${{ inputs.turbo-s3-access-key }}
        S3_SECRET_KEY: ${{ inputs.turbo-s3-secret-key }}
        S3_REGION: ${{ inputs.turbo-s3-region }}
        S3_ENDPOINT: ${{ inputs.turbo-s3-endpoint }}
        S3_USE_PATH_STYLE: ${{ inputs.turbo-s3-endpoint != '' && 'true' || 'false' }}
```

### Issue 2 of 2
.github/actions/setup/action.yml:92-97
**pnpm S3 cache: endpoint/bucket/region not passthrough-configurable**

The `cache-pnpm-s3` call only forwards `access-key` and `secret-key`; the `endpoint` (default `s3.hz.platforma.bio`), `bucket` (default `ci-actions-cache`), and `region` (default `us-east-1`) are hardcoded inside the [action](https://github.com/milaboratory/github-ci/blob/HEAD/actions/node/cache-pnpm-s3/action.yaml). Any future caller of `setup/action.yml` that needs a different RGW bucket or endpoint has no override path — they would need to modify the child action's defaults. Adding optional passthrough inputs (`cache-s3-endpoint`, `cache-s3-bucket`, `cache-s3-region`) here would keep the interface consistent with the turbo inputs and make reuse easier.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(hz): re-pin node/cache-pnpm-s3 @feat/..."](https://github.com/milaboratory/platforma/commit/2d1cb5367e16a11afed171e2a337640c8a7d88e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40859463)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->