### PR TITLE
polars-pf bump

### DIFF
--- a/.changeset/brave-badgers-sip.md
+++ b/.changeset/brave-badgers-sip.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+---
+
+polars-pf bump

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.51
+polars-pf==1.1.53
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^4.0.37
       version: 4.0.37
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.10.5
-      version: 1.10.5
+      specifier: 1.10.6
+      version: 1.10.6
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -3138,7 +3138,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.5
+        version: 1.10.6
       '@platforma-sdk/package-builder':
         specifier: workspace:*
         version: link:../../../tools/package-builder
@@ -3147,7 +3147,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.5
+        version: 1.10.6
       '@platforma-sdk/package-builder':
         specifier: 'workspace:'
         version: link:../../tools/package-builder
@@ -4159,7 +4159,7 @@ importers:
         version: link:../ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.5
+        version: 1.10.6
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.3(vitest@4.1.3)
@@ -5921,11 +5921,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0':
     resolution: {integrity: sha512-Z9OIHbWfq0OsTUvmJIK6HBm8qLIli5xxHlGsiNx012YU69snwgi2edioMjUQ1vr5eWPA/9+Xs8Ih9z+aWbmUpQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.19':
-    resolution: {integrity: sha512-8cqWtBASMmq9lAxD9Mz8PNiki8xYR/h7huW5+pGj07q8r+cxeCGuqP1T+sFgzU4aZ9Cr+xxIqQ2w8DiSWpox9A==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.20':
+    resolution: {integrity: sha512-A2+SYW2loIWrf33zbRjWimjsLx5scEOTL2VnTxlBQmuSWyxR1jjm711yaS+F76WoAMTBpaLbmwgO1WUP2cVAvg==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.5':
-    resolution: {integrity: sha512-Wd/LLjQ4XJI8LGxRj9eqKHhQQui4iAUXQI+BdWXHLqFEECUsuGpqXj27xOrojpsnzg9H0j9/QBUmApCMoZa32A==}
+  '@platforma-open/milaboratories.runenv-python-3@1.10.6':
+    resolution: {integrity: sha512-cAGuQ49mcagJsOPRb3EalJq8B5ADBeITrkCrnpattC7U2SjM+PkR60eqtt41CneaQZNP4DHjSGVNA8sKHSn+CA==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -12287,11 +12287,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.19': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.20': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.5':
+  '@platforma-open/milaboratories.runenv-python-3@1.10.6':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.19
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.20
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -297,7 +297,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.1.1
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.10.5
+  "@platforma-open/milaboratories.runenv-python-3": 1.10.6
 
   "shx": ^0.4.0
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps two dependencies used by the `ptabler` software package: `polars-pf` (Python, `1.1.51 → 1.1.53`) in `requirements.txt`, and the Node catalog entry `@platforma-open/milaboratories.runenv-python-3` (`1.10.5 → 1.10.6`) in `pnpm-workspace.yaml`, with the lockfile updated accordingly.

- **`polars-pf`** — PlatForm-specific Polars extension package pinned in the ptabler pip requirements. Advanced by two patch versions (`1.1.51 → 1.1.53`), skipping `1.1.52`; the pin remains exact (`==`), so no resolution ambiguity.
- **`runenv-python-3` / `runenv-python-3.12.10`** — Node packages bundling the Python 3 runtime environment for Platforma. The outer bundle moves from `1.10.5 → 1.10.6`; its transitive sub-package `runenv-python-3.12.10` advances from `1.3.19 → 1.3.20`. All three importer entries and the lockfile snapshot are updated consistently.
- A patch changeset (`brave-badgers-sip.md`) correctly records the release for `@platforma-open/milaboratories.software-ptabler`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Routine dependency bump with no logic changes; lockfile and catalog entries are all updated consistently.

Both dependency changes are exact-version pins with no wildcards introduced. The lockfile reflects all three importer entries and the snapshot section correctly. The changeset is appropriately scoped to the ptabler package at patch level.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/brave-badgers-sip.md | Patch changeset correctly marking the ptabler software package for a minor version release |
| lib/ptabler/software/src/requirements.txt | Bumps polars-pf from 1.1.51 to 1.1.53; all other pinned dependencies unchanged |
| pnpm-workspace.yaml | Catalog pin for runenv-python-3 updated from 1.10.5 to 1.10.6 |
| pnpm-lock.yaml | Lockfile updated consistently: runenv-python-3 → 1.10.6, runenv-python-3.12.10 → 1.3.20 across all three importers and snapshot sections |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ptabler["@platforma-open/milaboratories.software-ptabler\n(patch bump via changeset)"]
    req["lib/ptabler/software/src/requirements.txt\n(pip deps)"]
    ws["pnpm-workspace.yaml catalog\n@platforma-open/milaboratories.runenv-python-3"]

    ptabler --> req
    ptabler --> ws

    polars_pf["polars-pf\n1.1.51 → 1.1.53"]
    runenv3["runenv-python-3\n1.10.5 → 1.10.6"]
    runenv3_12["runenv-python-3.12.10\n1.3.19 → 1.3.20\n(transitive)"]

    req --> polars_pf
    ws --> runenv3
    runenv3 --> runenv3_12
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    ptabler["@platforma-open/milaboratories.software-ptabler\n(patch bump via changeset)"]
    req["lib/ptabler/software/src/requirements.txt\n(pip deps)"]
    ws["pnpm-workspace.yaml catalog\n@platforma-open/milaboratories.runenv-python-3"]

    ptabler --> req
    ptabler --> ws

    polars_pf["polars-pf\n1.1.51 → 1.1.53"]
    runenv3["runenv-python-3\n1.10.5 → 1.10.6"]
    runenv3_12["runenv-python-3.12.10\n1.3.19 → 1.3.20\n(transitive)"]

    req --> polars_pf
    ws --> runenv3
    runenv3 --> runenv3_12
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["polars-pf bump"](https://github.com/milaboratory/platforma/commit/b564ea24ba5d59b431c83f4050970cfc01cecdd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39544117)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->