### PR TITLE
fix(structurer): pass PL_DOCKER_* env through the build turbo task

### DIFF
--- a/.changeset/structurer-turbo-docker-env.md
+++ b/.changeset/structurer-turbo-docker-env.md
@@ -1,0 +1,18 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+structurer: pass `PL_DOCKER_*` env vars through the `build` turbo task
+
+The canonical root `turbo.json` only listed `PL_DOCKER_REGISTRY_PUSH_TO` in the
+`build` task's `env`. Turbo 2.x runs in strict env mode, so `PL_DOCKER_BUILD` and
+`PL_DOCKER_AUTOPUSH` (set by `build:dev-remote`) were stripped before `pl-pkg`
+ran. The docker image build+push was silently skipped while the emitted software
+descriptor still advertised a `docker.tag`, producing a green build whose image
+was never pushed — the backend then failed to pull it (`NotFound`). It also meant
+a failed `docker push` / login could never fail the build, because the push never
+ran.
+
+Widen the `env` glob to `PL_DOCKER_*` so the whole docker flow reaches `pl-pkg`.
+`build:dev-remote` now actually builds and pushes, and a push/login failure
+correctly fails the build (non-zero exit).

--- a/tools/block-tools/src/structure/templates/static/root/turbo.json
+++ b/tools/block-tools/src/structure/templates/static/root/turbo.json
@@ -12,7 +12,7 @@
     "build": {
       "dependsOn": ["^build", "check"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
+      "env": ["PL_PKG_DEV", "PL_DOCKER_*"],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"]
     },
     "build:dev": {


### PR DESCRIPTION
## Problem

A structured block's `build:dev-remote` (`PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build`) silently fails to push its docker image, and the build still exits 0. The backend then can't pull the image:

```
Failed to pull image "public.ecr.aws/.../gpu-info.main.bb4ac189ec21": ... not found
```

**Root cause.** The canonical root `turbo.json` (`templates/static/root/turbo.json`) declares the `build` task's env as:

```json
"env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"]
```

Turbo 2.x runs in **strict env mode**, so any var not listed is stripped from the task's environment. `PL_DOCKER_BUILD` and `PL_DOCKER_AUTOPUSH` never reach `pl-pkg`, so the docker build+push is skipped entirely — yet the emitted software descriptor still carries a `docker.tag`. Result: green build, no image pushed, backend `NotFound`. And a failed `docker push`/login can never fail the build, because the push never runs.

## Fix

Widen the glob so the whole docker flow reaches `pl-pkg`:

```diff
- "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
+ "env": ["PL_PKG_DEV", "PL_DOCKER_*"],
```

`PL_DOCKER_*` subsumes the previous `PL_DOCKER_REGISTRY_PUSH_TO` and adds `PL_DOCKER_BUILD`, `PL_DOCKER_AUTOPUSH`, `PL_DOCKER_REGISTRY`, etc.

## Verification (reproduced on `gpu-test`)

| turbo `env` | docker build | push | bad login | exit |
|-------------|--------------|------|-----------|------|
| `[PL_PKG_DEV, PL_DOCKER_REGISTRY_PUSH_TO]` (before) | skipped | never runs | n/a | **0 — green** |
| `[PL_PKG_DEV, PL_DOCKER_*]` (after) | ✅ | attempted | 403 Forbidden | **2 — fails** |

- `turbo.json` is root-scope (`when(!isSdkInternal)`), so `etc/blocks/*` are unaffected — no `check-blocks` impact.
- All 243 structurer tests pass.

## Rollout

Blocks pick this up via the structurer (`fixed("turbo.json", ...)` overwrites verbatim) on the next `upgrade-sdk` / `structure refresh` after this publishes.

Note: the local pre-push `block-tools#check` hook fails in this checkout on a pre-existing unrelated error (`Cannot find module '@inquirer/prompts'` — incomplete local link; the pkg is in the pnpm store). CI runs checks in a clean install.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent build failure where `build:dev-remote` for structured blocks never triggered docker image build/push because `PL_DOCKER_BUILD` and `PL_DOCKER_AUTOPUSH` were stripped by Turbo 2.x's strict env mode before reaching `pl-pkg`. The result was a green build with an unemitted image, later causing a backend `NotFound` pull failure.

- **Template `turbo.json` fix**: Replaces the explicit `"PL_DOCKER_REGISTRY_PUSH_TO"` entry in the `build` task's `env` array with the glob `"PL_DOCKER_*"`, which subsumes the previous var and adds `PL_DOCKER_BUILD`, `PL_DOCKER_AUTOPUSH`, `PL_DOCKER_REGISTRY`, `PL_DOCKER_NO_BUILD`, and `PL_DOCKER_NO_AUTOPUSH` — all vars the `pl-pkg` CLI reads to decide whether to build and push docker images.
- **Changeset**: Accurately describes the root cause and the fix as a `patch` on `@platforma-sdk/block-tools`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

A minimal, targeted one-line change in a static template file. The glob correctly captures all docker-related env vars that pl-pkg reads, and Turborepo 2.x explicitly documents wildcard support in env arrays.

The fix is a single token substitution in one template file, the root cause and solution are both well-understood and verified, glob support in Turbo env is documented, and the change is consistent with how the repo's own turbo.json handles analogous variables.

No files require special attention. turbo.json (template) is the only modified source file.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/templates/static/root/turbo.json | Single-line fix: replaces explicit PL_DOCKER_REGISTRY_PUSH_TO with the glob PL_DOCKER_* in the build task's env array so all docker-related vars reach pl-pkg under Turbo 2.x strict env mode. |
| .changeset/structurer-turbo-docker-env.md | New changeset for @platforma-sdk/block-tools at patch level; accurately describes root cause and fix with no issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant Turbo as Turbo 2.x (strict env)
    participant plpkg as pl-pkg
    participant Docker as Docker daemon / ECR

    Note over Dev,Docker: BEFORE fix — PL_DOCKER_BUILD & PL_DOCKER_AUTOPUSH stripped

    Dev->>Turbo: "turbo run build (PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1)"
    Turbo->>plpkg: env only contains PL_PKG_DEV, PL_DOCKER_REGISTRY_PUSH_TO
    plpkg->>plpkg: "PL_DOCKER_BUILD=false (default) → skip docker build"
    plpkg-->>Dev: exit 0 (green), descriptor has docker.tag
    Dev-->>Docker: (never pushed)
    Docker-->>Dev: NotFound on pull

    Note over Dev,Docker: AFTER fix — PL_DOCKER_* glob passes all docker vars

    Dev->>Turbo: "turbo run build (PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1)"
    Turbo->>plpkg: "env includes all PL_DOCKER_* vars"
    plpkg->>Docker: docker build
    Docker-->>plpkg: image built
    plpkg->>Docker: docker push
    Docker-->>plpkg: push result (success or 403)
    plpkg-->>Dev: exit 0 on success / non-zero on push failure
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant Turbo as Turbo 2.x (strict env)
    participant plpkg as pl-pkg
    participant Docker as Docker daemon / ECR

    Note over Dev,Docker: BEFORE fix — PL_DOCKER_BUILD & PL_DOCKER_AUTOPUSH stripped

    Dev->>Turbo: "turbo run build (PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1)"
    Turbo->>plpkg: env only contains PL_PKG_DEV, PL_DOCKER_REGISTRY_PUSH_TO
    plpkg->>plpkg: "PL_DOCKER_BUILD=false (default) → skip docker build"
    plpkg-->>Dev: exit 0 (green), descriptor has docker.tag
    Dev-->>Docker: (never pushed)
    Docker-->>Dev: NotFound on pull

    Note over Dev,Docker: AFTER fix — PL_DOCKER_* glob passes all docker vars

    Dev->>Turbo: "turbo run build (PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1)"
    Turbo->>plpkg: "env includes all PL_DOCKER_* vars"
    plpkg->>Docker: docker build
    Docker-->>plpkg: image built
    plpkg->>Docker: docker push
    Docker-->>plpkg: push result (success or 403)
    plpkg-->>Dev: exit 0 on success / non-zero on push failure
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(structurer): pass PL\_DOCKER\_\* env th..."](https://github.com/milaboratory/platforma/commit/d2b43c62dfdf2fd4e475633af8ff8433e7fce394) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39558598)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->