### PR TITLE
[MILAB-6431]: add setting for google OIDC

### DIFF
--- a/.changeset/light-shirts-prove.md
+++ b/.changeset/light-shirts-prove.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": minor
+---
+
+add settings for Google SSO

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,3 @@ work/
 __pycache__/
 .ruff_cache
 tests/mcp-server/.test_auth.json
-
-# Claude local settings
-CLAUDE.local.ms
-settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ work/
 __pycache__/
 .ruff_cache
 tests/mcp-server/.test_auth.json
+
+# Claude local settings
+CLAUDE.local.ms
+settings.local.json

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -259,6 +259,8 @@ service Platform {
   }
   rpc ListUserResources(AuthAPI.ListUserResources.Request) returns (stream AuthAPI.ListUserResources.Response) {}
 
+  rpc ListUsers(AuthAPI.ListUsers.Request) returns (AuthAPI.ListUsers.Response) {}
+
   //
   // Other stuff
   //
@@ -483,6 +485,7 @@ message TxAPI {
 
       AuthAPI.GrantAccess.Request grant_access = 410; // grant access to a resource within transaction
       AuthAPI.RevokeAccess.Request revoke_access = 411; // revoke access to a resource within transaction
+      AuthAPI.ListGrants.Request list_grants = 412; // list grants on a resource within transaction
     }
   }
 
@@ -585,6 +588,7 @@ message TxAPI {
 
       AuthAPI.GrantAccess.Response grant_access = 410;
       AuthAPI.RevokeAccess.Response revoke_access = 411;
+      AuthAPI.ListGrants.TxResponse list_grants = 412;
     }
 
     google.rpc.Status error = 3;
@@ -1866,6 +1870,10 @@ message AuthAPI {
     message Response {
       Grant grant = 1; // one per stream message
     }
+
+    message TxResponse {
+      repeated Grant grants = 1; // all grants for the resource in a single transactional response
+    }
   }
 
   message Grant {
@@ -1946,6 +1954,23 @@ message AuthAPI {
       bytes resource_signature = 2;
       Base.ResourceType resource_type = 3;
       Grant.Permissions permissions = 4;
+    }
+  }
+
+  message User {
+    // login is the stable identifier of the user — the grant target and the
+    // GetUserRoot key. Further fields (e.g. first name, last name, email) may
+    // be added later without breaking compatibility.
+    string login = 1;
+  }
+
+  message ListUsers {
+    message Request {}
+
+    // Lists users known to the server. A user becomes known on first login;
+    // provisioned users who have never logged in do not appear.
+    message Response {
+      repeated User users = 1;
     }
   }
 }

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -1703,8 +1703,9 @@ message AuthAPI {
       string user_id_claim = 8;
       string groups_claim = 9;
       FlowType flow_type = 10;
+      optional string access_type = 11; // "online" | "offline"; Google-specific (offline → refresh token)
 
-      // next free: 11;
+      // next free: 12;
     }
 
     message MethodInfo {
@@ -1739,6 +1740,15 @@ message AuthAPI {
     message PublicPKCE {
       string nonce = 1; // server-issued one-time value
       google.protobuf.Timestamp expires_at = 2; // after this, nonce is no longer valid (when enforced)
+      // Confidential-client secret for the IdP token exchange; absent for public clients.
+      // Rationale: Google's OIDC does not support public clients — it requires a
+      // client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+      // gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+      // leaving the server. So the backend holds the secret and forwards it here to the
+      // desktop, which performs the token exchange as a confidential client.
+      optional string client_secret = 3;
+
+      // next free: 4;
     }
 
     message Response {

--- a/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
@@ -155,22 +155,26 @@ message ResourceSchema {
   repeated FieldSchema fields = 2;
 
   message AccessFlags {
-    // Deny-list approach: default = allowed (true)
-    // Controllers set these to false to restrict non-controller roles (role='u', role='w')
+    // Allow-list approach: default = forbidden (false)
+    // Controllers set this to true allow non-controller roles (role='u', role='w')
     optional bool create_resource = 1; // default: true (creation allowed)
 
     // IMPORTANT: read_fields=false with write_fields=true is a forbidden combination
-    optional bool read_fields = 2; // default: true (reads allowed)
-    optional bool write_fields = 3; // default: true (writes allowed)
+    optional bool read_fields = 2; // default: false (reads denied)
+    optional bool write_fields = 3; // default: false (writes denied)
 
     // IMPORTANT: read_kv=false with write_kv=true is a forbidden combination
-    optional bool read_kv = 4; // if unset, falls back to read_fields
-    optional bool write_kv = 5; // if unset, falls back to write_fields
+    optional bool read_kv = 4; // default: false (KV reads denied)
+    optional bool write_kv = 5; // default: false (KV writes denied)
 
     // Per-field-type overrides (map: field_type → bool)
     // When defined for a field type, overrides resource-level flags
     map<uint32, bool> read_by_field_type = 6;
     map<uint32, bool> write_by_field_type = 7;
+
+    // Allows non-controller roles (role='u', role='w') to set error on the resource,
+    // marking it as failed and dropping it from recovery/deduplication indicies.
+    optional bool set_error = 8; // default: true (allowed)
   }
 
   // Access restriction flags for non-controller roles

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -851,6 +851,15 @@ components:
         expiresAt:
           type: string
           format: date-time
+        clientSecret:
+          type: string
+          description: |-
+            Confidential-client secret for the IdP token exchange; absent for public clients.
+             Rationale: Google's OIDC does not support public clients — it requires a
+             client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+             gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+             leaving the server. So the backend holds the secret and forwards it here to the
+             desktop, which performs the token exchange as a confidential client.
     AuthAPI_BeginSSOLogin_Request:
       type: object
       properties: {}
@@ -982,6 +991,8 @@ components:
         flowType:
           type: integer
           format: enum
+        accessType:
+          type: string
       description: |-
         SSOAuthMethod advertises an external IdP-based login flow. The desktop
          app uses the contents to drive the PKCE exchange locally, then hands the
@@ -1663,8 +1674,8 @@ components:
         createResource:
           type: boolean
           description: |-
-            Deny-list approach: default = allowed (true)
-             Controllers set these to false to restrict non-controller roles (role='u', role='w')
+            Allow-list approach: default = forbidden (false)
+             Controllers set this to true allow non-controller roles (role='u', role='w')
         readFields:
           type: boolean
           description: "IMPORTANT: read_fields=false with write_fields=true is a forbidden combination"
@@ -1689,10 +1700,8 @@ components:
         setError:
           type: boolean
           description: |-
-            SetError is a control-flow channel and is allowed by default even when
-             every other access bit is denied: a failing step on a closely-guarded
-             resource must surface to its caller. Controllers may opt out by
-             setting this to false.
+            Allows non-controller roles (role='u', role='w') to set error on the resource,
+             marking it as failed and dropping it from recovery/deduplication indicies.
     ResourceType:
       type: object
       properties:

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -3,1749 +3,1762 @@
 
 openapi: 3.0.3
 info:
-  title: Platform API
-  version: 1.0.0
+    title: Platform API
+    version: 1.0.0
 paths:
-  /v1/auth/grant-access:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GrantAccess
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GrantAccess_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GrantAccess_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/jwt-token:
-    post:
-      tags:
-        - Platform
-      description: |-
-        Deprecated: Use Login for session creation and role transitions,
-         and RefreshToken for token renewal. Backends implementing this API always return
-         codes.Unimplemented. Kept here so clients can still call old backends.
-      operationId: Platform_GetJWTToken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GetJWTToken_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GetJWTToken_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/login:
-    post:
-      tags:
-        - Platform
-      description: |-
-        Login authenticates with the given credentials and returns a new Platforma JWT.
-         Every Login call creates a new session. Use RefreshToken to renew an existing one.
-         This method is public: no Authorization header is required.
-      operationId: Platform_Login
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_Login_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_Login_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/methods:
-    get:
-      tags:
-        - Platform
-      description: Authentication
-      operationId: Platform_AuthMethods
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_ListMethods_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/mint-signature:
-    post:
-      tags:
-        - Platform
-      description: |-
-        MintSignature creates a resource signature bound to a target session.
-         Controllers use it during workflow bootstrap to pre-sign resources
-         so the workflow can access them under its own isolated session.
-      operationId: Platform_MintSignature
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_MintSignature_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_MintSignature_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/refresh:
-    post:
-      tags:
-        - Platform
-      description: |-
-        RefreshToken accepts a valid Platforma JWT and re-issues it with the same
-         session ID and role. Only the token expiration may be changed.
-         Workflow-scoped tokens cannot be refreshed; call Login instead.
-         This method is public: no Authorization header is required.
-      operationId: Platform_RefreshToken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_RefreshToken_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_RefreshToken_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/revoke-access:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_RevokeAccess
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_RevokeAccess_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_RevokeAccess_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/session-info:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetSessionInfo
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GetSessionInfo_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GetSessionInfo_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/sso/begin-login:
-    post:
-      tags:
-        - Platform
-      description: |-
-        BeginSSOLogin returns a fresh one-time nonce that the desktop must place
-         into the OIDC auth-request before redirecting to the IdP. Used by the SSO
-         login flow. This method is public: no Authorization header is required.
-      operationId: Platform_BeginSSOLogin
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/user-root:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetUserRoot
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GetUserRoot_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GetUserRoot_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/aliases-and-urls:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_WriteControllerAliasesAndUrls
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-    delete:
-      tags:
-        - Platform
-      operationId: Platform_RemoveControllerAliasesAndUrls
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/attach-subscription:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerAttachSubscription
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_AttachSubscription_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_AttachSubscription_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/create:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerCreate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Create_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Create_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/deregister:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerDeregister
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Deregister_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Deregister_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/exists:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerExists
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Exists_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Exists_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/features:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerSetFeatures
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_SetFeatures_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_SetFeatures_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-    delete:
-      tags:
-        - Platform
-      operationId: Platform_ControllerClearFeatures
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_ClearFeatures_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_ClearFeatures_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/get:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerGet
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Get_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Get_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/notifications:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetControllerNotifications
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_GetNotifications_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_GetNotifications_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/register:
-    post:
-      tags:
-        - Platform
-      description: Controllers
-      operationId: Platform_ControllerRegister
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Register_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Register_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/update:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerUpdate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Update_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Update_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/url:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetControllerUrl
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_GetUrl_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_GetUrl_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/license:
-    get:
-      tags:
-        - Platform
-      operationId: Platform_License
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MaintenanceAPI_License_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lease/create:
-    post:
-      tags:
-        - Platform
-      description: |-
-        LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
-         Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
-         To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
-      operationId: Platform_LeaseResource
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_Lease_Create_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_Lease_Create_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lease/release:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ReleaseLease
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_Lease_Release_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_Lease_Release_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lease/update:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_UpdateLease
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_Lease_Update_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_Lease_Update_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lock/create:
-    post:
-      tags:
-        - Platform
-      description: |-
-        LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
-           - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
-           - list resource's fields, take fields with names set in request
-           - get resolved values of listed fields (IDs of 'ON' resources).
-           - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
+    /v1/auth/grant-access:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GrantAccess
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GrantAccess_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GrantAccess_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/jwt-token:
+        post:
+            tags:
+                - Platform
+            description: |-
+                Deprecated: Use Login for session creation and role transitions,
+                 and RefreshToken for token renewal. Backends implementing this API always return
+                 codes.Unimplemented. Kept here so clients can still call old backends.
+            operationId: Platform_GetJWTToken
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GetJWTToken_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GetJWTToken_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/login:
+        post:
+            tags:
+                - Platform
+            description: |-
+                Login authenticates with the given credentials and returns a new Platforma JWT.
+                 Every Login call creates a new session. Use RefreshToken to renew an existing one.
+                 This method is public: no Authorization header is required.
+            operationId: Platform_Login
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_Login_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_Login_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/methods:
+        get:
+            tags:
+                - Platform
+            description: Authentication
+            operationId: Platform_AuthMethods
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_ListMethods_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/mint-signature:
+        post:
+            tags:
+                - Platform
+            description: |-
+                MintSignature creates a resource signature bound to a target session.
+                 Controllers use it during workflow bootstrap to pre-sign resources
+                 so the workflow can access them under its own isolated session.
+            operationId: Platform_MintSignature
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_MintSignature_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_MintSignature_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/refresh:
+        post:
+            tags:
+                - Platform
+            description: |-
+                RefreshToken accepts a valid Platforma JWT and re-issues it with the same
+                 session ID and role. Only the token expiration may be changed.
+                 Workflow-scoped tokens cannot be refreshed; call Login instead.
+                 This method is public: no Authorization header is required.
+            operationId: Platform_RefreshToken
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_RefreshToken_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_RefreshToken_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/revoke-access:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_RevokeAccess
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_RevokeAccess_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_RevokeAccess_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/session-info:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetSessionInfo
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GetSessionInfo_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GetSessionInfo_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/sso/begin-login:
+        post:
+            tags:
+                - Platform
+            description: |-
+                BeginSSOLogin returns a fresh one-time nonce that the desktop must place
+                 into the OIDC auth-request before redirecting to the IdP. Used by the SSO
+                 login flow. This method is public: no Authorization header is required.
+            operationId: Platform_BeginSSOLogin
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/user-root:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetUserRoot
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GetUserRoot_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GetUserRoot_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/aliases-and-urls:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_WriteControllerAliasesAndUrls
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Platform
+            operationId: Platform_RemoveControllerAliasesAndUrls
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/attach-subscription:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerAttachSubscription
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_AttachSubscription_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_AttachSubscription_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/create:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerCreate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Create_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Create_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/deregister:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerDeregister
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Deregister_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Deregister_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/exists:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerExists
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Exists_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Exists_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/features:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerSetFeatures
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_SetFeatures_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_SetFeatures_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Platform
+            operationId: Platform_ControllerClearFeatures
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_ClearFeatures_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_ClearFeatures_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/get:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerGet
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Get_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Get_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/notifications:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetControllerNotifications
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_GetNotifications_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_GetNotifications_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/register:
+        post:
+            tags:
+                - Platform
+            description: Controllers
+            operationId: Platform_ControllerRegister
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Register_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Register_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/update:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerUpdate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Update_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Update_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/url:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetControllerUrl
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_GetUrl_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_GetUrl_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/license:
+        get:
+            tags:
+                - Platform
+            operationId: Platform_License
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MaintenanceAPI_License_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lease/create:
+        post:
+            tags:
+                - Platform
+            description: |-
+                LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
+                 Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
+                 To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
+            operationId: Platform_LeaseResource
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_Lease_Create_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_Lease_Create_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lease/release:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ReleaseLease
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_Lease_Release_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_Lease_Release_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lease/update:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_UpdateLease
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_Lease_Update_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_Lease_Update_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lock/create:
+        post:
+            tags:
+                - Platform
+            description: |-
+                LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
+                   - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
+                   - list resource's fields, take fields with names set in request
+                   - get resolved values of listed fields (IDs of 'ON' resources).
+                   - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
 
-         Lock logic constraints:
-           - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
-             succeeds, while the other fails with an error (no long waiting)
-           - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
-             the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
-           - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
-             being lockable. An attempt to lock a resource that has not become original will fail.
-           - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
-      operationId: Platform_LockFieldValues
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/notifications/get:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_NotificationsGet
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/NotificationAPI_Get_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NotificationAPI_Get_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/ping:
-    get:
-      tags:
-        - Platform
-      description: Various service requests
-      operationId: Platform_Ping
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MaintenanceAPI_Ping_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/resource-types:
-    get:
-      tags:
-        - Platform
-      description: Other stuff
-      operationId: Platform_ListResourceTypes
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MiscAPI_ListResourceTypes_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/subscription/attach-filter:
-    post:
-      tags:
-        - Platform
-      description: Subscriptions
-      operationId: Platform_SubscriptionAttachFilter
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SubscriptionAPI_AttachFilter_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionAPI_AttachFilter_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/subscription/detach-filter:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_SubscriptionDetachFilter
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SubscriptionAPI_DetachFilter_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionAPI_DetachFilter_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/tx-sync:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_TxSync
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TxAPI_Sync_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TxAPI_Sync_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
+                 Lock logic constraints:
+                   - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
+                     succeeds, while the other fails with an error (no long waiting)
+                   - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
+                     the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
+                   - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
+                     being lockable. An attempt to lock a resource that has not become original will fail.
+                   - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
+            operationId: Platform_LockFieldValues
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/notifications/get:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_NotificationsGet
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/NotificationAPI_Get_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/NotificationAPI_Get_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/ping:
+        get:
+            tags:
+                - Platform
+            description: Various service requests
+            operationId: Platform_Ping
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MaintenanceAPI_Ping_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/resource-types:
+        get:
+            tags:
+                - Platform
+            description: Other stuff
+            operationId: Platform_ListResourceTypes
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MiscAPI_ListResourceTypes_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/subscription/attach-filter:
+        post:
+            tags:
+                - Platform
+            description: Subscriptions
+            operationId: Platform_SubscriptionAttachFilter
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SubscriptionAPI_AttachFilter_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SubscriptionAPI_AttachFilter_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/subscription/detach-filter:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_SubscriptionDetachFilter
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SubscriptionAPI_DetachFilter_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SubscriptionAPI_DetachFilter_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/tx-sync:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_TxSync
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TxAPI_Sync_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/TxAPI_Sync_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
-  schemas:
-    AuthAPI_BeginSSOLogin_PublicPKCE:
-      type: object
-      properties:
-        nonce:
-          type: string
-        expiresAt:
-          type: string
-          format: date-time
-    AuthAPI_BeginSSOLogin_Request:
-      type: object
-      properties: {}
-    AuthAPI_BeginSSOLogin_Response:
-      type: object
-      properties:
-        publicPkce:
-          $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_PublicPKCE"
-    AuthAPI_GetJWTToken_Request:
-      type: object
-      properties:
-        expiration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        requestedRole:
-          type: integer
-          format: enum
-    AuthAPI_GetJWTToken_Response:
-      type: object
-      properties:
-        token:
-          type: string
-        sessionId:
-          type: string
-          description: Session info fields
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_GetSessionInfo_Request:
-      type: object
-      properties: {}
-    AuthAPI_GetSessionInfo_Response:
-      type: object
-      properties:
-        sessionId:
-          type: string
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_GetUserRoot_Request:
-      type: object
-      properties:
-        login:
-          type: string
-        createIfNotExists:
-          type: boolean
-    AuthAPI_GetUserRoot_Response:
-      type: object
-      properties:
-        userRoot:
-          $ref: "#/components/schemas/AuthAPI_UserRoot"
-    AuthAPI_GrantAccess_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        targetUser:
-          type: string
-        permissions:
-          $ref: "#/components/schemas/AuthAPI_Grant_Permissions"
-        grantType:
-          type: integer
-          format: enum
-    AuthAPI_GrantAccess_Response:
-      type: object
-      properties: {}
-    AuthAPI_Grant_Permissions:
-      type: object
-      properties:
-        writable:
-          type: boolean
-      description: Permissions describes access level for a grant.
-    AuthAPI_ListMethods_BasicAuthMethod:
-      type: object
-      properties: {}
-    AuthAPI_ListMethods_MethodInfo:
-      type: object
-      properties:
-        id:
-          type: string
-          description: |-
-            id is the stable, machine-readable identifier of the login method
-             instance. Unique across the entire server.
-        description:
-          type: string
-          description: description is the human-readable label in case we'd like to render it in UI.
-        basic:
-          $ref: "#/components/schemas/AuthAPI_ListMethods_BasicAuthMethod"
-        token:
-          $ref: "#/components/schemas/AuthAPI_ListMethods_TokenAuthMethod"
-        sso:
-          $ref: "#/components/schemas/AuthAPI_ListMethods_SSOAuthMethod"
-    AuthAPI_ListMethods_Response:
-      type: object
-      properties:
-        methods:
-          type: array
-          items:
-            $ref: "#/components/schemas/AuthAPI_ListMethods_MethodInfo"
-    AuthAPI_ListMethods_SSOAuthMethod:
-      type: object
-      properties:
-        issuer:
-          type: string
-        clientId:
-          type: string
-        scopes:
-          type: string
-        resource:
-          type: string
-        prompt:
-          type: string
-        redirectPorts:
-          type: array
-          items:
-            type: integer
-            format: uint32
-        subjectTokenSource:
-          type: string
-        userIdClaim:
-          type: string
-        groupsClaim:
-          type: string
-        flowType:
-          type: integer
-          format: enum
-      description: |-
-        SSOAuthMethod advertises an external IdP-based login flow. The desktop
-         app uses the contents to drive the PKCE exchange locally, then hands the
-         resulting IdP token-response back via Login.SSOCredentials.
-    AuthAPI_ListMethods_TokenAuthMethod:
-      type: object
-      properties: {}
-    AuthAPI_Login_BasicCredentials:
-      type: object
-      properties:
-        login:
-          type: string
-        password:
-          type: string
-    AuthAPI_Login_Request:
-      type: object
-      properties:
-        basic:
-          $ref: "#/components/schemas/AuthAPI_Login_BasicCredentials"
-        token:
-          $ref: "#/components/schemas/AuthAPI_Login_TokenCredentials"
-        sso:
-          $ref: "#/components/schemas/AuthAPI_Login_SSOCredentials"
-        expiration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        requestedRole:
-          type: integer
-          format: enum
-    AuthAPI_Login_Response:
-      type: object
-      properties:
-        token:
-          type: string
-        sessionId:
-          type: string
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_Login_SSOCredentials:
-      type: object
-      properties:
-        tokenResponse:
-          type: string
-          format: bytes
-      description: |-
-        SSOCredentials carries the raw JSON body returned by the IdP's /token
-         endpoint after the desktop completes a PKCE exchange.
-    AuthAPI_Login_TokenCredentials:
-      type: object
-      properties:
-        token:
-          type: string
-          format: bytes
-      description: |-
-        TokenCredentials accepts any opaque bearer-style string: a controller
-         pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
-    AuthAPI_MintSignature_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        targetSid:
-          type: string
-          format: bytes
-        color:
-          $ref: "#/components/schemas/Color"
-    AuthAPI_MintSignature_Response:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-    AuthAPI_RefreshToken_Request:
-      type: object
-      properties:
-        token:
-          type: string
-        expiration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-    AuthAPI_RefreshToken_Response:
-      type: object
-      properties:
-        token:
-          type: string
-        sessionId:
-          type: string
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_RevokeAccess_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        targetUser:
-          type: string
-    AuthAPI_RevokeAccess_Response:
-      type: object
-      properties: {}
-    AuthAPI_UserRoot:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-    Color:
-      type: object
-      properties:
-        root:
-          type: string
-        permissions:
-          type: integer
-          format: uint32
-    Controller:
-      type: object
-      properties:
-        type:
-          type: string
-        id:
-          type: string
-        subscriptionID:
-          type: string
-    ControllerAPI_AttachSubscription_Request:
-      type: object
-      properties:
-        controllerId:
-          type: string
-        subscriptionId:
-          type: string
-    ControllerAPI_AttachSubscription_Response:
-      type: object
-      properties: {}
-    ControllerAPI_ClearFeatures_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_ClearFeatures_Response:
-      type: object
-      properties: {}
-    ControllerAPI_Create_Request:
-      type: object
-      properties:
-        id:
-          type: string
-        controllerType:
-          type: string
-    ControllerAPI_Create_Response:
-      type: object
-      properties:
-        controllerId:
-          type: string
-    ControllerAPI_Deregister_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_Deregister_Response:
-      type: object
-      properties: {}
-    ControllerAPI_Exists_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_Exists_Response:
-      type: object
-      properties:
-        exists:
-          type: boolean
-    ControllerAPI_GetNotifications_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        maxNotifications:
-          type: integer
-          format: uint32
-    ControllerAPI_GetNotifications_Response:
-      type: object
-      properties:
-        notifications:
-          type: array
-          items:
-            $ref: "#/components/schemas/Notification"
-    ControllerAPI_GetUrl_Request:
-      type: object
-      properties:
-        controllerAlias:
-          type: string
-        resourceId:
-          type: string
-    ControllerAPI_GetUrl_Response:
-      type: object
-      properties:
-        controllerUrl:
-          type: string
-    ControllerAPI_Get_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_Get_Response:
-      type: object
-      properties:
-        controller:
-          $ref: "#/components/schemas/Controller"
-    ControllerAPI_Register_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        filters:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/NotificationFilter"
-        resourceSchemas:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceSchema"
-    ControllerAPI_Register_Response:
-      type: object
-      properties:
-        controllerId:
-          type: string
-        subscriptionId:
-          type: string
-    ControllerAPI_RemoveAliasesAndUrls_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_RemoveAliasesAndUrls_Response:
-      type: object
-      properties: {}
-    ControllerAPI_SetFeatures_Request:
-      type: object
-      properties:
-        features:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceAPIFeature"
-    ControllerAPI_SetFeatures_Response:
-      type: object
-      properties: {}
-    ControllerAPI_Update_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        filters:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/NotificationFilter"
-        resourceSchemas:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceSchema"
-    ControllerAPI_Update_Response:
-      type: object
-      properties: {}
-    ControllerAPI_WriteAliasesAndUrls_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        aliasesToUrls:
-          type: object
-          additionalProperties:
-            type: string
-    ControllerAPI_WriteAliasesAndUrls_Response:
-      type: object
-      properties: {}
-    Field:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: "#/components/schemas/FieldRef"
-          description: field ID is always combination of parent resource ID and field name
-        type:
-          type: integer
-          format: enum
-        features:
-          $ref: "#/components/schemas/Resource_Features"
-        value:
-          type: string
-          description: |-
-            _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
-             If a field refers to another field, it will get
-             a value only when this chain of references ends up with a direct resource
-             reference. At that moment, all fields in the chain will get their values
-             resolved and will start to refer to the same resource directly.
-        valueSignature:
-          type: string
-          description: |-
-            Signature for value resource ID, inheriting the parent resource's color.
-             Populated server-side when the parent resource has a known color in the current TX.
-          format: bytes
-        valueStatus:
-          type: integer
-          description: Whether the value is empty, assigned, or finally resolved.
-          format: enum
-        valueIsFinal:
-          type: boolean
-          description: If the value is in its final state (ready, duplicate or error)
-        error:
-          type: string
-          description: |-
-            Error resource ID, if any.
-             Is intended to report problems _from_ the platform to the client.
-        errorSignature:
-          type: string
-          description: Signature for error resource ID, inheriting the parent resource's color.
-          format: bytes
-    FieldRef:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        fieldName:
-          type: string
-    FieldSchema:
-      type: object
-      properties:
-        type:
-          type: integer
-          format: enum
-        name:
-          type: string
-    GoogleProtobufAny:
-      type: object
-      properties:
-        "@type":
-          type: string
-          description: The type of the serialized message.
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-    LocksAPI_Lease_Create_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        timeout:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        name:
-          type: string
-    LocksAPI_Lease_Create_Response:
-      type: object
-      properties:
-        leaseId:
-          type: string
-          format: bytes
-    LocksAPI_Lease_Release_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        leaseId:
-          type: string
-          format: bytes
-    LocksAPI_Lease_Release_Response:
-      type: object
-      properties: {}
-    LocksAPI_Lease_Update_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        leaseId:
-          type: string
-          format: bytes
-        timeout:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        name:
-          type: string
-    LocksAPI_Lease_Update_Response:
-      type: object
-      properties: {}
-    LocksAPI_LockFieldValues_Create_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        lockReferencesOf:
-          type: array
-          items:
-            type: string
-        comment:
-          type: string
-    LocksAPI_LockFieldValues_Create_Response:
-      type: object
-      properties:
-        acquired:
-          type: boolean
-          description: |-
-            true when lock was acquired (new, or already owned by the owner)
-             Client MUST pay attention to this flag, as it shows if lock was successful.
-        conflictingLocks:
-          type: array
-          items:
-            $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Response_LockInfo"
-          description: |-
-            Info about why lock was not acquired.
-             Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
-             The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
-        conflictsListTruncated:
-          type: boolean
-    LocksAPI_LockFieldValues_Create_Response_LockInfo:
-      type: object
-      properties:
-        targetId:
-          type: string
-        fieldName:
-          type: string
-        lockedBy:
-          type: string
-        lockedAt:
-          type: string
-          format: date-time
-        comment:
-          type: string
-    MaintenanceAPI_License_Response:
-      type: object
-      properties:
-        status:
-          type: integer
-          format: int32
-        isOk:
-          type: boolean
-        responseBody:
-          type: string
-          description: Raw response body as it was received from the license server.
-          format: bytes
-    MaintenanceAPI_Ping_Response:
-      type: object
-      properties:
-        coreVersion:
-          type: string
-        coreFullVersion:
-          type: string
-        compression:
-          type: integer
-          format: enum
-        instanceId:
-          type: string
-          description: |-
-            instanceID is a unique ID that changes when we reset DB state.
-             If we reset a state and a database, but the address of the backend is still the same,
-             without instanceID we are not sure if it's the same state or not,
-             and UI can't detect it and clear its state (e.g. caches of drivers).
-        platform:
-          type: string
-        os:
-          type: string
-        arch:
-          type: string
-        capabilities:
-          type: array
-          items:
-            type: string
-          description: |-
-            Opt-in capabilities advertised by this server instance, used by
-             clients to pick between fast and fallback code paths without waiting
-             for a failed RPC.
+    schemas:
+        AuthAPI_BeginSSOLogin_PublicPKCE:
+            type: object
+            properties:
+                nonce:
+                    type: string
+                expiresAt:
+                    type: string
+                    format: date-time
+        AuthAPI_BeginSSOLogin_Request:
+            type: object
+            properties: {}
+        AuthAPI_BeginSSOLogin_Response:
+            type: object
+            properties:
+                publicPkce:
+                    $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_PublicPKCE'
+        AuthAPI_GetJWTToken_Request:
+            type: object
+            properties:
+                expiration:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                requestedRole:
+                    type: integer
+                    format: enum
+        AuthAPI_GetJWTToken_Response:
+            type: object
+            properties:
+                token:
+                    type: string
+                sessionId:
+                    type: string
+                    description: Session info fields
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_GetSessionInfo_Request:
+            type: object
+            properties: {}
+        AuthAPI_GetSessionInfo_Response:
+            type: object
+            properties:
+                sessionId:
+                    type: string
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_GetUserRoot_Request:
+            type: object
+            properties:
+                login:
+                    type: string
+                createIfNotExists:
+                    type: boolean
+        AuthAPI_GetUserRoot_Response:
+            type: object
+            properties:
+                userRoot:
+                    $ref: '#/components/schemas/AuthAPI_UserRoot'
+        AuthAPI_GrantAccess_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                targetUser:
+                    type: string
+                permissions:
+                    $ref: '#/components/schemas/AuthAPI_Grant_Permissions'
+                grantType:
+                    type: integer
+                    format: enum
+        AuthAPI_GrantAccess_Response:
+            type: object
+            properties: {}
+        AuthAPI_Grant_Permissions:
+            type: object
+            properties:
+                writable:
+                    type: boolean
+            description: Permissions describes access level for a grant.
+        AuthAPI_ListMethods_BasicAuthMethod:
+            type: object
+            properties: {}
+        AuthAPI_ListMethods_MethodInfo:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: |-
+                        id is the stable, machine-readable identifier of the login method
+                         instance. Unique across the entire server.
+                description:
+                    type: string
+                    description: description is the human-readable label in case we'd like to render it in UI.
+                basic:
+                    $ref: '#/components/schemas/AuthAPI_ListMethods_BasicAuthMethod'
+                token:
+                    $ref: '#/components/schemas/AuthAPI_ListMethods_TokenAuthMethod'
+                sso:
+                    $ref: '#/components/schemas/AuthAPI_ListMethods_SSOAuthMethod'
+        AuthAPI_ListMethods_Response:
+            type: object
+            properties:
+                methods:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AuthAPI_ListMethods_MethodInfo'
+        AuthAPI_ListMethods_SSOAuthMethod:
+            type: object
+            properties:
+                issuer:
+                    type: string
+                clientId:
+                    type: string
+                scopes:
+                    type: string
+                resource:
+                    type: string
+                prompt:
+                    type: string
+                redirectPorts:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                subjectTokenSource:
+                    type: string
+                userIdClaim:
+                    type: string
+                groupsClaim:
+                    type: string
+                flowType:
+                    type: integer
+                    format: enum
+            description: |-
+                SSOAuthMethod advertises an external IdP-based login flow. The desktop
+                 app uses the contents to drive the PKCE exchange locally, then hands the
+                 resulting IdP token-response back via Login.SSOCredentials.
+        AuthAPI_ListMethods_TokenAuthMethod:
+            type: object
+            properties: {}
+        AuthAPI_Login_BasicCredentials:
+            type: object
+            properties:
+                login:
+                    type: string
+                password:
+                    type: string
+        AuthAPI_Login_Request:
+            type: object
+            properties:
+                basic:
+                    $ref: '#/components/schemas/AuthAPI_Login_BasicCredentials'
+                token:
+                    $ref: '#/components/schemas/AuthAPI_Login_TokenCredentials'
+                sso:
+                    $ref: '#/components/schemas/AuthAPI_Login_SSOCredentials'
+                expiration:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                requestedRole:
+                    type: integer
+                    format: enum
+        AuthAPI_Login_Response:
+            type: object
+            properties:
+                token:
+                    type: string
+                sessionId:
+                    type: string
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_Login_SSOCredentials:
+            type: object
+            properties:
+                tokenResponse:
+                    type: string
+                    format: bytes
+            description: |-
+                SSOCredentials carries the raw JSON body returned by the IdP's /token
+                 endpoint after the desktop completes a PKCE exchange.
+        AuthAPI_Login_TokenCredentials:
+            type: object
+            properties:
+                token:
+                    type: string
+                    format: bytes
+            description: |-
+                TokenCredentials accepts any opaque bearer-style string: a controller
+                 pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
+        AuthAPI_MintSignature_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                targetSid:
+                    type: string
+                    format: bytes
+                color:
+                    $ref: '#/components/schemas/Color'
+        AuthAPI_MintSignature_Response:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+        AuthAPI_RefreshToken_Request:
+            type: object
+            properties:
+                token:
+                    type: string
+                expiration:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+        AuthAPI_RefreshToken_Response:
+            type: object
+            properties:
+                token:
+                    type: string
+                sessionId:
+                    type: string
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_RevokeAccess_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                targetUser:
+                    type: string
+        AuthAPI_RevokeAccess_Response:
+            type: object
+            properties: {}
+        AuthAPI_UserRoot:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+        Color:
+            type: object
+            properties:
+                root:
+                    type: string
+                permissions:
+                    type: integer
+                    format: uint32
+        Controller:
+            type: object
+            properties:
+                type:
+                    type: string
+                id:
+                    type: string
+                subscriptionID:
+                    type: string
+        ControllerAPI_AttachSubscription_Request:
+            type: object
+            properties:
+                controllerId:
+                    type: string
+                subscriptionId:
+                    type: string
+        ControllerAPI_AttachSubscription_Response:
+            type: object
+            properties: {}
+        ControllerAPI_ClearFeatures_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_ClearFeatures_Response:
+            type: object
+            properties: {}
+        ControllerAPI_Create_Request:
+            type: object
+            properties:
+                id:
+                    type: string
+                controllerType:
+                    type: string
+        ControllerAPI_Create_Response:
+            type: object
+            properties:
+                controllerId:
+                    type: string
+        ControllerAPI_Deregister_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_Deregister_Response:
+            type: object
+            properties: {}
+        ControllerAPI_Exists_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_Exists_Response:
+            type: object
+            properties:
+                exists:
+                    type: boolean
+        ControllerAPI_GetNotifications_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                maxNotifications:
+                    type: integer
+                    format: uint32
+        ControllerAPI_GetNotifications_Response:
+            type: object
+            properties:
+                notifications:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Notification'
+        ControllerAPI_GetUrl_Request:
+            type: object
+            properties:
+                controllerAlias:
+                    type: string
+                resourceId:
+                    type: string
+        ControllerAPI_GetUrl_Response:
+            type: object
+            properties:
+                controllerUrl:
+                    type: string
+        ControllerAPI_Get_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_Get_Response:
+            type: object
+            properties:
+                controller:
+                    $ref: '#/components/schemas/Controller'
+        ControllerAPI_Register_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                filters:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/NotificationFilter'
+                resourceSchemas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceSchema'
+        ControllerAPI_Register_Response:
+            type: object
+            properties:
+                controllerId:
+                    type: string
+                subscriptionId:
+                    type: string
+        ControllerAPI_RemoveAliasesAndUrls_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_RemoveAliasesAndUrls_Response:
+            type: object
+            properties: {}
+        ControllerAPI_SetFeatures_Request:
+            type: object
+            properties:
+                features:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceAPIFeature'
+        ControllerAPI_SetFeatures_Response:
+            type: object
+            properties: {}
+        ControllerAPI_Update_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                filters:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/NotificationFilter'
+                resourceSchemas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceSchema'
+        ControllerAPI_Update_Response:
+            type: object
+            properties: {}
+        ControllerAPI_WriteAliasesAndUrls_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                aliasesToUrls:
+                    type: object
+                    additionalProperties:
+                        type: string
+        ControllerAPI_WriteAliasesAndUrls_Response:
+            type: object
+            properties: {}
+        Field:
+            type: object
+            properties:
+                id:
+                    allOf:
+                        - $ref: '#/components/schemas/FieldRef'
+                    description: field ID is always combination of parent resource ID and field name
+                type:
+                    type: integer
+                    format: enum
+                features:
+                    $ref: '#/components/schemas/Resource_Features'
+                value:
+                    type: string
+                    description: |-
+                        _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
+                         If a field refers to another field, it will get
+                         a value only when this chain of references ends up with a direct resource
+                         reference. At that moment, all fields in the chain will get their values
+                         resolved and will start to refer to the same resource directly.
+                valueSignature:
+                    type: string
+                    description: |-
+                        Signature for value resource ID, inheriting the parent resource's color.
+                         Populated server-side when the parent resource has a known color in the current TX.
+                    format: bytes
+                valueStatus:
+                    type: integer
+                    description: Whether the value is empty, assigned, or finally resolved.
+                    format: enum
+                valueIsFinal:
+                    type: boolean
+                    description: If the value is in its final state (ready, duplicate or error)
+                error:
+                    type: string
+                    description: |-
+                        Error resource ID, if any.
+                         Is intended to report problems _from_ the platform to the client.
+                errorSignature:
+                    type: string
+                    description: Signature for error resource ID, inheriting the parent resource's color.
+                    format: bytes
+        FieldRef:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                fieldName:
+                    type: string
+        FieldSchema:
+            type: object
+            properties:
+                type:
+                    type: integer
+                    format: enum
+                name:
+                    type: string
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        LocksAPI_Lease_Create_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                timeout:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                name:
+                    type: string
+        LocksAPI_Lease_Create_Response:
+            type: object
+            properties:
+                leaseId:
+                    type: string
+                    format: bytes
+        LocksAPI_Lease_Release_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                leaseId:
+                    type: string
+                    format: bytes
+        LocksAPI_Lease_Release_Response:
+            type: object
+            properties: {}
+        LocksAPI_Lease_Update_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                leaseId:
+                    type: string
+                    format: bytes
+                timeout:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                name:
+                    type: string
+        LocksAPI_Lease_Update_Response:
+            type: object
+            properties: {}
+        LocksAPI_LockFieldValues_Create_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                lockReferencesOf:
+                    type: array
+                    items:
+                        type: string
+                comment:
+                    type: string
+        LocksAPI_LockFieldValues_Create_Response:
+            type: object
+            properties:
+                acquired:
+                    type: boolean
+                    description: |-
+                        true when lock was acquired (new, or already owned by the owner)
+                         Client MUST pay attention to this flag, as it shows if lock was successful.
+                conflictingLocks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Response_LockInfo'
+                    description: |-
+                        Info about why lock was not acquired.
+                         Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
+                         The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
+                conflictsListTruncated:
+                    type: boolean
+        LocksAPI_LockFieldValues_Create_Response_LockInfo:
+            type: object
+            properties:
+                targetId:
+                    type: string
+                fieldName:
+                    type: string
+                lockedBy:
+                    type: string
+                lockedAt:
+                    type: string
+                    format: date-time
+                comment:
+                    type: string
+        MaintenanceAPI_License_Response:
+            type: object
+            properties:
+                status:
+                    type: integer
+                    format: int32
+                isOk:
+                    type: boolean
+                responseBody:
+                    type: string
+                    description: Raw response body as it was received from the license server.
+                    format: bytes
+        MaintenanceAPI_Ping_Response:
+            type: object
+            properties:
+                coreVersion:
+                    type: string
+                coreFullVersion:
+                    type: string
+                compression:
+                    type: integer
+                    format: enum
+                instanceId:
+                    type: string
+                    description: |-
+                        instanceID is a unique ID that changes when we reset DB state.
+                         If we reset a state and a database, but the address of the backend is still the same,
+                         without instanceID we are not sure if it's the same state or not,
+                         and UI can't detect it and clear its state (e.g. caches of drivers).
+                platform:
+                    type: string
+                os:
+                    type: string
+                arch:
+                    type: string
+                capabilities:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        Opt-in capabilities advertised by this server instance. Two
+                         client-side usage modes share this same wire field, decided
+                         per-token by the client:
+                           - Optimization hint. Client picks between a fast path and a
+                             fallback without probing by trial-and-error; missing tokens
+                             just cause the fallback to run (e.g. "treeFilter:v2").
+                           - Install-time gate. Client refuses to install a block whose
+                             manifest declares a required capability the server doesn't
+                             advertise; missing tokens fail closed (e.g. "wasm:v1").
 
-             Each entry is an opaque token "<feature>:<version>" (e.g.
-             "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
-             The field is unset on servers predating this mechanism, which the
-             client treats as "no optional capabilities advertised".
+                         Each entry is an opaque token "<feature>:<version>" (e.g.
+                         "treeFilter:v2"). The field is unset on servers predating this
+                         mechanism, which the client treats as "no optional capabilities
+                         advertised" — fallback for hints, fail-closed for gates.
 
-             All list see pl/platform/api/plapiserver/server_capabilities.go
-    MiscAPI_ListResourceTypes_Response:
-      type: object
-      properties:
-        types:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceType"
-    Notification:
-      type: object
-      properties:
-        subscriptionId:
-          type: string
-        eventId:
-          type: string
-        resourceId:
-          type: string
-        resourceType:
-          $ref: "#/components/schemas/ResourceType"
-        events:
-          $ref: "#/components/schemas/Notification_Events"
-        fieldChanges:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/Notification_FieldChange"
-        payload:
-          $ref: "#/components/schemas/NotificationFilter_Payload"
-        filterName:
-          type: string
-        txSpan:
-          $ref: "#/components/schemas/SpanInfo"
-    NotificationAPI_Get_Request:
-      type: object
-      properties:
-        subscription:
-          type: string
-        maxNotifications:
-          type: integer
-          format: uint32
-    NotificationAPI_Get_Response:
-      type: object
-      properties:
-        notifications:
-          type: array
-          items:
-            $ref: "#/components/schemas/Notification"
-    NotificationFilter:
-      type: object
-      properties:
-        resourceType:
-          $ref: "#/components/schemas/ResourceType"
-        resourceId:
-          type: string
-        eventFilter:
-          $ref: "#/components/schemas/NotificationFilter_EventFilter"
-        payload:
-          $ref: "#/components/schemas/NotificationFilter_Payload"
-    NotificationFilter_EventFilter:
-      type: object
-      properties:
-        all:
-          type: boolean
-        resourceCreated:
-          type: boolean
-        resourceDeleted:
-          type: boolean
-        resourceReady:
-          type: boolean
-        resourceRecovered:
-          type: boolean
-        resourceDuplicate:
-          type: boolean
-        resourceError:
-          type: boolean
-        inputsLocked:
-          type: boolean
-          description: Field events
-        outputsLocked:
-          type: boolean
-        fieldCreated:
-          type: boolean
-        fieldGotError:
-          type: boolean
-        inputSet:
-          type: boolean
-        allInputsSet:
-          type: boolean
-        outputSet:
-          type: boolean
-        allOutputsSet:
-          type: boolean
-        genericOtwSet:
-          type: boolean
-        dynamicChanged:
-          type: boolean
-    NotificationFilter_Payload:
-      type: object
-      properties:
-        values:
-          type: object
-          additionalProperties:
-            type: string
-            format: bytes
-    Notification_Events:
-      type: object
-      properties:
-        resourceCreated:
-          type: boolean
-        resourceDeleted:
-          type: boolean
-        resourceReady:
-          type: boolean
-        resourceDuplicate:
-          type: boolean
-        resourceError:
-          type: boolean
-        inputsLocked:
-          type: boolean
-        outputsLocked:
-          type: boolean
-        fieldCreated:
-          type: boolean
-        fieldGotError:
-          type: boolean
-        inputSet:
-          type: boolean
-        allInputsSet:
-          type: boolean
-        outputSet:
-          type: boolean
-        allOutputsSet:
-          type: boolean
-        genericOtwSet:
-          type: boolean
-        dynamicChanged:
-          type: boolean
-        resourceRecovered:
-          type: boolean
-    Notification_FieldChange:
-      type: object
-      properties:
-        old:
-          $ref: "#/components/schemas/Field"
-        new:
-          $ref: "#/components/schemas/Field"
-    ResourceAPIFeature:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        featureName:
-          type: string
-        resourceType:
-          $ref: "#/components/schemas/ResourceType"
-        endpoint:
-          type: string
-    ResourceSchema:
-      type: object
-      properties:
-        type:
-          $ref: "#/components/schemas/ResourceType"
-        fields:
-          type: array
-          items:
-            $ref: "#/components/schemas/FieldSchema"
-        accessFlags:
-          allOf:
-            - $ref: "#/components/schemas/ResourceSchema_AccessFlags"
-          description: Access restriction flags for non-controller roles
-        freeInputs:
-          type: boolean
-        freeOutputs:
-          type: boolean
-    ResourceSchema_AccessFlags:
-      type: object
-      properties:
-        createResource:
-          type: boolean
-          description: |-
-            Deny-list approach: default = allowed (true)
-             Controllers set these to false to restrict non-controller roles (role='u', role='w')
-        readFields:
-          type: boolean
-          description: "IMPORTANT: read_fields=false with write_fields=true is a forbidden combination"
-        writeFields:
-          type: boolean
-        readKv:
-          type: boolean
-          description: "IMPORTANT: read_kv=false with write_kv=true is a forbidden combination"
-        writeKv:
-          type: boolean
-        readByFieldType:
-          type: object
-          additionalProperties:
-            type: boolean
-          description: |-
-            Per-field-type overrides (map: field_type → bool)
-             When defined for a field type, overrides resource-level flags
-        writeByFieldType:
-          type: object
-          additionalProperties:
-            type: boolean
-    ResourceType:
-      type: object
-      properties:
-        name:
-          type: string
-        version:
-          type: string
-    Resource_Features:
-      type: object
-      properties:
-        ephemeral:
-          type: boolean
-    SpanInfo:
-      type: object
-      properties:
-        path:
-          type: string
-        carrier:
-          type: object
-          additionalProperties:
-            type: string
-    Status:
-      type: object
-      properties:
-        code:
-          type: integer
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-          format: int32
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        details:
-          type: array
-          items:
-            $ref: "#/components/schemas/GoogleProtobufAny"
-          description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
-      description: "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
-    SubscriptionAPI_AttachFilter_Request:
-      type: object
-      properties:
-        subscriptionId:
-          type: string
-        filterName:
-          type: string
-        filterId:
-          type: string
-    SubscriptionAPI_AttachFilter_Response:
-      type: object
-      properties: {}
-    SubscriptionAPI_DetachFilter_Request:
-      type: object
-      properties:
-        subscriptionId:
-          type: string
-        filterName:
-          type: string
-    SubscriptionAPI_DetachFilter_Response:
-      type: object
-      properties: {}
-    TxAPI_Sync_Request:
-      type: object
-      properties:
-        txId:
-          type: string
-    TxAPI_Sync_Response:
-      type: object
-      properties: {}
+                         All list see pl/platform/api/plapiserver/server_capabilities.go
+        MiscAPI_ListResourceTypes_Response:
+            type: object
+            properties:
+                types:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceType'
+        Notification:
+            type: object
+            properties:
+                subscriptionId:
+                    type: string
+                eventId:
+                    type: string
+                resourceId:
+                    type: string
+                resourceType:
+                    $ref: '#/components/schemas/ResourceType'
+                events:
+                    $ref: '#/components/schemas/Notification_Events'
+                fieldChanges:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/Notification_FieldChange'
+                payload:
+                    $ref: '#/components/schemas/NotificationFilter_Payload'
+                filterName:
+                    type: string
+                txSpan:
+                    $ref: '#/components/schemas/SpanInfo'
+        NotificationAPI_Get_Request:
+            type: object
+            properties:
+                subscription:
+                    type: string
+                maxNotifications:
+                    type: integer
+                    format: uint32
+        NotificationAPI_Get_Response:
+            type: object
+            properties:
+                notifications:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Notification'
+        NotificationFilter:
+            type: object
+            properties:
+                resourceType:
+                    $ref: '#/components/schemas/ResourceType'
+                resourceId:
+                    type: string
+                eventFilter:
+                    $ref: '#/components/schemas/NotificationFilter_EventFilter'
+                payload:
+                    $ref: '#/components/schemas/NotificationFilter_Payload'
+        NotificationFilter_EventFilter:
+            type: object
+            properties:
+                all:
+                    type: boolean
+                resourceCreated:
+                    type: boolean
+                resourceDeleted:
+                    type: boolean
+                resourceReady:
+                    type: boolean
+                resourceRecovered:
+                    type: boolean
+                resourceDuplicate:
+                    type: boolean
+                resourceError:
+                    type: boolean
+                inputsLocked:
+                    type: boolean
+                    description: Field events
+                outputsLocked:
+                    type: boolean
+                fieldCreated:
+                    type: boolean
+                fieldGotError:
+                    type: boolean
+                inputSet:
+                    type: boolean
+                allInputsSet:
+                    type: boolean
+                outputSet:
+                    type: boolean
+                allOutputsSet:
+                    type: boolean
+                genericOtwSet:
+                    type: boolean
+                dynamicChanged:
+                    type: boolean
+        NotificationFilter_Payload:
+            type: object
+            properties:
+                values:
+                    type: object
+                    additionalProperties:
+                        type: string
+                        format: bytes
+        Notification_Events:
+            type: object
+            properties:
+                resourceCreated:
+                    type: boolean
+                resourceDeleted:
+                    type: boolean
+                resourceReady:
+                    type: boolean
+                resourceDuplicate:
+                    type: boolean
+                resourceError:
+                    type: boolean
+                inputsLocked:
+                    type: boolean
+                outputsLocked:
+                    type: boolean
+                fieldCreated:
+                    type: boolean
+                fieldGotError:
+                    type: boolean
+                inputSet:
+                    type: boolean
+                allInputsSet:
+                    type: boolean
+                outputSet:
+                    type: boolean
+                allOutputsSet:
+                    type: boolean
+                genericOtwSet:
+                    type: boolean
+                dynamicChanged:
+                    type: boolean
+                resourceRecovered:
+                    type: boolean
+        Notification_FieldChange:
+            type: object
+            properties:
+                old:
+                    $ref: '#/components/schemas/Field'
+                new:
+                    $ref: '#/components/schemas/Field'
+        ResourceAPIFeature:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                featureName:
+                    type: string
+                resourceType:
+                    $ref: '#/components/schemas/ResourceType'
+                endpoint:
+                    type: string
+        ResourceSchema:
+            type: object
+            properties:
+                type:
+                    $ref: '#/components/schemas/ResourceType'
+                fields:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/FieldSchema'
+                accessFlags:
+                    allOf:
+                        - $ref: '#/components/schemas/ResourceSchema_AccessFlags'
+                    description: Access restriction flags for non-controller roles
+                freeInputs:
+                    type: boolean
+                freeOutputs:
+                    type: boolean
+        ResourceSchema_AccessFlags:
+            type: object
+            properties:
+                createResource:
+                    type: boolean
+                    description: |-
+                        Deny-list approach: default = allowed (true)
+                         Controllers set these to false to restrict non-controller roles (role='u', role='w')
+                readFields:
+                    type: boolean
+                    description: 'IMPORTANT: read_fields=false with write_fields=true is a forbidden combination'
+                writeFields:
+                    type: boolean
+                readKv:
+                    type: boolean
+                    description: 'IMPORTANT: read_kv=false with write_kv=true is a forbidden combination'
+                writeKv:
+                    type: boolean
+                readByFieldType:
+                    type: object
+                    additionalProperties:
+                        type: boolean
+                    description: |-
+                        Per-field-type overrides (map: field_type → bool)
+                         When defined for a field type, overrides resource-level flags
+                writeByFieldType:
+                    type: object
+                    additionalProperties:
+                        type: boolean
+                setError:
+                    type: boolean
+                    description: |-
+                        SetError is a control-flow channel and is allowed by default even when
+                         every other access bit is denied: a failing step on a closely-guarded
+                         resource must surface to its caller. Controllers may opt out by
+                         setting this to false.
+        ResourceType:
+            type: object
+            properties:
+                name:
+                    type: string
+                version:
+                    type: string
+        Resource_Features:
+            type: object
+            properties:
+                ephemeral:
+                    type: boolean
+        SpanInfo:
+            type: object
+            properties:
+                path:
+                    type: string
+                carrier:
+                    type: object
+                    additionalProperties:
+                        type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        SubscriptionAPI_AttachFilter_Request:
+            type: object
+            properties:
+                subscriptionId:
+                    type: string
+                filterName:
+                    type: string
+                filterId:
+                    type: string
+        SubscriptionAPI_AttachFilter_Response:
+            type: object
+            properties: {}
+        SubscriptionAPI_DetachFilter_Request:
+            type: object
+            properties:
+                subscriptionId:
+                    type: string
+                filterName:
+                    type: string
+        SubscriptionAPI_DetachFilter_Response:
+            type: object
+            properties: {}
+        TxAPI_Sync_Request:
+            type: object
+            properties:
+                txId:
+                    type: string
+        TxAPI_Sync_Response:
+            type: object
+            properties: {}
 tags:
-  - name: Platform
+    - name: Platform

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -3,1762 +3,1762 @@
 
 openapi: 3.0.3
 info:
-    title: Platform API
-    version: 1.0.0
+  title: Platform API
+  version: 1.0.0
 paths:
-    /v1/auth/grant-access:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_GrantAccess
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_GrantAccess_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_GrantAccess_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/jwt-token:
-        post:
-            tags:
-                - Platform
-            description: |-
-                Deprecated: Use Login for session creation and role transitions,
-                 and RefreshToken for token renewal. Backends implementing this API always return
-                 codes.Unimplemented. Kept here so clients can still call old backends.
-            operationId: Platform_GetJWTToken
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_GetJWTToken_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_GetJWTToken_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/login:
-        post:
-            tags:
-                - Platform
-            description: |-
-                Login authenticates with the given credentials and returns a new Platforma JWT.
-                 Every Login call creates a new session. Use RefreshToken to renew an existing one.
-                 This method is public: no Authorization header is required.
-            operationId: Platform_Login
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_Login_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_Login_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/methods:
-        get:
-            tags:
-                - Platform
-            description: Authentication
-            operationId: Platform_AuthMethods
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_ListMethods_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/mint-signature:
-        post:
-            tags:
-                - Platform
-            description: |-
-                MintSignature creates a resource signature bound to a target session.
-                 Controllers use it during workflow bootstrap to pre-sign resources
-                 so the workflow can access them under its own isolated session.
-            operationId: Platform_MintSignature
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_MintSignature_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_MintSignature_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/refresh:
-        post:
-            tags:
-                - Platform
-            description: |-
-                RefreshToken accepts a valid Platforma JWT and re-issues it with the same
-                 session ID and role. Only the token expiration may be changed.
-                 Workflow-scoped tokens cannot be refreshed; call Login instead.
-                 This method is public: no Authorization header is required.
-            operationId: Platform_RefreshToken
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_RefreshToken_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_RefreshToken_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/revoke-access:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_RevokeAccess
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_RevokeAccess_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_RevokeAccess_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/session-info:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_GetSessionInfo
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_GetSessionInfo_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_GetSessionInfo_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/sso/begin-login:
-        post:
-            tags:
-                - Platform
-            description: |-
-                BeginSSOLogin returns a fresh one-time nonce that the desktop must place
-                 into the OIDC auth-request before redirecting to the IdP. Used by the SSO
-                 login flow. This method is public: no Authorization header is required.
-            operationId: Platform_BeginSSOLogin
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/auth/user-root:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_GetUserRoot
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/AuthAPI_GetUserRoot_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/AuthAPI_GetUserRoot_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/aliases-and-urls:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_WriteControllerAliasesAndUrls
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-        delete:
-            tags:
-                - Platform
-            operationId: Platform_RemoveControllerAliasesAndUrls
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/attach-subscription:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerAttachSubscription
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_AttachSubscription_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_AttachSubscription_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/create:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerCreate
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_Create_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_Create_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/deregister:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerDeregister
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_Deregister_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_Deregister_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/exists:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerExists
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_Exists_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_Exists_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/features:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerSetFeatures
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_SetFeatures_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_SetFeatures_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-        delete:
-            tags:
-                - Platform
-            operationId: Platform_ControllerClearFeatures
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_ClearFeatures_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_ClearFeatures_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/get:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerGet
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_Get_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_Get_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/notifications:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_GetControllerNotifications
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_GetNotifications_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_GetNotifications_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/register:
-        post:
-            tags:
-                - Platform
-            description: Controllers
-            operationId: Platform_ControllerRegister
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_Register_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_Register_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/update:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ControllerUpdate
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_Update_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_Update_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/controller/url:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_GetControllerUrl
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/ControllerAPI_GetUrl_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/ControllerAPI_GetUrl_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/license:
-        get:
-            tags:
-                - Platform
-            operationId: Platform_License
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/MaintenanceAPI_License_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/locks/lease/create:
-        post:
-            tags:
-                - Platform
-            description: |-
-                LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
-                 Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
-                 To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
-            operationId: Platform_LeaseResource
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/LocksAPI_Lease_Create_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/LocksAPI_Lease_Create_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/locks/lease/release:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_ReleaseLease
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/LocksAPI_Lease_Release_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/LocksAPI_Lease_Release_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/locks/lease/update:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_UpdateLease
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/LocksAPI_Lease_Update_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/LocksAPI_Lease_Update_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/locks/lock/create:
-        post:
-            tags:
-                - Platform
-            description: |-
-                LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
-                   - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
-                   - list resource's fields, take fields with names set in request
-                   - get resolved values of listed fields (IDs of 'ON' resources).
-                   - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
+  /v1/auth/grant-access:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_GrantAccess
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_GrantAccess_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_GrantAccess_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/jwt-token:
+    post:
+      tags:
+        - Platform
+      description: |-
+        Deprecated: Use Login for session creation and role transitions,
+         and RefreshToken for token renewal. Backends implementing this API always return
+         codes.Unimplemented. Kept here so clients can still call old backends.
+      operationId: Platform_GetJWTToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_GetJWTToken_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_GetJWTToken_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/login:
+    post:
+      tags:
+        - Platform
+      description: |-
+        Login authenticates with the given credentials and returns a new Platforma JWT.
+         Every Login call creates a new session. Use RefreshToken to renew an existing one.
+         This method is public: no Authorization header is required.
+      operationId: Platform_Login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_Login_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_Login_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/methods:
+    get:
+      tags:
+        - Platform
+      description: Authentication
+      operationId: Platform_AuthMethods
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_ListMethods_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/mint-signature:
+    post:
+      tags:
+        - Platform
+      description: |-
+        MintSignature creates a resource signature bound to a target session.
+         Controllers use it during workflow bootstrap to pre-sign resources
+         so the workflow can access them under its own isolated session.
+      operationId: Platform_MintSignature
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_MintSignature_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_MintSignature_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/refresh:
+    post:
+      tags:
+        - Platform
+      description: |-
+        RefreshToken accepts a valid Platforma JWT and re-issues it with the same
+         session ID and role. Only the token expiration may be changed.
+         Workflow-scoped tokens cannot be refreshed; call Login instead.
+         This method is public: no Authorization header is required.
+      operationId: Platform_RefreshToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_RefreshToken_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_RefreshToken_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/revoke-access:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_RevokeAccess
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_RevokeAccess_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_RevokeAccess_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/session-info:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_GetSessionInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_GetSessionInfo_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_GetSessionInfo_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/sso/begin-login:
+    post:
+      tags:
+        - Platform
+      description: |-
+        BeginSSOLogin returns a fresh one-time nonce that the desktop must place
+         into the OIDC auth-request before redirecting to the IdP. Used by the SSO
+         login flow. This method is public: no Authorization header is required.
+      operationId: Platform_BeginSSOLogin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/auth/user-root:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_GetUserRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthAPI_GetUserRoot_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthAPI_GetUserRoot_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/aliases-and-urls:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_WriteControllerAliasesAndUrls
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+    delete:
+      tags:
+        - Platform
+      operationId: Platform_RemoveControllerAliasesAndUrls
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/attach-subscription:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerAttachSubscription
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_AttachSubscription_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_AttachSubscription_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/create:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerCreate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_Create_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_Create_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/deregister:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerDeregister
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_Deregister_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_Deregister_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/exists:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerExists
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_Exists_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_Exists_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/features:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerSetFeatures
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_SetFeatures_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_SetFeatures_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+    delete:
+      tags:
+        - Platform
+      operationId: Platform_ControllerClearFeatures
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_ClearFeatures_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_ClearFeatures_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/get:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerGet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_Get_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_Get_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/notifications:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_GetControllerNotifications
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_GetNotifications_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_GetNotifications_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/register:
+    post:
+      tags:
+        - Platform
+      description: Controllers
+      operationId: Platform_ControllerRegister
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_Register_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_Register_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/update:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ControllerUpdate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_Update_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_Update_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/controller/url:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_GetControllerUrl
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ControllerAPI_GetUrl_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerAPI_GetUrl_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/license:
+    get:
+      tags:
+        - Platform
+      operationId: Platform_License
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MaintenanceAPI_License_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/locks/lease/create:
+    post:
+      tags:
+        - Platform
+      description: |-
+        LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
+         Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
+         To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
+      operationId: Platform_LeaseResource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocksAPI_Lease_Create_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocksAPI_Lease_Create_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/locks/lease/release:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_ReleaseLease
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocksAPI_Lease_Release_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocksAPI_Lease_Release_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/locks/lease/update:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_UpdateLease
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocksAPI_Lease_Update_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocksAPI_Lease_Update_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/locks/lock/create:
+    post:
+      tags:
+        - Platform
+      description: |-
+        LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
+           - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
+           - list resource's fields, take fields with names set in request
+           - get resolved values of listed fields (IDs of 'ON' resources).
+           - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
 
-                 Lock logic constraints:
-                   - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
-                     succeeds, while the other fails with an error (no long waiting)
-                   - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
-                     the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
-                   - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
-                     being lockable. An attempt to lock a resource that has not become original will fail.
-                   - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
-            operationId: Platform_LockFieldValues
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/notifications/get:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_NotificationsGet
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/NotificationAPI_Get_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/NotificationAPI_Get_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/ping:
-        get:
-            tags:
-                - Platform
-            description: Various service requests
-            operationId: Platform_Ping
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/MaintenanceAPI_Ping_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/resource-types:
-        get:
-            tags:
-                - Platform
-            description: Other stuff
-            operationId: Platform_ListResourceTypes
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/MiscAPI_ListResourceTypes_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/subscription/attach-filter:
-        post:
-            tags:
-                - Platform
-            description: Subscriptions
-            operationId: Platform_SubscriptionAttachFilter
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/SubscriptionAPI_AttachFilter_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SubscriptionAPI_AttachFilter_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/subscription/detach-filter:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_SubscriptionDetachFilter
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/SubscriptionAPI_DetachFilter_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SubscriptionAPI_DetachFilter_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
-    /v1/tx-sync:
-        post:
-            tags:
-                - Platform
-            operationId: Platform_TxSync
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/TxAPI_Sync_Request'
-                required: true
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/TxAPI_Sync_Response'
-                default:
-                    description: Default error response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Status'
+         Lock logic constraints:
+           - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
+             succeeds, while the other fails with an error (no long waiting)
+           - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
+             the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
+           - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
+             being lockable. An attempt to lock a resource that has not become original will fail.
+           - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
+      operationId: Platform_LockFieldValues
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/notifications/get:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_NotificationsGet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NotificationAPI_Get_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationAPI_Get_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/ping:
+    get:
+      tags:
+        - Platform
+      description: Various service requests
+      operationId: Platform_Ping
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MaintenanceAPI_Ping_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/resource-types:
+    get:
+      tags:
+        - Platform
+      description: Other stuff
+      operationId: Platform_ListResourceTypes
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MiscAPI_ListResourceTypes_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/subscription/attach-filter:
+    post:
+      tags:
+        - Platform
+      description: Subscriptions
+      operationId: Platform_SubscriptionAttachFilter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionAPI_AttachFilter_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionAPI_AttachFilter_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/subscription/detach-filter:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_SubscriptionDetachFilter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionAPI_DetachFilter_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionAPI_DetachFilter_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /v1/tx-sync:
+    post:
+      tags:
+        - Platform
+      operationId: Platform_TxSync
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TxAPI_Sync_Request"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TxAPI_Sync_Response"
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
 components:
-    schemas:
-        AuthAPI_BeginSSOLogin_PublicPKCE:
-            type: object
-            properties:
-                nonce:
-                    type: string
-                expiresAt:
-                    type: string
-                    format: date-time
-        AuthAPI_BeginSSOLogin_Request:
-            type: object
-            properties: {}
-        AuthAPI_BeginSSOLogin_Response:
-            type: object
-            properties:
-                publicPkce:
-                    $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_PublicPKCE'
-        AuthAPI_GetJWTToken_Request:
-            type: object
-            properties:
-                expiration:
-                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-                    type: string
-                requestedRole:
-                    type: integer
-                    format: enum
-        AuthAPI_GetJWTToken_Response:
-            type: object
-            properties:
-                token:
-                    type: string
-                sessionId:
-                    type: string
-                    description: Session info fields
-                    format: bytes
-                role:
-                    type: integer
-                    format: enum
-        AuthAPI_GetSessionInfo_Request:
-            type: object
-            properties: {}
-        AuthAPI_GetSessionInfo_Response:
-            type: object
-            properties:
-                sessionId:
-                    type: string
-                    format: bytes
-                role:
-                    type: integer
-                    format: enum
-        AuthAPI_GetUserRoot_Request:
-            type: object
-            properties:
-                login:
-                    type: string
-                createIfNotExists:
-                    type: boolean
-        AuthAPI_GetUserRoot_Response:
-            type: object
-            properties:
-                userRoot:
-                    $ref: '#/components/schemas/AuthAPI_UserRoot'
-        AuthAPI_GrantAccess_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-                targetUser:
-                    type: string
-                permissions:
-                    $ref: '#/components/schemas/AuthAPI_Grant_Permissions'
-                grantType:
-                    type: integer
-                    format: enum
-        AuthAPI_GrantAccess_Response:
-            type: object
-            properties: {}
-        AuthAPI_Grant_Permissions:
-            type: object
-            properties:
-                writable:
-                    type: boolean
-            description: Permissions describes access level for a grant.
-        AuthAPI_ListMethods_BasicAuthMethod:
-            type: object
-            properties: {}
-        AuthAPI_ListMethods_MethodInfo:
-            type: object
-            properties:
-                id:
-                    type: string
-                    description: |-
-                        id is the stable, machine-readable identifier of the login method
-                         instance. Unique across the entire server.
-                description:
-                    type: string
-                    description: description is the human-readable label in case we'd like to render it in UI.
-                basic:
-                    $ref: '#/components/schemas/AuthAPI_ListMethods_BasicAuthMethod'
-                token:
-                    $ref: '#/components/schemas/AuthAPI_ListMethods_TokenAuthMethod'
-                sso:
-                    $ref: '#/components/schemas/AuthAPI_ListMethods_SSOAuthMethod'
-        AuthAPI_ListMethods_Response:
-            type: object
-            properties:
-                methods:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/AuthAPI_ListMethods_MethodInfo'
-        AuthAPI_ListMethods_SSOAuthMethod:
-            type: object
-            properties:
-                issuer:
-                    type: string
-                clientId:
-                    type: string
-                scopes:
-                    type: string
-                resource:
-                    type: string
-                prompt:
-                    type: string
-                redirectPorts:
-                    type: array
-                    items:
-                        type: integer
-                        format: uint32
-                subjectTokenSource:
-                    type: string
-                userIdClaim:
-                    type: string
-                groupsClaim:
-                    type: string
-                flowType:
-                    type: integer
-                    format: enum
-            description: |-
-                SSOAuthMethod advertises an external IdP-based login flow. The desktop
-                 app uses the contents to drive the PKCE exchange locally, then hands the
-                 resulting IdP token-response back via Login.SSOCredentials.
-        AuthAPI_ListMethods_TokenAuthMethod:
-            type: object
-            properties: {}
-        AuthAPI_Login_BasicCredentials:
-            type: object
-            properties:
-                login:
-                    type: string
-                password:
-                    type: string
-        AuthAPI_Login_Request:
-            type: object
-            properties:
-                basic:
-                    $ref: '#/components/schemas/AuthAPI_Login_BasicCredentials'
-                token:
-                    $ref: '#/components/schemas/AuthAPI_Login_TokenCredentials'
-                sso:
-                    $ref: '#/components/schemas/AuthAPI_Login_SSOCredentials'
-                expiration:
-                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-                    type: string
-                requestedRole:
-                    type: integer
-                    format: enum
-        AuthAPI_Login_Response:
-            type: object
-            properties:
-                token:
-                    type: string
-                sessionId:
-                    type: string
-                    format: bytes
-                role:
-                    type: integer
-                    format: enum
-        AuthAPI_Login_SSOCredentials:
-            type: object
-            properties:
-                tokenResponse:
-                    type: string
-                    format: bytes
-            description: |-
-                SSOCredentials carries the raw JSON body returned by the IdP's /token
-                 endpoint after the desktop completes a PKCE exchange.
-        AuthAPI_Login_TokenCredentials:
-            type: object
-            properties:
-                token:
-                    type: string
-                    format: bytes
-            description: |-
-                TokenCredentials accepts any opaque bearer-style string: a controller
-                 pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
-        AuthAPI_MintSignature_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                targetSid:
-                    type: string
-                    format: bytes
-                color:
-                    $ref: '#/components/schemas/Color'
-        AuthAPI_MintSignature_Response:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-        AuthAPI_RefreshToken_Request:
-            type: object
-            properties:
-                token:
-                    type: string
-                expiration:
-                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-                    type: string
-        AuthAPI_RefreshToken_Response:
-            type: object
-            properties:
-                token:
-                    type: string
-                sessionId:
-                    type: string
-                    format: bytes
-                role:
-                    type: integer
-                    format: enum
-        AuthAPI_RevokeAccess_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-                targetUser:
-                    type: string
-        AuthAPI_RevokeAccess_Response:
-            type: object
-            properties: {}
-        AuthAPI_UserRoot:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-        Color:
-            type: object
-            properties:
-                root:
-                    type: string
-                permissions:
-                    type: integer
-                    format: uint32
-        Controller:
-            type: object
-            properties:
-                type:
-                    type: string
-                id:
-                    type: string
-                subscriptionID:
-                    type: string
-        ControllerAPI_AttachSubscription_Request:
-            type: object
-            properties:
-                controllerId:
-                    type: string
-                subscriptionId:
-                    type: string
-        ControllerAPI_AttachSubscription_Response:
-            type: object
-            properties: {}
-        ControllerAPI_ClearFeatures_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-        ControllerAPI_ClearFeatures_Response:
-            type: object
-            properties: {}
-        ControllerAPI_Create_Request:
-            type: object
-            properties:
-                id:
-                    type: string
-                controllerType:
-                    type: string
-        ControllerAPI_Create_Response:
-            type: object
-            properties:
-                controllerId:
-                    type: string
-        ControllerAPI_Deregister_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-        ControllerAPI_Deregister_Response:
-            type: object
-            properties: {}
-        ControllerAPI_Exists_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-        ControllerAPI_Exists_Response:
-            type: object
-            properties:
-                exists:
-                    type: boolean
-        ControllerAPI_GetNotifications_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-                maxNotifications:
-                    type: integer
-                    format: uint32
-        ControllerAPI_GetNotifications_Response:
-            type: object
-            properties:
-                notifications:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/Notification'
-        ControllerAPI_GetUrl_Request:
-            type: object
-            properties:
-                controllerAlias:
-                    type: string
-                resourceId:
-                    type: string
-        ControllerAPI_GetUrl_Response:
-            type: object
-            properties:
-                controllerUrl:
-                    type: string
-        ControllerAPI_Get_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-        ControllerAPI_Get_Response:
-            type: object
-            properties:
-                controller:
-                    $ref: '#/components/schemas/Controller'
-        ControllerAPI_Register_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-                filters:
-                    type: object
-                    additionalProperties:
-                        $ref: '#/components/schemas/NotificationFilter'
-                resourceSchemas:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ResourceSchema'
-        ControllerAPI_Register_Response:
-            type: object
-            properties:
-                controllerId:
-                    type: string
-                subscriptionId:
-                    type: string
-        ControllerAPI_RemoveAliasesAndUrls_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-        ControllerAPI_RemoveAliasesAndUrls_Response:
-            type: object
-            properties: {}
-        ControllerAPI_SetFeatures_Request:
-            type: object
-            properties:
-                features:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ResourceAPIFeature'
-        ControllerAPI_SetFeatures_Response:
-            type: object
-            properties: {}
-        ControllerAPI_Update_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-                filters:
-                    type: object
-                    additionalProperties:
-                        $ref: '#/components/schemas/NotificationFilter'
-                resourceSchemas:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ResourceSchema'
-        ControllerAPI_Update_Response:
-            type: object
-            properties: {}
-        ControllerAPI_WriteAliasesAndUrls_Request:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-                aliasesToUrls:
-                    type: object
-                    additionalProperties:
-                        type: string
-        ControllerAPI_WriteAliasesAndUrls_Response:
-            type: object
-            properties: {}
-        Field:
-            type: object
-            properties:
-                id:
-                    allOf:
-                        - $ref: '#/components/schemas/FieldRef'
-                    description: field ID is always combination of parent resource ID and field name
-                type:
-                    type: integer
-                    format: enum
-                features:
-                    $ref: '#/components/schemas/Resource_Features'
-                value:
-                    type: string
-                    description: |-
-                        _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
-                         If a field refers to another field, it will get
-                         a value only when this chain of references ends up with a direct resource
-                         reference. At that moment, all fields in the chain will get their values
-                         resolved and will start to refer to the same resource directly.
-                valueSignature:
-                    type: string
-                    description: |-
-                        Signature for value resource ID, inheriting the parent resource's color.
-                         Populated server-side when the parent resource has a known color in the current TX.
-                    format: bytes
-                valueStatus:
-                    type: integer
-                    description: Whether the value is empty, assigned, or finally resolved.
-                    format: enum
-                valueIsFinal:
-                    type: boolean
-                    description: If the value is in its final state (ready, duplicate or error)
-                error:
-                    type: string
-                    description: |-
-                        Error resource ID, if any.
-                         Is intended to report problems _from_ the platform to the client.
-                errorSignature:
-                    type: string
-                    description: Signature for error resource ID, inheriting the parent resource's color.
-                    format: bytes
-        FieldRef:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-                fieldName:
-                    type: string
-        FieldSchema:
-            type: object
-            properties:
-                type:
-                    type: integer
-                    format: enum
-                name:
-                    type: string
-        GoogleProtobufAny:
-            type: object
-            properties:
-                '@type':
-                    type: string
-                    description: The type of the serialized message.
-            additionalProperties: true
-            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-        LocksAPI_Lease_Create_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-                timeout:
-                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-                    type: string
-                name:
-                    type: string
-        LocksAPI_Lease_Create_Response:
-            type: object
-            properties:
-                leaseId:
-                    type: string
-                    format: bytes
-        LocksAPI_Lease_Release_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-                leaseId:
-                    type: string
-                    format: bytes
-        LocksAPI_Lease_Release_Response:
-            type: object
-            properties: {}
-        LocksAPI_Lease_Update_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                resourceSignature:
-                    type: string
-                    format: bytes
-                leaseId:
-                    type: string
-                    format: bytes
-                timeout:
-                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-                    type: string
-                name:
-                    type: string
-        LocksAPI_Lease_Update_Response:
-            type: object
-            properties: {}
-        LocksAPI_LockFieldValues_Create_Request:
-            type: object
-            properties:
-                resourceId:
-                    type: string
-                lockReferencesOf:
-                    type: array
-                    items:
-                        type: string
-                comment:
-                    type: string
-        LocksAPI_LockFieldValues_Create_Response:
-            type: object
-            properties:
-                acquired:
-                    type: boolean
-                    description: |-
-                        true when lock was acquired (new, or already owned by the owner)
-                         Client MUST pay attention to this flag, as it shows if lock was successful.
-                conflictingLocks:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Response_LockInfo'
-                    description: |-
-                        Info about why lock was not acquired.
-                         Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
-                         The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
-                conflictsListTruncated:
-                    type: boolean
-        LocksAPI_LockFieldValues_Create_Response_LockInfo:
-            type: object
-            properties:
-                targetId:
-                    type: string
-                fieldName:
-                    type: string
-                lockedBy:
-                    type: string
-                lockedAt:
-                    type: string
-                    format: date-time
-                comment:
-                    type: string
-        MaintenanceAPI_License_Response:
-            type: object
-            properties:
-                status:
-                    type: integer
-                    format: int32
-                isOk:
-                    type: boolean
-                responseBody:
-                    type: string
-                    description: Raw response body as it was received from the license server.
-                    format: bytes
-        MaintenanceAPI_Ping_Response:
-            type: object
-            properties:
-                coreVersion:
-                    type: string
-                coreFullVersion:
-                    type: string
-                compression:
-                    type: integer
-                    format: enum
-                instanceId:
-                    type: string
-                    description: |-
-                        instanceID is a unique ID that changes when we reset DB state.
-                         If we reset a state and a database, but the address of the backend is still the same,
-                         without instanceID we are not sure if it's the same state or not,
-                         and UI can't detect it and clear its state (e.g. caches of drivers).
-                platform:
-                    type: string
-                os:
-                    type: string
-                arch:
-                    type: string
-                capabilities:
-                    type: array
-                    items:
-                        type: string
-                    description: |-
-                        Opt-in capabilities advertised by this server instance. Two
-                         client-side usage modes share this same wire field, decided
-                         per-token by the client:
-                           - Optimization hint. Client picks between a fast path and a
-                             fallback without probing by trial-and-error; missing tokens
-                             just cause the fallback to run (e.g. "treeFilter:v2").
-                           - Install-time gate. Client refuses to install a block whose
-                             manifest declares a required capability the server doesn't
-                             advertise; missing tokens fail closed (e.g. "wasm:v1").
+  schemas:
+    AuthAPI_BeginSSOLogin_PublicPKCE:
+      type: object
+      properties:
+        nonce:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+    AuthAPI_BeginSSOLogin_Request:
+      type: object
+      properties: {}
+    AuthAPI_BeginSSOLogin_Response:
+      type: object
+      properties:
+        publicPkce:
+          $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_PublicPKCE"
+    AuthAPI_GetJWTToken_Request:
+      type: object
+      properties:
+        expiration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+        requestedRole:
+          type: integer
+          format: enum
+    AuthAPI_GetJWTToken_Response:
+      type: object
+      properties:
+        token:
+          type: string
+        sessionId:
+          type: string
+          description: Session info fields
+          format: bytes
+        role:
+          type: integer
+          format: enum
+    AuthAPI_GetSessionInfo_Request:
+      type: object
+      properties: {}
+    AuthAPI_GetSessionInfo_Response:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          format: bytes
+        role:
+          type: integer
+          format: enum
+    AuthAPI_GetUserRoot_Request:
+      type: object
+      properties:
+        login:
+          type: string
+        createIfNotExists:
+          type: boolean
+    AuthAPI_GetUserRoot_Response:
+      type: object
+      properties:
+        userRoot:
+          $ref: "#/components/schemas/AuthAPI_UserRoot"
+    AuthAPI_GrantAccess_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+        targetUser:
+          type: string
+        permissions:
+          $ref: "#/components/schemas/AuthAPI_Grant_Permissions"
+        grantType:
+          type: integer
+          format: enum
+    AuthAPI_GrantAccess_Response:
+      type: object
+      properties: {}
+    AuthAPI_Grant_Permissions:
+      type: object
+      properties:
+        writable:
+          type: boolean
+      description: Permissions describes access level for a grant.
+    AuthAPI_ListMethods_BasicAuthMethod:
+      type: object
+      properties: {}
+    AuthAPI_ListMethods_MethodInfo:
+      type: object
+      properties:
+        id:
+          type: string
+          description: |-
+            id is the stable, machine-readable identifier of the login method
+             instance. Unique across the entire server.
+        description:
+          type: string
+          description: description is the human-readable label in case we'd like to render it in UI.
+        basic:
+          $ref: "#/components/schemas/AuthAPI_ListMethods_BasicAuthMethod"
+        token:
+          $ref: "#/components/schemas/AuthAPI_ListMethods_TokenAuthMethod"
+        sso:
+          $ref: "#/components/schemas/AuthAPI_ListMethods_SSOAuthMethod"
+    AuthAPI_ListMethods_Response:
+      type: object
+      properties:
+        methods:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuthAPI_ListMethods_MethodInfo"
+    AuthAPI_ListMethods_SSOAuthMethod:
+      type: object
+      properties:
+        issuer:
+          type: string
+        clientId:
+          type: string
+        scopes:
+          type: string
+        resource:
+          type: string
+        prompt:
+          type: string
+        redirectPorts:
+          type: array
+          items:
+            type: integer
+            format: uint32
+        subjectTokenSource:
+          type: string
+        userIdClaim:
+          type: string
+        groupsClaim:
+          type: string
+        flowType:
+          type: integer
+          format: enum
+      description: |-
+        SSOAuthMethod advertises an external IdP-based login flow. The desktop
+         app uses the contents to drive the PKCE exchange locally, then hands the
+         resulting IdP token-response back via Login.SSOCredentials.
+    AuthAPI_ListMethods_TokenAuthMethod:
+      type: object
+      properties: {}
+    AuthAPI_Login_BasicCredentials:
+      type: object
+      properties:
+        login:
+          type: string
+        password:
+          type: string
+    AuthAPI_Login_Request:
+      type: object
+      properties:
+        basic:
+          $ref: "#/components/schemas/AuthAPI_Login_BasicCredentials"
+        token:
+          $ref: "#/components/schemas/AuthAPI_Login_TokenCredentials"
+        sso:
+          $ref: "#/components/schemas/AuthAPI_Login_SSOCredentials"
+        expiration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+        requestedRole:
+          type: integer
+          format: enum
+    AuthAPI_Login_Response:
+      type: object
+      properties:
+        token:
+          type: string
+        sessionId:
+          type: string
+          format: bytes
+        role:
+          type: integer
+          format: enum
+    AuthAPI_Login_SSOCredentials:
+      type: object
+      properties:
+        tokenResponse:
+          type: string
+          format: bytes
+      description: |-
+        SSOCredentials carries the raw JSON body returned by the IdP's /token
+         endpoint after the desktop completes a PKCE exchange.
+    AuthAPI_Login_TokenCredentials:
+      type: object
+      properties:
+        token:
+          type: string
+          format: bytes
+      description: |-
+        TokenCredentials accepts any opaque bearer-style string: a controller
+         pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
+    AuthAPI_MintSignature_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        targetSid:
+          type: string
+          format: bytes
+        color:
+          $ref: "#/components/schemas/Color"
+    AuthAPI_MintSignature_Response:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+    AuthAPI_RefreshToken_Request:
+      type: object
+      properties:
+        token:
+          type: string
+        expiration:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+    AuthAPI_RefreshToken_Response:
+      type: object
+      properties:
+        token:
+          type: string
+        sessionId:
+          type: string
+          format: bytes
+        role:
+          type: integer
+          format: enum
+    AuthAPI_RevokeAccess_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+        targetUser:
+          type: string
+    AuthAPI_RevokeAccess_Response:
+      type: object
+      properties: {}
+    AuthAPI_UserRoot:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+    Color:
+      type: object
+      properties:
+        root:
+          type: string
+        permissions:
+          type: integer
+          format: uint32
+    Controller:
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        subscriptionID:
+          type: string
+    ControllerAPI_AttachSubscription_Request:
+      type: object
+      properties:
+        controllerId:
+          type: string
+        subscriptionId:
+          type: string
+    ControllerAPI_AttachSubscription_Response:
+      type: object
+      properties: {}
+    ControllerAPI_ClearFeatures_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+    ControllerAPI_ClearFeatures_Response:
+      type: object
+      properties: {}
+    ControllerAPI_Create_Request:
+      type: object
+      properties:
+        id:
+          type: string
+        controllerType:
+          type: string
+    ControllerAPI_Create_Response:
+      type: object
+      properties:
+        controllerId:
+          type: string
+    ControllerAPI_Deregister_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+    ControllerAPI_Deregister_Response:
+      type: object
+      properties: {}
+    ControllerAPI_Exists_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+    ControllerAPI_Exists_Response:
+      type: object
+      properties:
+        exists:
+          type: boolean
+    ControllerAPI_GetNotifications_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+        maxNotifications:
+          type: integer
+          format: uint32
+    ControllerAPI_GetNotifications_Response:
+      type: object
+      properties:
+        notifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/Notification"
+    ControllerAPI_GetUrl_Request:
+      type: object
+      properties:
+        controllerAlias:
+          type: string
+        resourceId:
+          type: string
+    ControllerAPI_GetUrl_Response:
+      type: object
+      properties:
+        controllerUrl:
+          type: string
+    ControllerAPI_Get_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+    ControllerAPI_Get_Response:
+      type: object
+      properties:
+        controller:
+          $ref: "#/components/schemas/Controller"
+    ControllerAPI_Register_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+        filters:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/NotificationFilter"
+        resourceSchemas:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceSchema"
+    ControllerAPI_Register_Response:
+      type: object
+      properties:
+        controllerId:
+          type: string
+        subscriptionId:
+          type: string
+    ControllerAPI_RemoveAliasesAndUrls_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+    ControllerAPI_RemoveAliasesAndUrls_Response:
+      type: object
+      properties: {}
+    ControllerAPI_SetFeatures_Request:
+      type: object
+      properties:
+        features:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceAPIFeature"
+    ControllerAPI_SetFeatures_Response:
+      type: object
+      properties: {}
+    ControllerAPI_Update_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+        filters:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/NotificationFilter"
+        resourceSchemas:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceSchema"
+    ControllerAPI_Update_Response:
+      type: object
+      properties: {}
+    ControllerAPI_WriteAliasesAndUrls_Request:
+      type: object
+      properties:
+        controllerType:
+          type: string
+        aliasesToUrls:
+          type: object
+          additionalProperties:
+            type: string
+    ControllerAPI_WriteAliasesAndUrls_Response:
+      type: object
+      properties: {}
+    Field:
+      type: object
+      properties:
+        id:
+          allOf:
+            - $ref: "#/components/schemas/FieldRef"
+          description: field ID is always combination of parent resource ID and field name
+        type:
+          type: integer
+          format: enum
+        features:
+          $ref: "#/components/schemas/Resource_Features"
+        value:
+          type: string
+          description: |-
+            _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
+             If a field refers to another field, it will get
+             a value only when this chain of references ends up with a direct resource
+             reference. At that moment, all fields in the chain will get their values
+             resolved and will start to refer to the same resource directly.
+        valueSignature:
+          type: string
+          description: |-
+            Signature for value resource ID, inheriting the parent resource's color.
+             Populated server-side when the parent resource has a known color in the current TX.
+          format: bytes
+        valueStatus:
+          type: integer
+          description: Whether the value is empty, assigned, or finally resolved.
+          format: enum
+        valueIsFinal:
+          type: boolean
+          description: If the value is in its final state (ready, duplicate or error)
+        error:
+          type: string
+          description: |-
+            Error resource ID, if any.
+             Is intended to report problems _from_ the platform to the client.
+        errorSignature:
+          type: string
+          description: Signature for error resource ID, inheriting the parent resource's color.
+          format: bytes
+    FieldRef:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+        fieldName:
+          type: string
+    FieldSchema:
+      type: object
+      properties:
+        type:
+          type: integer
+          format: enum
+        name:
+          type: string
+    GoogleProtobufAny:
+      type: object
+      properties:
+        "@type":
+          type: string
+          description: The type of the serialized message.
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+    LocksAPI_Lease_Create_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+        timeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+        name:
+          type: string
+    LocksAPI_Lease_Create_Response:
+      type: object
+      properties:
+        leaseId:
+          type: string
+          format: bytes
+    LocksAPI_Lease_Release_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+        leaseId:
+          type: string
+          format: bytes
+    LocksAPI_Lease_Release_Response:
+      type: object
+      properties: {}
+    LocksAPI_Lease_Update_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        resourceSignature:
+          type: string
+          format: bytes
+        leaseId:
+          type: string
+          format: bytes
+        timeout:
+          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+          type: string
+        name:
+          type: string
+    LocksAPI_Lease_Update_Response:
+      type: object
+      properties: {}
+    LocksAPI_LockFieldValues_Create_Request:
+      type: object
+      properties:
+        resourceId:
+          type: string
+        lockReferencesOf:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+    LocksAPI_LockFieldValues_Create_Response:
+      type: object
+      properties:
+        acquired:
+          type: boolean
+          description: |-
+            true when lock was acquired (new, or already owned by the owner)
+             Client MUST pay attention to this flag, as it shows if lock was successful.
+        conflictingLocks:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Response_LockInfo"
+          description: |-
+            Info about why lock was not acquired.
+             Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
+             The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
+        conflictsListTruncated:
+          type: boolean
+    LocksAPI_LockFieldValues_Create_Response_LockInfo:
+      type: object
+      properties:
+        targetId:
+          type: string
+        fieldName:
+          type: string
+        lockedBy:
+          type: string
+        lockedAt:
+          type: string
+          format: date-time
+        comment:
+          type: string
+    MaintenanceAPI_License_Response:
+      type: object
+      properties:
+        status:
+          type: integer
+          format: int32
+        isOk:
+          type: boolean
+        responseBody:
+          type: string
+          description: Raw response body as it was received from the license server.
+          format: bytes
+    MaintenanceAPI_Ping_Response:
+      type: object
+      properties:
+        coreVersion:
+          type: string
+        coreFullVersion:
+          type: string
+        compression:
+          type: integer
+          format: enum
+        instanceId:
+          type: string
+          description: |-
+            instanceID is a unique ID that changes when we reset DB state.
+             If we reset a state and a database, but the address of the backend is still the same,
+             without instanceID we are not sure if it's the same state or not,
+             and UI can't detect it and clear its state (e.g. caches of drivers).
+        platform:
+          type: string
+        os:
+          type: string
+        arch:
+          type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: |-
+            Opt-in capabilities advertised by this server instance. Two
+             client-side usage modes share this same wire field, decided
+             per-token by the client:
+               - Optimization hint. Client picks between a fast path and a
+                 fallback without probing by trial-and-error; missing tokens
+                 just cause the fallback to run (e.g. "treeFilter:v2").
+               - Install-time gate. Client refuses to install a block whose
+                 manifest declares a required capability the server doesn't
+                 advertise; missing tokens fail closed (e.g. "wasm:v1").
 
-                         Each entry is an opaque token "<feature>:<version>" (e.g.
-                         "treeFilter:v2"). The field is unset on servers predating this
-                         mechanism, which the client treats as "no optional capabilities
-                         advertised" — fallback for hints, fail-closed for gates.
+             Each entry is an opaque token "<feature>:<version>" (e.g.
+             "treeFilter:v2"). The field is unset on servers predating this
+             mechanism, which the client treats as "no optional capabilities
+             advertised" — fallback for hints, fail-closed for gates.
 
-                         All list see pl/platform/api/plapiserver/server_capabilities.go
-        MiscAPI_ListResourceTypes_Response:
-            type: object
-            properties:
-                types:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ResourceType'
-        Notification:
-            type: object
-            properties:
-                subscriptionId:
-                    type: string
-                eventId:
-                    type: string
-                resourceId:
-                    type: string
-                resourceType:
-                    $ref: '#/components/schemas/ResourceType'
-                events:
-                    $ref: '#/components/schemas/Notification_Events'
-                fieldChanges:
-                    type: object
-                    additionalProperties:
-                        $ref: '#/components/schemas/Notification_FieldChange'
-                payload:
-                    $ref: '#/components/schemas/NotificationFilter_Payload'
-                filterName:
-                    type: string
-                txSpan:
-                    $ref: '#/components/schemas/SpanInfo'
-        NotificationAPI_Get_Request:
-            type: object
-            properties:
-                subscription:
-                    type: string
-                maxNotifications:
-                    type: integer
-                    format: uint32
-        NotificationAPI_Get_Response:
-            type: object
-            properties:
-                notifications:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/Notification'
-        NotificationFilter:
-            type: object
-            properties:
-                resourceType:
-                    $ref: '#/components/schemas/ResourceType'
-                resourceId:
-                    type: string
-                eventFilter:
-                    $ref: '#/components/schemas/NotificationFilter_EventFilter'
-                payload:
-                    $ref: '#/components/schemas/NotificationFilter_Payload'
-        NotificationFilter_EventFilter:
-            type: object
-            properties:
-                all:
-                    type: boolean
-                resourceCreated:
-                    type: boolean
-                resourceDeleted:
-                    type: boolean
-                resourceReady:
-                    type: boolean
-                resourceRecovered:
-                    type: boolean
-                resourceDuplicate:
-                    type: boolean
-                resourceError:
-                    type: boolean
-                inputsLocked:
-                    type: boolean
-                    description: Field events
-                outputsLocked:
-                    type: boolean
-                fieldCreated:
-                    type: boolean
-                fieldGotError:
-                    type: boolean
-                inputSet:
-                    type: boolean
-                allInputsSet:
-                    type: boolean
-                outputSet:
-                    type: boolean
-                allOutputsSet:
-                    type: boolean
-                genericOtwSet:
-                    type: boolean
-                dynamicChanged:
-                    type: boolean
-        NotificationFilter_Payload:
-            type: object
-            properties:
-                values:
-                    type: object
-                    additionalProperties:
-                        type: string
-                        format: bytes
-        Notification_Events:
-            type: object
-            properties:
-                resourceCreated:
-                    type: boolean
-                resourceDeleted:
-                    type: boolean
-                resourceReady:
-                    type: boolean
-                resourceDuplicate:
-                    type: boolean
-                resourceError:
-                    type: boolean
-                inputsLocked:
-                    type: boolean
-                outputsLocked:
-                    type: boolean
-                fieldCreated:
-                    type: boolean
-                fieldGotError:
-                    type: boolean
-                inputSet:
-                    type: boolean
-                allInputsSet:
-                    type: boolean
-                outputSet:
-                    type: boolean
-                allOutputsSet:
-                    type: boolean
-                genericOtwSet:
-                    type: boolean
-                dynamicChanged:
-                    type: boolean
-                resourceRecovered:
-                    type: boolean
-        Notification_FieldChange:
-            type: object
-            properties:
-                old:
-                    $ref: '#/components/schemas/Field'
-                new:
-                    $ref: '#/components/schemas/Field'
-        ResourceAPIFeature:
-            type: object
-            properties:
-                controllerType:
-                    type: string
-                featureName:
-                    type: string
-                resourceType:
-                    $ref: '#/components/schemas/ResourceType'
-                endpoint:
-                    type: string
-        ResourceSchema:
-            type: object
-            properties:
-                type:
-                    $ref: '#/components/schemas/ResourceType'
-                fields:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/FieldSchema'
-                accessFlags:
-                    allOf:
-                        - $ref: '#/components/schemas/ResourceSchema_AccessFlags'
-                    description: Access restriction flags for non-controller roles
-                freeInputs:
-                    type: boolean
-                freeOutputs:
-                    type: boolean
-        ResourceSchema_AccessFlags:
-            type: object
-            properties:
-                createResource:
-                    type: boolean
-                    description: |-
-                        Deny-list approach: default = allowed (true)
-                         Controllers set these to false to restrict non-controller roles (role='u', role='w')
-                readFields:
-                    type: boolean
-                    description: 'IMPORTANT: read_fields=false with write_fields=true is a forbidden combination'
-                writeFields:
-                    type: boolean
-                readKv:
-                    type: boolean
-                    description: 'IMPORTANT: read_kv=false with write_kv=true is a forbidden combination'
-                writeKv:
-                    type: boolean
-                readByFieldType:
-                    type: object
-                    additionalProperties:
-                        type: boolean
-                    description: |-
-                        Per-field-type overrides (map: field_type → bool)
-                         When defined for a field type, overrides resource-level flags
-                writeByFieldType:
-                    type: object
-                    additionalProperties:
-                        type: boolean
-                setError:
-                    type: boolean
-                    description: |-
-                        SetError is a control-flow channel and is allowed by default even when
-                         every other access bit is denied: a failing step on a closely-guarded
-                         resource must surface to its caller. Controllers may opt out by
-                         setting this to false.
-        ResourceType:
-            type: object
-            properties:
-                name:
-                    type: string
-                version:
-                    type: string
-        Resource_Features:
-            type: object
-            properties:
-                ephemeral:
-                    type: boolean
-        SpanInfo:
-            type: object
-            properties:
-                path:
-                    type: string
-                carrier:
-                    type: object
-                    additionalProperties:
-                        type: string
-        Status:
-            type: object
-            properties:
-                code:
-                    type: integer
-                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-                    format: int32
-                message:
-                    type: string
-                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-                details:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/GoogleProtobufAny'
-                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
-            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
-        SubscriptionAPI_AttachFilter_Request:
-            type: object
-            properties:
-                subscriptionId:
-                    type: string
-                filterName:
-                    type: string
-                filterId:
-                    type: string
-        SubscriptionAPI_AttachFilter_Response:
-            type: object
-            properties: {}
-        SubscriptionAPI_DetachFilter_Request:
-            type: object
-            properties:
-                subscriptionId:
-                    type: string
-                filterName:
-                    type: string
-        SubscriptionAPI_DetachFilter_Response:
-            type: object
-            properties: {}
-        TxAPI_Sync_Request:
-            type: object
-            properties:
-                txId:
-                    type: string
-        TxAPI_Sync_Response:
-            type: object
-            properties: {}
+             All list see pl/platform/api/plapiserver/server_capabilities.go
+    MiscAPI_ListResourceTypes_Response:
+      type: object
+      properties:
+        types:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceType"
+    Notification:
+      type: object
+      properties:
+        subscriptionId:
+          type: string
+        eventId:
+          type: string
+        resourceId:
+          type: string
+        resourceType:
+          $ref: "#/components/schemas/ResourceType"
+        events:
+          $ref: "#/components/schemas/Notification_Events"
+        fieldChanges:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/Notification_FieldChange"
+        payload:
+          $ref: "#/components/schemas/NotificationFilter_Payload"
+        filterName:
+          type: string
+        txSpan:
+          $ref: "#/components/schemas/SpanInfo"
+    NotificationAPI_Get_Request:
+      type: object
+      properties:
+        subscription:
+          type: string
+        maxNotifications:
+          type: integer
+          format: uint32
+    NotificationAPI_Get_Response:
+      type: object
+      properties:
+        notifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/Notification"
+    NotificationFilter:
+      type: object
+      properties:
+        resourceType:
+          $ref: "#/components/schemas/ResourceType"
+        resourceId:
+          type: string
+        eventFilter:
+          $ref: "#/components/schemas/NotificationFilter_EventFilter"
+        payload:
+          $ref: "#/components/schemas/NotificationFilter_Payload"
+    NotificationFilter_EventFilter:
+      type: object
+      properties:
+        all:
+          type: boolean
+        resourceCreated:
+          type: boolean
+        resourceDeleted:
+          type: boolean
+        resourceReady:
+          type: boolean
+        resourceRecovered:
+          type: boolean
+        resourceDuplicate:
+          type: boolean
+        resourceError:
+          type: boolean
+        inputsLocked:
+          type: boolean
+          description: Field events
+        outputsLocked:
+          type: boolean
+        fieldCreated:
+          type: boolean
+        fieldGotError:
+          type: boolean
+        inputSet:
+          type: boolean
+        allInputsSet:
+          type: boolean
+        outputSet:
+          type: boolean
+        allOutputsSet:
+          type: boolean
+        genericOtwSet:
+          type: boolean
+        dynamicChanged:
+          type: boolean
+    NotificationFilter_Payload:
+      type: object
+      properties:
+        values:
+          type: object
+          additionalProperties:
+            type: string
+            format: bytes
+    Notification_Events:
+      type: object
+      properties:
+        resourceCreated:
+          type: boolean
+        resourceDeleted:
+          type: boolean
+        resourceReady:
+          type: boolean
+        resourceDuplicate:
+          type: boolean
+        resourceError:
+          type: boolean
+        inputsLocked:
+          type: boolean
+        outputsLocked:
+          type: boolean
+        fieldCreated:
+          type: boolean
+        fieldGotError:
+          type: boolean
+        inputSet:
+          type: boolean
+        allInputsSet:
+          type: boolean
+        outputSet:
+          type: boolean
+        allOutputsSet:
+          type: boolean
+        genericOtwSet:
+          type: boolean
+        dynamicChanged:
+          type: boolean
+        resourceRecovered:
+          type: boolean
+    Notification_FieldChange:
+      type: object
+      properties:
+        old:
+          $ref: "#/components/schemas/Field"
+        new:
+          $ref: "#/components/schemas/Field"
+    ResourceAPIFeature:
+      type: object
+      properties:
+        controllerType:
+          type: string
+        featureName:
+          type: string
+        resourceType:
+          $ref: "#/components/schemas/ResourceType"
+        endpoint:
+          type: string
+    ResourceSchema:
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/ResourceType"
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/FieldSchema"
+        accessFlags:
+          allOf:
+            - $ref: "#/components/schemas/ResourceSchema_AccessFlags"
+          description: Access restriction flags for non-controller roles
+        freeInputs:
+          type: boolean
+        freeOutputs:
+          type: boolean
+    ResourceSchema_AccessFlags:
+      type: object
+      properties:
+        createResource:
+          type: boolean
+          description: |-
+            Deny-list approach: default = allowed (true)
+             Controllers set these to false to restrict non-controller roles (role='u', role='w')
+        readFields:
+          type: boolean
+          description: "IMPORTANT: read_fields=false with write_fields=true is a forbidden combination"
+        writeFields:
+          type: boolean
+        readKv:
+          type: boolean
+          description: "IMPORTANT: read_kv=false with write_kv=true is a forbidden combination"
+        writeKv:
+          type: boolean
+        readByFieldType:
+          type: object
+          additionalProperties:
+            type: boolean
+          description: |-
+            Per-field-type overrides (map: field_type → bool)
+             When defined for a field type, overrides resource-level flags
+        writeByFieldType:
+          type: object
+          additionalProperties:
+            type: boolean
+        setError:
+          type: boolean
+          description: |-
+            SetError is a control-flow channel and is allowed by default even when
+             every other access bit is denied: a failing step on a closely-guarded
+             resource must surface to its caller. Controllers may opt out by
+             setting this to false.
+    ResourceType:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+    Resource_Features:
+      type: object
+      properties:
+        ephemeral:
+          type: boolean
+    SpanInfo:
+      type: object
+      properties:
+        path:
+          type: string
+        carrier:
+          type: object
+          additionalProperties:
+            type: string
+    Status:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+          format: int32
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        details:
+          type: array
+          items:
+            $ref: "#/components/schemas/GoogleProtobufAny"
+          description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+      description: "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
+    SubscriptionAPI_AttachFilter_Request:
+      type: object
+      properties:
+        subscriptionId:
+          type: string
+        filterName:
+          type: string
+        filterId:
+          type: string
+    SubscriptionAPI_AttachFilter_Response:
+      type: object
+      properties: {}
+    SubscriptionAPI_DetachFilter_Request:
+      type: object
+      properties:
+        subscriptionId:
+          type: string
+        filterName:
+          type: string
+    SubscriptionAPI_DetachFilter_Response:
+      type: object
+      properties: {}
+    TxAPI_Sync_Request:
+      type: object
+      properties:
+        txId:
+          type: string
+    TxAPI_Sync_Response:
+      type: object
+      properties: {}
 tags:
-    - name: Platform
+  - name: Platform

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -649,7 +649,7 @@ export class LLPlClient implements WireClientProviderFactory {
   /** Request a one-time PKCE nonce + its expiry from the backend. The desktop is
    * expected to place the nonce verbatim into the OIDC auth-request before
    * redirecting to the IdP; the backend enforces the expiry on {@link loginSSO}. */
-  public async beginSSOLogin(): Promise<{ nonce: string; expiresAt: Date }> {
+  public async beginSSOLogin(): Promise<{ nonce: string; expiresAt: Date; clientSecret?: string }> {
     const cl = this.clientProvider.get();
     if (cl instanceof GrpcPlApiClient) {
       const resp = (await cl.beginSSOLogin({}).response).flow;
@@ -660,6 +660,7 @@ export class LLPlClient implements WireClientProviderFactory {
       return {
         nonce: resp.publicPkce.nonce,
         expiresAt: Timestamp.toDate(exp),
+        clientSecret: resp.publicPkce.clientSecret,
       };
     } else {
       const wsResponse = notEmpty(
@@ -667,7 +668,11 @@ export class LLPlClient implements WireClientProviderFactory {
         "REST: empty response for beginSSOLogin request",
       );
       const pkce = notEmpty(wsResponse.publicPkce, "REST: missing publicPkce in beginSSOLogin");
-      return { nonce: pkce.nonce, expiresAt: new Date(pkce.expiresAt) };
+      return {
+        nonce: pkce.nonce,
+        expiresAt: new Date(pkce.expiresAt),
+        clientSecret: pkce.clientSecret,
+      };
     }
   }
 

--- a/lib/node/pl-client/src/core/unauth_client.ts
+++ b/lib/node/pl-client/src/core/unauth_client.ts
@@ -30,8 +30,9 @@ export type SSOAuthMethod = {
   groupsClaim: string;
   flowType: SSOFlowType;
   /** OIDC `access_type` auth-request param ("online" | "offline"). Google-specific:
-   * "offline" makes Google issue a refresh token; other IdPs ignore it. May be empty. */
-  accessType: string;
+   * "offline" makes Google issue a refresh token; other IdPs ignore it. Absent when
+   * the server does not set it — never send an empty string to the IdP. */
+  accessType?: string;
 };
 
 /** Server-issued material returned by {@link UnauthenticatedPlClient.beginSSOLogin}.
@@ -112,7 +113,7 @@ export class UnauthenticatedPlClient {
         subjectTokenSource: sso.subjectTokenSource,
         userIdClaim: sso.userIdClaim,
         groupsClaim: sso.groupsClaim,
-        accessType: sso.accessType,
+        accessType: sso.accessType || undefined,
         flowType: "public_pkce",
       };
     }

--- a/lib/node/pl-client/src/core/unauth_client.ts
+++ b/lib/node/pl-client/src/core/unauth_client.ts
@@ -29,6 +29,9 @@ export type SSOAuthMethod = {
   userIdClaim: string;
   groupsClaim: string;
   flowType: SSOFlowType;
+  /** OIDC `access_type` auth-request param ("online" | "offline"). Google-specific:
+   * "offline" makes Google issue a refresh token; other IdPs ignore it. May be empty. */
+  accessType: string;
 };
 
 /** Server-issued material returned by {@link UnauthenticatedPlClient.beginSSOLogin}.
@@ -37,6 +40,11 @@ export type SSOLoginAttempt = {
   flow: "public_pkce";
   nonce: string;
   expiresAt: Date;
+  /** Confidential-client secret for the IdP token exchange; absent for public clients.
+   * Google's OIDC has no public-client mode — it requires a client_secret at the token
+   * endpoint even with PKCE — so for Google the backend forwards its secret here and the
+   * desktop exchanges the code as a confidential client. */
+  clientSecret?: string;
 };
 
 /** Primarily used for initial authentication (login) */
@@ -104,6 +112,7 @@ export class UnauthenticatedPlClient {
         subjectTokenSource: sso.subjectTokenSource,
         userIdClaim: sso.userIdClaim,
         groupsClaim: sso.groupsClaim,
+        accessType: sso.accessType,
         flowType: "public_pkce",
       };
     }
@@ -149,8 +158,13 @@ export class UnauthenticatedPlClient {
   /** Request fresh server-issued login material. v1 only emits the public-PKCE flow;
    * desktop MUST place the returned `nonce` verbatim into the OIDC auth-request. */
   public async beginSSOLogin(): Promise<SSOLoginAttempt> {
-    const { nonce, expiresAt } = await this.ll.beginSSOLogin();
-    return { flow: "public_pkce", nonce, expiresAt };
+    const attempt = await this.ll.beginSSOLogin();
+    return {
+      flow: "public_pkce",
+      nonce: attempt.nonce,
+      expiresAt: attempt.expiresAt,
+      clientSecret: attempt.clientSecret,
+    };
   }
 
   /** Forward the verbatim IdP `/token` response body and receive a Platforma JWT. */

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.client.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.client.ts
@@ -10,6 +10,8 @@ import type { MaintenanceAPI_Ping_Response } from "./api";
 import type { MaintenanceAPI_Ping_Request } from "./api";
 import type { MiscAPI_ListResourceTypes_Response } from "./api";
 import type { MiscAPI_ListResourceTypes_Request } from "./api";
+import type { AuthAPI_ListUsers_Response } from "./api";
+import type { AuthAPI_ListUsers_Request } from "./api";
 import type { AuthAPI_ListUserResources_Response } from "./api";
 import type { AuthAPI_ListUserResources_Request } from "./api";
 import type { AuthAPI_GetUserRoot_Response } from "./api";
@@ -284,6 +286,10 @@ export interface IPlatformClient {
      * @generated from protobuf rpc: ListUserResources
      */
     listUserResources(input: AuthAPI_ListUserResources_Request, options?: RpcOptions): ServerStreamingCall<AuthAPI_ListUserResources_Request, AuthAPI_ListUserResources_Response>;
+    /**
+     * @generated from protobuf rpc: ListUsers
+     */
+    listUsers(input: AuthAPI_ListUsers_Request, options?: RpcOptions): UnaryCall<AuthAPI_ListUsers_Request, AuthAPI_ListUsers_Response>;
     /**
      *
      * Other stuff
@@ -614,6 +620,13 @@ export class PlatformClient implements IPlatformClient, ServiceInfo {
         return stackIntercept<AuthAPI_ListUserResources_Request, AuthAPI_ListUserResources_Response>("serverStreaming", this._transport, method, opt, input);
     }
     /**
+     * @generated from protobuf rpc: ListUsers
+     */
+    listUsers(input: AuthAPI_ListUsers_Request, options?: RpcOptions): UnaryCall<AuthAPI_ListUsers_Request, AuthAPI_ListUsers_Response> {
+        const method = this.methods[34], opt = this._transport.mergeOptions(options);
+        return stackIntercept<AuthAPI_ListUsers_Request, AuthAPI_ListUsers_Response>("unary", this._transport, method, opt, input);
+    }
+    /**
      *
      * Other stuff
      *
@@ -621,7 +634,7 @@ export class PlatformClient implements IPlatformClient, ServiceInfo {
      * @generated from protobuf rpc: ListResourceTypes
      */
     listResourceTypes(input: MiscAPI_ListResourceTypes_Request, options?: RpcOptions): UnaryCall<MiscAPI_ListResourceTypes_Request, MiscAPI_ListResourceTypes_Response> {
-        const method = this.methods[34], opt = this._transport.mergeOptions(options);
+        const method = this.methods[35], opt = this._transport.mergeOptions(options);
         return stackIntercept<MiscAPI_ListResourceTypes_Request, MiscAPI_ListResourceTypes_Response>("unary", this._transport, method, opt, input);
     }
     /**
@@ -632,14 +645,14 @@ export class PlatformClient implements IPlatformClient, ServiceInfo {
      * @generated from protobuf rpc: Ping
      */
     ping(input: MaintenanceAPI_Ping_Request, options?: RpcOptions): UnaryCall<MaintenanceAPI_Ping_Request, MaintenanceAPI_Ping_Response> {
-        const method = this.methods[35], opt = this._transport.mergeOptions(options);
+        const method = this.methods[36], opt = this._transport.mergeOptions(options);
         return stackIntercept<MaintenanceAPI_Ping_Request, MaintenanceAPI_Ping_Response>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: License
      */
     license(input: MaintenanceAPI_License_Request, options?: RpcOptions): UnaryCall<MaintenanceAPI_License_Request, MaintenanceAPI_License_Response> {
-        const method = this.methods[36], opt = this._transport.mergeOptions(options);
+        const method = this.methods[37], opt = this._transport.mergeOptions(options);
         return stackIntercept<MaintenanceAPI_License_Request, MaintenanceAPI_License_Response>("unary", this._transport, method, opt, input);
     }
 }

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -3605,6 +3605,10 @@ export interface AuthAPI_ListMethods_SSOAuthMethod {
      * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType flow_type = 10
      */
     flowType: AuthAPI_ListMethods_SSOAuthMethod_FlowType;
+    /**
+     * @generated from protobuf field: optional string access_type = 11
+     */
+    accessType?: string; // "online" | "offline"; Google-specific (offline → refresh token)
 }
 /**
  * @generated from protobuf enum MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType
@@ -3684,6 +3688,17 @@ export interface AuthAPI_BeginSSOLogin_PublicPKCE {
      * @generated from protobuf field: google.protobuf.Timestamp expires_at = 2
      */
     expiresAt?: Timestamp; // after this, nonce is no longer valid (when enforced)
+    /**
+     * Confidential-client secret for the IdP token exchange; absent for public clients.
+     * Rationale: Google's OIDC does not support public clients — it requires a
+     * client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+     * gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+     * leaving the server. So the backend holds the secret and forwards it here to the
+     * desktop, which performs the token exchange as a confidential client.
+     *
+     * @generated from protobuf field: optional string client_secret = 3
+     */
+    clientSecret?: string;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.Response
@@ -17552,7 +17567,8 @@ class AuthAPI_ListMethods_SSOAuthMethod$Type extends MessageType<AuthAPI_ListMet
             { no: 7, name: "subject_token_source", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 8, name: "user_id_claim", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 9, name: "groups_claim", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 10, name: "flow_type", kind: "enum", T: () => ["MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType", AuthAPI_ListMethods_SSOAuthMethod_FlowType] }
+            { no: 10, name: "flow_type", kind: "enum", T: () => ["MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType", AuthAPI_ListMethods_SSOAuthMethod_FlowType] },
+            { no: 11, name: "access_type", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_ListMethods_SSOAuthMethod>): AuthAPI_ListMethods_SSOAuthMethod {
@@ -17610,6 +17626,9 @@ class AuthAPI_ListMethods_SSOAuthMethod$Type extends MessageType<AuthAPI_ListMet
                 case /* MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType flow_type */ 10:
                     message.flowType = reader.int32();
                     break;
+                case /* optional string access_type */ 11:
+                    message.accessType = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -17656,6 +17675,9 @@ class AuthAPI_ListMethods_SSOAuthMethod$Type extends MessageType<AuthAPI_ListMet
         /* MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType flow_type = 10; */
         if (message.flowType !== 0)
             writer.tag(10, WireType.Varint).int32(message.flowType);
+        /* optional string access_type = 11; */
+        if (message.accessType !== undefined)
+            writer.tag(11, WireType.LengthDelimited).string(message.accessType);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -17833,7 +17855,8 @@ class AuthAPI_BeginSSOLogin_PublicPKCE$Type extends MessageType<AuthAPI_BeginSSO
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.PublicPKCE", [
             { no: 1, name: "nonce", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "expires_at", kind: "message", T: () => Timestamp }
+            { no: 2, name: "expires_at", kind: "message", T: () => Timestamp },
+            { no: 3, name: "client_secret", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_BeginSSOLogin_PublicPKCE>): AuthAPI_BeginSSOLogin_PublicPKCE {
@@ -17854,6 +17877,9 @@ class AuthAPI_BeginSSOLogin_PublicPKCE$Type extends MessageType<AuthAPI_BeginSSO
                 case /* google.protobuf.Timestamp expires_at */ 2:
                     message.expiresAt = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.expiresAt);
                     break;
+                case /* optional string client_secret */ 3:
+                    message.clientSecret = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -17872,6 +17898,9 @@ class AuthAPI_BeginSSOLogin_PublicPKCE$Type extends MessageType<AuthAPI_BeginSSO
         /* google.protobuf.Timestamp expires_at = 2; */
         if (message.expiresAt)
             Timestamp.internalBinaryWrite(message.expiresAt, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional string client_secret = 3; */
+        if (message.clientSecret !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.clientSecret);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -540,6 +540,12 @@ export interface TxAPI_ClientMessage {
          */
         revokeAccess: AuthAPI_RevokeAccess_Request; // revoke access to a resource within transaction
     } | {
+        oneofKind: "listGrants";
+        /**
+         * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.ListGrants.Request list_grants = 412
+         */
+        listGrants: AuthAPI_ListGrants_Request; // list grants on a resource within transaction
+    } | {
         oneofKind: undefined;
     };
 }
@@ -928,6 +934,12 @@ export interface TxAPI_ServerMessage {
          * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.RevokeAccess.Response revoke_access = 411
          */
         revokeAccess: AuthAPI_RevokeAccess_Response;
+    } | {
+        oneofKind: "listGrants";
+        /**
+         * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse list_grants = 412
+         */
+        listGrants: AuthAPI_ListGrants_TxResponse;
     } | {
         oneofKind: undefined;
     };
@@ -3992,6 +4004,15 @@ export interface AuthAPI_ListGrants_Response {
     grant?: AuthAPI_Grant; // one per stream message
 }
 /**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse
+ */
+export interface AuthAPI_ListGrants_TxResponse {
+    /**
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.AuthAPI.Grant grants = 1
+     */
+    grants: AuthAPI_Grant[]; // all grants for the resource in a single transactional response
+}
+/**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.Grant
  */
 export interface AuthAPI_Grant {
@@ -4187,6 +4208,41 @@ export interface AuthAPI_ListUserResources_SharedResource {
      * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.Grant.Permissions permissions = 4
      */
     permissions?: AuthAPI_Grant_Permissions;
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.User
+ */
+export interface AuthAPI_User {
+    /**
+     * login is the stable identifier of the user — the grant target and the
+     * GetUserRoot key. Further fields (e.g. first name, last name, email) may
+     * be added later without breaking compatibility.
+     *
+     * @generated from protobuf field: string login = 1
+     */
+    login: string;
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers
+ */
+export interface AuthAPI_ListUsers {
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Request
+ */
+export interface AuthAPI_ListUsers_Request {
+}
+/**
+ * Lists users known to the server. A user becomes known on first login;
+ * provisioned users who have never logged in do not appear.
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Response
+ */
+export interface AuthAPI_ListUsers_Response {
+    /**
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.AuthAPI.User users = 1
+     */
+    users: AuthAPI_User[];
 }
 /**
  * @generated from protobuf enum MiLaboratories.PL.API.AuthAPI.Role
@@ -4474,7 +4530,8 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
             { no: 351, name: "controller_features_clear", kind: "message", oneof: "request", T: () => ControllerAPI_ClearFeatures_Request },
             { no: 400, name: "set_default_color", kind: "message", oneof: "request", T: () => TxAPI_SetDefaultColor_Request },
             { no: 410, name: "grant_access", kind: "message", oneof: "request", T: () => AuthAPI_GrantAccess_Request },
-            { no: 411, name: "revoke_access", kind: "message", oneof: "request", T: () => AuthAPI_RevokeAccess_Request }
+            { no: 411, name: "revoke_access", kind: "message", oneof: "request", T: () => AuthAPI_RevokeAccess_Request },
+            { no: 412, name: "list_grants", kind: "message", oneof: "request", T: () => AuthAPI_ListGrants_Request }
         ]);
     }
     create(value?: PartialMessage<TxAPI_ClientMessage>): TxAPI_ClientMessage {
@@ -4859,6 +4916,12 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
                         revokeAccess: AuthAPI_RevokeAccess_Request.internalBinaryRead(reader, reader.uint32(), options, (message.request as any).revokeAccess)
                     };
                     break;
+                case /* MiLaboratories.PL.API.AuthAPI.ListGrants.Request list_grants */ 412:
+                    message.request = {
+                        oneofKind: "listGrants",
+                        listGrants: AuthAPI_ListGrants_Request.internalBinaryRead(reader, reader.uint32(), options, (message.request as any).listGrants)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -5057,6 +5120,9 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
         /* MiLaboratories.PL.API.AuthAPI.RevokeAccess.Request revoke_access = 411; */
         if (message.request.oneofKind === "revokeAccess")
             AuthAPI_RevokeAccess_Request.internalBinaryWrite(message.request.revokeAccess, writer.tag(411, WireType.LengthDelimited).fork(), options).join();
+        /* MiLaboratories.PL.API.AuthAPI.ListGrants.Request list_grants = 412; */
+        if (message.request.oneofKind === "listGrants")
+            AuthAPI_ListGrants_Request.internalBinaryWrite(message.request.listGrants, writer.tag(412, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -5134,6 +5200,7 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
             { no: 400, name: "set_default_color", kind: "message", oneof: "response", T: () => TxAPI_SetDefaultColor_Response },
             { no: 410, name: "grant_access", kind: "message", oneof: "response", T: () => AuthAPI_GrantAccess_Response },
             { no: 411, name: "revoke_access", kind: "message", oneof: "response", T: () => AuthAPI_RevokeAccess_Response },
+            { no: 412, name: "list_grants", kind: "message", oneof: "response", T: () => AuthAPI_ListGrants_TxResponse },
             { no: 3, name: "error", kind: "message", T: () => Status }
         ]);
     }
@@ -5522,6 +5589,12 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
                         revokeAccess: AuthAPI_RevokeAccess_Response.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).revokeAccess)
                     };
                     break;
+                case /* MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse list_grants */ 412:
+                    message.response = {
+                        oneofKind: "listGrants",
+                        listGrants: AuthAPI_ListGrants_TxResponse.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).listGrants)
+                    };
+                    break;
                 case /* google.rpc.Status error */ 3:
                     message.error = Status.internalBinaryRead(reader, reader.uint32(), options, message.error);
                     break;
@@ -5729,6 +5802,9 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
         /* MiLaboratories.PL.API.AuthAPI.RevokeAccess.Response revoke_access = 411; */
         if (message.response.oneofKind === "revokeAccess")
             AuthAPI_RevokeAccess_Response.internalBinaryWrite(message.response.revokeAccess, writer.tag(411, WireType.LengthDelimited).fork(), options).join();
+        /* MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse list_grants = 412; */
+        if (message.response.oneofKind === "listGrants")
+            AuthAPI_ListGrants_TxResponse.internalBinaryWrite(message.response.listGrants, writer.tag(412, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -19063,6 +19139,53 @@ class AuthAPI_ListGrants_Response$Type extends MessageType<AuthAPI_ListGrants_Re
  */
 export const AuthAPI_ListGrants_Response = new AuthAPI_ListGrants_Response$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListGrants_TxResponse$Type extends MessageType<AuthAPI_ListGrants_TxResponse> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse", [
+            { no: 1, name: "grants", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => AuthAPI_Grant }
+        ]);
+    }
+    create(value?: PartialMessage<AuthAPI_ListGrants_TxResponse>): AuthAPI_ListGrants_TxResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.grants = [];
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListGrants_TxResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListGrants_TxResponse): AuthAPI_ListGrants_TxResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated MiLaboratories.PL.API.AuthAPI.Grant grants */ 1:
+                    message.grants.push(AuthAPI_Grant.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListGrants_TxResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated MiLaboratories.PL.API.AuthAPI.Grant grants = 1; */
+        for (let i = 0; i < message.grants.length; i++)
+            AuthAPI_Grant.internalBinaryWrite(message.grants[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse
+ */
+export const AuthAPI_ListGrants_TxResponse = new AuthAPI_ListGrants_TxResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class AuthAPI_Grant$Type extends MessageType<AuthAPI_Grant> {
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.Grant", [
@@ -19775,6 +19898,176 @@ class AuthAPI_ListUserResources_SharedResource$Type extends MessageType<AuthAPI_
  */
 export const AuthAPI_ListUserResources_SharedResource = new AuthAPI_ListUserResources_SharedResource$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_User$Type extends MessageType<AuthAPI_User> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.User", [
+            { no: 1, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<AuthAPI_User>): AuthAPI_User {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.login = "";
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_User>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_User): AuthAPI_User {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string login */ 1:
+                    message.login = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_User, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string login = 1; */
+        if (message.login !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.login);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.User
+ */
+export const AuthAPI_User = new AuthAPI_User$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListUsers$Type extends MessageType<AuthAPI_ListUsers> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListUsers", []);
+    }
+    create(value?: PartialMessage<AuthAPI_ListUsers>): AuthAPI_ListUsers {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListUsers>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListUsers): AuthAPI_ListUsers {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListUsers, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers
+ */
+export const AuthAPI_ListUsers = new AuthAPI_ListUsers$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListUsers_Request$Type extends MessageType<AuthAPI_ListUsers_Request> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListUsers.Request", []);
+    }
+    create(value?: PartialMessage<AuthAPI_ListUsers_Request>): AuthAPI_ListUsers_Request {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListUsers_Request>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListUsers_Request): AuthAPI_ListUsers_Request {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListUsers_Request, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Request
+ */
+export const AuthAPI_ListUsers_Request = new AuthAPI_ListUsers_Request$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListUsers_Response$Type extends MessageType<AuthAPI_ListUsers_Response> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListUsers.Response", [
+            { no: 1, name: "users", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => AuthAPI_User }
+        ]);
+    }
+    create(value?: PartialMessage<AuthAPI_ListUsers_Response>): AuthAPI_ListUsers_Response {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.users = [];
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListUsers_Response>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListUsers_Response): AuthAPI_ListUsers_Response {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated MiLaboratories.PL.API.AuthAPI.User users */ 1:
+                    message.users.push(AuthAPI_User.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListUsers_Response, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated MiLaboratories.PL.API.AuthAPI.User users = 1; */
+        for (let i = 0; i < message.users.length; i++)
+            AuthAPI_User.internalBinaryWrite(message.users[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Response
+ */
+export const AuthAPI_ListUsers_Response = new AuthAPI_ListUsers_Response$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class MiscAPI$Type extends MessageType<MiscAPI> {
     constructor() {
         super("MiLaboratories.PL.API.MiscAPI", []);
@@ -20405,6 +20698,7 @@ export const Platform = new ServiceType("MiLaboratories.PL.API.Platform", [
     { name: "MintSignature", options: { "google.api.http": { post: "/v1/auth/mint-signature", body: "*" } }, I: AuthAPI_MintSignature_Request, O: AuthAPI_MintSignature_Response },
     { name: "GetUserRoot", options: { "google.api.http": { post: "/v1/auth/user-root", body: "*" } }, I: AuthAPI_GetUserRoot_Request, O: AuthAPI_GetUserRoot_Response },
     { name: "ListUserResources", serverStreaming: true, options: {}, I: AuthAPI_ListUserResources_Request, O: AuthAPI_ListUserResources_Response },
+    { name: "ListUsers", options: {}, I: AuthAPI_ListUsers_Request, O: AuthAPI_ListUsers_Response },
     { name: "ListResourceTypes", options: { "google.api.http": { get: "/v1/resource-types" } }, I: MiscAPI_ListResourceTypes_Request, O: MiscAPI_ListResourceTypes_Response },
     { name: "Ping", options: { "google.api.http": { get: "/v1/ping" } }, I: MaintenanceAPI_Ping_Request, O: MaintenanceAPI_Ping_Response },
     { name: "License", options: { "google.api.http": { get: "/v1/license" } }, I: MaintenanceAPI_License_Request, O: MaintenanceAPI_License_Response }

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
@@ -417,8 +417,8 @@ export interface ResourceSchema {
  */
 export interface ResourceSchema_AccessFlags {
     /**
-     * Deny-list approach: default = allowed (true)
-     * Controllers set these to false to restrict non-controller roles (role='u', role='w')
+     * Allow-list approach: default = forbidden (false)
+     * Controllers set this to true allow non-controller roles (role='u', role='w')
      *
      * @generated from protobuf field: optional bool create_resource = 1
      */
@@ -428,21 +428,21 @@ export interface ResourceSchema_AccessFlags {
      *
      * @generated from protobuf field: optional bool read_fields = 2
      */
-    readFields?: boolean; // default: true (reads allowed)
+    readFields?: boolean; // default: false (reads denied)
     /**
      * @generated from protobuf field: optional bool write_fields = 3
      */
-    writeFields?: boolean; // default: true (writes allowed)
+    writeFields?: boolean; // default: false (writes denied)
     /**
      * IMPORTANT: read_kv=false with write_kv=true is a forbidden combination
      *
      * @generated from protobuf field: optional bool read_kv = 4
      */
-    readKv?: boolean; // if unset, falls back to read_fields
+    readKv?: boolean; // default: false (KV reads denied)
     /**
      * @generated from protobuf field: optional bool write_kv = 5
      */
-    writeKv?: boolean; // if unset, falls back to write_fields
+    writeKv?: boolean; // default: false (KV writes denied)
     /**
      * Per-field-type overrides (map: field_type → bool)
      * When defined for a field type, overrides resource-level flags
@@ -458,6 +458,13 @@ export interface ResourceSchema_AccessFlags {
     writeByFieldType: {
         [key: number]: boolean;
     };
+    /**
+     * Allows non-controller roles (role='u', role='w') to set error on the resource,
+     * marking it as failed and dropping it from recovery/deduplication indicies.
+     *
+     * @generated from protobuf field: optional bool set_error = 8
+     */
+    setError?: boolean; // default: true (allowed)
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.FieldSchema
@@ -1506,7 +1513,8 @@ class ResourceSchema_AccessFlags$Type extends MessageType<ResourceSchema_AccessF
             { no: 4, name: "read_kv", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 5, name: "write_kv", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 6, name: "read_by_field_type", kind: "map", K: 13 /*ScalarType.UINT32*/, V: { kind: "scalar", T: 8 /*ScalarType.BOOL*/ } },
-            { no: 7, name: "write_by_field_type", kind: "map", K: 13 /*ScalarType.UINT32*/, V: { kind: "scalar", T: 8 /*ScalarType.BOOL*/ } }
+            { no: 7, name: "write_by_field_type", kind: "map", K: 13 /*ScalarType.UINT32*/, V: { kind: "scalar", T: 8 /*ScalarType.BOOL*/ } },
+            { no: 8, name: "set_error", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ResourceSchema_AccessFlags>): ResourceSchema_AccessFlags {
@@ -1542,6 +1550,9 @@ class ResourceSchema_AccessFlags$Type extends MessageType<ResourceSchema_AccessF
                     break;
                 case /* map<uint32, bool> write_by_field_type */ 7:
                     this.binaryReadMap7(message.writeByFieldType, reader, options);
+                    break;
+                case /* optional bool set_error */ 8:
+                    message.setError = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1608,6 +1619,9 @@ class ResourceSchema_AccessFlags$Type extends MessageType<ResourceSchema_AccessF
         /* map<uint32, bool> write_by_field_type = 7; */
         for (let k of globalThis.Object.keys(message.writeByFieldType))
             writer.tag(7, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).bool(message.writeByFieldType[k as any]).join();
+        /* optional bool set_error = 8; */
+        if (message.setError !== undefined)
+            writer.tag(8, WireType.Varint).bool(message.setError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -4,2252 +4,2252 @@
  */
 
 export interface paths {
-    "/v1/auth/grant-access": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_GrantAccess"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/v1/auth/grant-access": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/jwt-token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description Deprecated: Use Login for session creation and role transitions,
-         *      and RefreshToken for token renewal. Backends implementing this API always return
-         *      codes.Unimplemented. Kept here so clients can still call old backends.
-         */
-        post: operations["Platform_GetJWTToken"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_GrantAccess"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/jwt-token": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description Login authenticates with the given credentials and returns a new Platforma JWT.
-         *      Every Login call creates a new session. Use RefreshToken to renew an existing one.
-         *      This method is public: no Authorization header is required.
-         */
-        post: operations["Platform_Login"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description Deprecated: Use Login for session creation and role transitions,
+     *      and RefreshToken for token renewal. Backends implementing this API always return
+     *      codes.Unimplemented. Kept here so clients can still call old backends.
+     */
+    post: operations["Platform_GetJWTToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/login": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/methods": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Authentication */
-        get: operations["Platform_AuthMethods"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description Login authenticates with the given credentials and returns a new Platforma JWT.
+     *      Every Login call creates a new session. Use RefreshToken to renew an existing one.
+     *      This method is public: no Authorization header is required.
+     */
+    post: operations["Platform_Login"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/methods": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/mint-signature": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description MintSignature creates a resource signature bound to a target session.
-         *      Controllers use it during workflow bootstrap to pre-sign resources
-         *      so the workflow can access them under its own isolated session.
-         */
-        post: operations["Platform_MintSignature"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** @description Authentication */
+    get: operations["Platform_AuthMethods"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/mint-signature": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description RefreshToken accepts a valid Platforma JWT and re-issues it with the same
-         *      session ID and role. Only the token expiration may be changed.
-         *      Workflow-scoped tokens cannot be refreshed; call Login instead.
-         *      This method is public: no Authorization header is required.
-         */
-        post: operations["Platform_RefreshToken"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description MintSignature creates a resource signature bound to a target session.
+     *      Controllers use it during workflow bootstrap to pre-sign resources
+     *      so the workflow can access them under its own isolated session.
+     */
+    post: operations["Platform_MintSignature"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/revoke-access": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_RevokeAccess"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description RefreshToken accepts a valid Platforma JWT and re-issues it with the same
+     *      session ID and role. Only the token expiration may be changed.
+     *      Workflow-scoped tokens cannot be refreshed; call Login instead.
+     *      This method is public: no Authorization header is required.
+     */
+    post: operations["Platform_RefreshToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/revoke-access": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/session-info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_GetSessionInfo"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_RevokeAccess"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/session-info": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/sso/begin-login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description BeginSSOLogin returns a fresh one-time nonce that the desktop must place
-         *      into the OIDC auth-request before redirecting to the IdP. Used by the SSO
-         *      login flow. This method is public: no Authorization header is required.
-         */
-        post: operations["Platform_BeginSSOLogin"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_GetSessionInfo"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/sso/begin-login": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/auth/user-root": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_GetUserRoot"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description BeginSSOLogin returns a fresh one-time nonce that the desktop must place
+     *      into the OIDC auth-request before redirecting to the IdP. Used by the SSO
+     *      login flow. This method is public: no Authorization header is required.
+     */
+    post: operations["Platform_BeginSSOLogin"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/auth/user-root": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/aliases-and-urls": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_WriteControllerAliasesAndUrls"];
-        delete: operations["Platform_RemoveControllerAliasesAndUrls"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_GetUserRoot"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/aliases-and-urls": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/attach-subscription": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerAttachSubscription"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_WriteControllerAliasesAndUrls"];
+    delete: operations["Platform_RemoveControllerAliasesAndUrls"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/attach-subscription": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/create": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerCreate"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerAttachSubscription"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/create": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/deregister": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerDeregister"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerCreate"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/deregister": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/exists": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerExists"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerDeregister"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/exists": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/features": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerSetFeatures"];
-        delete: operations["Platform_ControllerClearFeatures"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerExists"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/features": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/get": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerGet"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerSetFeatures"];
+    delete: operations["Platform_ControllerClearFeatures"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/get": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/notifications": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_GetControllerNotifications"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerGet"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/notifications": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/register": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Controllers */
-        post: operations["Platform_ControllerRegister"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_GetControllerNotifications"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/register": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ControllerUpdate"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** @description Controllers */
+    post: operations["Platform_ControllerRegister"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/update": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/controller/url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_GetControllerUrl"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ControllerUpdate"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/controller/url": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/license": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: operations["Platform_License"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_GetControllerUrl"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/license": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/locks/lease/create": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
-         *      Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
-         *      To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
-         */
-        post: operations["Platform_LeaseResource"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get: operations["Platform_License"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/locks/lease/create": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/locks/lease/release": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_ReleaseLease"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
+     *      Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
+     *      To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
+     */
+    post: operations["Platform_LeaseResource"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/locks/lease/release": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/locks/lease/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_UpdateLease"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_ReleaseLease"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/locks/lease/update": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/locks/lock/create": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * @description LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
-         *        - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
-         *        - list resource's fields, take fields with names set in request
-         *        - get resolved values of listed fields (IDs of 'ON' resources).
-         *        - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
-         *
-         *      Lock logic constraints:
-         *        - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
-         *          succeeds, while the other fails with an error (no long waiting)
-         *        - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
-         *          the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
-         *        - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
-         *          being lockable. An attempt to lock a resource that has not become original will fail.
-         *        - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
-         */
-        post: operations["Platform_LockFieldValues"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_UpdateLease"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/locks/lock/create": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/notifications/get": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_NotificationsGet"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * @description LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
+     *        - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
+     *        - list resource's fields, take fields with names set in request
+     *        - get resolved values of listed fields (IDs of 'ON' resources).
+     *        - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
+     *
+     *      Lock logic constraints:
+     *        - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
+     *          succeeds, while the other fails with an error (no long waiting)
+     *        - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
+     *          the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
+     *        - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
+     *          being lockable. An attempt to lock a resource that has not become original will fail.
+     *        - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
+     */
+    post: operations["Platform_LockFieldValues"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/notifications/get": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/ping": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Various service requests */
-        get: operations["Platform_Ping"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_NotificationsGet"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/ping": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-types": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** @description Other stuff */
-        get: operations["Platform_ListResourceTypes"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** @description Various service requests */
+    get: operations["Platform_Ping"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resource-types": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/subscription/attach-filter": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Subscriptions */
-        post: operations["Platform_SubscriptionAttachFilter"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** @description Other stuff */
+    get: operations["Platform_ListResourceTypes"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/subscription/attach-filter": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/subscription/detach-filter": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_SubscriptionDetachFilter"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** @description Subscriptions */
+    post: operations["Platform_SubscriptionAttachFilter"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/subscription/detach-filter": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/tx-sync": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["Platform_TxSync"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post: operations["Platform_SubscriptionDetachFilter"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/tx-sync": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    post: operations["Platform_TxSync"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        AuthAPI_BeginSSOLogin_PublicPKCE: {
-            nonce: string;
-            /** Format: date-time */
-            expiresAt: string;
-        };
-        AuthAPI_BeginSSOLogin_Request: Record<string, never>;
-        AuthAPI_BeginSSOLogin_Response: {
-            publicPkce: components["schemas"]["AuthAPI_BeginSSOLogin_PublicPKCE"];
-        };
-        AuthAPI_GetJWTToken_Request: {
-            expiration: string;
-            /** Format: enum */
-            requestedRole: number;
-        };
-        AuthAPI_GetJWTToken_Response: {
-            token: string;
-            /**
-             * Format: bytes
-             * @description Session info fields
-             */
-            sessionId: string;
-            /** Format: enum */
-            role: number;
-        };
-        AuthAPI_GetSessionInfo_Request: Record<string, never>;
-        AuthAPI_GetSessionInfo_Response: {
-            /** Format: bytes */
-            sessionId: string;
-            /** Format: enum */
-            role: number;
-        };
-        AuthAPI_GetUserRoot_Request: {
-            login: string;
-            createIfNotExists: boolean;
-        };
-        AuthAPI_GetUserRoot_Response: {
-            userRoot: components["schemas"]["AuthAPI_UserRoot"];
-        };
-        AuthAPI_GrantAccess_Request: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-            targetUser: string;
-            permissions: components["schemas"]["AuthAPI_Grant_Permissions"];
-            /** Format: enum */
-            grantType: number;
-        };
-        AuthAPI_GrantAccess_Response: Record<string, never>;
-        /** @description Permissions describes access level for a grant. */
-        AuthAPI_Grant_Permissions: {
-            writable: boolean;
-        };
-        AuthAPI_ListMethods_BasicAuthMethod: Record<string, never>;
-        AuthAPI_ListMethods_MethodInfo: {
-            /**
-             * @description id is the stable, machine-readable identifier of the login method
-             *      instance. Unique across the entire server.
-             */
-            id: string;
-            /** @description description is the human-readable label in case we'd like to render it in UI. */
-            description: string;
-            basic: components["schemas"]["AuthAPI_ListMethods_BasicAuthMethod"];
-            token: components["schemas"]["AuthAPI_ListMethods_TokenAuthMethod"];
-            sso: components["schemas"]["AuthAPI_ListMethods_SSOAuthMethod"];
-        };
-        AuthAPI_ListMethods_Response: {
-            methods: components["schemas"]["AuthAPI_ListMethods_MethodInfo"][];
-        };
-        /**
-         * @description SSOAuthMethod advertises an external IdP-based login flow. The desktop
-         *      app uses the contents to drive the PKCE exchange locally, then hands the
-         *      resulting IdP token-response back via Login.SSOCredentials.
-         */
-        AuthAPI_ListMethods_SSOAuthMethod: {
-            issuer: string;
-            clientId: string;
-            scopes: string;
-            resource: string;
-            prompt: string;
-            redirectPorts: number[];
-            subjectTokenSource: string;
-            userIdClaim: string;
-            groupsClaim: string;
-            /** Format: enum */
-            flowType: number;
-        };
-        AuthAPI_ListMethods_TokenAuthMethod: Record<string, never>;
-        AuthAPI_Login_BasicCredentials: {
-            login: string;
-            password: string;
-        };
-        AuthAPI_Login_Request: {
-            basic: components["schemas"]["AuthAPI_Login_BasicCredentials"];
-            token: components["schemas"]["AuthAPI_Login_TokenCredentials"];
-            sso: components["schemas"]["AuthAPI_Login_SSOCredentials"];
-            expiration: string;
-            /** Format: enum */
-            requestedRole: number;
-        };
-        AuthAPI_Login_Response: {
-            token: string;
-            /** Format: bytes */
-            sessionId: string;
-            /** Format: enum */
-            role: number;
-        };
-        /**
-         * @description SSOCredentials carries the raw JSON body returned by the IdP's /token
-         *      endpoint after the desktop completes a PKCE exchange.
-         */
-        AuthAPI_Login_SSOCredentials: {
-            /** Format: bytes */
-            tokenResponse: string;
-        };
-        /**
-         * @description TokenCredentials accepts any opaque bearer-style string: a controller
-         *      pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
-         */
-        AuthAPI_Login_TokenCredentials: {
-            /** Format: bytes */
-            token: string;
-        };
-        AuthAPI_MintSignature_Request: {
-            resourceId: string;
-            /** Format: bytes */
-            targetSid: string;
-            color: components["schemas"]["Color"];
-        };
-        AuthAPI_MintSignature_Response: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-        };
-        AuthAPI_RefreshToken_Request: {
-            token: string;
-            expiration: string;
-        };
-        AuthAPI_RefreshToken_Response: {
-            token: string;
-            /** Format: bytes */
-            sessionId: string;
-            /** Format: enum */
-            role: number;
-        };
-        AuthAPI_RevokeAccess_Request: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-            targetUser: string;
-        };
-        AuthAPI_RevokeAccess_Response: Record<string, never>;
-        AuthAPI_UserRoot: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-        };
-        Color: {
-            root: string;
-            /** Format: uint32 */
-            permissions: number;
-        };
-        Controller: {
-            type: string;
-            id: string;
-            subscriptionID: string;
-        };
-        ControllerAPI_AttachSubscription_Request: {
-            controllerId: string;
-            subscriptionId: string;
-        };
-        ControllerAPI_AttachSubscription_Response: Record<string, never>;
-        ControllerAPI_ClearFeatures_Request: {
-            controllerType: string;
-        };
-        ControllerAPI_ClearFeatures_Response: Record<string, never>;
-        ControllerAPI_Create_Request: {
-            id: string;
-            controllerType: string;
-        };
-        ControllerAPI_Create_Response: {
-            controllerId: string;
-        };
-        ControllerAPI_Deregister_Request: {
-            controllerType: string;
-        };
-        ControllerAPI_Deregister_Response: Record<string, never>;
-        ControllerAPI_Exists_Request: {
-            controllerType: string;
-        };
-        ControllerAPI_Exists_Response: {
-            exists: boolean;
-        };
-        ControllerAPI_GetNotifications_Request: {
-            controllerType: string;
-            /** Format: uint32 */
-            maxNotifications: number;
-        };
-        ControllerAPI_GetNotifications_Response: {
-            notifications: components["schemas"]["Notification"][];
-        };
-        ControllerAPI_GetUrl_Request: {
-            controllerAlias: string;
-            resourceId: string;
-        };
-        ControllerAPI_GetUrl_Response: {
-            controllerUrl: string;
-        };
-        ControllerAPI_Get_Request: {
-            controllerType: string;
-        };
-        ControllerAPI_Get_Response: {
-            controller: components["schemas"]["Controller"];
-        };
-        ControllerAPI_Register_Request: {
-            controllerType: string;
-            filters: {
-                [key: string]: components["schemas"]["NotificationFilter"];
-            };
-            resourceSchemas: components["schemas"]["ResourceSchema"][];
-        };
-        ControllerAPI_Register_Response: {
-            controllerId: string;
-            subscriptionId: string;
-        };
-        ControllerAPI_RemoveAliasesAndUrls_Request: {
-            controllerType: string;
-        };
-        ControllerAPI_RemoveAliasesAndUrls_Response: Record<string, never>;
-        ControllerAPI_SetFeatures_Request: {
-            features: components["schemas"]["ResourceAPIFeature"][];
-        };
-        ControllerAPI_SetFeatures_Response: Record<string, never>;
-        ControllerAPI_Update_Request: {
-            controllerType: string;
-            filters: {
-                [key: string]: components["schemas"]["NotificationFilter"];
-            };
-            resourceSchemas: components["schemas"]["ResourceSchema"][];
-        };
-        ControllerAPI_Update_Response: Record<string, never>;
-        ControllerAPI_WriteAliasesAndUrls_Request: {
-            controllerType: string;
-            aliasesToUrls: {
-                [key: string]: string;
-            };
-        };
-        ControllerAPI_WriteAliasesAndUrls_Response: Record<string, never>;
-        Field: {
-            /** @description field ID is always combination of parent resource ID and field name */
-            id: components["schemas"]["FieldRef"];
-            /** Format: enum */
-            type: number;
-            features: components["schemas"]["Resource_Features"];
-            /**
-             * @description _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
-             *      If a field refers to another field, it will get
-             *      a value only when this chain of references ends up with a direct resource
-             *      reference. At that moment, all fields in the chain will get their values
-             *      resolved and will start to refer to the same resource directly.
-             */
-            value: string;
-            /**
-             * Format: bytes
-             * @description Signature for value resource ID, inheriting the parent resource's color.
-             *      Populated server-side when the parent resource has a known color in the current TX.
-             */
-            valueSignature: string;
-            /**
-             * Format: enum
-             * @description Whether the value is empty, assigned, or finally resolved.
-             */
-            valueStatus: number;
-            /** @description If the value is in its final state (ready, duplicate or error) */
-            valueIsFinal: boolean;
-            /**
-             * @description Error resource ID, if any.
-             *      Is intended to report problems _from_ the platform to the client.
-             */
-            error: string;
-            /**
-             * Format: bytes
-             * @description Signature for error resource ID, inheriting the parent resource's color.
-             */
-            errorSignature: string;
-        };
-        FieldRef: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-            fieldName: string;
-        };
-        FieldSchema: {
-            /** Format: enum */
-            type: number;
-            name: string;
-        };
-        /** @description Contains an arbitrary serialized message along with a @type that describes the type of the serialized message. */
-        GoogleProtobufAny: {
-            /** @description The type of the serialized message. */
-            "@type": string;
-        } & {
-            [key: string]: unknown;
-        };
-        LocksAPI_Lease_Create_Request: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-            timeout: string;
-            name: string;
-        };
-        LocksAPI_Lease_Create_Response: {
-            /** Format: bytes */
-            leaseId: string;
-        };
-        LocksAPI_Lease_Release_Request: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-            /** Format: bytes */
-            leaseId: string;
-        };
-        LocksAPI_Lease_Release_Response: Record<string, never>;
-        LocksAPI_Lease_Update_Request: {
-            resourceId: string;
-            /** Format: bytes */
-            resourceSignature: string;
-            /** Format: bytes */
-            leaseId: string;
-            timeout: string;
-            name: string;
-        };
-        LocksAPI_Lease_Update_Response: Record<string, never>;
-        LocksAPI_LockFieldValues_Create_Request: {
-            resourceId: string;
-            lockReferencesOf: string[];
-            comment: string;
-        };
-        LocksAPI_LockFieldValues_Create_Response: {
-            /**
-             * @description true when lock was acquired (new, or already owned by the owner)
-             *      Client MUST pay attention to this flag, as it shows if lock was successful.
-             */
-            acquired: boolean;
-            /**
-             * @description Info about why lock was not acquired.
-             *      Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
-             *      The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
-             */
-            conflictingLocks: components["schemas"]["LocksAPI_LockFieldValues_Create_Response_LockInfo"][];
-            conflictsListTruncated: boolean;
-        };
-        LocksAPI_LockFieldValues_Create_Response_LockInfo: {
-            targetId: string;
-            fieldName: string;
-            lockedBy: string;
-            /** Format: date-time */
-            lockedAt: string;
-            comment: string;
-        };
-        MaintenanceAPI_License_Response: {
-            /** Format: int32 */
-            status: number;
-            isOk: boolean;
-            /**
-             * Format: bytes
-             * @description Raw response body as it was received from the license server.
-             */
-            responseBody: string;
-        };
-        MaintenanceAPI_Ping_Response: {
-            coreVersion: string;
-            coreFullVersion: string;
-            /** Format: enum */
-            compression: number;
-            /**
-             * @description instanceID is a unique ID that changes when we reset DB state.
-             *      If we reset a state and a database, but the address of the backend is still the same,
-             *      without instanceID we are not sure if it's the same state or not,
-             *      and UI can't detect it and clear its state (e.g. caches of drivers).
-             */
-            instanceId: string;
-            platform: string;
-            os: string;
-            arch: string;
-            /**
-             * @description Opt-in capabilities advertised by this server instance. Two
-             *      client-side usage modes share this same wire field, decided
-             *      per-token by the client:
-             *        - Optimization hint. Client picks between a fast path and a
-             *          fallback without probing by trial-and-error; missing tokens
-             *          just cause the fallback to run (e.g. "treeFilter:v2").
-             *        - Install-time gate. Client refuses to install a block whose
-             *          manifest declares a required capability the server doesn't
-             *          advertise; missing tokens fail closed (e.g. "wasm:v1").
-             *
-             *      Each entry is an opaque token "<feature>:<version>" (e.g.
-             *      "treeFilter:v2"). The field is unset on servers predating this
-             *      mechanism, which the client treats as "no optional capabilities
-             *      advertised" — fallback for hints, fail-closed for gates.
-             *
-             *      All list see pl/platform/api/plapiserver/server_capabilities.go
-             */
-            capabilities: string[];
-        };
-        MiscAPI_ListResourceTypes_Response: {
-            types: components["schemas"]["ResourceType"][];
-        };
-        Notification: {
-            subscriptionId: string;
-            eventId: string;
-            resourceId: string;
-            resourceType: components["schemas"]["ResourceType"];
-            events: components["schemas"]["Notification_Events"];
-            fieldChanges: {
-                [key: string]: components["schemas"]["Notification_FieldChange"];
-            };
-            payload: components["schemas"]["NotificationFilter_Payload"];
-            filterName: string;
-            txSpan: components["schemas"]["SpanInfo"];
-        };
-        NotificationAPI_Get_Request: {
-            subscription: string;
-            /** Format: uint32 */
-            maxNotifications: number;
-        };
-        NotificationAPI_Get_Response: {
-            notifications: components["schemas"]["Notification"][];
-        };
-        NotificationFilter: {
-            resourceType: components["schemas"]["ResourceType"];
-            resourceId: string;
-            eventFilter: components["schemas"]["NotificationFilter_EventFilter"];
-            payload: components["schemas"]["NotificationFilter_Payload"];
-        };
-        NotificationFilter_EventFilter: {
-            all: boolean;
-            resourceCreated: boolean;
-            resourceDeleted: boolean;
-            resourceReady: boolean;
-            resourceRecovered: boolean;
-            resourceDuplicate: boolean;
-            resourceError: boolean;
-            /** @description Field events */
-            inputsLocked: boolean;
-            outputsLocked: boolean;
-            fieldCreated: boolean;
-            fieldGotError: boolean;
-            inputSet: boolean;
-            allInputsSet: boolean;
-            outputSet: boolean;
-            allOutputsSet: boolean;
-            genericOtwSet: boolean;
-            dynamicChanged: boolean;
-        };
-        NotificationFilter_Payload: {
-            values: {
-                [key: string]: string;
-            };
-        };
-        Notification_Events: {
-            resourceCreated: boolean;
-            resourceDeleted: boolean;
-            resourceReady: boolean;
-            resourceDuplicate: boolean;
-            resourceError: boolean;
-            inputsLocked: boolean;
-            outputsLocked: boolean;
-            fieldCreated: boolean;
-            fieldGotError: boolean;
-            inputSet: boolean;
-            allInputsSet: boolean;
-            outputSet: boolean;
-            allOutputsSet: boolean;
-            genericOtwSet: boolean;
-            dynamicChanged: boolean;
-            resourceRecovered: boolean;
-        };
-        Notification_FieldChange: {
-            old: components["schemas"]["Field"];
-            new: components["schemas"]["Field"];
-        };
-        ResourceAPIFeature: {
-            controllerType: string;
-            featureName: string;
-            resourceType: components["schemas"]["ResourceType"];
-            endpoint: string;
-        };
-        ResourceSchema: {
-            type: components["schemas"]["ResourceType"];
-            fields: components["schemas"]["FieldSchema"][];
-            /** @description Access restriction flags for non-controller roles */
-            accessFlags: components["schemas"]["ResourceSchema_AccessFlags"];
-            freeInputs: boolean;
-            freeOutputs: boolean;
-        };
-        ResourceSchema_AccessFlags: {
-            /**
-             * @description Deny-list approach: default = allowed (true)
-             *      Controllers set these to false to restrict non-controller roles (role='u', role='w')
-             */
-            createResource: boolean;
-            /** @description IMPORTANT: read_fields=false with write_fields=true is a forbidden combination */
-            readFields: boolean;
-            writeFields: boolean;
-            /** @description IMPORTANT: read_kv=false with write_kv=true is a forbidden combination */
-            readKv: boolean;
-            writeKv: boolean;
-            /**
-             * @description Per-field-type overrides (map: field_type → bool)
-             *      When defined for a field type, overrides resource-level flags
-             */
-            readByFieldType: {
-                [key: string]: boolean;
-            };
-            writeByFieldType: {
-                [key: string]: boolean;
-            };
-            /**
-             * @description SetError is a control-flow channel and is allowed by default even when
-             *      every other access bit is denied: a failing step on a closely-guarded
-             *      resource must surface to its caller. Controllers may opt out by
-             *      setting this to false.
-             */
-            setError: boolean;
-        };
-        ResourceType: {
-            name: string;
-            version: string;
-        };
-        Resource_Features: {
-            ephemeral: boolean;
-        };
-        SpanInfo: {
-            path: string;
-            carrier: {
-                [key: string]: string;
-            };
-        };
-        /** @description The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors). */
-        Status: {
-            /**
-             * Format: int32
-             * @description The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-             */
-            code: number;
-            /** @description A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client. */
-            message: string;
-            /** @description A list of messages that carry the error details.  There is a common set of message types for APIs to use. */
-            details: components["schemas"]["GoogleProtobufAny"][];
-        };
-        SubscriptionAPI_AttachFilter_Request: {
-            subscriptionId: string;
-            filterName: string;
-            filterId: string;
-        };
-        SubscriptionAPI_AttachFilter_Response: Record<string, never>;
-        SubscriptionAPI_DetachFilter_Request: {
-            subscriptionId: string;
-            filterName: string;
-        };
-        SubscriptionAPI_DetachFilter_Response: Record<string, never>;
-        TxAPI_Sync_Request: {
-            txId: string;
-        };
-        TxAPI_Sync_Response: Record<string, never>;
+  schemas: {
+    AuthAPI_BeginSSOLogin_PublicPKCE: {
+      nonce: string;
+      /** Format: date-time */
+      expiresAt: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    AuthAPI_BeginSSOLogin_Request: Record<string, never>;
+    AuthAPI_BeginSSOLogin_Response: {
+      publicPkce: components["schemas"]["AuthAPI_BeginSSOLogin_PublicPKCE"];
+    };
+    AuthAPI_GetJWTToken_Request: {
+      expiration: string;
+      /** Format: enum */
+      requestedRole: number;
+    };
+    AuthAPI_GetJWTToken_Response: {
+      token: string;
+      /**
+       * Format: bytes
+       * @description Session info fields
+       */
+      sessionId: string;
+      /** Format: enum */
+      role: number;
+    };
+    AuthAPI_GetSessionInfo_Request: Record<string, never>;
+    AuthAPI_GetSessionInfo_Response: {
+      /** Format: bytes */
+      sessionId: string;
+      /** Format: enum */
+      role: number;
+    };
+    AuthAPI_GetUserRoot_Request: {
+      login: string;
+      createIfNotExists: boolean;
+    };
+    AuthAPI_GetUserRoot_Response: {
+      userRoot: components["schemas"]["AuthAPI_UserRoot"];
+    };
+    AuthAPI_GrantAccess_Request: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+      targetUser: string;
+      permissions: components["schemas"]["AuthAPI_Grant_Permissions"];
+      /** Format: enum */
+      grantType: number;
+    };
+    AuthAPI_GrantAccess_Response: Record<string, never>;
+    /** @description Permissions describes access level for a grant. */
+    AuthAPI_Grant_Permissions: {
+      writable: boolean;
+    };
+    AuthAPI_ListMethods_BasicAuthMethod: Record<string, never>;
+    AuthAPI_ListMethods_MethodInfo: {
+      /**
+       * @description id is the stable, machine-readable identifier of the login method
+       *      instance. Unique across the entire server.
+       */
+      id: string;
+      /** @description description is the human-readable label in case we'd like to render it in UI. */
+      description: string;
+      basic: components["schemas"]["AuthAPI_ListMethods_BasicAuthMethod"];
+      token: components["schemas"]["AuthAPI_ListMethods_TokenAuthMethod"];
+      sso: components["schemas"]["AuthAPI_ListMethods_SSOAuthMethod"];
+    };
+    AuthAPI_ListMethods_Response: {
+      methods: components["schemas"]["AuthAPI_ListMethods_MethodInfo"][];
+    };
+    /**
+     * @description SSOAuthMethod advertises an external IdP-based login flow. The desktop
+     *      app uses the contents to drive the PKCE exchange locally, then hands the
+     *      resulting IdP token-response back via Login.SSOCredentials.
+     */
+    AuthAPI_ListMethods_SSOAuthMethod: {
+      issuer: string;
+      clientId: string;
+      scopes: string;
+      resource: string;
+      prompt: string;
+      redirectPorts: number[];
+      subjectTokenSource: string;
+      userIdClaim: string;
+      groupsClaim: string;
+      /** Format: enum */
+      flowType: number;
+    };
+    AuthAPI_ListMethods_TokenAuthMethod: Record<string, never>;
+    AuthAPI_Login_BasicCredentials: {
+      login: string;
+      password: string;
+    };
+    AuthAPI_Login_Request: {
+      basic: components["schemas"]["AuthAPI_Login_BasicCredentials"];
+      token: components["schemas"]["AuthAPI_Login_TokenCredentials"];
+      sso: components["schemas"]["AuthAPI_Login_SSOCredentials"];
+      expiration: string;
+      /** Format: enum */
+      requestedRole: number;
+    };
+    AuthAPI_Login_Response: {
+      token: string;
+      /** Format: bytes */
+      sessionId: string;
+      /** Format: enum */
+      role: number;
+    };
+    /**
+     * @description SSOCredentials carries the raw JSON body returned by the IdP's /token
+     *      endpoint after the desktop completes a PKCE exchange.
+     */
+    AuthAPI_Login_SSOCredentials: {
+      /** Format: bytes */
+      tokenResponse: string;
+    };
+    /**
+     * @description TokenCredentials accepts any opaque bearer-style string: a controller
+     *      pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
+     */
+    AuthAPI_Login_TokenCredentials: {
+      /** Format: bytes */
+      token: string;
+    };
+    AuthAPI_MintSignature_Request: {
+      resourceId: string;
+      /** Format: bytes */
+      targetSid: string;
+      color: components["schemas"]["Color"];
+    };
+    AuthAPI_MintSignature_Response: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+    };
+    AuthAPI_RefreshToken_Request: {
+      token: string;
+      expiration: string;
+    };
+    AuthAPI_RefreshToken_Response: {
+      token: string;
+      /** Format: bytes */
+      sessionId: string;
+      /** Format: enum */
+      role: number;
+    };
+    AuthAPI_RevokeAccess_Request: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+      targetUser: string;
+    };
+    AuthAPI_RevokeAccess_Response: Record<string, never>;
+    AuthAPI_UserRoot: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+    };
+    Color: {
+      root: string;
+      /** Format: uint32 */
+      permissions: number;
+    };
+    Controller: {
+      type: string;
+      id: string;
+      subscriptionID: string;
+    };
+    ControllerAPI_AttachSubscription_Request: {
+      controllerId: string;
+      subscriptionId: string;
+    };
+    ControllerAPI_AttachSubscription_Response: Record<string, never>;
+    ControllerAPI_ClearFeatures_Request: {
+      controllerType: string;
+    };
+    ControllerAPI_ClearFeatures_Response: Record<string, never>;
+    ControllerAPI_Create_Request: {
+      id: string;
+      controllerType: string;
+    };
+    ControllerAPI_Create_Response: {
+      controllerId: string;
+    };
+    ControllerAPI_Deregister_Request: {
+      controllerType: string;
+    };
+    ControllerAPI_Deregister_Response: Record<string, never>;
+    ControllerAPI_Exists_Request: {
+      controllerType: string;
+    };
+    ControllerAPI_Exists_Response: {
+      exists: boolean;
+    };
+    ControllerAPI_GetNotifications_Request: {
+      controllerType: string;
+      /** Format: uint32 */
+      maxNotifications: number;
+    };
+    ControllerAPI_GetNotifications_Response: {
+      notifications: components["schemas"]["Notification"][];
+    };
+    ControllerAPI_GetUrl_Request: {
+      controllerAlias: string;
+      resourceId: string;
+    };
+    ControllerAPI_GetUrl_Response: {
+      controllerUrl: string;
+    };
+    ControllerAPI_Get_Request: {
+      controllerType: string;
+    };
+    ControllerAPI_Get_Response: {
+      controller: components["schemas"]["Controller"];
+    };
+    ControllerAPI_Register_Request: {
+      controllerType: string;
+      filters: {
+        [key: string]: components["schemas"]["NotificationFilter"];
+      };
+      resourceSchemas: components["schemas"]["ResourceSchema"][];
+    };
+    ControllerAPI_Register_Response: {
+      controllerId: string;
+      subscriptionId: string;
+    };
+    ControllerAPI_RemoveAliasesAndUrls_Request: {
+      controllerType: string;
+    };
+    ControllerAPI_RemoveAliasesAndUrls_Response: Record<string, never>;
+    ControllerAPI_SetFeatures_Request: {
+      features: components["schemas"]["ResourceAPIFeature"][];
+    };
+    ControllerAPI_SetFeatures_Response: Record<string, never>;
+    ControllerAPI_Update_Request: {
+      controllerType: string;
+      filters: {
+        [key: string]: components["schemas"]["NotificationFilter"];
+      };
+      resourceSchemas: components["schemas"]["ResourceSchema"][];
+    };
+    ControllerAPI_Update_Response: Record<string, never>;
+    ControllerAPI_WriteAliasesAndUrls_Request: {
+      controllerType: string;
+      aliasesToUrls: {
+        [key: string]: string;
+      };
+    };
+    ControllerAPI_WriteAliasesAndUrls_Response: Record<string, never>;
+    Field: {
+      /** @description field ID is always combination of parent resource ID and field name */
+      id: components["schemas"]["FieldRef"];
+      /** Format: enum */
+      type: number;
+      features: components["schemas"]["Resource_Features"];
+      /**
+       * @description _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
+       *      If a field refers to another field, it will get
+       *      a value only when this chain of references ends up with a direct resource
+       *      reference. At that moment, all fields in the chain will get their values
+       *      resolved and will start to refer to the same resource directly.
+       */
+      value: string;
+      /**
+       * Format: bytes
+       * @description Signature for value resource ID, inheriting the parent resource's color.
+       *      Populated server-side when the parent resource has a known color in the current TX.
+       */
+      valueSignature: string;
+      /**
+       * Format: enum
+       * @description Whether the value is empty, assigned, or finally resolved.
+       */
+      valueStatus: number;
+      /** @description If the value is in its final state (ready, duplicate or error) */
+      valueIsFinal: boolean;
+      /**
+       * @description Error resource ID, if any.
+       *      Is intended to report problems _from_ the platform to the client.
+       */
+      error: string;
+      /**
+       * Format: bytes
+       * @description Signature for error resource ID, inheriting the parent resource's color.
+       */
+      errorSignature: string;
+    };
+    FieldRef: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+      fieldName: string;
+    };
+    FieldSchema: {
+      /** Format: enum */
+      type: number;
+      name: string;
+    };
+    /** @description Contains an arbitrary serialized message along with a @type that describes the type of the serialized message. */
+    GoogleProtobufAny: {
+      /** @description The type of the serialized message. */
+      "@type": string;
+    } & {
+      [key: string]: unknown;
+    };
+    LocksAPI_Lease_Create_Request: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+      timeout: string;
+      name: string;
+    };
+    LocksAPI_Lease_Create_Response: {
+      /** Format: bytes */
+      leaseId: string;
+    };
+    LocksAPI_Lease_Release_Request: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+      /** Format: bytes */
+      leaseId: string;
+    };
+    LocksAPI_Lease_Release_Response: Record<string, never>;
+    LocksAPI_Lease_Update_Request: {
+      resourceId: string;
+      /** Format: bytes */
+      resourceSignature: string;
+      /** Format: bytes */
+      leaseId: string;
+      timeout: string;
+      name: string;
+    };
+    LocksAPI_Lease_Update_Response: Record<string, never>;
+    LocksAPI_LockFieldValues_Create_Request: {
+      resourceId: string;
+      lockReferencesOf: string[];
+      comment: string;
+    };
+    LocksAPI_LockFieldValues_Create_Response: {
+      /**
+       * @description true when lock was acquired (new, or already owned by the owner)
+       *      Client MUST pay attention to this flag, as it shows if lock was successful.
+       */
+      acquired: boolean;
+      /**
+       * @description Info about why lock was not acquired.
+       *      Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
+       *      The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
+       */
+      conflictingLocks: components["schemas"]["LocksAPI_LockFieldValues_Create_Response_LockInfo"][];
+      conflictsListTruncated: boolean;
+    };
+    LocksAPI_LockFieldValues_Create_Response_LockInfo: {
+      targetId: string;
+      fieldName: string;
+      lockedBy: string;
+      /** Format: date-time */
+      lockedAt: string;
+      comment: string;
+    };
+    MaintenanceAPI_License_Response: {
+      /** Format: int32 */
+      status: number;
+      isOk: boolean;
+      /**
+       * Format: bytes
+       * @description Raw response body as it was received from the license server.
+       */
+      responseBody: string;
+    };
+    MaintenanceAPI_Ping_Response: {
+      coreVersion: string;
+      coreFullVersion: string;
+      /** Format: enum */
+      compression: number;
+      /**
+       * @description instanceID is a unique ID that changes when we reset DB state.
+       *      If we reset a state and a database, but the address of the backend is still the same,
+       *      without instanceID we are not sure if it's the same state or not,
+       *      and UI can't detect it and clear its state (e.g. caches of drivers).
+       */
+      instanceId: string;
+      platform: string;
+      os: string;
+      arch: string;
+      /**
+       * @description Opt-in capabilities advertised by this server instance. Two
+       *      client-side usage modes share this same wire field, decided
+       *      per-token by the client:
+       *        - Optimization hint. Client picks between a fast path and a
+       *          fallback without probing by trial-and-error; missing tokens
+       *          just cause the fallback to run (e.g. "treeFilter:v2").
+       *        - Install-time gate. Client refuses to install a block whose
+       *          manifest declares a required capability the server doesn't
+       *          advertise; missing tokens fail closed (e.g. "wasm:v1").
+       *
+       *      Each entry is an opaque token "<feature>:<version>" (e.g.
+       *      "treeFilter:v2"). The field is unset on servers predating this
+       *      mechanism, which the client treats as "no optional capabilities
+       *      advertised" — fallback for hints, fail-closed for gates.
+       *
+       *      All list see pl/platform/api/plapiserver/server_capabilities.go
+       */
+      capabilities: string[];
+    };
+    MiscAPI_ListResourceTypes_Response: {
+      types: components["schemas"]["ResourceType"][];
+    };
+    Notification: {
+      subscriptionId: string;
+      eventId: string;
+      resourceId: string;
+      resourceType: components["schemas"]["ResourceType"];
+      events: components["schemas"]["Notification_Events"];
+      fieldChanges: {
+        [key: string]: components["schemas"]["Notification_FieldChange"];
+      };
+      payload: components["schemas"]["NotificationFilter_Payload"];
+      filterName: string;
+      txSpan: components["schemas"]["SpanInfo"];
+    };
+    NotificationAPI_Get_Request: {
+      subscription: string;
+      /** Format: uint32 */
+      maxNotifications: number;
+    };
+    NotificationAPI_Get_Response: {
+      notifications: components["schemas"]["Notification"][];
+    };
+    NotificationFilter: {
+      resourceType: components["schemas"]["ResourceType"];
+      resourceId: string;
+      eventFilter: components["schemas"]["NotificationFilter_EventFilter"];
+      payload: components["schemas"]["NotificationFilter_Payload"];
+    };
+    NotificationFilter_EventFilter: {
+      all: boolean;
+      resourceCreated: boolean;
+      resourceDeleted: boolean;
+      resourceReady: boolean;
+      resourceRecovered: boolean;
+      resourceDuplicate: boolean;
+      resourceError: boolean;
+      /** @description Field events */
+      inputsLocked: boolean;
+      outputsLocked: boolean;
+      fieldCreated: boolean;
+      fieldGotError: boolean;
+      inputSet: boolean;
+      allInputsSet: boolean;
+      outputSet: boolean;
+      allOutputsSet: boolean;
+      genericOtwSet: boolean;
+      dynamicChanged: boolean;
+    };
+    NotificationFilter_Payload: {
+      values: {
+        [key: string]: string;
+      };
+    };
+    Notification_Events: {
+      resourceCreated: boolean;
+      resourceDeleted: boolean;
+      resourceReady: boolean;
+      resourceDuplicate: boolean;
+      resourceError: boolean;
+      inputsLocked: boolean;
+      outputsLocked: boolean;
+      fieldCreated: boolean;
+      fieldGotError: boolean;
+      inputSet: boolean;
+      allInputsSet: boolean;
+      outputSet: boolean;
+      allOutputsSet: boolean;
+      genericOtwSet: boolean;
+      dynamicChanged: boolean;
+      resourceRecovered: boolean;
+    };
+    Notification_FieldChange: {
+      old: components["schemas"]["Field"];
+      new: components["schemas"]["Field"];
+    };
+    ResourceAPIFeature: {
+      controllerType: string;
+      featureName: string;
+      resourceType: components["schemas"]["ResourceType"];
+      endpoint: string;
+    };
+    ResourceSchema: {
+      type: components["schemas"]["ResourceType"];
+      fields: components["schemas"]["FieldSchema"][];
+      /** @description Access restriction flags for non-controller roles */
+      accessFlags: components["schemas"]["ResourceSchema_AccessFlags"];
+      freeInputs: boolean;
+      freeOutputs: boolean;
+    };
+    ResourceSchema_AccessFlags: {
+      /**
+       * @description Deny-list approach: default = allowed (true)
+       *      Controllers set these to false to restrict non-controller roles (role='u', role='w')
+       */
+      createResource: boolean;
+      /** @description IMPORTANT: read_fields=false with write_fields=true is a forbidden combination */
+      readFields: boolean;
+      writeFields: boolean;
+      /** @description IMPORTANT: read_kv=false with write_kv=true is a forbidden combination */
+      readKv: boolean;
+      writeKv: boolean;
+      /**
+       * @description Per-field-type overrides (map: field_type → bool)
+       *      When defined for a field type, overrides resource-level flags
+       */
+      readByFieldType: {
+        [key: string]: boolean;
+      };
+      writeByFieldType: {
+        [key: string]: boolean;
+      };
+      /**
+       * @description SetError is a control-flow channel and is allowed by default even when
+       *      every other access bit is denied: a failing step on a closely-guarded
+       *      resource must surface to its caller. Controllers may opt out by
+       *      setting this to false.
+       */
+      setError: boolean;
+    };
+    ResourceType: {
+      name: string;
+      version: string;
+    };
+    Resource_Features: {
+      ephemeral: boolean;
+    };
+    SpanInfo: {
+      path: string;
+      carrier: {
+        [key: string]: string;
+      };
+    };
+    /** @description The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors). */
+    Status: {
+      /**
+       * Format: int32
+       * @description The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+       */
+      code: number;
+      /** @description A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client. */
+      message: string;
+      /** @description A list of messages that carry the error details.  There is a common set of message types for APIs to use. */
+      details: components["schemas"]["GoogleProtobufAny"][];
+    };
+    SubscriptionAPI_AttachFilter_Request: {
+      subscriptionId: string;
+      filterName: string;
+      filterId: string;
+    };
+    SubscriptionAPI_AttachFilter_Response: Record<string, never>;
+    SubscriptionAPI_DetachFilter_Request: {
+      subscriptionId: string;
+      filterName: string;
+    };
+    SubscriptionAPI_DetachFilter_Response: Record<string, never>;
+    TxAPI_Sync_Request: {
+      txId: string;
+    };
+    TxAPI_Sync_Response: Record<string, never>;
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    Platform_GrantAccess: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_GrantAccess_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_GrantAccess_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  Platform_GrantAccess: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_GetJWTToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_GetJWTToken_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_GetJWTToken_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_GrantAccess_Request"];
+      };
     };
-    Platform_Login: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_Login_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_GrantAccess_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_Login_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_AuthMethods: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_ListMethods_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_GetJWTToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_MintSignature: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_MintSignature_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_MintSignature_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_GetJWTToken_Request"];
+      };
     };
-    Platform_RefreshToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_RefreshToken_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_GetJWTToken_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_RefreshToken_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_RevokeAccess: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_RevokeAccess_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_RevokeAccess_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_Login: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_GetSessionInfo: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_Login_Request"];
+      };
     };
-    Platform_BeginSSOLogin: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_Login_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_GetUserRoot: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AuthAPI_GetUserRoot_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthAPI_GetUserRoot_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_AuthMethods: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_WriteControllerAliasesAndUrls: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_ListMethods_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_RemoveControllerAliasesAndUrls: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_MintSignature: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_ControllerAttachSubscription: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_MintSignature_Request"];
+      };
     };
-    Platform_ControllerCreate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_Create_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_MintSignature_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_Create_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_ControllerDeregister: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_Deregister_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_Deregister_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_RefreshToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_ControllerExists: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_Exists_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_Exists_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_RefreshToken_Request"];
+      };
     };
-    Platform_ControllerSetFeatures: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_SetFeatures_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_RefreshToken_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_SetFeatures_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_ControllerClearFeatures: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_RevokeAccess: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_ControllerGet: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_Get_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_Get_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_RevokeAccess_Request"];
+      };
     };
-    Platform_GetControllerNotifications: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_GetNotifications_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_RevokeAccess_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_GetNotifications_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_ControllerRegister: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_Register_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_Register_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_GetSessionInfo: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_ControllerUpdate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_Update_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_Update_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Request"];
+      };
     };
-    Platform_GetControllerUrl: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ControllerAPI_GetUrl_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ControllerAPI_GetUrl_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_License: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MaintenanceAPI_License_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_BeginSSOLogin: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_LeaseResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LocksAPI_Lease_Create_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LocksAPI_Lease_Create_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Request"];
+      };
     };
-    Platform_ReleaseLease: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LocksAPI_Lease_Release_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LocksAPI_Lease_Release_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_UpdateLease: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LocksAPI_Lease_Update_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LocksAPI_Lease_Update_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_GetUserRoot: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_LockFieldValues: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AuthAPI_GetUserRoot_Request"];
+      };
     };
-    Platform_NotificationsGet: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NotificationAPI_Get_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["AuthAPI_GetUserRoot_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotificationAPI_Get_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_Ping: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MaintenanceAPI_Ping_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_WriteControllerAliasesAndUrls: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_ListResourceTypes: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MiscAPI_ListResourceTypes_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Request"];
+      };
     };
-    Platform_SubscriptionAttachFilter: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Request"];
-            };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Response"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
     };
-    Platform_SubscriptionDetachFilter: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+  };
+  Platform_RemoveControllerAliasesAndUrls: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    Platform_TxSync: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TxAPI_Sync_Request"];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TxAPI_Sync_Response"];
-                };
-            };
-            /** @description Default error response */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Status"];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Request"];
+      };
     };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerAttachSubscription: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerCreate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_Create_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_Create_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerDeregister: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_Deregister_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_Deregister_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerExists: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_Exists_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_Exists_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerSetFeatures: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_SetFeatures_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_SetFeatures_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerClearFeatures: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerGet: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_Get_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_Get_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_GetControllerNotifications: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_GetNotifications_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_GetNotifications_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerRegister: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_Register_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_Register_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ControllerUpdate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_Update_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_Update_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_GetControllerUrl: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ControllerAPI_GetUrl_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ControllerAPI_GetUrl_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_License: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MaintenanceAPI_License_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_LeaseResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LocksAPI_Lease_Create_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["LocksAPI_Lease_Create_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ReleaseLease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LocksAPI_Lease_Release_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["LocksAPI_Lease_Release_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_UpdateLease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LocksAPI_Lease_Update_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["LocksAPI_Lease_Update_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_LockFieldValues: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_NotificationsGet: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["NotificationAPI_Get_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotificationAPI_Get_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_Ping: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MaintenanceAPI_Ping_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_ListResourceTypes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MiscAPI_ListResourceTypes_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_SubscriptionAttachFilter: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_SubscriptionDetachFilter: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
+  Platform_TxSync: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TxAPI_Sync_Request"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["TxAPI_Sync_Response"];
+        };
+      };
+      /** @description Default error response */
+      default: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Status"];
+        };
+      };
+    };
+  };
 }

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -4,2239 +4,2252 @@
  */
 
 export interface paths {
-  "/v1/auth/grant-access": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/grant-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_GrantAccess"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_GrantAccess"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/jwt-token": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/jwt-token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Deprecated: Use Login for session creation and role transitions,
+         *      and RefreshToken for token renewal. Backends implementing this API always return
+         *      codes.Unimplemented. Kept here so clients can still call old backends.
+         */
+        post: operations["Platform_GetJWTToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description Deprecated: Use Login for session creation and role transitions,
-     *      and RefreshToken for token renewal. Backends implementing this API always return
-     *      codes.Unimplemented. Kept here so clients can still call old backends.
-     */
-    post: operations["Platform_GetJWTToken"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/login": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description Login authenticates with the given credentials and returns a new Platforma JWT.
+         *      Every Login call creates a new session. Use RefreshToken to renew an existing one.
+         *      This method is public: no Authorization header is required.
+         */
+        post: operations["Platform_Login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description Login authenticates with the given credentials and returns a new Platforma JWT.
-     *      Every Login call creates a new session. Use RefreshToken to renew an existing one.
-     *      This method is public: no Authorization header is required.
-     */
-    post: operations["Platform_Login"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/methods": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/methods": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Authentication */
+        get: operations["Platform_AuthMethods"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** @description Authentication */
-    get: operations["Platform_AuthMethods"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/mint-signature": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/mint-signature": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description MintSignature creates a resource signature bound to a target session.
+         *      Controllers use it during workflow bootstrap to pre-sign resources
+         *      so the workflow can access them under its own isolated session.
+         */
+        post: operations["Platform_MintSignature"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description MintSignature creates a resource signature bound to a target session.
-     *      Controllers use it during workflow bootstrap to pre-sign resources
-     *      so the workflow can access them under its own isolated session.
-     */
-    post: operations["Platform_MintSignature"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/refresh": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description RefreshToken accepts a valid Platforma JWT and re-issues it with the same
+         *      session ID and role. Only the token expiration may be changed.
+         *      Workflow-scoped tokens cannot be refreshed; call Login instead.
+         *      This method is public: no Authorization header is required.
+         */
+        post: operations["Platform_RefreshToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description RefreshToken accepts a valid Platforma JWT and re-issues it with the same
-     *      session ID and role. Only the token expiration may be changed.
-     *      Workflow-scoped tokens cannot be refreshed; call Login instead.
-     *      This method is public: no Authorization header is required.
-     */
-    post: operations["Platform_RefreshToken"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/revoke-access": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/revoke-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_RevokeAccess"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_RevokeAccess"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/session-info": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/session-info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_GetSessionInfo"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_GetSessionInfo"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/sso/begin-login": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/sso/begin-login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description BeginSSOLogin returns a fresh one-time nonce that the desktop must place
+         *      into the OIDC auth-request before redirecting to the IdP. Used by the SSO
+         *      login flow. This method is public: no Authorization header is required.
+         */
+        post: operations["Platform_BeginSSOLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description BeginSSOLogin returns a fresh one-time nonce that the desktop must place
-     *      into the OIDC auth-request before redirecting to the IdP. Used by the SSO
-     *      login flow. This method is public: no Authorization header is required.
-     */
-    post: operations["Platform_BeginSSOLogin"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/auth/user-root": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/auth/user-root": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_GetUserRoot"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_GetUserRoot"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/aliases-and-urls": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/aliases-and-urls": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_WriteControllerAliasesAndUrls"];
+        delete: operations["Platform_RemoveControllerAliasesAndUrls"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_WriteControllerAliasesAndUrls"];
-    delete: operations["Platform_RemoveControllerAliasesAndUrls"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/attach-subscription": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/attach-subscription": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerAttachSubscription"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerAttachSubscription"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/create": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerCreate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerCreate"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/deregister": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/deregister": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerDeregister"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerDeregister"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/exists": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/exists": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerExists"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerExists"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/features": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/features": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerSetFeatures"];
+        delete: operations["Platform_ControllerClearFeatures"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerSetFeatures"];
-    delete: operations["Platform_ControllerClearFeatures"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/get": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerGet"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/notifications": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_GetControllerNotifications"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_GetControllerNotifications"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/register": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Controllers */
+        post: operations["Platform_ControllerRegister"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** @description Controllers */
-    post: operations["Platform_ControllerRegister"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/update": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ControllerUpdate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ControllerUpdate"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/controller/url": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/controller/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_GetControllerUrl"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_GetControllerUrl"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/license": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/license": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["Platform_License"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["Platform_License"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/locks/lease/create": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/locks/lease/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
+         *      Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
+         *      To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
+         */
+        post: operations["Platform_LeaseResource"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
-     *      Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
-     *      To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
-     */
-    post: operations["Platform_LeaseResource"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/locks/lease/release": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/locks/lease/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_ReleaseLease"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_ReleaseLease"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/locks/lease/update": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/locks/lease/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_UpdateLease"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_UpdateLease"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/locks/lock/create": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/locks/lock/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * @description LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
+         *        - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
+         *        - list resource's fields, take fields with names set in request
+         *        - get resolved values of listed fields (IDs of 'ON' resources).
+         *        - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
+         *
+         *      Lock logic constraints:
+         *        - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
+         *          succeeds, while the other fails with an error (no long waiting)
+         *        - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
+         *          the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
+         *        - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
+         *          being lockable. An attempt to lock a resource that has not become original will fail.
+         *        - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
+         */
+        post: operations["Platform_LockFieldValues"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * @description LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
-     *        - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
-     *        - list resource's fields, take fields with names set in request
-     *        - get resolved values of listed fields (IDs of 'ON' resources).
-     *        - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
-     *
-     *      Lock logic constraints:
-     *        - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
-     *          succeeds, while the other fails with an error (no long waiting)
-     *        - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
-     *          the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
-     *        - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
-     *          being lockable. An attempt to lock a resource that has not become original will fail.
-     *        - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
-     */
-    post: operations["Platform_LockFieldValues"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/notifications/get": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/notifications/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_NotificationsGet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_NotificationsGet"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/ping": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/ping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Various service requests */
+        get: operations["Platform_Ping"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** @description Various service requests */
-    get: operations["Platform_Ping"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resource-types": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Other stuff */
+        get: operations["Platform_ListResourceTypes"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** @description Other stuff */
-    get: operations["Platform_ListResourceTypes"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/subscription/attach-filter": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/subscription/attach-filter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Subscriptions */
+        post: operations["Platform_SubscriptionAttachFilter"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** @description Subscriptions */
-    post: operations["Platform_SubscriptionAttachFilter"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/subscription/detach-filter": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/subscription/detach-filter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_SubscriptionDetachFilter"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_SubscriptionDetachFilter"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/tx-sync": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/tx-sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["Platform_TxSync"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations["Platform_TxSync"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    AuthAPI_BeginSSOLogin_PublicPKCE: {
-      nonce: string;
-      /** Format: date-time */
-      expiresAt: string;
-    };
-    AuthAPI_BeginSSOLogin_Request: Record<string, never>;
-    AuthAPI_BeginSSOLogin_Response: {
-      publicPkce: components["schemas"]["AuthAPI_BeginSSOLogin_PublicPKCE"];
-    };
-    AuthAPI_GetJWTToken_Request: {
-      expiration: string;
-      /** Format: enum */
-      requestedRole: number;
-    };
-    AuthAPI_GetJWTToken_Response: {
-      token: string;
-      /**
-       * Format: bytes
-       * @description Session info fields
-       */
-      sessionId: string;
-      /** Format: enum */
-      role: number;
-    };
-    AuthAPI_GetSessionInfo_Request: Record<string, never>;
-    AuthAPI_GetSessionInfo_Response: {
-      /** Format: bytes */
-      sessionId: string;
-      /** Format: enum */
-      role: number;
-    };
-    AuthAPI_GetUserRoot_Request: {
-      login: string;
-      createIfNotExists: boolean;
-    };
-    AuthAPI_GetUserRoot_Response: {
-      userRoot: components["schemas"]["AuthAPI_UserRoot"];
-    };
-    AuthAPI_GrantAccess_Request: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-      targetUser: string;
-      permissions: components["schemas"]["AuthAPI_Grant_Permissions"];
-      /** Format: enum */
-      grantType: number;
-    };
-    AuthAPI_GrantAccess_Response: Record<string, never>;
-    /** @description Permissions describes access level for a grant. */
-    AuthAPI_Grant_Permissions: {
-      writable: boolean;
-    };
-    AuthAPI_ListMethods_BasicAuthMethod: Record<string, never>;
-    AuthAPI_ListMethods_MethodInfo: {
-      /**
-       * @description id is the stable, machine-readable identifier of the login method
-       *      instance. Unique across the entire server.
-       */
-      id: string;
-      /** @description description is the human-readable label in case we'd like to render it in UI. */
-      description: string;
-      basic: components["schemas"]["AuthAPI_ListMethods_BasicAuthMethod"];
-      token: components["schemas"]["AuthAPI_ListMethods_TokenAuthMethod"];
-      sso: components["schemas"]["AuthAPI_ListMethods_SSOAuthMethod"];
-    };
-    AuthAPI_ListMethods_Response: {
-      methods: components["schemas"]["AuthAPI_ListMethods_MethodInfo"][];
-    };
-    /**
-     * @description SSOAuthMethod advertises an external IdP-based login flow. The desktop
-     *      app uses the contents to drive the PKCE exchange locally, then hands the
-     *      resulting IdP token-response back via Login.SSOCredentials.
-     */
-    AuthAPI_ListMethods_SSOAuthMethod: {
-      issuer: string;
-      clientId: string;
-      scopes: string;
-      resource: string;
-      prompt: string;
-      redirectPorts: number[];
-      subjectTokenSource: string;
-      userIdClaim: string;
-      groupsClaim: string;
-      /** Format: enum */
-      flowType: number;
-    };
-    AuthAPI_ListMethods_TokenAuthMethod: Record<string, never>;
-    AuthAPI_Login_BasicCredentials: {
-      login: string;
-      password: string;
-    };
-    AuthAPI_Login_Request: {
-      basic: components["schemas"]["AuthAPI_Login_BasicCredentials"];
-      token: components["schemas"]["AuthAPI_Login_TokenCredentials"];
-      sso: components["schemas"]["AuthAPI_Login_SSOCredentials"];
-      expiration: string;
-      /** Format: enum */
-      requestedRole: number;
-    };
-    AuthAPI_Login_Response: {
-      token: string;
-      /** Format: bytes */
-      sessionId: string;
-      /** Format: enum */
-      role: number;
-    };
-    /**
-     * @description SSOCredentials carries the raw JSON body returned by the IdP's /token
-     *      endpoint after the desktop completes a PKCE exchange.
-     */
-    AuthAPI_Login_SSOCredentials: {
-      /** Format: bytes */
-      tokenResponse: string;
-    };
-    /**
-     * @description TokenCredentials accepts any opaque bearer-style string: a controller
-     *      pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
-     */
-    AuthAPI_Login_TokenCredentials: {
-      /** Format: bytes */
-      token: string;
-    };
-    AuthAPI_MintSignature_Request: {
-      resourceId: string;
-      /** Format: bytes */
-      targetSid: string;
-      color: components["schemas"]["Color"];
-    };
-    AuthAPI_MintSignature_Response: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-    };
-    AuthAPI_RefreshToken_Request: {
-      token: string;
-      expiration: string;
-    };
-    AuthAPI_RefreshToken_Response: {
-      token: string;
-      /** Format: bytes */
-      sessionId: string;
-      /** Format: enum */
-      role: number;
-    };
-    AuthAPI_RevokeAccess_Request: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-      targetUser: string;
-    };
-    AuthAPI_RevokeAccess_Response: Record<string, never>;
-    AuthAPI_UserRoot: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-    };
-    Color: {
-      root: string;
-      /** Format: uint32 */
-      permissions: number;
-    };
-    Controller: {
-      type: string;
-      id: string;
-      subscriptionID: string;
-    };
-    ControllerAPI_AttachSubscription_Request: {
-      controllerId: string;
-      subscriptionId: string;
-    };
-    ControllerAPI_AttachSubscription_Response: Record<string, never>;
-    ControllerAPI_ClearFeatures_Request: {
-      controllerType: string;
-    };
-    ControllerAPI_ClearFeatures_Response: Record<string, never>;
-    ControllerAPI_Create_Request: {
-      id: string;
-      controllerType: string;
-    };
-    ControllerAPI_Create_Response: {
-      controllerId: string;
-    };
-    ControllerAPI_Deregister_Request: {
-      controllerType: string;
-    };
-    ControllerAPI_Deregister_Response: Record<string, never>;
-    ControllerAPI_Exists_Request: {
-      controllerType: string;
-    };
-    ControllerAPI_Exists_Response: {
-      exists: boolean;
-    };
-    ControllerAPI_GetNotifications_Request: {
-      controllerType: string;
-      /** Format: uint32 */
-      maxNotifications: number;
-    };
-    ControllerAPI_GetNotifications_Response: {
-      notifications: components["schemas"]["Notification"][];
-    };
-    ControllerAPI_GetUrl_Request: {
-      controllerAlias: string;
-      resourceId: string;
-    };
-    ControllerAPI_GetUrl_Response: {
-      controllerUrl: string;
-    };
-    ControllerAPI_Get_Request: {
-      controllerType: string;
-    };
-    ControllerAPI_Get_Response: {
-      controller: components["schemas"]["Controller"];
-    };
-    ControllerAPI_Register_Request: {
-      controllerType: string;
-      filters: {
-        [key: string]: components["schemas"]["NotificationFilter"];
-      };
-      resourceSchemas: components["schemas"]["ResourceSchema"][];
-    };
-    ControllerAPI_Register_Response: {
-      controllerId: string;
-      subscriptionId: string;
-    };
-    ControllerAPI_RemoveAliasesAndUrls_Request: {
-      controllerType: string;
-    };
-    ControllerAPI_RemoveAliasesAndUrls_Response: Record<string, never>;
-    ControllerAPI_SetFeatures_Request: {
-      features: components["schemas"]["ResourceAPIFeature"][];
-    };
-    ControllerAPI_SetFeatures_Response: Record<string, never>;
-    ControllerAPI_Update_Request: {
-      controllerType: string;
-      filters: {
-        [key: string]: components["schemas"]["NotificationFilter"];
-      };
-      resourceSchemas: components["schemas"]["ResourceSchema"][];
-    };
-    ControllerAPI_Update_Response: Record<string, never>;
-    ControllerAPI_WriteAliasesAndUrls_Request: {
-      controllerType: string;
-      aliasesToUrls: {
-        [key: string]: string;
-      };
-    };
-    ControllerAPI_WriteAliasesAndUrls_Response: Record<string, never>;
-    Field: {
-      /** @description field ID is always combination of parent resource ID and field name */
-      id: components["schemas"]["FieldRef"];
-      /** Format: enum */
-      type: number;
-      features: components["schemas"]["Resource_Features"];
-      /**
-       * @description _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
-       *      If a field refers to another field, it will get
-       *      a value only when this chain of references ends up with a direct resource
-       *      reference. At that moment, all fields in the chain will get their values
-       *      resolved and will start to refer to the same resource directly.
-       */
-      value: string;
-      /**
-       * Format: bytes
-       * @description Signature for value resource ID, inheriting the parent resource's color.
-       *      Populated server-side when the parent resource has a known color in the current TX.
-       */
-      valueSignature: string;
-      /**
-       * Format: enum
-       * @description Whether the value is empty, assigned, or finally resolved.
-       */
-      valueStatus: number;
-      /** @description If the value is in its final state (ready, duplicate or error) */
-      valueIsFinal: boolean;
-      /**
-       * @description Error resource ID, if any.
-       *      Is intended to report problems _from_ the platform to the client.
-       */
-      error: string;
-      /**
-       * Format: bytes
-       * @description Signature for error resource ID, inheriting the parent resource's color.
-       */
-      errorSignature: string;
-    };
-    FieldRef: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-      fieldName: string;
-    };
-    FieldSchema: {
-      /** Format: enum */
-      type: number;
-      name: string;
-    };
-    /** @description Contains an arbitrary serialized message along with a @type that describes the type of the serialized message. */
-    GoogleProtobufAny: {
-      /** @description The type of the serialized message. */
-      "@type": string;
-    } & {
-      [key: string]: unknown;
-    };
-    LocksAPI_Lease_Create_Request: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-      timeout: string;
-      name: string;
-    };
-    LocksAPI_Lease_Create_Response: {
-      /** Format: bytes */
-      leaseId: string;
-    };
-    LocksAPI_Lease_Release_Request: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-      /** Format: bytes */
-      leaseId: string;
-    };
-    LocksAPI_Lease_Release_Response: Record<string, never>;
-    LocksAPI_Lease_Update_Request: {
-      resourceId: string;
-      /** Format: bytes */
-      resourceSignature: string;
-      /** Format: bytes */
-      leaseId: string;
-      timeout: string;
-      name: string;
-    };
-    LocksAPI_Lease_Update_Response: Record<string, never>;
-    LocksAPI_LockFieldValues_Create_Request: {
-      resourceId: string;
-      lockReferencesOf: string[];
-      comment: string;
-    };
-    LocksAPI_LockFieldValues_Create_Response: {
-      /**
-       * @description true when lock was acquired (new, or already owned by the owner)
-       *      Client MUST pay attention to this flag, as it shows if lock was successful.
-       */
-      acquired: boolean;
-      /**
-       * @description Info about why lock was not acquired.
-       *      Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
-       *      The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
-       */
-      conflictingLocks: components["schemas"]["LocksAPI_LockFieldValues_Create_Response_LockInfo"][];
-      conflictsListTruncated: boolean;
-    };
-    LocksAPI_LockFieldValues_Create_Response_LockInfo: {
-      targetId: string;
-      fieldName: string;
-      lockedBy: string;
-      /** Format: date-time */
-      lockedAt: string;
-      comment: string;
-    };
-    MaintenanceAPI_License_Response: {
-      /** Format: int32 */
-      status: number;
-      isOk: boolean;
-      /**
-       * Format: bytes
-       * @description Raw response body as it was received from the license server.
-       */
-      responseBody: string;
-    };
-    MaintenanceAPI_Ping_Response: {
-      coreVersion: string;
-      coreFullVersion: string;
-      /** Format: enum */
-      compression: number;
-      /**
-       * @description instanceID is a unique ID that changes when we reset DB state.
-       *      If we reset a state and a database, but the address of the backend is still the same,
-       *      without instanceID we are not sure if it's the same state or not,
-       *      and UI can't detect it and clear its state (e.g. caches of drivers).
-       */
-      instanceId: string;
-      platform: string;
-      os: string;
-      arch: string;
-      /**
-       * @description Opt-in capabilities advertised by this server instance, used by
-       *      clients to pick between fast and fallback code paths without waiting
-       *      for a failed RPC.
-       *
-       *      Each entry is an opaque token "<feature>:<version>" (e.g.
-       *      "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
-       *      The field is unset on servers predating this mechanism, which the
-       *      client treats as "no optional capabilities advertised".
-       *
-       *      All list see pl/platform/api/plapiserver/server_capabilities.go
-       */
-      capabilities: string[];
-    };
-    MiscAPI_ListResourceTypes_Response: {
-      types: components["schemas"]["ResourceType"][];
-    };
-    Notification: {
-      subscriptionId: string;
-      eventId: string;
-      resourceId: string;
-      resourceType: components["schemas"]["ResourceType"];
-      events: components["schemas"]["Notification_Events"];
-      fieldChanges: {
-        [key: string]: components["schemas"]["Notification_FieldChange"];
-      };
-      payload: components["schemas"]["NotificationFilter_Payload"];
-      filterName: string;
-      txSpan: components["schemas"]["SpanInfo"];
-    };
-    NotificationAPI_Get_Request: {
-      subscription: string;
-      /** Format: uint32 */
-      maxNotifications: number;
-    };
-    NotificationAPI_Get_Response: {
-      notifications: components["schemas"]["Notification"][];
-    };
-    NotificationFilter: {
-      resourceType: components["schemas"]["ResourceType"];
-      resourceId: string;
-      eventFilter: components["schemas"]["NotificationFilter_EventFilter"];
-      payload: components["schemas"]["NotificationFilter_Payload"];
-    };
-    NotificationFilter_EventFilter: {
-      all: boolean;
-      resourceCreated: boolean;
-      resourceDeleted: boolean;
-      resourceReady: boolean;
-      resourceRecovered: boolean;
-      resourceDuplicate: boolean;
-      resourceError: boolean;
-      /** @description Field events */
-      inputsLocked: boolean;
-      outputsLocked: boolean;
-      fieldCreated: boolean;
-      fieldGotError: boolean;
-      inputSet: boolean;
-      allInputsSet: boolean;
-      outputSet: boolean;
-      allOutputsSet: boolean;
-      genericOtwSet: boolean;
-      dynamicChanged: boolean;
-    };
-    NotificationFilter_Payload: {
-      values: {
-        [key: string]: string;
-      };
-    };
-    Notification_Events: {
-      resourceCreated: boolean;
-      resourceDeleted: boolean;
-      resourceReady: boolean;
-      resourceDuplicate: boolean;
-      resourceError: boolean;
-      inputsLocked: boolean;
-      outputsLocked: boolean;
-      fieldCreated: boolean;
-      fieldGotError: boolean;
-      inputSet: boolean;
-      allInputsSet: boolean;
-      outputSet: boolean;
-      allOutputsSet: boolean;
-      genericOtwSet: boolean;
-      dynamicChanged: boolean;
-      resourceRecovered: boolean;
-    };
-    Notification_FieldChange: {
-      old: components["schemas"]["Field"];
-      new: components["schemas"]["Field"];
-    };
-    ResourceAPIFeature: {
-      controllerType: string;
-      featureName: string;
-      resourceType: components["schemas"]["ResourceType"];
-      endpoint: string;
-    };
-    ResourceSchema: {
-      type: components["schemas"]["ResourceType"];
-      fields: components["schemas"]["FieldSchema"][];
-      /** @description Access restriction flags for non-controller roles */
-      accessFlags: components["schemas"]["ResourceSchema_AccessFlags"];
-      freeInputs: boolean;
-      freeOutputs: boolean;
-    };
-    ResourceSchema_AccessFlags: {
-      /**
-       * @description Deny-list approach: default = allowed (true)
-       *      Controllers set these to false to restrict non-controller roles (role='u', role='w')
-       */
-      createResource: boolean;
-      /** @description IMPORTANT: read_fields=false with write_fields=true is a forbidden combination */
-      readFields: boolean;
-      writeFields: boolean;
-      /** @description IMPORTANT: read_kv=false with write_kv=true is a forbidden combination */
-      readKv: boolean;
-      writeKv: boolean;
-      /**
-       * @description Per-field-type overrides (map: field_type → bool)
-       *      When defined for a field type, overrides resource-level flags
-       */
-      readByFieldType: {
-        [key: string]: boolean;
-      };
-      writeByFieldType: {
-        [key: string]: boolean;
-      };
-    };
-    ResourceType: {
-      name: string;
-      version: string;
-    };
-    Resource_Features: {
-      ephemeral: boolean;
-    };
-    SpanInfo: {
-      path: string;
-      carrier: {
-        [key: string]: string;
-      };
-    };
-    /** @description The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors). */
-    Status: {
-      /**
-       * Format: int32
-       * @description The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-       */
-      code: number;
-      /** @description A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client. */
-      message: string;
-      /** @description A list of messages that carry the error details.  There is a common set of message types for APIs to use. */
-      details: components["schemas"]["GoogleProtobufAny"][];
-    };
-    SubscriptionAPI_AttachFilter_Request: {
-      subscriptionId: string;
-      filterName: string;
-      filterId: string;
-    };
-    SubscriptionAPI_AttachFilter_Response: Record<string, never>;
-    SubscriptionAPI_DetachFilter_Request: {
-      subscriptionId: string;
-      filterName: string;
-    };
-    SubscriptionAPI_DetachFilter_Response: Record<string, never>;
-    TxAPI_Sync_Request: {
-      txId: string;
-    };
-    TxAPI_Sync_Response: Record<string, never>;
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    schemas: {
+        AuthAPI_BeginSSOLogin_PublicPKCE: {
+            nonce: string;
+            /** Format: date-time */
+            expiresAt: string;
+        };
+        AuthAPI_BeginSSOLogin_Request: Record<string, never>;
+        AuthAPI_BeginSSOLogin_Response: {
+            publicPkce: components["schemas"]["AuthAPI_BeginSSOLogin_PublicPKCE"];
+        };
+        AuthAPI_GetJWTToken_Request: {
+            expiration: string;
+            /** Format: enum */
+            requestedRole: number;
+        };
+        AuthAPI_GetJWTToken_Response: {
+            token: string;
+            /**
+             * Format: bytes
+             * @description Session info fields
+             */
+            sessionId: string;
+            /** Format: enum */
+            role: number;
+        };
+        AuthAPI_GetSessionInfo_Request: Record<string, never>;
+        AuthAPI_GetSessionInfo_Response: {
+            /** Format: bytes */
+            sessionId: string;
+            /** Format: enum */
+            role: number;
+        };
+        AuthAPI_GetUserRoot_Request: {
+            login: string;
+            createIfNotExists: boolean;
+        };
+        AuthAPI_GetUserRoot_Response: {
+            userRoot: components["schemas"]["AuthAPI_UserRoot"];
+        };
+        AuthAPI_GrantAccess_Request: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+            targetUser: string;
+            permissions: components["schemas"]["AuthAPI_Grant_Permissions"];
+            /** Format: enum */
+            grantType: number;
+        };
+        AuthAPI_GrantAccess_Response: Record<string, never>;
+        /** @description Permissions describes access level for a grant. */
+        AuthAPI_Grant_Permissions: {
+            writable: boolean;
+        };
+        AuthAPI_ListMethods_BasicAuthMethod: Record<string, never>;
+        AuthAPI_ListMethods_MethodInfo: {
+            /**
+             * @description id is the stable, machine-readable identifier of the login method
+             *      instance. Unique across the entire server.
+             */
+            id: string;
+            /** @description description is the human-readable label in case we'd like to render it in UI. */
+            description: string;
+            basic: components["schemas"]["AuthAPI_ListMethods_BasicAuthMethod"];
+            token: components["schemas"]["AuthAPI_ListMethods_TokenAuthMethod"];
+            sso: components["schemas"]["AuthAPI_ListMethods_SSOAuthMethod"];
+        };
+        AuthAPI_ListMethods_Response: {
+            methods: components["schemas"]["AuthAPI_ListMethods_MethodInfo"][];
+        };
+        /**
+         * @description SSOAuthMethod advertises an external IdP-based login flow. The desktop
+         *      app uses the contents to drive the PKCE exchange locally, then hands the
+         *      resulting IdP token-response back via Login.SSOCredentials.
+         */
+        AuthAPI_ListMethods_SSOAuthMethod: {
+            issuer: string;
+            clientId: string;
+            scopes: string;
+            resource: string;
+            prompt: string;
+            redirectPorts: number[];
+            subjectTokenSource: string;
+            userIdClaim: string;
+            groupsClaim: string;
+            /** Format: enum */
+            flowType: number;
+        };
+        AuthAPI_ListMethods_TokenAuthMethod: Record<string, never>;
+        AuthAPI_Login_BasicCredentials: {
+            login: string;
+            password: string;
+        };
+        AuthAPI_Login_Request: {
+            basic: components["schemas"]["AuthAPI_Login_BasicCredentials"];
+            token: components["schemas"]["AuthAPI_Login_TokenCredentials"];
+            sso: components["schemas"]["AuthAPI_Login_SSOCredentials"];
+            expiration: string;
+            /** Format: enum */
+            requestedRole: number;
+        };
+        AuthAPI_Login_Response: {
+            token: string;
+            /** Format: bytes */
+            sessionId: string;
+            /** Format: enum */
+            role: number;
+        };
+        /**
+         * @description SSOCredentials carries the raw JSON body returned by the IdP's /token
+         *      endpoint after the desktop completes a PKCE exchange.
+         */
+        AuthAPI_Login_SSOCredentials: {
+            /** Format: bytes */
+            tokenResponse: string;
+        };
+        /**
+         * @description TokenCredentials accepts any opaque bearer-style string: a controller
+         *      pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
+         */
+        AuthAPI_Login_TokenCredentials: {
+            /** Format: bytes */
+            token: string;
+        };
+        AuthAPI_MintSignature_Request: {
+            resourceId: string;
+            /** Format: bytes */
+            targetSid: string;
+            color: components["schemas"]["Color"];
+        };
+        AuthAPI_MintSignature_Response: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+        };
+        AuthAPI_RefreshToken_Request: {
+            token: string;
+            expiration: string;
+        };
+        AuthAPI_RefreshToken_Response: {
+            token: string;
+            /** Format: bytes */
+            sessionId: string;
+            /** Format: enum */
+            role: number;
+        };
+        AuthAPI_RevokeAccess_Request: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+            targetUser: string;
+        };
+        AuthAPI_RevokeAccess_Response: Record<string, never>;
+        AuthAPI_UserRoot: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+        };
+        Color: {
+            root: string;
+            /** Format: uint32 */
+            permissions: number;
+        };
+        Controller: {
+            type: string;
+            id: string;
+            subscriptionID: string;
+        };
+        ControllerAPI_AttachSubscription_Request: {
+            controllerId: string;
+            subscriptionId: string;
+        };
+        ControllerAPI_AttachSubscription_Response: Record<string, never>;
+        ControllerAPI_ClearFeatures_Request: {
+            controllerType: string;
+        };
+        ControllerAPI_ClearFeatures_Response: Record<string, never>;
+        ControllerAPI_Create_Request: {
+            id: string;
+            controllerType: string;
+        };
+        ControllerAPI_Create_Response: {
+            controllerId: string;
+        };
+        ControllerAPI_Deregister_Request: {
+            controllerType: string;
+        };
+        ControllerAPI_Deregister_Response: Record<string, never>;
+        ControllerAPI_Exists_Request: {
+            controllerType: string;
+        };
+        ControllerAPI_Exists_Response: {
+            exists: boolean;
+        };
+        ControllerAPI_GetNotifications_Request: {
+            controllerType: string;
+            /** Format: uint32 */
+            maxNotifications: number;
+        };
+        ControllerAPI_GetNotifications_Response: {
+            notifications: components["schemas"]["Notification"][];
+        };
+        ControllerAPI_GetUrl_Request: {
+            controllerAlias: string;
+            resourceId: string;
+        };
+        ControllerAPI_GetUrl_Response: {
+            controllerUrl: string;
+        };
+        ControllerAPI_Get_Request: {
+            controllerType: string;
+        };
+        ControllerAPI_Get_Response: {
+            controller: components["schemas"]["Controller"];
+        };
+        ControllerAPI_Register_Request: {
+            controllerType: string;
+            filters: {
+                [key: string]: components["schemas"]["NotificationFilter"];
+            };
+            resourceSchemas: components["schemas"]["ResourceSchema"][];
+        };
+        ControllerAPI_Register_Response: {
+            controllerId: string;
+            subscriptionId: string;
+        };
+        ControllerAPI_RemoveAliasesAndUrls_Request: {
+            controllerType: string;
+        };
+        ControllerAPI_RemoveAliasesAndUrls_Response: Record<string, never>;
+        ControllerAPI_SetFeatures_Request: {
+            features: components["schemas"]["ResourceAPIFeature"][];
+        };
+        ControllerAPI_SetFeatures_Response: Record<string, never>;
+        ControllerAPI_Update_Request: {
+            controllerType: string;
+            filters: {
+                [key: string]: components["schemas"]["NotificationFilter"];
+            };
+            resourceSchemas: components["schemas"]["ResourceSchema"][];
+        };
+        ControllerAPI_Update_Response: Record<string, never>;
+        ControllerAPI_WriteAliasesAndUrls_Request: {
+            controllerType: string;
+            aliasesToUrls: {
+                [key: string]: string;
+            };
+        };
+        ControllerAPI_WriteAliasesAndUrls_Response: Record<string, never>;
+        Field: {
+            /** @description field ID is always combination of parent resource ID and field name */
+            id: components["schemas"]["FieldRef"];
+            /** Format: enum */
+            type: number;
+            features: components["schemas"]["Resource_Features"];
+            /**
+             * @description _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
+             *      If a field refers to another field, it will get
+             *      a value only when this chain of references ends up with a direct resource
+             *      reference. At that moment, all fields in the chain will get their values
+             *      resolved and will start to refer to the same resource directly.
+             */
+            value: string;
+            /**
+             * Format: bytes
+             * @description Signature for value resource ID, inheriting the parent resource's color.
+             *      Populated server-side when the parent resource has a known color in the current TX.
+             */
+            valueSignature: string;
+            /**
+             * Format: enum
+             * @description Whether the value is empty, assigned, or finally resolved.
+             */
+            valueStatus: number;
+            /** @description If the value is in its final state (ready, duplicate or error) */
+            valueIsFinal: boolean;
+            /**
+             * @description Error resource ID, if any.
+             *      Is intended to report problems _from_ the platform to the client.
+             */
+            error: string;
+            /**
+             * Format: bytes
+             * @description Signature for error resource ID, inheriting the parent resource's color.
+             */
+            errorSignature: string;
+        };
+        FieldRef: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+            fieldName: string;
+        };
+        FieldSchema: {
+            /** Format: enum */
+            type: number;
+            name: string;
+        };
+        /** @description Contains an arbitrary serialized message along with a @type that describes the type of the serialized message. */
+        GoogleProtobufAny: {
+            /** @description The type of the serialized message. */
+            "@type": string;
+        } & {
+            [key: string]: unknown;
+        };
+        LocksAPI_Lease_Create_Request: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+            timeout: string;
+            name: string;
+        };
+        LocksAPI_Lease_Create_Response: {
+            /** Format: bytes */
+            leaseId: string;
+        };
+        LocksAPI_Lease_Release_Request: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+            /** Format: bytes */
+            leaseId: string;
+        };
+        LocksAPI_Lease_Release_Response: Record<string, never>;
+        LocksAPI_Lease_Update_Request: {
+            resourceId: string;
+            /** Format: bytes */
+            resourceSignature: string;
+            /** Format: bytes */
+            leaseId: string;
+            timeout: string;
+            name: string;
+        };
+        LocksAPI_Lease_Update_Response: Record<string, never>;
+        LocksAPI_LockFieldValues_Create_Request: {
+            resourceId: string;
+            lockReferencesOf: string[];
+            comment: string;
+        };
+        LocksAPI_LockFieldValues_Create_Response: {
+            /**
+             * @description true when lock was acquired (new, or already owned by the owner)
+             *      Client MUST pay attention to this flag, as it shows if lock was successful.
+             */
+            acquired: boolean;
+            /**
+             * @description Info about why lock was not acquired.
+             *      Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
+             *      The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
+             */
+            conflictingLocks: components["schemas"]["LocksAPI_LockFieldValues_Create_Response_LockInfo"][];
+            conflictsListTruncated: boolean;
+        };
+        LocksAPI_LockFieldValues_Create_Response_LockInfo: {
+            targetId: string;
+            fieldName: string;
+            lockedBy: string;
+            /** Format: date-time */
+            lockedAt: string;
+            comment: string;
+        };
+        MaintenanceAPI_License_Response: {
+            /** Format: int32 */
+            status: number;
+            isOk: boolean;
+            /**
+             * Format: bytes
+             * @description Raw response body as it was received from the license server.
+             */
+            responseBody: string;
+        };
+        MaintenanceAPI_Ping_Response: {
+            coreVersion: string;
+            coreFullVersion: string;
+            /** Format: enum */
+            compression: number;
+            /**
+             * @description instanceID is a unique ID that changes when we reset DB state.
+             *      If we reset a state and a database, but the address of the backend is still the same,
+             *      without instanceID we are not sure if it's the same state or not,
+             *      and UI can't detect it and clear its state (e.g. caches of drivers).
+             */
+            instanceId: string;
+            platform: string;
+            os: string;
+            arch: string;
+            /**
+             * @description Opt-in capabilities advertised by this server instance. Two
+             *      client-side usage modes share this same wire field, decided
+             *      per-token by the client:
+             *        - Optimization hint. Client picks between a fast path and a
+             *          fallback without probing by trial-and-error; missing tokens
+             *          just cause the fallback to run (e.g. "treeFilter:v2").
+             *        - Install-time gate. Client refuses to install a block whose
+             *          manifest declares a required capability the server doesn't
+             *          advertise; missing tokens fail closed (e.g. "wasm:v1").
+             *
+             *      Each entry is an opaque token "<feature>:<version>" (e.g.
+             *      "treeFilter:v2"). The field is unset on servers predating this
+             *      mechanism, which the client treats as "no optional capabilities
+             *      advertised" — fallback for hints, fail-closed for gates.
+             *
+             *      All list see pl/platform/api/plapiserver/server_capabilities.go
+             */
+            capabilities: string[];
+        };
+        MiscAPI_ListResourceTypes_Response: {
+            types: components["schemas"]["ResourceType"][];
+        };
+        Notification: {
+            subscriptionId: string;
+            eventId: string;
+            resourceId: string;
+            resourceType: components["schemas"]["ResourceType"];
+            events: components["schemas"]["Notification_Events"];
+            fieldChanges: {
+                [key: string]: components["schemas"]["Notification_FieldChange"];
+            };
+            payload: components["schemas"]["NotificationFilter_Payload"];
+            filterName: string;
+            txSpan: components["schemas"]["SpanInfo"];
+        };
+        NotificationAPI_Get_Request: {
+            subscription: string;
+            /** Format: uint32 */
+            maxNotifications: number;
+        };
+        NotificationAPI_Get_Response: {
+            notifications: components["schemas"]["Notification"][];
+        };
+        NotificationFilter: {
+            resourceType: components["schemas"]["ResourceType"];
+            resourceId: string;
+            eventFilter: components["schemas"]["NotificationFilter_EventFilter"];
+            payload: components["schemas"]["NotificationFilter_Payload"];
+        };
+        NotificationFilter_EventFilter: {
+            all: boolean;
+            resourceCreated: boolean;
+            resourceDeleted: boolean;
+            resourceReady: boolean;
+            resourceRecovered: boolean;
+            resourceDuplicate: boolean;
+            resourceError: boolean;
+            /** @description Field events */
+            inputsLocked: boolean;
+            outputsLocked: boolean;
+            fieldCreated: boolean;
+            fieldGotError: boolean;
+            inputSet: boolean;
+            allInputsSet: boolean;
+            outputSet: boolean;
+            allOutputsSet: boolean;
+            genericOtwSet: boolean;
+            dynamicChanged: boolean;
+        };
+        NotificationFilter_Payload: {
+            values: {
+                [key: string]: string;
+            };
+        };
+        Notification_Events: {
+            resourceCreated: boolean;
+            resourceDeleted: boolean;
+            resourceReady: boolean;
+            resourceDuplicate: boolean;
+            resourceError: boolean;
+            inputsLocked: boolean;
+            outputsLocked: boolean;
+            fieldCreated: boolean;
+            fieldGotError: boolean;
+            inputSet: boolean;
+            allInputsSet: boolean;
+            outputSet: boolean;
+            allOutputsSet: boolean;
+            genericOtwSet: boolean;
+            dynamicChanged: boolean;
+            resourceRecovered: boolean;
+        };
+        Notification_FieldChange: {
+            old: components["schemas"]["Field"];
+            new: components["schemas"]["Field"];
+        };
+        ResourceAPIFeature: {
+            controllerType: string;
+            featureName: string;
+            resourceType: components["schemas"]["ResourceType"];
+            endpoint: string;
+        };
+        ResourceSchema: {
+            type: components["schemas"]["ResourceType"];
+            fields: components["schemas"]["FieldSchema"][];
+            /** @description Access restriction flags for non-controller roles */
+            accessFlags: components["schemas"]["ResourceSchema_AccessFlags"];
+            freeInputs: boolean;
+            freeOutputs: boolean;
+        };
+        ResourceSchema_AccessFlags: {
+            /**
+             * @description Deny-list approach: default = allowed (true)
+             *      Controllers set these to false to restrict non-controller roles (role='u', role='w')
+             */
+            createResource: boolean;
+            /** @description IMPORTANT: read_fields=false with write_fields=true is a forbidden combination */
+            readFields: boolean;
+            writeFields: boolean;
+            /** @description IMPORTANT: read_kv=false with write_kv=true is a forbidden combination */
+            readKv: boolean;
+            writeKv: boolean;
+            /**
+             * @description Per-field-type overrides (map: field_type → bool)
+             *      When defined for a field type, overrides resource-level flags
+             */
+            readByFieldType: {
+                [key: string]: boolean;
+            };
+            writeByFieldType: {
+                [key: string]: boolean;
+            };
+            /**
+             * @description SetError is a control-flow channel and is allowed by default even when
+             *      every other access bit is denied: a failing step on a closely-guarded
+             *      resource must surface to its caller. Controllers may opt out by
+             *      setting this to false.
+             */
+            setError: boolean;
+        };
+        ResourceType: {
+            name: string;
+            version: string;
+        };
+        Resource_Features: {
+            ephemeral: boolean;
+        };
+        SpanInfo: {
+            path: string;
+            carrier: {
+                [key: string]: string;
+            };
+        };
+        /** @description The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors). */
+        Status: {
+            /**
+             * Format: int32
+             * @description The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+             */
+            code: number;
+            /** @description A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client. */
+            message: string;
+            /** @description A list of messages that carry the error details.  There is a common set of message types for APIs to use. */
+            details: components["schemas"]["GoogleProtobufAny"][];
+        };
+        SubscriptionAPI_AttachFilter_Request: {
+            subscriptionId: string;
+            filterName: string;
+            filterId: string;
+        };
+        SubscriptionAPI_AttachFilter_Response: Record<string, never>;
+        SubscriptionAPI_DetachFilter_Request: {
+            subscriptionId: string;
+            filterName: string;
+        };
+        SubscriptionAPI_DetachFilter_Response: Record<string, never>;
+        TxAPI_Sync_Request: {
+            txId: string;
+        };
+        TxAPI_Sync_Response: Record<string, never>;
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  Platform_GrantAccess: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_GrantAccess_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_GrantAccess_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_GetJWTToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_GetJWTToken_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_GetJWTToken_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_Login: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_Login_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_Login_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_AuthMethods: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_ListMethods_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_MintSignature: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_MintSignature_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_MintSignature_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_RefreshToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_RefreshToken_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_RefreshToken_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_RevokeAccess: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_RevokeAccess_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_RevokeAccess_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_GetSessionInfo: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_BeginSSOLogin: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_GetUserRoot: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AuthAPI_GetUserRoot_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AuthAPI_GetUserRoot_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_WriteControllerAliasesAndUrls: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_RemoveControllerAliasesAndUrls: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerAttachSubscription: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerCreate: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_Create_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_Create_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerDeregister: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_Deregister_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_Deregister_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerExists: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_Exists_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_Exists_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerSetFeatures: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_SetFeatures_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_SetFeatures_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerClearFeatures: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerGet: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_Get_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_Get_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_GetControllerNotifications: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_GetNotifications_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_GetNotifications_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerRegister: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_Register_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_Register_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ControllerUpdate: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_Update_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_Update_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_GetControllerUrl: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ControllerAPI_GetUrl_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ControllerAPI_GetUrl_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_License: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["MaintenanceAPI_License_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_LeaseResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LocksAPI_Lease_Create_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LocksAPI_Lease_Create_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ReleaseLease: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LocksAPI_Lease_Release_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LocksAPI_Lease_Release_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_UpdateLease: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LocksAPI_Lease_Update_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LocksAPI_Lease_Update_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_LockFieldValues: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_NotificationsGet: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["NotificationAPI_Get_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["NotificationAPI_Get_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_Ping: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["MaintenanceAPI_Ping_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_ListResourceTypes: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["MiscAPI_ListResourceTypes_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_SubscriptionAttachFilter: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_SubscriptionDetachFilter: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
-  Platform_TxSync: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["TxAPI_Sync_Request"];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["TxAPI_Sync_Response"];
-        };
-      };
-      /** @description Default error response */
-      default: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Status"];
-        };
-      };
-    };
-  };
+    Platform_GrantAccess: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_GrantAccess_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_GrantAccess_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_GetJWTToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_GetJWTToken_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_GetJWTToken_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_Login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_Login_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_Login_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_AuthMethods: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_ListMethods_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_MintSignature: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_MintSignature_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_MintSignature_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_RefreshToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_RefreshToken_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_RefreshToken_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_RevokeAccess: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_RevokeAccess_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_RevokeAccess_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_GetSessionInfo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_GetSessionInfo_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_BeginSSOLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_BeginSSOLogin_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_GetUserRoot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthAPI_GetUserRoot_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthAPI_GetUserRoot_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_WriteControllerAliasesAndUrls: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_WriteAliasesAndUrls_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_RemoveControllerAliasesAndUrls: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_RemoveAliasesAndUrls_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerAttachSubscription: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_AttachSubscription_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerCreate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_Create_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_Create_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerDeregister: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_Deregister_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_Deregister_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerExists: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_Exists_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_Exists_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerSetFeatures: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_SetFeatures_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_SetFeatures_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerClearFeatures: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_ClearFeatures_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_Get_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_Get_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_GetControllerNotifications: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_GetNotifications_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_GetNotifications_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerRegister: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_Register_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_Register_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ControllerUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_Update_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_Update_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_GetControllerUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ControllerAPI_GetUrl_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ControllerAPI_GetUrl_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_License: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaintenanceAPI_License_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_LeaseResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LocksAPI_Lease_Create_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LocksAPI_Lease_Create_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ReleaseLease: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LocksAPI_Lease_Release_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LocksAPI_Lease_Release_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_UpdateLease: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LocksAPI_Lease_Update_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LocksAPI_Lease_Update_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_LockFieldValues: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LocksAPI_LockFieldValues_Create_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_NotificationsGet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationAPI_Get_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationAPI_Get_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_Ping: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaintenanceAPI_Ping_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_ListResourceTypes: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MiscAPI_ListResourceTypes_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_SubscriptionAttachFilter: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionAPI_AttachFilter_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_SubscriptionDetachFilter: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionAPI_DetachFilter_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
+    Platform_TxSync: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TxAPI_Sync_Request"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TxAPI_Sync_Response"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Status"];
+                };
+            };
+        };
+    };
 }

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -576,6 +576,15 @@ export interface components {
       nonce: string;
       /** Format: date-time */
       expiresAt: string;
+      /**
+       * @description Confidential-client secret for the IdP token exchange; absent for public clients.
+       *      Rationale: Google's OIDC does not support public clients — it requires a
+       *      client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+       *      gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+       *      leaving the server. So the backend holds the secret and forwards it here to the
+       *      desktop, which performs the token exchange as a confidential client.
+       */
+      clientSecret: string;
     };
     AuthAPI_BeginSSOLogin_Request: Record<string, never>;
     AuthAPI_BeginSSOLogin_Response: {
@@ -657,6 +666,7 @@ export interface components {
       groupsClaim: string;
       /** Format: enum */
       flowType: number;
+      accessType: string;
     };
     AuthAPI_ListMethods_TokenAuthMethod: Record<string, never>;
     AuthAPI_Login_BasicCredentials: {
@@ -1069,8 +1079,8 @@ export interface components {
     };
     ResourceSchema_AccessFlags: {
       /**
-       * @description Deny-list approach: default = allowed (true)
-       *      Controllers set these to false to restrict non-controller roles (role='u', role='w')
+       * @description Allow-list approach: default = forbidden (false)
+       *      Controllers set this to true allow non-controller roles (role='u', role='w')
        */
       createResource: boolean;
       /** @description IMPORTANT: read_fields=false with write_fields=true is a forbidden combination */
@@ -1090,10 +1100,8 @@ export interface components {
         [key: string]: boolean;
       };
       /**
-       * @description SetError is a control-flow channel and is allowed by default even when
-       *      every other access bit is denied: a failing step on a closely-guarded
-       *      resource must surface to its caller. Controllers may opt out by
-       *      setting this to false.
+       * @description Allows non-controller roles (role='u', role='w') to set error on the resource,
+       *      marking it as failed and dropping it from recovery/deduplication indicies.
        */
       setError: boolean;
     };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the SSO authentication flow to support Google OIDC requirements — specifically propagating `access_type` and a `clientSecret` from the server to the desktop client — and syncs several proto changes into the vendored snapshot and generated TypeScript.

- **Google OIDC fields**: Adds `accessType?: string` to `SSOAuthMethod` and `clientSecret?: string` to `SSOLoginAttempt` (and the corresponding `beginSSOLogin` return), enabling the desktop to perform Google's confidential-client token exchange and send `access_type=offline` to request a refresh token.
- **Proto & generated-type additions**: `ListUsers` RPC, `ListGrants.TxResponse` for transactional grant listing, `AuthAPI_User` and related messages, `ResourceSchema_AccessFlags.set_error` field, and a semantics flip on `AccessFlags` defaults from deny-list to allow-list.
- **Method-index bump**: `listResourceTypes`, `ping`, and `license` methods in the gRPC client are correctly renumbered (34→35, 35→36, 36→37) to accommodate the inserted `ListUsers` slot.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core Google OIDC confidential-client flow is broken: `clientSecret` is read from `PublicPKCE` on both the gRPC and REST paths, but the proto message was never extended with that field, so the secret will never reach the desktop.

Both the gRPC and REST implementations of `beginSSOLogin` attempt to forward `clientSecret` from the server, but `AuthAPI_BeginSSOLogin_PublicPKCE` has no such field in the proto or the generated TypeScript types. The result is that `clientSecret` is silently `undefined` in every call, making the Google OIDC token exchange fall back to a public-client mode that Google does not support. Everything else in the PR — the `ListUsers` RPC, `ListGrants.TxResponse`, `AccessFlags` semantic update, and method-index renumbering — looks correct.

`lib/node/pl-client/src/core/ll_client.ts` and `lib/node/pl-client/proto/plapi/plapiproto/api.proto` need attention: `client_secret` must be added to `BeginSSOLogin.PublicPKCE` in the proto, the generated types must be updated, and then `ll_client.ts` can correctly forward the field.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/ll_client.ts | Returns `clientSecret` from `beginSSOLogin` but reads it from `resp.publicPkce.clientSecret` and `pkce.clientSecret` — fields that do not exist on the generated gRPC or REST types, so `clientSecret` will always be `undefined` at runtime. |
| lib/node/pl-client/src/core/unauth_client.ts | Adds `accessType` and `clientSecret` optional fields to `SSOAuthMethod` and `SSOLoginAttempt` public types; `clientSecret` propagation depends on the broken `ll_client.ts` read; `accessType` mapping flagged in previous review thread. |
| lib/node/pl-client/proto/plapi/plapiproto/api.proto | Adds `ListUsers` RPC, `ListGrants.TxResponse`, `AuthAPI_User`/`ListUsers` messages; the new `access_type` and `client_secret` fields needed for Google OIDC are absent from `SSOAuthMethod` and `BeginSSOLogin.PublicPKCE`. |
| lib/node/pl-client/proto/plapi/plapiproto/api_types.proto | Flips `AccessFlags` semantics from deny-list to allow-list in comments and adds new `set_error` field (field 8); purely documentation and additive proto field change. |
| lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.client.ts | Adds `listUsers` to both the interface and class, correctly renumbers subsequent methods (listResourceTypes/ping/license). |
| lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts | Generated types for `AuthAPI_ListGrants_TxResponse`, `AuthAPI_User`, `AuthAPI_ListUsers_*`; transaction oneof correctly adds field 412 for `listGrants`; `Platform` service registration updated. |
| lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts | Adds `setError?: boolean` (field 8) to `ResourceSchema_AccessFlags` with correct binary read/write; comment updates match proto. |
| lib/node/pl-client/src/proto-rest/plapi.ts | Adds `setError: boolean` to `ResourceSchema_AccessFlags` REST type; updates capabilities description; no `clientSecret` or `accessType` additions to `BeginSSOLogin` types. |
| .gitignore | Adds Claude local settings to gitignore; contains typo `CLAUDE.local.ms` instead of `CLAUDE.local.md`, making the ignore rule ineffective. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Desktop
    participant UnauthClient as UnauthenticatedPlClient
    participant LLClient as LLPlClient
    participant Backend as PL Backend (gRPC/REST)

    Desktop->>UnauthClient: listMethods()
    UnauthClient->>LLClient: listMethods()
    LLClient->>Backend: ListMethods RPC
    Backend-->>LLClient: "SSOAuthMethod { issuer, clientId, scopes, flowType, [access_type?] }"
    Note over LLClient: sso.accessType read from proto (field absent → always undefined)
    LLClient-->>UnauthClient: SSOAuthMethod
    UnauthClient-->>Desktop: "SSOAuthMethod { accessType? }"

    Desktop->>UnauthClient: beginSSOLogin()
    UnauthClient->>LLClient: beginSSOLogin()
    LLClient->>Backend: BeginSSOLogin RPC
    Backend-->>LLClient: "PublicPKCE { nonce, expiresAt, [client_secret?] }"
    Note over LLClient: publicPkce.clientSecret read (field absent in proto → always undefined)
    LLClient-->>UnauthClient: "{ nonce, expiresAt, clientSecret? }"
    UnauthClient-->>Desktop: "SSOLoginAttempt { flow, nonce, expiresAt, clientSecret? }"

    Desktop->>Backend: OIDC token exchange (with clientSecret if present)
    Desktop->>UnauthClient: loginSSO(tokenResponse)
    UnauthClient->>Backend: Login RPC
    Backend-->>Desktop: Platforma JWT
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Desktop
    participant UnauthClient as UnauthenticatedPlClient
    participant LLClient as LLPlClient
    participant Backend as PL Backend (gRPC/REST)

    Desktop->>UnauthClient: listMethods()
    UnauthClient->>LLClient: listMethods()
    LLClient->>Backend: ListMethods RPC
    Backend-->>LLClient: "SSOAuthMethod { issuer, clientId, scopes, flowType, [access_type?] }"
    Note over LLClient: sso.accessType read from proto (field absent → always undefined)
    LLClient-->>UnauthClient: SSOAuthMethod
    UnauthClient-->>Desktop: "SSOAuthMethod { accessType? }"

    Desktop->>UnauthClient: beginSSOLogin()
    UnauthClient->>LLClient: beginSSOLogin()
    LLClient->>Backend: BeginSSOLogin RPC
    Backend-->>LLClient: "PublicPKCE { nonce, expiresAt, [client_secret?] }"
    Note over LLClient: publicPkce.clientSecret read (field absent in proto → always undefined)
    LLClient-->>UnauthClient: "{ nonce, expiresAt, clientSecret? }"
    UnauthClient-->>Desktop: "SSOLoginAttempt { flow, nonce, expiresAt, clientSecret? }"

    Desktop->>Backend: OIDC token exchange (with clientSecret if present)
    Desktop->>UnauthClient: loginSSO(tokenResponse)
    UnauthClient->>Backend: Login RPC
    Backend-->>Desktop: Platforma JWT
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fll_client.ts%3A202-214%0A**%60clientSecret%60%20not%20in%20proto%20%E2%80%94%20always%20%60undefined%60%20on%20both%20code%20paths**%0A%0A%60AuthAPI_BeginSSOLogin_PublicPKCE%60%20%28gRPC%29%20has%20only%20%60nonce%60%20and%20%60expiresAt%60%20%28fields%201%E2%80%932%29%3B%20%60client_secret%60%20was%20never%20added%20to%20the%20%60BeginSSOLogin.PublicPKCE%60%20proto%20message.%20The%20REST%20schema%20at%20%60components%5B%22schemas%22%5D%5B%22AuthAPI_BeginSSOLogin_PublicPKCE%22%5D%60%20in%20%60plapi.ts%60%20likewise%20has%20only%20%60nonce%60%20and%20%60expiresAt%60.%20Both%20%60resp.publicPkce.clientSecret%60%20%28gRPC%20path%29%20and%20%60pkce.clientSecret%60%20%28REST%20path%29%20therefore%20silently%20resolve%20to%20%60undefined%60%20at%20runtime%2C%20so%20the%20confidential-client%20exchange%20for%20Google%20OIDC%20will%20never%20receive%20the%20server-issued%20secret.%20The%20proto%20field%20%60string%20client_secret%20%3D%20N%60%20must%20be%20added%20to%20%60BeginSSOLogin.PublicPKCE%60%2C%20the%20gRPC%20and%20REST%20generated%20types%20must%20be%20regenerated%2Fhand-patched%2C%20and%20%60ll_client.ts%60%20can%20then%20read%20the%20field%20correctly.%0A%0A&repo=milaboratory%2Fplatforma&pr=1718&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/node/pl-client/src/core/ll_client.ts:202-214
**`clientSecret` not in proto — always `undefined` on both code paths**

`AuthAPI_BeginSSOLogin_PublicPKCE` (gRPC) has only `nonce` and `expiresAt` (fields 1–2); `client_secret` was never added to the `BeginSSOLogin.PublicPKCE` proto message. The REST schema at `components["schemas"]["AuthAPI_BeginSSOLogin_PublicPKCE"]` in `plapi.ts` likewise has only `nonce` and `expiresAt`. Both `resp.publicPkce.clientSecret` (gRPC path) and `pkce.clientSecret` (REST path) therefore silently resolve to `undefined` at runtime, so the confidential-client exchange for Google OIDC will never receive the server-issued secret. The proto field `string client_secret = N` must be added to `BeginSSOLogin.PublicPKCE`, the gRPC and REST generated types must be regenerated/hand-patched, and `ll_client.ts` can then read the field correctly.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["\[MILAB-6431\]: fix(pl-client): make acces..."](https://github.com/milaboratory/platforma/commit/3b255549c779f2006b810c2885ffd216ba1ee1e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39574134)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->