### PR TITLE
MILAB-6497: block-tools software build command (channel/variant/location)

### DIFF
--- a/.changeset/dev-remote-build-mode.md
+++ b/.changeset/dev-remote-build-mode.md
@@ -1,0 +1,15 @@
+---
+"@platforma-sdk/package-builder-lib": minor
+---
+
+Add the `dev-remote` build mode: a dev-channel build that builds and uploads a binary
+archive (today's `dev-local` skips the archive and emits a same-host `local` descriptor).
+The `BuildMode` enum now separates the two axes it conflated — `isDevMode()` (channel: dev
+naming + `isDev` marker) and `producesRegistryDescriptor()` (descriptor shape: registry vs
+same-host). `dev-local` and `release` are unchanged.
+
+On the dev channel the embedded binary registry name is the built-in `midev`, flipping to
+`dev` and routing uploads to the developer's endpoint when `PL_DEV_BINARY_UPLOAD_URL` is set;
+`PL_RELEASE_BINARY_UPLOAD_URL` overrides the release upload endpoint without renaming. A
+referenced run environment keeps its own published registry. No default dev endpoint URL is
+committed — dev remote upload requires the endpoint to be supplied.

--- a/.changeset/software-build-command.md
+++ b/.changeset/software-build-command.md
@@ -1,0 +1,15 @@
+---
+"@platforma-sdk/block-tools": minor
+---
+
+Add the `block-tools software build` command: the single-pass software builder driven by
+three knobs — `--channel`/`PL_BUILD_CHANNEL` (dev|release), `--variant`/`PL_BUILD_VARIANT`
+(docker|binary), `--location`/`PL_BUILD_LOCATION` (local|remote) — plus `--use-published`/
+`PL_BUILD_USE_PUBLISHED` (build-against-existing). It builds the artifact, pushes it when the
+target is remote, then writes the `.sw.json` descriptor last (ready ⟺ the descriptor exists).
+
+With no knobs it reproduces `pl-pkg build` (release, version-derived, per-entrypoint variant,
+docker push only in CI, no binary upload). Dev binary remote uploads a content-addressed
+archive to the dev binary registry (endpoint via `PL_DEV_BINARY_UPLOAD_URL`). `location=ssh`
+and `ecr://` auto docker-login are not yet implemented. The command is additive — no block is
+retargeted to it yet, and `pl-pkg` is unchanged.

--- a/lib/node/package-builder-lib/src/core/core.ts
+++ b/lib/node/package-builder-lib/src/core/core.ts
@@ -244,6 +244,32 @@ export class Core {
     }
   }
 
+  // Build-against-existing (A-0016): write artifact-info pointing at the already-published,
+  // version-derived artifact WITHOUT building or uploading, so a subsequent buildSwJsonFiles
+  // renders a registry descriptor for it. Must run in "release" buildMode (version-derived
+  // naming, no content hash). Binary family only — docker is not referenced this way.
+  public writePublishedArtifactInfo(options?: { ids?: string[] }) {
+    for (const [id, artifact] of this.buildablePackages) {
+      if (options?.ids && !options.ids.includes(id)) continue;
+
+      // The renderer reads cross-platform artifacts with an undefined platform and
+      // per-platform ones with the current platform (see renderBinaryInfo); mirror that.
+      const platform = artifacts.isCrossPlatform(artifact.type)
+        ? undefined
+        : util.currentPlatform();
+      const registry = this.pkgInfo.artifactRegistrySettings(artifact);
+
+      writeBuiltArtifactInfo(this.pkgInfo.artifactInfoLocation(id, "archive", platform), {
+        type: artifact.type,
+        platform: platform ?? util.currentPlatform(),
+        registryURL: registry.downloadURL,
+        registryName: registry.name,
+        remoteArtifactLocation: this.pkgInfo.artifactArchiveAddressPattern(artifact),
+        uploadPath: this.pkgInfo.artifactArchiveFullName(artifact, util.currentPlatform()),
+      });
+    }
+  }
+
   public async buildSoftwareArchives(options?: {
     ids?: string[];
     forceBuild?: boolean;
@@ -349,7 +375,7 @@ export class Core {
       }
     }
 
-    if (util.isDevLocalMode(this.buildMode)) {
+    if (!util.producesRegistryDescriptor(this.buildMode)) {
       this.logger.info(
         `  no need to build software archive in '${this.buildMode}' mode: archive build was skipped`,
       );

--- a/lib/node/package-builder-lib/src/core/envs.ts
+++ b/lib/node/package-builder-lib/src/core/envs.ts
@@ -15,6 +15,12 @@ export const PL_CONDA_NO_BUILD = "PL_CONDA_NO_BUILD";
 export const PL_DOCKER_REGISTRY = "PL_DOCKER_REGISTRY";
 export const PL_DOCKER_REGISTRY_PUSH_TO = "PL_DOCKER_REGISTRY_PUSH_TO";
 
+// Channel binary-upload endpoint overrides. When set on the dev channel, PL_DEV_BINARY_UPLOAD_URL
+// is where a dev archive is uploaded AND it flips the embedded registry name midev -> dev.
+// PL_RELEASE_BINARY_UPLOAD_URL overrides the release upload endpoint without renaming the registry.
+export const PL_DEV_BINARY_UPLOAD_URL = "PL_DEV_BINARY_UPLOAD_URL";
+export const PL_RELEASE_BINARY_UPLOAD_URL = "PL_RELEASE_BINARY_UPLOAD_URL";
+
 export const PL_DOCKER_BUILD = "PL_DOCKER_BUILD";
 export const PL_DOCKER_NO_BUILD = "PL_DOCKER_NO_BUILD";
 export const PL_DOCKER_AUTOPUSH = "PL_DOCKER_AUTOPUSH";

--- a/lib/node/package-builder-lib/src/core/package-info.test.ts
+++ b/lib/node/package-builder-lib/src/core/package-info.test.ts
@@ -1,7 +1,8 @@
 import { PackageInfo } from "./package-info";
 import * as testArtifacts from "./schemas/test-artifacts";
-import { createLogger } from "./util";
-import { test, expect } from "vitest";
+import { createLogger, isDevMode, producesRegistryDescriptor } from "./util";
+import * as envs from "./envs";
+import { test, expect, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -123,4 +124,57 @@ test("content-addressable dev naming appends a content hash", () => {
 
   fs.rmSync(root, { recursive: true, force: true });
   fs.rmSync(root2, { recursive: true, force: true });
+});
+
+test("build-mode predicates split channel from descriptor shape", () => {
+  expect(isDevMode("dev-local")).toBe(true);
+  expect(isDevMode("dev-remote")).toBe(true);
+  expect(isDevMode("release")).toBe(false);
+
+  // dev-local is the only same-host mode: it does NOT build an archive / registry descriptor.
+  expect(producesRegistryDescriptor("dev-local")).toBe(false);
+  expect(producesRegistryDescriptor("dev-remote")).toBe(true);
+  expect(producesRegistryDescriptor("release")).toBe(true);
+});
+
+const devUploadEnv = envs.PL_DEV_BINARY_UPLOAD_URL;
+const releaseUploadEnv = envs.PL_RELEASE_BINARY_UPLOAD_URL;
+afterEach(() => {
+  delete process.env[devUploadEnv];
+  delete process.env[releaseUploadEnv];
+});
+
+test("dev channel flips the embedded binary registry name to midev/dev", () => {
+  const l = createLogger("error");
+  const i = new PackageInfo(l, { pkgJsonData: testArtifacts.SingleBinaryackageJson });
+  const binary = i.getArtifact(testArtifacts.EPNameBinary, "binary");
+
+  // Release: keeps the artifact's resolved registry name (default platforma-open here).
+  const releaseName = i.artifactRegistrySettings(binary).name;
+  expect(releaseName).toEqual("platforma-open");
+
+  // Dev, built-in default: name flips to midev, no upload URL forced.
+  i.buildMode = "dev-remote";
+  expect(i.artifactRegistrySettings(binary).name).toEqual("midev");
+
+  // Dev with an explicit endpoint: name flips to dev and the upload URL routes there.
+  process.env[devUploadEnv] = "s3://my-bucket/dev?region=eu-central-1";
+  const dev = i.artifactRegistrySettings(binary);
+  expect(dev.name).toEqual("dev");
+  expect(dev.storageURL).toEqual("s3://my-bucket/dev?region=eu-central-1");
+
+  // dev-local channel behaves the same for naming.
+  i.buildMode = "dev-local";
+  expect(i.artifactRegistrySettings(binary).name).toEqual("dev");
+});
+
+test("release honors PL_RELEASE_BINARY_UPLOAD_URL without renaming", () => {
+  const l = createLogger("error");
+  const i = new PackageInfo(l, { pkgJsonData: testArtifacts.SingleBinaryackageJson });
+  const binary = i.getArtifact(testArtifacts.EPNameBinary, "binary");
+
+  process.env[releaseUploadEnv] = "s3://release-bucket/pub?region=eu-central-1";
+  const rel = i.artifactRegistrySettings(binary);
+  expect(rel.name).toEqual("platforma-open");
+  expect(rel.storageURL).toEqual("s3://release-bucket/pub?region=eu-central-1");
 });

--- a/lib/node/package-builder-lib/src/core/package-info.ts
+++ b/lib/node/package-builder-lib/src/core/package-info.ts
@@ -506,7 +506,7 @@ export class PackageInfo {
   public artifactVersion(artifact: artifacts.anyArtifactType): string {
     const base = this.baseArtifactVersion(artifact);
 
-    if (this.buildMode !== "release" && artifact.type !== "docker") {
+    if (util.isDevMode(this.buildMode) && artifact.type !== "docker") {
       const hash = this.devContentHash(artifact);
       if (hash) {
         return `${base}-${hash}`;
@@ -607,6 +607,27 @@ export class PackageInfo {
     const downloadFrom = process.env[`PL_REGISTRY_${regNameUpper}_DOWNLOAD_URL`];
     if (downloadFrom) {
       result.downloadURL = downloadFrom;
+    }
+
+    // Channel binary-upload overrides (A-0012/A-0029). On the dev channel the embedded binary
+    // registry name is the built-in `midev`, flipping to `dev` (and routing uploads to the
+    // developer's own endpoint) when PL_DEV_BINARY_UPLOAD_URL is set. Release may override its
+    // upload endpoint via PL_RELEASE_BINARY_UPLOAD_URL without renaming the registry. This
+    // replaces the artifact's declared registry name only for the channel; a referenced runenv
+    // is resolved separately (resolver.ts) and keeps its own published registry.
+    if (util.isDevMode(this.buildMode)) {
+      const devUpload = process.env[envs.PL_DEV_BINARY_UPLOAD_URL];
+      result.name = devUpload
+        ? defaults.DEV_BIN_REGISTRY_NAME_OVERRIDDEN
+        : defaults.DEV_BIN_REGISTRY_NAME;
+      if (devUpload) {
+        result.storageURL = devUpload;
+      }
+    } else {
+      const releaseUpload = process.env[envs.PL_RELEASE_BINARY_UPLOAD_URL];
+      if (releaseUpload) {
+        result.storageURL = releaseUpload;
+      }
     }
 
     if (result.downloadURL) {

--- a/lib/node/package-builder-lib/src/core/sw-json-render.ts
+++ b/lib/node/package-builder-lib/src/core/sw-json-render.ts
@@ -58,12 +58,12 @@ export class SwJsonRenderer {
         throw util.CLIError(`Entrypoint ${epName} not found in result`);
       }
 
-      if (mode !== "release") {
+      if (util.isDevMode(mode)) {
         info.isDev = true;
       }
 
       const pkg = ep.artifact;
-      if (util.isDevLocalMode(mode)) {
+      if (!util.producesRegistryDescriptor(mode)) {
         switch (pkg.type) {
           case "docker": {
             info.docker = this.renderDockerInfo(epName, ep, options?.requireAllArtifacts);
@@ -297,6 +297,7 @@ export class SwJsonRenderer {
   ): swJson.remoteSoftwareType | undefined {
     switch (mode) {
       case "release":
+      case "dev-remote":
         break;
 
       case "dev-local":
@@ -433,6 +434,7 @@ export class SwJsonRenderer {
   ): swJson.runEnvInfo | undefined {
     switch (mode) {
       case "release":
+      case "dev-remote":
         break;
 
       case "dev-local":
@@ -482,6 +484,7 @@ export class SwJsonRenderer {
   ): swJson.assetInfo | undefined {
     switch (mode) {
       case "release":
+      case "dev-remote":
         break;
 
       case "dev-local":

--- a/lib/node/package-builder-lib/src/core/util.ts
+++ b/lib/node/package-builder-lib/src/core/util.ts
@@ -299,11 +299,27 @@ export function currentPlatform(): PlatformType {
 export const AllSoftwareSources = ["archive", "docker"] as const; // add 'image', '<whatever>' here when supported
 export type SoftwareSource = (typeof AllSoftwareSources)[number];
 
-export type BuildMode = "dev-local" | "release";
+// Two orthogonal axes are folded into one enum: the channel (dev vs release — drives
+// content-addressable naming, isDev, and which registry the artifact lands in) and the
+// descriptor shape (same-host `local` descriptor vs registry-pointing `binary`/`docker`).
+// - dev-local : dev channel, same-host    (content-addressed name, isDev, local descriptor, no archive)
+// - dev-remote: dev channel, pushed        (content-addressed name, isDev, registry descriptor, archive built+uploaded)
+// - release   : release channel, pushed    (version-derived name, registry descriptor)
+export type BuildMode = "dev-local" | "dev-remote" | "release";
 
-/** True for dev-local build mode. */
+/** True for dev-local build mode (same-host, files referenced in place). */
 export function isDevLocalMode(mode: BuildMode): mode is "dev-local" {
   return mode === "dev-local";
+}
+
+/** Channel predicate: dev builds get content-addressable naming and the `isDev` marker. */
+export function isDevMode(mode: BuildMode): mode is "dev-local" | "dev-remote" {
+  return mode === "dev-local" || mode === "dev-remote";
+}
+
+/** Descriptor-shape predicate: these modes build an archive and emit a registry-pointing descriptor. */
+export function producesRegistryDescriptor(mode: BuildMode): mode is "dev-remote" | "release" {
+  return mode === "dev-remote" || mode === "release";
 }
 
 export type artifactID = {

--- a/lib/node/package-builder-lib/src/defaults.ts
+++ b/lib/node/package-builder-lib/src/defaults.ts
@@ -8,6 +8,13 @@
 export const BIN_REGISTRY_NAME = "platforma-open";
 export const BIN_REGISTRY_DOWNLOAD_URL = "https://bin.pl-open.science/";
 
+// Dev channel binary registry name embedded in dev descriptors. Built-in default `midev`
+// (open, zero-config dev area). Flips to `dev` when PL_DEV_BINARY_UPLOAD_URL routes uploads
+// to a developer's own endpoint. No URL default is committed — the dev endpoint is supplied
+// per-run via PL_DEV_BINARY_UPLOAD_URL.
+export const DEV_BIN_REGISTRY_NAME = "midev";
+export const DEV_BIN_REGISTRY_NAME_OVERRIDDEN = "dev";
+
 // Python
 export const PYTHON_TOOLSET = "pip";
 export const PYTHON_REQUIREMENTS_FILE = "requirements.txt";

--- a/lib/node/package-builder-lib/src/index.ts
+++ b/lib/node/package-builder-lib/src/index.ts
@@ -22,6 +22,7 @@ export type Builder = Pick<
   | "buildDockerImages"
   | "buildSoftwareArchives"
   | "buildSwJsonFiles"
+  | "writePublishedArtifactInfo"
   | "publishPackages"
   | "publishDockerImages"
 >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3991,6 +3991,9 @@ importers:
       '@platforma-sdk/blocks-deps-updater':
         specifier: workspace:*
         version: link:../blocks-deps-updater
+      '@platforma-sdk/package-builder-lib':
+        specifier: workspace:*
+        version: link:../../lib/node/package-builder-lib
       canonicalize:
         specifier: 'catalog:'
         version: 2.1.0

--- a/tools/block-tools/package.json
+++ b/tools/block-tools/package.json
@@ -42,6 +42,7 @@
     "@milaboratories/resolve-helper": "workspace:*",
     "@milaboratories/ts-helpers": "workspace:*",
     "@platforma-sdk/blocks-deps-updater": "workspace:*",
+    "@platforma-sdk/package-builder-lib": "workspace:*",
     "canonicalize": "catalog:",
     "commander": "catalog:",
     "lru-cache": "catalog:",

--- a/tools/block-tools/src/cli.test.ts
+++ b/tools/block-tools/src/cli.test.ts
@@ -15,7 +15,7 @@ function longNames(cmd: Command): string[] {
 describe("block-tools CLI structure", () => {
   const program = buildProgram();
 
-  it("exposes the full command surface (10 commands + structure topic)", () => {
+  it("exposes the full command surface (11 commands + structure topic)", () => {
     expect(program.commands.map((c) => c.name()).sort()).toEqual([
       "build-meta",
       "build-model",
@@ -25,6 +25,7 @@ describe("block-tools CLI structure", () => {
       "publish",
       "refresh-registry",
       "restore-overview-from-snapshot",
+      "software",
       "structure",
       "update-deps",
       "upload-package-v1",
@@ -34,6 +35,24 @@ describe("block-tools CLI structure", () => {
         .commands.map((c) => c.name())
         .sort(),
     ).toEqual(["check", "init", "refresh"]);
+    expect(
+      subcommand(program, "software")
+        .commands.map((c) => c.name())
+        .sort(),
+    ).toEqual(["build"]);
+  });
+
+  it("software build exposes the three knobs + use-published with env bindings", () => {
+    const build = subcommand(subcommand(program, "software"), "build");
+    const names = longNames(build);
+    for (const f of ["--channel", "--variant", "--location", "--use-published"]) {
+      expect(names).toContain(f);
+    }
+    const env = (long: string) => build.options.find((o) => o.long === long)?.envVar;
+    expect(env("--channel")).toBe("PL_BUILD_CHANNEL");
+    expect(env("--variant")).toBe("PL_BUILD_VARIANT");
+    expect(env("--location")).toBe("PL_BUILD_LOCATION");
+    expect(env("--use-published")).toBe("PL_BUILD_USE_PUBLISHED");
   });
 
   it("preserves key flags + env bindings", () => {

--- a/tools/block-tools/src/cli.ts
+++ b/tools/block-tools/src/cli.ts
@@ -12,6 +12,7 @@ import { uploadPackageV1Command } from "./cmd/upload-package-v1";
 import { structureCheckCommand } from "./cmd/structure/check";
 import { structureInitCommand } from "./cmd/structure/init";
 import { structureRefreshCommand } from "./cmd/structure/refresh";
+import { softwareCommand } from "./cmd/software";
 
 // `packageRoot` is the package install root (the dir containing `src/` and
 // `bin/`); the `structure` commands resolve their templates under it. bin/run.js
@@ -32,6 +33,7 @@ export function buildProgram(packageRoot: string = process.cwd()): Command {
   program.addCommand(listOverviewSnapshotsCommand());
   program.addCommand(restoreOverviewFromSnapshotCommand());
   program.addCommand(uploadPackageV1Command());
+  program.addCommand(softwareCommand());
 
   // `structure` subcommands: check | init | refresh.
   const structure = new Command("structure").description(

--- a/tools/block-tools/src/cmd/software/build.ts
+++ b/tools/block-tools/src/cmd/software/build.ts
@@ -1,0 +1,208 @@
+import { Command, Option } from "commander";
+import { util, envs, defaults, createBuilder } from "@platforma-sdk/package-builder-lib";
+import { resolvePlan, channels, variants, locations, type Knobs } from "./knobs";
+
+// The three knobs reach the command as env vars (set by the block's build:<scenario>
+// scripts) or as the mirroring flags below. PL_BUILD_USE_PUBLISHED selects build-against-existing.
+const PL_BUILD_CHANNEL = "PL_BUILD_CHANNEL";
+const PL_BUILD_VARIANT = "PL_BUILD_VARIANT";
+const PL_BUILD_LOCATION = "PL_BUILD_LOCATION";
+const PL_BUILD_USE_PUBLISHED = "PL_BUILD_USE_PUBLISHED";
+
+function collect(value: string, previous?: string[]): string[] {
+  return previous ? [...previous, value] : [value];
+}
+
+// `software build` — does the whole make-it-runnable-at-the-target action for one
+// software module in one pass: build the artifact, push it when the target is remote,
+// then write the per-target `.sw.json` descriptor LAST (ready ⟺ the descriptor exists).
+// With no knobs it reproduces `pl-pkg build` (release, version-derived, push only in CI).
+export function softwareBuildCommand(): Command {
+  const cmd = new Command("build").description(
+    "Build a software module for a target and write its .sw.json descriptor (build + push in one pass)",
+  );
+
+  // The three target knobs (env-backed; flag wins on conflict).
+  cmd.addOption(
+    new Option("--channel <channel>", "registry channel to build for")
+      .choices([...channels])
+      .env(PL_BUILD_CHANNEL),
+  );
+  cmd.addOption(
+    new Option("--variant <variant>", "artifact kind to build (default: per entrypoint)")
+      .choices([...variants])
+      .env(PL_BUILD_VARIANT),
+  );
+  cmd.addOption(
+    new Option("--location <location>", "where the artifact lands (local = no push)")
+      .choices([...locations])
+      .env(PL_BUILD_LOCATION),
+  );
+  cmd.addOption(
+    new Option(
+      "--use-published",
+      "do not build or push; emit a descriptor pointing at the already-published release artifact",
+    ).env(PL_BUILD_USE_PUBLISHED),
+  );
+
+  // Pass-through build options, mirroring `pl-pkg build` so this is a drop-in replacement.
+  cmd.addOption(
+    new Option("--log-level <level>", "logging level")
+      .choices(["error", "warn", "info", "debug"])
+      .default("info"),
+  );
+  cmd.addOption(new Option("--package-root <path>", "path to directory with package.json file"));
+  cmd.addOption(
+    new Option("--force", "force action, ignoring automatic safety checks").default(false),
+  );
+  cmd.addOption(new Option("--version <value>", "override package version (ignore package.json)"));
+  cmd.addOption(
+    new Option("--platform <os-arch>", "{os}-{arch} pair; no effect on cross-platform packages")
+      .choices([...util.AllPlatforms])
+      .env(envs.PL_PKG_OS),
+  );
+  cmd.addOption(new Option("--all-platforms", "build for all supported platforms").default(false));
+  cmd.addOption(
+    new Option("--full-dir-hash", "hash file contents (not metadata) for the dev content hash")
+      .env(envs.PL_PKG_FULL_HASH)
+      .default(false),
+  );
+  cmd.addOption(
+    new Option("--package-id <id>", "act only on selected packages").argParser(collect),
+  );
+  cmd.addOption(
+    new Option("--content-root <path>", "override software content root").env(
+      envs.PL_PKG_CONTENT_ROOT,
+    ),
+  );
+  cmd.addOption(
+    new Option("--storage-url <url>", "override binary upload registry URL").env(
+      envs.PL_PKG_STORAGE_URL,
+    ),
+  );
+  cmd.addOption(
+    new Option(
+      "--docker-registry <registry>",
+      "docker pull registry embedded in the descriptor",
+    ).env(envs.PL_DOCKER_REGISTRY),
+  );
+  cmd.addOption(
+    new Option("--docker-push-to <registry>", "alternative registry for docker push").env(
+      envs.PL_DOCKER_REGISTRY_PUSH_TO,
+    ),
+  );
+  cmd.addOption(
+    new Option("--docker-build", "build docker images").env(envs.PL_DOCKER_BUILD).default(false),
+  );
+  cmd.addOption(
+    new Option("--docker-no-build", "do not build docker images")
+      .env(envs.PL_DOCKER_NO_BUILD)
+      .default(false),
+  );
+  cmd.addOption(
+    new Option("--docker-autopush", "push docker images after build")
+      .env(envs.PL_DOCKER_AUTOPUSH)
+      .default(false),
+  );
+  cmd.addOption(
+    new Option("--docker-no-autopush", "do not push docker images")
+      .env(envs.PL_DOCKER_NO_AUTOPUSH)
+      .default(false),
+  );
+  cmd.addOption(
+    new Option("--conda-build", "build conda environment before packing")
+      .env(envs.PL_CONDA_BUILD)
+      .default(false),
+  );
+  cmd.addOption(
+    new Option("--conda-no-build", "do not build conda environment")
+      .env(envs.PL_CONDA_NO_BUILD)
+      .default(false),
+  );
+
+  cmd.action(async (o) => {
+    const logger = util.createLogger(o.logLevel);
+
+    try {
+      const knobs: Knobs = {
+        channel: o.channel,
+        variant: o.variant,
+        location: o.location,
+        usePublished: Boolean(o.usePublished),
+      };
+      const plan = resolvePlan(knobs);
+
+      const core = createBuilder(logger, { packageRoot: o.packageRoot });
+      core.buildMode = plan.buildMode;
+      core.version = o.version;
+      core.targetPlatform = o.platform as util.PlatformType;
+      core.allPlatforms = Boolean(o.allPlatforms);
+      core.fullDirHash = Boolean(o.fullDirHash);
+
+      const ids: string[] | undefined = o.packageId;
+      const isDev = (o.channel ?? "release") === "dev";
+
+      // Docker build/push: when location is unset (legacy parity) defer to the CI default
+      // via the same opt-in/out flags pl-pkg uses; otherwise the variant/location decide.
+      const buildDocker = plan.isCIDefaultPush
+        ? shouldDoAction(envs.isCI(), o.dockerBuild, o.dockerNoBuild)
+        : plan.buildDocker;
+      const pushDocker = plan.isCIDefaultPush
+        ? buildDocker &&
+          shouldDoAction(envs.isCI() && !core.isPrivate, o.dockerAutopush, o.dockerNoAutopush)
+        : plan.pushDocker;
+
+      const dockerRegistry =
+        o.dockerRegistry ?? (isDev && buildDocker ? defaults.DEV_DOCKER_REGISTRY : undefined);
+
+      // 1. BUILD (descriptor not written yet).
+      if (buildDocker) {
+        core.buildDockerImages({
+          ids,
+          registry: dockerRegistry,
+          strictPlatformMatching: envs.isCI(),
+        });
+      }
+      if (plan.usePublished) {
+        core.writePublishedArtifactInfo({ ids });
+      } else if (plan.buildBinary) {
+        await core.buildSoftwareArchives({
+          ids,
+          forceBuild: Boolean(o.force),
+          contentRoot: o.contentRoot,
+          skipIfEmpty: ids ? false : true,
+          condaBuild: shouldDoAction(true, o.condaBuild, o.condaNoBuild),
+        });
+      }
+
+      // 2. PUSH when the target is remote (still no descriptor on disk).
+      if (pushDocker) {
+        core.publishDockerImages({
+          ids,
+          pushTo: o.dockerPushTo,
+          strictPlatformMatching: envs.isCI(),
+        });
+      }
+      if (plan.uploadBinary) {
+        // storageURL falls through to the engine, which resolves the dev/release endpoint.
+        await core.publishPackages({ ids, storageURL: o.storageUrl });
+      }
+
+      // 3. DESCRIPTOR LAST — only after build + push have succeeded (A-0013).
+      core.buildSwJsonFiles({ packageIds: ids });
+    } catch (e) {
+      logger.debug(e);
+      if (e instanceof Error) logger.debug(e.stack);
+      throw e;
+    }
+  });
+
+  return cmd;
+}
+
+// Mirrors pl-pkg's shouldDoAction: explicit no-flag wins, then explicit yes-flag, else default.
+function shouldDoAction(defaultValue: boolean, doFlag: boolean, noDoFlag: boolean): boolean {
+  if (noDoFlag) return false;
+  if (doFlag) return true;
+  return defaultValue;
+}

--- a/tools/block-tools/src/cmd/software/index.ts
+++ b/tools/block-tools/src/cmd/software/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+import { softwareBuildCommand } from "./build";
+
+// `software` parent command: per-target software build (and future software subcommands).
+export function softwareCommand(): Command {
+  const cmd = new Command("software").description("Build and publish a block's software modules");
+  cmd.addCommand(softwareBuildCommand());
+  return cmd;
+}

--- a/tools/block-tools/src/cmd/software/knobs.test.ts
+++ b/tools/block-tools/src/cmd/software/knobs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { resolvePlan } from "./knobs";
+
+describe("software build knob → plan mapping", () => {
+  it("no knobs == pl-pkg build (release, build both, no binary upload, CI-gated docker push)", () => {
+    const p = resolvePlan({});
+    expect(p).toMatchObject({
+      buildMode: "release",
+      buildDocker: true,
+      buildBinary: true,
+      uploadBinary: false, // location unset => never uploads binaries (pl-pkg parity)
+      usePublished: false,
+      isCIDefaultPush: true,
+    });
+  });
+
+  it("dev-binary-local => dev-local, local descriptor, no push", () => {
+    const p = resolvePlan({ channel: "dev", variant: "binary", location: "local" });
+    expect(p).toMatchObject({ buildMode: "dev-local", uploadBinary: false, pushDocker: false });
+  });
+
+  it("dev-binary-remote => dev-remote, build + upload (the net-new cell)", () => {
+    const p = resolvePlan({ channel: "dev", variant: "binary", location: "remote" });
+    expect(p).toMatchObject({ buildMode: "dev-remote", buildBinary: true, uploadBinary: true });
+  });
+
+  it("dev-docker-local/remote stay dev-local (docker is orthogonal to the dev binary mode)", () => {
+    expect(resolvePlan({ channel: "dev", variant: "docker", location: "local" })).toMatchObject({
+      buildMode: "dev-local",
+      buildDocker: true,
+      pushDocker: false,
+    });
+    expect(resolvePlan({ channel: "dev", variant: "docker", location: "remote" })).toMatchObject({
+      buildMode: "dev-local",
+      buildDocker: true,
+      pushDocker: true,
+    });
+  });
+
+  it("release + remote folds in the binary upload", () => {
+    const p = resolvePlan({ channel: "release", variant: "binary", location: "remote" });
+    expect(p).toMatchObject({ buildMode: "release", uploadBinary: true });
+  });
+
+  it("use-published => descriptor only, no build/push", () => {
+    const p = resolvePlan({ channel: "dev", usePublished: true });
+    expect(p).toMatchObject({
+      buildMode: "release",
+      buildDocker: false,
+      buildBinary: false,
+      pushDocker: false,
+      uploadBinary: false,
+      usePublished: true,
+    });
+  });
+
+  it("ssh and use-published+docker are rejected", () => {
+    expect(() => resolvePlan({ location: "ssh" })).toThrow(/ssh/);
+    expect(() => resolvePlan({ usePublished: true, variant: "docker" })).toThrow(/binary-only/);
+  });
+});

--- a/tools/block-tools/src/cmd/software/knobs.ts
+++ b/tools/block-tools/src/cmd/software/knobs.ts
@@ -1,0 +1,87 @@
+import { util } from "@platforma-sdk/package-builder-lib";
+
+// The three target knobs of `software build`. Each is also accepted as an env var
+// (see build.ts); the flag wins on conflict (commander resolves that).
+export const channels = ["dev", "release"] as const;
+export const variants = ["docker", "binary"] as const;
+export const locations = ["local", "remote", "ssh"] as const;
+
+export type Channel = (typeof channels)[number];
+export type Variant = (typeof variants)[number];
+export type Location = (typeof locations)[number];
+
+export interface Knobs {
+  channel?: Channel; // default: release
+  variant?: Variant; // default: per-entrypoint (act on every artifact kind)
+  location?: Location; // default: undefined => legacy pl-pkg behaviour (push only in CI)
+  usePublished?: boolean; // build-against-existing: descriptor only, no build/push
+}
+
+// What the action should do, derived from the knobs. `buildMode` is the engine mode;
+// the booleans gate the build/push steps. `usePublished` short-circuits to descriptor-only.
+export interface BuildPlan {
+  buildMode: util.BuildMode;
+  buildDocker: boolean;
+  buildBinary: boolean;
+  pushDocker: boolean;
+  uploadBinary: boolean;
+  usePublished: boolean;
+  isCIDefaultPush: boolean; // location unset => docker push follows the CI default (pl-pkg parity)
+}
+
+/**
+ * Map the knobs to a concrete build plan. Pure — no env/CLI/engine access.
+ *
+ * Defaults reproduce today's `pl-pkg build`: channel=release, per-entrypoint variant,
+ * location unset => build archives + (docker in CI) + push docker in CI, NO binary upload.
+ * Explicit `location=remote` opts a target into pushing (binary upload + docker push).
+ */
+export function resolvePlan(knobs: Knobs): BuildPlan {
+  const channel: Channel = knobs.channel ?? "release";
+
+  if (knobs.location === "ssh") {
+    throw new Error("location 'ssh' is not implemented yet");
+  }
+
+  if (knobs.usePublished) {
+    // Binary only, no build, no push — descriptor points at the published release artifact.
+    if (knobs.variant === "docker") {
+      throw new Error(
+        "--use-published is binary-only and cannot be combined with --variant docker",
+      );
+    }
+    return {
+      buildMode: "release",
+      buildDocker: false,
+      buildBinary: false,
+      pushDocker: false,
+      uploadBinary: false,
+      usePublished: true,
+      isCIDefaultPush: false,
+    };
+  }
+
+  // Which artifact kinds to act on. Unset variant = per-entrypoint (both), matching pl-pkg.
+  const doDocker = knobs.variant !== "binary";
+  const doBinary = knobs.variant !== "docker";
+
+  const remote = knobs.location === "remote";
+
+  const buildMode: util.BuildMode =
+    channel === "release"
+      ? "release"
+      : doBinary && remote
+        ? "dev-remote" // the only cell that builds+uploads a dev binary
+        : "dev-local";
+
+  return {
+    buildMode,
+    buildDocker: doDocker,
+    buildBinary: doBinary,
+    pushDocker: doDocker && remote,
+    uploadBinary: doBinary && remote,
+    usePublished: false,
+    // Legacy parity: when location is unset, docker build/push defer to the CI default.
+    isCIDefaultPush: knobs.location === undefined,
+  };
+}


### PR DESCRIPTION
> **Stacked on #1720** (content-addressable dev naming). Review/merge that first; this PR's base is `MILAB-6497_content-addressable-dev-naming`. Diff shown here is only this PR's commit.

## What

Adds the single-pass software builder **`block-tools software build`** (STATUS items 69 + 70 + 71, plus 81). It builds an artifact, pushes it when the target is remote, and writes the `.sw.json` descriptor **last** — "ready ⟺ the descriptor exists" (A-0013). Driven by three knobs, each an env var mirrored by a flag (flag wins):

- `--channel` / `PL_BUILD_CHANNEL` — `dev` | `release`
- `--variant` / `PL_BUILD_VARIANT` — `docker` | `binary` (default: per-entrypoint)
- `--location` / `PL_BUILD_LOCATION` — `local` | `remote` (`ssh` deferred)
- `--use-published` / `PL_BUILD_USE_PUBLISHED` — build-against-existing (A-0016)

## Engine changes (`package-builder-lib`)

- New **`dev-remote`** build mode: builds + uploads a dev binary archive (`dev-local` still skips). `BuildMode` split into two predicates — `isDevMode` (channel: content-addressed naming + `isDev`) and `producesRegistryDescriptor` (descriptor shape: registry vs same-host). `dev-local`/`release` are byte-identical to before.
- Dev binary registry name is the built-in `midev`, flipping to `dev` and routing uploads to the developer endpoint when `PL_DEV_BINARY_UPLOAD_URL` is set; `PL_RELEASE_BINARY_UPLOAD_URL` overrides the release endpoint. A referenced runenv keeps its own published registry.
- `writePublishedArtifactInfo()` synthesizes artifact-info from version-derived naming for build-against-existing, reusing the release render path (no build, no push).

## Parity & scope

- **No knobs = `pl-pkg build`** — verified **byte-identical** `dist/tengo/*.sw.json` on a real leaf (`lib/ptabler/software`) for both release default and `--dev local`.
- `pl-pkg` is untouched; **no block is retargeted** to the new command yet (items 84/87).
- **Deferred:** `location=ssh` (A-0015), `ecr://` auto docker-login (A-0044), and `PL_DEV_DOCKER_*` / `PL_RELEASE_DOCKER_*` docker push/pull overrides (the docker half of A-0012).

## Tests

Engine: `dev-remote` registry-name flip (`midev`/`dev`) + `PL_DEV_/PL_RELEASE_BINARY_UPLOAD_URL` overrides; predicate behavior; existing 111 suite green. block-tools: command surface + knob env bindings in `cli.test.ts`; pure knob→plan mapping unit tests (`knobs.test.ts`). Both suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `block-tools software build` command — a single-pass builder that drives the `package-builder-lib` engine via three knobs (`--channel`, `--variant`, `--location`) plus `--use-published`, writing the `.sw.json` descriptor only after build and push succeed (A-0013). It also extends `package-builder-lib` with a new `dev-remote` `BuildMode`, splitting the previous `BuildMode` into two orthogonal predicates (`isDevMode`, `producesRegistryDescriptor`) and adding dev-channel binary registry name overrides (`midev` / `dev` flip via `PL_DEV_BINARY_UPLOAD_URL`).

- **`BuildMode` expansion**: `\"dev-remote\"` joins `\"dev-local\"` and `\"release\"`, with two new predicate functions cleanly separating the channel axis from the descriptor-shape axis; `sw-json-render.ts` is updated to route `dev-remote` through the registry-descriptor path alongside `release`.
- **`writePublishedArtifactInfo()`**: new method on `Core` that synthesises artifact-info from version-derived naming for build-against-existing (A-0016) without building or uploading.
- **`software build` command**: orchestrates build → push → descriptor in one pass; knob-to-plan mapping is cleanly isolated in `knobs.ts` as a pure function; `isCIDefaultPush` mode retains `pl-pkg` parity when no `--location` is specified.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The engine-layer changes are solid and byte-identical for existing modes; the main risk is in the new CLI command where the isCIDefaultPush branch can silently build Docker images when the caller specified --variant binary without --location.

The command is not yet wired to any block, so the impact is currently limited to direct use of the new CLI. However, the isCIDefaultPush logic defect would silently produce incorrect behavior the moment a block script omits --location while setting --variant binary, and the test suite has no coverage for this exact cell.

tools/block-tools/src/cmd/software/build.ts — the isCIDefaultPush/buildDocker interaction at lines 147-153 needs a fix before blocks are retargeted to this command.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/cmd/software/build.ts | New `software build` command with correct build/push/descriptor ordering (A-0013); `isCIDefaultPush` path ignores `plan.buildDocker`, breaking `--variant binary` without `--location` in CI. |
| tools/block-tools/src/cmd/software/knobs.ts | Pure plan-mapping function; `ssh` is included in the exported `locations` tuple, causing it to appear as a valid CLI choice even though it throws immediately. |
| lib/node/package-builder-lib/src/core/core.ts | Adds `writePublishedArtifactInfo()` (A-0016) and flips the archive-skip guard from `isDevLocalMode` to `!producesRegistryDescriptor`; both changes look correct and consistent with the new three-way `BuildMode`. |
| lib/node/package-builder-lib/src/core/util.ts | Adds `dev-remote` to `BuildMode` and introduces two orthogonal predicates (`isDevMode`, `producesRegistryDescriptor`); existing `isDevLocalMode` is preserved for backward compat. |
| lib/node/package-builder-lib/src/core/package-info.ts | Dev/release binary-upload endpoint overrides: `midev`/`dev` registry name flip for dev channel and `PL_RELEASE_BINARY_UPLOAD_URL` for release, applied after the standard per-registry env resolution. |
| lib/node/package-builder-lib/src/core/sw-json-render.ts | Adds `dev-remote` to the `release` branches in `renderRemoteSoftwareInfo`, `renderRunEnvInfo`, and `renderAssetInfo`, enabling registry descriptors for dev-remote builds. |
| lib/node/package-builder-lib/src/defaults.ts | Adds `DEV_BIN_REGISTRY_NAME = "midev"` and `DEV_BIN_REGISTRY_NAME_OVERRIDDEN = "dev"` constants for the dev-channel registry name flip. |
| tools/block-tools/src/cmd/software/knobs.test.ts | Good coverage of named plan cells; the `--variant binary` without `--location` CI scenario (where `isCIDefaultPush` conflicts with `plan.buildDocker`) is not tested. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["software build\nchannel/variant/location/use-published"] --> B["resolvePlan → BuildPlan"]
    B --> C{use-published?}
    C -- yes --> D["writePublishedArtifactInfo\nno build no push"]
    C -- no --> E{isCIDefaultPush?}
    E -- "yes: location unset" --> F["buildDocker = shouldDoAction(isCI, flags)\npushDocker = buildDocker AND isCI AND !private"]
    E -- "no: location explicit" --> G["buildDocker = plan.buildDocker\npushDocker = plan.pushDocker"]
    F --> H["1 BUILD"]
    G --> H
    D --> I["3 DESCRIPTOR"]
    H --> J["buildDockerImages"]
    H --> K["buildSoftwareArchives"]
    J --> L["2 PUSH"]
    K --> L
    L --> M["publishDockerImages"]
    L --> N["publishPackages"]
    M --> I
    N --> I
    I --> O["buildSwJsonFiles\n.sw.json written LAST\nA-0013: ready = descriptor exists"]
    subgraph engine["BuildMode in package-builder-lib"]
        BM1["dev-local: isDevMode=true producesRegistry=false"]
        BM2["dev-remote: isDevMode=true producesRegistry=true"]
        BM3["release: isDevMode=false producesRegistry=true"]
    end
    B -.-> engine
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["software build\nchannel/variant/location/use-published"] --> B["resolvePlan → BuildPlan"]
    B --> C{use-published?}
    C -- yes --> D["writePublishedArtifactInfo\nno build no push"]
    C -- no --> E{isCIDefaultPush?}
    E -- "yes: location unset" --> F["buildDocker = shouldDoAction(isCI, flags)\npushDocker = buildDocker AND isCI AND !private"]
    E -- "no: location explicit" --> G["buildDocker = plan.buildDocker\npushDocker = plan.pushDocker"]
    F --> H["1 BUILD"]
    G --> H
    D --> I["3 DESCRIPTOR"]
    H --> J["buildDockerImages"]
    H --> K["buildSoftwareArchives"]
    J --> L["2 PUSH"]
    K --> L
    L --> M["publishDockerImages"]
    L --> N["publishPackages"]
    M --> I
    N --> I
    I --> O["buildSwJsonFiles\n.sw.json written LAST\nA-0013: ready = descriptor exists"]
    subgraph engine["BuildMode in package-builder-lib"]
        BM1["dev-local: isDevMode=true producesRegistry=false"]
        BM2["dev-remote: isDevMode=true producesRegistry=true"]
        BM3["release: isDevMode=false producesRegistry=true"]
    end
    B -.-> engine
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atools%2Fblock-tools%2Fsrc%2Fcmd%2Fsoftware%2Fbuild.ts%3A147-153%0A**%60isCIDefaultPush%60%20silently%20overrides%20%60plan.buildDocker%60**%0A%0AWhen%20%60--variant%20binary%60%20is%20passed%20without%20%60--location%60%2C%20%60resolvePlan%60%20correctly%20sets%20%60plan.buildDocker%20%3D%20false%60%2C%20but%20%60isCIDefaultPush%20%3D%20true%60%20%28location%20is%20undefined%29.%20The%20action%20then%20computes%20%60buildDocker%20%3D%20shouldDoAction%28envs.isCI%28%29%2C%20...%29%60%20which%20returns%20%60true%60%20in%20CI%20%E2%80%94%20building%20Docker%20images%20even%20though%20the%20caller%20explicitly%20opted%20into%20binary-only%20mode.%20The%20%60plan.buildDocker%60%20result%20is%20completely%20dropped%20in%20this%20path.%20The%20fix%20is%20to%20AND%20it%20in%3A%20%60plan.buildDocker%20%26%26%20shouldDoAction%28envs.isCI%28%29%2C%20o.dockerBuild%2C%20o.dockerNoBuild%29%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Atools%2Fblock-tools%2Fsrc%2Fcmd%2Fsoftware%2Fbuild.ts%3A36-40%0A**%60ssh%60%20exposed%20as%20a%20valid%20choice%20but%20immediately%20throws**%0A%0A%60locations%60%20includes%20%60%22ssh%22%60%20and%20it%20is%20spread%20into%20%60.choices%28%5B...locations%5D%29%60%2C%20so%20Commander%20accepts%20%60--location%20ssh%60%20as%20syntactically%20valid%20and%20shows%20it%20in%20help%20text.%20The%20very%20first%20thing%20%60resolvePlan%60%20does%2C%20however%2C%20is%20%60throw%20new%20Error%28%22location%20'ssh'%20is%20not%20implemented%20yet%22%29%60.%20A%20user%20who%20sees%20%60ssh%60%20in%20the%20help%20output%20and%20tries%20it%20will%20get%20an%20opaque%20runtime%20error%20rather%20than%20a%20Commander%20validation%20message.%20Consider%20removing%20%60%22ssh%22%60%20from%20%60choices%60%20until%20it%20is%20implemented%2C%20or%20splitting%20the%20type%20into%20%60%22local%22%20%7C%20%22remote%22%60%20for%20the%20CLI%20option%20and%20keeping%20the%20full%20union%20only%20in%20the%20type%20system.%0A%0A&repo=milaboratory%2Fplatforma&pr=1721&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tools/block-tools/src/cmd/software/build.ts:147-153
**`isCIDefaultPush` silently overrides `plan.buildDocker`**

When `--variant binary` is passed without `--location`, `resolvePlan` correctly sets `plan.buildDocker = false`, but `isCIDefaultPush = true` (location is undefined). The action then computes `buildDocker = shouldDoAction(envs.isCI(), ...)` which returns `true` in CI — building Docker images even though the caller explicitly opted into binary-only mode. The `plan.buildDocker` result is completely dropped in this path. The fix is to AND it in: `plan.buildDocker && shouldDoAction(envs.isCI(), o.dockerBuild, o.dockerNoBuild)`.

### Issue 2 of 2
tools/block-tools/src/cmd/software/build.ts:36-40
**`ssh` exposed as a valid choice but immediately throws**

`locations` includes `"ssh"` and it is spread into `.choices([...locations])`, so Commander accepts `--location ssh` as syntactically valid and shows it in help text. The very first thing `resolvePlan` does, however, is `throw new Error("location 'ssh' is not implemented yet")`. A user who sees `ssh` in the help output and tries it will get an opaque runtime error rather than a Commander validation message. Consider removing `"ssh"` from `choices` until it is implemented, or splitting the type into `"local" | "remote"` for the CLI option and keeping the full union only in the type system.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6497: block-tools software build c..."](https://github.com/milaboratory/platforma/commit/01bcd51da32b057e046ac80dbb34abf9600b02d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40078148)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->