### PR TITLE
fix(structurer): route in-SDK blocks to the aux/dev registry

### DIFF
--- a/etc/blocks/blob-url-custom-protocol/block/package.json
+++ b/etc/blocks/blob-url-custom-protocol/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/download-file/block/package.json
+++ b/etc/blocks/download-file/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/enter-numbers-v3/block/package.json
+++ b/etc/blocks/enter-numbers-v3/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/enter-numbers/block/package.json
+++ b/etc/blocks/enter-numbers/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/filter-column-test/block/package.json
+++ b/etc/blocks/filter-column-test/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/model-test/block/package.json
+++ b/etc/blocks/model-test/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/monetization-test/block/package.json
+++ b/etc/blocks/monetization-test/block/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/pool-explorer/block/package.json
+++ b/etc/blocks/pool-explorer/block/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/read-logs/block/package.json
+++ b/etc/blocks/read-logs/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/sum-numbers-v3/block/package.json
+++ b/etc/blocks/sum-numbers-v3/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/sum-numbers/block/package.json
+++ b/etc/blocks/sum-numbers/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/table-test/block/package.json
+++ b/etc/blocks/table-test/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/transfer-files/block/package.json
+++ b/etc/blocks/transfer-files/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/ui-examples/block/package.json
+++ b/etc/blocks/ui-examples/block/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/etc/blocks/upload-file/block/package.json
+++ b/etc/blocks/upload-file/block/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science",
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
+++ b/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
@@ -125,6 +125,46 @@ describe("facade: slim `package.json` end-state", () => {
   });
 });
 
+describe("facade: `prepublishOnly` publish target branches on isSdkInternal", () => {
+  const AUX_DEV =
+    "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1 --registry-serve-url https://aux-blocks.pl-open.science";
+
+  test("in-SDK blocks publish to the aux/dev registry, regardless of org", () => {
+    // `@milaboratories` would route to production via ORG_PUBLISH_TARGETS — the
+    // isSdkInternal branch must override that and send it to aux/dev.
+    const vars: BlockVars = {
+      facadeName: "@milaboratories/test-org.demo",
+      baseName: "test-org.demo",
+      npmOrg: "@milaboratories",
+      orgScope: "test-org",
+      shortName: "demo",
+    };
+    const { fs } = simulateInit({ vars, isSdkInternal: true });
+    const p = JSON.parse(fs.read("block/package.json"));
+    expect(p.scripts.prepublishOnly).toBe(AUX_DEV);
+  });
+
+  test("standalone blocks publish to their per-org production target", () => {
+    const open = simulateInit({ vars: VARS });
+    expect(JSON.parse(open.fs.read("block/package.json")).scripts.prepublishOnly).toBe(
+      "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
+    );
+
+    const milab = simulateInit({
+      vars: {
+        facadeName: "@milaboratories/test-org.demo",
+        baseName: "test-org.demo",
+        npmOrg: "@milaboratories",
+        orgScope: "test-org",
+        shortName: "demo",
+      },
+    });
+    expect(JSON.parse(milab.fs.read("block/package.json")).scripts.prepublishOnly).toBe(
+      "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://block.registry.platforma.bio/releases",
+    );
+  });
+});
+
 describe("facade: sibling package privacy", () => {
   test("model / ui / workflow / test are `private` with no `version`", () => {
     const { fs } = simulateInit({ vars: VARS });

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -42,8 +42,19 @@ const FALLBACK_PUBLISH_TARGET = {
   serveUrl: "https://blocks.pl-open.science",
 };
 
-function prepublishScript(npmOrg: string): string {
-  const t = ORG_PUBLISH_TARGETS[npmOrg] ?? FALLBACK_PUBLISH_TARGET;
+/** Where the in-SDK blocks (`etc/blocks/*`) publish: the aux/dev registry, not
+ *  production `pub/releases/`. These are the monorepo's test/example blocks, so
+ *  one target regardless of org — their `@milaboratories` scope must NOT route
+ *  them to the real catalog alongside standalone blocks. */
+const SDK_INTERNAL_PUBLISH_TARGET = {
+  s3: "s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1",
+  serveUrl: "https://aux-blocks.pl-open.science",
+};
+
+function prepublishScript(npmOrg: string, isSdkInternal: boolean): string {
+  const t = isSdkInternal
+    ? SDK_INTERNAL_PUBLISH_TARGET
+    : (ORG_PUBLISH_TARGETS[npmOrg] ?? FALLBACK_PUBLISH_TARGET);
   return `block-tools publish -r ${t.s3} --registry-serve-url ${t.serveUrl}`;
 }
 
@@ -63,13 +74,13 @@ export function blockComponents(ctx: RunContext): Record<string, string> {
 
 /** The slim facade's canonical scripts (build / check / prepublishOnly /
  *  do-pack). Shared by the initial generator and the body rule so they cannot
- *  drift apart. `prepublishOnly` depends on the block's org for its publish
- *  coordinates. */
-function blockScripts(npmOrg: string): Record<string, string> {
+ *  drift apart. `prepublishOnly` routes by block kind: in-SDK blocks publish to
+ *  the aux/dev registry, standalone blocks to their per-org production target. */
+function blockScripts(npmOrg: string, isSdkInternal: boolean): Record<string, string> {
   return {
     build: "ts-builder build --target block-facade && block-tools pack",
     check: "ts-builder type-check --target block-facade",
-    prepublishOnly: prepublishScript(npmOrg),
+    prepublishOnly: prepublishScript(npmOrg, isSdkInternal),
     "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
   };
 }
@@ -172,7 +183,7 @@ export function blockPackageJsonInitial(ctx: RunContext): Record<string, unknown
     module: "./dist/index.js",
     types: "./dist/index.d.ts",
     exports: FACADE_EXPORTS,
-    scripts: blockScripts(v.npmOrg),
+    scripts: blockScripts(v.npmOrg, ctx.isSdkInternal),
     // Slim invariant: zero runtime deps reach the consumer.
     dependencies: {},
     devDependencies: devDeps,
@@ -190,7 +201,7 @@ export function blockPackageJsonRules(ctx: RunContext): void {
   ensureField("types", "./dist/index.d.ts");
   ensureField("exports", FACADE_EXPORTS);
 
-  const scripts = blockScripts(v.npmOrg);
+  const scripts = blockScripts(v.npmOrg, ctx.isSdkInternal);
   for (const [name, command] of Object.entries(scripts)) ensureScript(name, command);
   removeScript("mark-stable");
 


### PR DESCRIPTION
## What

In-SDK blocks (`etc/blocks/*`) must publish to the alternative **aux/dev** registry, not to production `pub/releases/`. A prior structure PR gave these in-repo test/example blocks `prepublishOnly` scripts, and step 07's `ORG_PUBLISH_TARGETS` (keyed only by npm org) sent every `@milaboratories` block — including all 15 in-SDK blocks — to production. Org alone can't distinguish an in-repo test block from a real standalone `@milaboratories` block.

## Change

`tools/block-tools/src/structure/rules/block-package-json.ts`: `prepublishScript` (and its caller `blockScripts`) now branch on `ctx.isSdkInternal`:

- **in-SDK** (`isSdkInternal === true`) → `s3://milab-euce1-prod-pkgs-s3-block-registry/aux/dev/?region=eu-central-1` + serve URL `https://aux-blocks.pl-open.science`, regardless of org.
- **standalone** → unchanged step-07 per-org production targets.

Command shape is unchanged.

## Verification

- `refresh-blocks` flipped all 15 `etc/blocks/*/block/package.json` `prepublishOnly` scripts to the aux/dev target (one-line change each).
- `check-blocks` is a zero-change fixpoint.
- Test in `facade-end-state.test.ts` pins both branches (in-SDK → aux/dev; standalone `@platforma-open` and `@milaboratories` → their production targets).
- Full local monorepo suite green vs a live backend — only the allowlisted `pl-package-builder-tests` Docker/Mac failure remains.

## Notes

- Stacked on `feat/facade-slim-package` (base is that branch, **not** `main`).
- This is the publish **address** only. Removing already-leaked in-SDK blocks from the production registry is a separate task.

Two commits: the hand rule + test, then the generated `refresh-blocks` output.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a publish routing bug where all 15 in-SDK test/example blocks (`etc/blocks/*`) were erroneously sending their `prepublishOnly` artifacts to the production registry because step 07's `ORG_PUBLISH_TARGETS` map, keyed only by npm org, could not distinguish an in-repo block from a standalone one.

- **Core fix** (`block-package-json.ts`): adds `SDK_INTERNAL_PUBLISH_TARGET` (aux/dev S3 + aux-blocks serve URL), threads the existing `RunContext.isSdkInternal` flag through `prepublishScript` → `blockScripts` → both `blockPackageJsonInitial` and `blockPackageJsonRules`, giving the flag priority over the per-org production table for all in-SDK blocks.
- **Generated output** (15 `etc/blocks/*/block/package.json`): each `prepublishOnly` line flipped from `pub/releases` to `aux/dev`, consistent with what the updated rule now enforces.
- **Test** (`facade-end-state.test.ts`): new `describe` block pins both branches — `isSdkInternal: true` with `@milaboratories` → aux/dev; standalone `@platforma-open` and `@milaboratories` → their respective production targets.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped and correct; standalone block routing is untouched.

The routing logic is simple and correct; `isSdkInternal` is already a well-typed field on `RunContext` with a stable default of `false`, so standalone blocks are unaffected. The new tests directly exercise the broken path and both standalone-org paths. The only finding is a now-inaccurate JSDoc with no runtime impact.

No files require special attention; the `ORG_PUBLISH_TARGETS` comment in `block-package-json.ts` has a minor stale description worth updating.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/rules/block-package-json.ts | Adds `SDK_INTERNAL_PUBLISH_TARGET` constant and threads `isSdkInternal` through `prepublishScript`/`blockScripts`/`blockPackageJsonInitial`/`blockPackageJsonRules`; routing logic is correct; one stale JSDoc comment on `ORG_PUBLISH_TARGETS` remains. |
| tools/block-tools/src/structure/__tests__/facade-end-state.test.ts | Adds a dedicated `describe` block that pins both branches: in-SDK `@milaboratories` → aux/dev, standalone `@platforma-open` and `@milaboratories` → their respective production targets. Coverage is complete. |
| etc/blocks/blob-url-custom-protocol/block/package.json | Representative of all 15 in-SDK block `package.json` files: `prepublishOnly` updated from `pub/releases` to `aux/dev` S3 path and matching serve URL. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["prepublishScript(npmOrg, isSdkInternal)"] --> B{isSdkInternal?}
    B -- true --> C["SDK_INTERNAL_PUBLISH_TARGET\naux/dev S3 + aux-blocks.pl-open.science"]
    B -- false --> D{npmOrg in ORG_PUBLISH_TARGETS?}
    D -- found --> E["Per-org production target\nplatforma-open or milaboratories"]
    D -- not found --> F["FALLBACK_PUBLISH_TARGET\nblocks.pl-open.science"]
    C --> G["block-tools publish command"]
    E --> G
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["prepublishScript(npmOrg, isSdkInternal)"] --> B{isSdkInternal?}
    B -- true --> C["SDK_INTERNAL_PUBLISH_TARGET\naux/dev S3 + aux-blocks.pl-open.science"]
    B -- false --> D{npmOrg in ORG_PUBLISH_TARGETS?}
    D -- found --> E["Per-org production target\nplatforma-open or milaboratories"]
    D -- not found --> F["FALLBACK_PUBLISH_TARGET\nblocks.pl-open.science"]
    C --> G["block-tools publish command"]
    E --> G
    F --> G
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fblock-tools%2Fsrc%2Fstructure%2Frules%2Fblock-package-json.ts%3A22-26%0AThe%20JSDoc%20on%20%60ORG_PUBLISH_TARGETS%60%20still%20says%20%22Safe%20for%20the%20never-published%20%60etc%2Fblocks%60%20test%20blocks%20%E2%80%94%20the%20script%20never%20runs%20for%20them.%22%20After%20this%20PR%20that%20sentence%20is%20doubly%20incorrect%3A%20the%20in-SDK%20blocks%20do%20publish%20%28to%20aux%2Fdev%29%2C%20and%20the%20table%20is%20now%20bypassed%20entirely%20for%20them%20by%20the%20%60isSdkInternal%60%20branch.%20Leaving%20the%20stale%20wording%20here%20may%20confuse%20the%20next%20reader%20who%20consults%20the%20table%20to%20understand%20routing.%0A%0A%60%60%60suggestion%0A%2F**%20Per-org%20publish%20coordinates%3A%20the%20S3%20upload%20bucket%20and%20the%20public%20registry%0A%20*%20%20serve%20URL%20the%20facade's%20%60prepublishOnly%60%20script%20passes%20to%20%60block-tools%0A%20*%20%20publish%60.%20One%20block-registry%20bucket%20serves%20both%20orgs%3B%20only%20the%20public%20read%0A%20*%20%20hostname%20differs%20by%20org.%20In-SDK%20blocks%20bypass%20this%20table%20%E2%80%94%20they%20always%20use%0A%20*%20%20SDK_INTERNAL_PUBLISH_TARGET%20regardless%20of%20org.%20Extend%20the%20map%20per%20new%20org.%20*%2F%0A%60%60%60%0A%0A&repo=milaboratory%2Fplatforma&pr=1722&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/block-tools/src/structure/rules/block-package-json.ts:22-26
The JSDoc on `ORG_PUBLISH_TARGETS` still says "Safe for the never-published `etc/blocks` test blocks — the script never runs for them." After this PR that sentence is doubly incorrect: the in-SDK blocks do publish (to aux/dev), and the table is now bypassed entirely for them by the `isSdkInternal` branch. Leaving the stale wording here may confuse the next reader who consults the table to understand routing.

```suggestion
/** Per-org publish coordinates: the S3 upload bucket and the public registry
 *  serve URL the facade's `prepublishOnly` script passes to `block-tools
 *  publish`. One block-registry bucket serves both orgs; only the public read
 *  hostname differs by org. In-SDK blocks bypass this table — they always use
 *  SDK_INTERNAL_PUBLISH_TARGET regardless of org. Extend the map per new org. */
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(blocks): refresh-blocks route in-S..."](https://github.com/milaboratory/platforma/commit/a2a09d0718d772715031dbdd783d988a1cd21392) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40393373)</sub>

<!-- /greptile_comment -->