### PR TITLE
MILAB-6484: sync plapi proto with backend main

### DIFF
--- a/.changeset/milab-6484-sync-plapi-proto.md
+++ b/.changeset/milab-6484-sync-plapi-proto.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": minor
+---
+
+Sync plapi proto with backend main. Adds the ListUsers RPC, in-transaction ListGrants, the AccessControl.set_error field, and SSO access_type/client_secret fields.

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -259,6 +259,8 @@ service Platform {
   }
   rpc ListUserResources(AuthAPI.ListUserResources.Request) returns (stream AuthAPI.ListUserResources.Response) {}
 
+  rpc ListUsers(AuthAPI.ListUsers.Request) returns (AuthAPI.ListUsers.Response) {}
+
   //
   // Other stuff
   //
@@ -483,6 +485,7 @@ message TxAPI {
 
       AuthAPI.GrantAccess.Request grant_access = 410; // grant access to a resource within transaction
       AuthAPI.RevokeAccess.Request revoke_access = 411; // revoke access to a resource within transaction
+      AuthAPI.ListGrants.Request list_grants = 412; // list grants on a resource within transaction
     }
   }
 
@@ -585,6 +588,7 @@ message TxAPI {
 
       AuthAPI.GrantAccess.Response grant_access = 410;
       AuthAPI.RevokeAccess.Response revoke_access = 411;
+      AuthAPI.ListGrants.TxResponse list_grants = 412;
     }
 
     google.rpc.Status error = 3;
@@ -1699,8 +1703,9 @@ message AuthAPI {
       string user_id_claim = 8;
       string groups_claim = 9;
       FlowType flow_type = 10;
+      optional string access_type = 11; // "online" | "offline"; Google-specific (offline → refresh token)
 
-      // next free: 11;
+      // next free: 12;
     }
 
     message MethodInfo {
@@ -1735,6 +1740,15 @@ message AuthAPI {
     message PublicPKCE {
       string nonce = 1; // server-issued one-time value
       google.protobuf.Timestamp expires_at = 2; // after this, nonce is no longer valid (when enforced)
+      // Confidential-client secret for the IdP token exchange; absent for public clients.
+      // Rationale: Google's OIDC does not support public clients — it requires a
+      // client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+      // gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+      // leaving the server. So the backend holds the secret and forwards it here to the
+      // desktop, which performs the token exchange as a confidential client.
+      optional string client_secret = 3;
+
+      // next free: 4;
     }
 
     message Response {
@@ -1866,6 +1880,10 @@ message AuthAPI {
     message Response {
       Grant grant = 1; // one per stream message
     }
+
+    message TxResponse {
+      repeated Grant grants = 1; // all grants for the resource in a single transactional response
+    }
   }
 
   message Grant {
@@ -1946,6 +1964,23 @@ message AuthAPI {
       bytes resource_signature = 2;
       Base.ResourceType resource_type = 3;
       Grant.Permissions permissions = 4;
+    }
+  }
+
+  message User {
+    // login is the stable identifier of the user — the grant target and the
+    // GetUserRoot key. Further fields (e.g. first name, last name, email) may
+    // be added later without breaking compatibility.
+    string login = 1;
+  }
+
+  message ListUsers {
+    message Request {}
+
+    // Lists users known to the server. A user becomes known on first login;
+    // provisioned users who have never logged in do not appear.
+    message Response {
+      repeated User users = 1;
     }
   }
 }

--- a/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api_types.proto
@@ -155,22 +155,26 @@ message ResourceSchema {
   repeated FieldSchema fields = 2;
 
   message AccessFlags {
-    // Deny-list approach: default = allowed (true)
-    // Controllers set these to false to restrict non-controller roles (role='u', role='w')
+    // Allow-list approach: default = forbidden (false)
+    // Controllers set this to true allow non-controller roles (role='u', role='w')
     optional bool create_resource = 1; // default: true (creation allowed)
 
     // IMPORTANT: read_fields=false with write_fields=true is a forbidden combination
-    optional bool read_fields = 2; // default: true (reads allowed)
-    optional bool write_fields = 3; // default: true (writes allowed)
+    optional bool read_fields = 2; // default: false (reads denied)
+    optional bool write_fields = 3; // default: false (writes denied)
 
     // IMPORTANT: read_kv=false with write_kv=true is a forbidden combination
-    optional bool read_kv = 4; // if unset, falls back to read_fields
-    optional bool write_kv = 5; // if unset, falls back to write_fields
+    optional bool read_kv = 4; // default: false (KV reads denied)
+    optional bool write_kv = 5; // default: false (KV writes denied)
 
     // Per-field-type overrides (map: field_type → bool)
     // When defined for a field type, overrides resource-level flags
     map<uint32, bool> read_by_field_type = 6;
     map<uint32, bool> write_by_field_type = 7;
+
+    // Allows non-controller roles (role='u', role='w') to set error on the resource,
+    // marking it as failed and dropping it from recovery/deduplication indicies.
+    optional bool set_error = 8; // default: true (allowed)
   }
 
   // Access restriction flags for non-controller roles

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -851,6 +851,15 @@ components:
         expiresAt:
           type: string
           format: date-time
+        clientSecret:
+          type: string
+          description: |-
+            Confidential-client secret for the IdP token exchange; absent for public clients.
+             Rationale: Google's OIDC does not support public clients — it requires a
+             client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+             gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+             leaving the server. So the backend holds the secret and forwards it here to the
+             desktop, which performs the token exchange as a confidential client.
     AuthAPI_BeginSSOLogin_Request:
       type: object
       properties: {}
@@ -982,6 +991,8 @@ components:
         flowType:
           type: integer
           format: enum
+        accessType:
+          type: string
       description: |-
         SSOAuthMethod advertises an external IdP-based login flow. The desktop
          app uses the contents to drive the PKCE exchange locally, then hands the
@@ -1469,14 +1480,20 @@ components:
           items:
             type: string
           description: |-
-            Opt-in capabilities advertised by this server instance, used by
-             clients to pick between fast and fallback code paths without waiting
-             for a failed RPC.
+            Opt-in capabilities advertised by this server instance. Two
+             client-side usage modes share this same wire field, decided
+             per-token by the client:
+               - Optimization hint. Client picks between a fast path and a
+                 fallback without probing by trial-and-error; missing tokens
+                 just cause the fallback to run (e.g. "treeFilter:v2").
+               - Install-time gate. Client refuses to install a block whose
+                 manifest declares a required capability the server doesn't
+                 advertise; missing tokens fail closed (e.g. "wasm:v1").
 
              Each entry is an opaque token "<feature>:<version>" (e.g.
-             "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
-             The field is unset on servers predating this mechanism, which the
-             client treats as "no optional capabilities advertised".
+             "treeFilter:v2"). The field is unset on servers predating this
+             mechanism, which the client treats as "no optional capabilities
+             advertised" — fallback for hints, fail-closed for gates.
 
              All list see pl/platform/api/plapiserver/server_capabilities.go
     MiscAPI_ListResourceTypes_Response:
@@ -1657,8 +1674,8 @@ components:
         createResource:
           type: boolean
           description: |-
-            Deny-list approach: default = allowed (true)
-             Controllers set these to false to restrict non-controller roles (role='u', role='w')
+            Allow-list approach: default = forbidden (false)
+             Controllers set this to true allow non-controller roles (role='u', role='w')
         readFields:
           type: boolean
           description: "IMPORTANT: read_fields=false with write_fields=true is a forbidden combination"
@@ -1680,6 +1697,11 @@ components:
           type: object
           additionalProperties:
             type: boolean
+        setError:
+          type: boolean
+          description: |-
+            Allows non-controller roles (role='u', role='w') to set error on the resource,
+             marking it as failed and dropping it from recovery/deduplication indicies.
     ResourceType:
       type: object
       properties:

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.client.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.client.ts
@@ -10,6 +10,8 @@ import type { MaintenanceAPI_Ping_Response } from "./api";
 import type { MaintenanceAPI_Ping_Request } from "./api";
 import type { MiscAPI_ListResourceTypes_Response } from "./api";
 import type { MiscAPI_ListResourceTypes_Request } from "./api";
+import type { AuthAPI_ListUsers_Response } from "./api";
+import type { AuthAPI_ListUsers_Request } from "./api";
 import type { AuthAPI_ListUserResources_Response } from "./api";
 import type { AuthAPI_ListUserResources_Request } from "./api";
 import type { AuthAPI_GetUserRoot_Response } from "./api";
@@ -284,6 +286,10 @@ export interface IPlatformClient {
      * @generated from protobuf rpc: ListUserResources
      */
     listUserResources(input: AuthAPI_ListUserResources_Request, options?: RpcOptions): ServerStreamingCall<AuthAPI_ListUserResources_Request, AuthAPI_ListUserResources_Response>;
+    /**
+     * @generated from protobuf rpc: ListUsers
+     */
+    listUsers(input: AuthAPI_ListUsers_Request, options?: RpcOptions): UnaryCall<AuthAPI_ListUsers_Request, AuthAPI_ListUsers_Response>;
     /**
      *
      * Other stuff
@@ -614,6 +620,13 @@ export class PlatformClient implements IPlatformClient, ServiceInfo {
         return stackIntercept<AuthAPI_ListUserResources_Request, AuthAPI_ListUserResources_Response>("serverStreaming", this._transport, method, opt, input);
     }
     /**
+     * @generated from protobuf rpc: ListUsers
+     */
+    listUsers(input: AuthAPI_ListUsers_Request, options?: RpcOptions): UnaryCall<AuthAPI_ListUsers_Request, AuthAPI_ListUsers_Response> {
+        const method = this.methods[34], opt = this._transport.mergeOptions(options);
+        return stackIntercept<AuthAPI_ListUsers_Request, AuthAPI_ListUsers_Response>("unary", this._transport, method, opt, input);
+    }
+    /**
      *
      * Other stuff
      *
@@ -621,7 +634,7 @@ export class PlatformClient implements IPlatformClient, ServiceInfo {
      * @generated from protobuf rpc: ListResourceTypes
      */
     listResourceTypes(input: MiscAPI_ListResourceTypes_Request, options?: RpcOptions): UnaryCall<MiscAPI_ListResourceTypes_Request, MiscAPI_ListResourceTypes_Response> {
-        const method = this.methods[34], opt = this._transport.mergeOptions(options);
+        const method = this.methods[35], opt = this._transport.mergeOptions(options);
         return stackIntercept<MiscAPI_ListResourceTypes_Request, MiscAPI_ListResourceTypes_Response>("unary", this._transport, method, opt, input);
     }
     /**
@@ -632,14 +645,14 @@ export class PlatformClient implements IPlatformClient, ServiceInfo {
      * @generated from protobuf rpc: Ping
      */
     ping(input: MaintenanceAPI_Ping_Request, options?: RpcOptions): UnaryCall<MaintenanceAPI_Ping_Request, MaintenanceAPI_Ping_Response> {
-        const method = this.methods[35], opt = this._transport.mergeOptions(options);
+        const method = this.methods[36], opt = this._transport.mergeOptions(options);
         return stackIntercept<MaintenanceAPI_Ping_Request, MaintenanceAPI_Ping_Response>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: License
      */
     license(input: MaintenanceAPI_License_Request, options?: RpcOptions): UnaryCall<MaintenanceAPI_License_Request, MaintenanceAPI_License_Response> {
-        const method = this.methods[36], opt = this._transport.mergeOptions(options);
+        const method = this.methods[37], opt = this._transport.mergeOptions(options);
         return stackIntercept<MaintenanceAPI_License_Request, MaintenanceAPI_License_Response>("unary", this._transport, method, opt, input);
     }
 }

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -540,6 +540,12 @@ export interface TxAPI_ClientMessage {
          */
         revokeAccess: AuthAPI_RevokeAccess_Request; // revoke access to a resource within transaction
     } | {
+        oneofKind: "listGrants";
+        /**
+         * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.ListGrants.Request list_grants = 412
+         */
+        listGrants: AuthAPI_ListGrants_Request; // list grants on a resource within transaction
+    } | {
         oneofKind: undefined;
     };
 }
@@ -928,6 +934,12 @@ export interface TxAPI_ServerMessage {
          * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.RevokeAccess.Response revoke_access = 411
          */
         revokeAccess: AuthAPI_RevokeAccess_Response;
+    } | {
+        oneofKind: "listGrants";
+        /**
+         * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse list_grants = 412
+         */
+        listGrants: AuthAPI_ListGrants_TxResponse;
     } | {
         oneofKind: undefined;
     };
@@ -3593,6 +3605,10 @@ export interface AuthAPI_ListMethods_SSOAuthMethod {
      * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType flow_type = 10
      */
     flowType: AuthAPI_ListMethods_SSOAuthMethod_FlowType;
+    /**
+     * @generated from protobuf field: optional string access_type = 11
+     */
+    accessType?: string; // "online" | "offline"; Google-specific (offline → refresh token)
 }
 /**
  * @generated from protobuf enum MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType
@@ -3672,6 +3688,17 @@ export interface AuthAPI_BeginSSOLogin_PublicPKCE {
      * @generated from protobuf field: google.protobuf.Timestamp expires_at = 2
      */
     expiresAt?: Timestamp; // after this, nonce is no longer valid (when enforced)
+    /**
+     * Confidential-client secret for the IdP token exchange; absent for public clients.
+     * Rationale: Google's OIDC does not support public clients — it requires a
+     * client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+     * gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+     * leaving the server. So the backend holds the secret and forwards it here to the
+     * desktop, which performs the token exchange as a confidential client.
+     *
+     * @generated from protobuf field: optional string client_secret = 3
+     */
+    clientSecret?: string;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.Response
@@ -3992,6 +4019,15 @@ export interface AuthAPI_ListGrants_Response {
     grant?: AuthAPI_Grant; // one per stream message
 }
 /**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse
+ */
+export interface AuthAPI_ListGrants_TxResponse {
+    /**
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.AuthAPI.Grant grants = 1
+     */
+    grants: AuthAPI_Grant[]; // all grants for the resource in a single transactional response
+}
+/**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.Grant
  */
 export interface AuthAPI_Grant {
@@ -4187,6 +4223,41 @@ export interface AuthAPI_ListUserResources_SharedResource {
      * @generated from protobuf field: MiLaboratories.PL.API.AuthAPI.Grant.Permissions permissions = 4
      */
     permissions?: AuthAPI_Grant_Permissions;
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.User
+ */
+export interface AuthAPI_User {
+    /**
+     * login is the stable identifier of the user — the grant target and the
+     * GetUserRoot key. Further fields (e.g. first name, last name, email) may
+     * be added later without breaking compatibility.
+     *
+     * @generated from protobuf field: string login = 1
+     */
+    login: string;
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers
+ */
+export interface AuthAPI_ListUsers {
+}
+/**
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Request
+ */
+export interface AuthAPI_ListUsers_Request {
+}
+/**
+ * Lists users known to the server. A user becomes known on first login;
+ * provisioned users who have never logged in do not appear.
+ *
+ * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Response
+ */
+export interface AuthAPI_ListUsers_Response {
+    /**
+     * @generated from protobuf field: repeated MiLaboratories.PL.API.AuthAPI.User users = 1
+     */
+    users: AuthAPI_User[];
 }
 /**
  * @generated from protobuf enum MiLaboratories.PL.API.AuthAPI.Role
@@ -4474,7 +4545,8 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
             { no: 351, name: "controller_features_clear", kind: "message", oneof: "request", T: () => ControllerAPI_ClearFeatures_Request },
             { no: 400, name: "set_default_color", kind: "message", oneof: "request", T: () => TxAPI_SetDefaultColor_Request },
             { no: 410, name: "grant_access", kind: "message", oneof: "request", T: () => AuthAPI_GrantAccess_Request },
-            { no: 411, name: "revoke_access", kind: "message", oneof: "request", T: () => AuthAPI_RevokeAccess_Request }
+            { no: 411, name: "revoke_access", kind: "message", oneof: "request", T: () => AuthAPI_RevokeAccess_Request },
+            { no: 412, name: "list_grants", kind: "message", oneof: "request", T: () => AuthAPI_ListGrants_Request }
         ]);
     }
     create(value?: PartialMessage<TxAPI_ClientMessage>): TxAPI_ClientMessage {
@@ -4859,6 +4931,12 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
                         revokeAccess: AuthAPI_RevokeAccess_Request.internalBinaryRead(reader, reader.uint32(), options, (message.request as any).revokeAccess)
                     };
                     break;
+                case /* MiLaboratories.PL.API.AuthAPI.ListGrants.Request list_grants */ 412:
+                    message.request = {
+                        oneofKind: "listGrants",
+                        listGrants: AuthAPI_ListGrants_Request.internalBinaryRead(reader, reader.uint32(), options, (message.request as any).listGrants)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -5057,6 +5135,9 @@ class TxAPI_ClientMessage$Type extends MessageType<TxAPI_ClientMessage> {
         /* MiLaboratories.PL.API.AuthAPI.RevokeAccess.Request revoke_access = 411; */
         if (message.request.oneofKind === "revokeAccess")
             AuthAPI_RevokeAccess_Request.internalBinaryWrite(message.request.revokeAccess, writer.tag(411, WireType.LengthDelimited).fork(), options).join();
+        /* MiLaboratories.PL.API.AuthAPI.ListGrants.Request list_grants = 412; */
+        if (message.request.oneofKind === "listGrants")
+            AuthAPI_ListGrants_Request.internalBinaryWrite(message.request.listGrants, writer.tag(412, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -5134,6 +5215,7 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
             { no: 400, name: "set_default_color", kind: "message", oneof: "response", T: () => TxAPI_SetDefaultColor_Response },
             { no: 410, name: "grant_access", kind: "message", oneof: "response", T: () => AuthAPI_GrantAccess_Response },
             { no: 411, name: "revoke_access", kind: "message", oneof: "response", T: () => AuthAPI_RevokeAccess_Response },
+            { no: 412, name: "list_grants", kind: "message", oneof: "response", T: () => AuthAPI_ListGrants_TxResponse },
             { no: 3, name: "error", kind: "message", T: () => Status }
         ]);
     }
@@ -5522,6 +5604,12 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
                         revokeAccess: AuthAPI_RevokeAccess_Response.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).revokeAccess)
                     };
                     break;
+                case /* MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse list_grants */ 412:
+                    message.response = {
+                        oneofKind: "listGrants",
+                        listGrants: AuthAPI_ListGrants_TxResponse.internalBinaryRead(reader, reader.uint32(), options, (message.response as any).listGrants)
+                    };
+                    break;
                 case /* google.rpc.Status error */ 3:
                     message.error = Status.internalBinaryRead(reader, reader.uint32(), options, message.error);
                     break;
@@ -5729,6 +5817,9 @@ class TxAPI_ServerMessage$Type extends MessageType<TxAPI_ServerMessage> {
         /* MiLaboratories.PL.API.AuthAPI.RevokeAccess.Response revoke_access = 411; */
         if (message.response.oneofKind === "revokeAccess")
             AuthAPI_RevokeAccess_Response.internalBinaryWrite(message.response.revokeAccess, writer.tag(411, WireType.LengthDelimited).fork(), options).join();
+        /* MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse list_grants = 412; */
+        if (message.response.oneofKind === "listGrants")
+            AuthAPI_ListGrants_TxResponse.internalBinaryWrite(message.response.listGrants, writer.tag(412, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -17476,7 +17567,8 @@ class AuthAPI_ListMethods_SSOAuthMethod$Type extends MessageType<AuthAPI_ListMet
             { no: 7, name: "subject_token_source", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 8, name: "user_id_claim", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 9, name: "groups_claim", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 10, name: "flow_type", kind: "enum", T: () => ["MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType", AuthAPI_ListMethods_SSOAuthMethod_FlowType] }
+            { no: 10, name: "flow_type", kind: "enum", T: () => ["MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType", AuthAPI_ListMethods_SSOAuthMethod_FlowType] },
+            { no: 11, name: "access_type", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_ListMethods_SSOAuthMethod>): AuthAPI_ListMethods_SSOAuthMethod {
@@ -17534,6 +17626,9 @@ class AuthAPI_ListMethods_SSOAuthMethod$Type extends MessageType<AuthAPI_ListMet
                 case /* MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType flow_type */ 10:
                     message.flowType = reader.int32();
                     break;
+                case /* optional string access_type */ 11:
+                    message.accessType = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -17580,6 +17675,9 @@ class AuthAPI_ListMethods_SSOAuthMethod$Type extends MessageType<AuthAPI_ListMet
         /* MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod.FlowType flow_type = 10; */
         if (message.flowType !== 0)
             writer.tag(10, WireType.Varint).int32(message.flowType);
+        /* optional string access_type = 11; */
+        if (message.accessType !== undefined)
+            writer.tag(11, WireType.LengthDelimited).string(message.accessType);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -17757,7 +17855,8 @@ class AuthAPI_BeginSSOLogin_PublicPKCE$Type extends MessageType<AuthAPI_BeginSSO
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.PublicPKCE", [
             { no: 1, name: "nonce", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "expires_at", kind: "message", T: () => Timestamp }
+            { no: 2, name: "expires_at", kind: "message", T: () => Timestamp },
+            { no: 3, name: "client_secret", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_BeginSSOLogin_PublicPKCE>): AuthAPI_BeginSSOLogin_PublicPKCE {
@@ -17778,6 +17877,9 @@ class AuthAPI_BeginSSOLogin_PublicPKCE$Type extends MessageType<AuthAPI_BeginSSO
                 case /* google.protobuf.Timestamp expires_at */ 2:
                     message.expiresAt = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.expiresAt);
                     break;
+                case /* optional string client_secret */ 3:
+                    message.clientSecret = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -17796,6 +17898,9 @@ class AuthAPI_BeginSSOLogin_PublicPKCE$Type extends MessageType<AuthAPI_BeginSSO
         /* google.protobuf.Timestamp expires_at = 2; */
         if (message.expiresAt)
             Timestamp.internalBinaryWrite(message.expiresAt, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional string client_secret = 3; */
+        if (message.clientSecret !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.clientSecret);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -19063,6 +19168,53 @@ class AuthAPI_ListGrants_Response$Type extends MessageType<AuthAPI_ListGrants_Re
  */
 export const AuthAPI_ListGrants_Response = new AuthAPI_ListGrants_Response$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListGrants_TxResponse$Type extends MessageType<AuthAPI_ListGrants_TxResponse> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse", [
+            { no: 1, name: "grants", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => AuthAPI_Grant }
+        ]);
+    }
+    create(value?: PartialMessage<AuthAPI_ListGrants_TxResponse>): AuthAPI_ListGrants_TxResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.grants = [];
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListGrants_TxResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListGrants_TxResponse): AuthAPI_ListGrants_TxResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated MiLaboratories.PL.API.AuthAPI.Grant grants */ 1:
+                    message.grants.push(AuthAPI_Grant.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListGrants_TxResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated MiLaboratories.PL.API.AuthAPI.Grant grants = 1; */
+        for (let i = 0; i < message.grants.length; i++)
+            AuthAPI_Grant.internalBinaryWrite(message.grants[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListGrants.TxResponse
+ */
+export const AuthAPI_ListGrants_TxResponse = new AuthAPI_ListGrants_TxResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class AuthAPI_Grant$Type extends MessageType<AuthAPI_Grant> {
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.Grant", [
@@ -19775,6 +19927,176 @@ class AuthAPI_ListUserResources_SharedResource$Type extends MessageType<AuthAPI_
  */
 export const AuthAPI_ListUserResources_SharedResource = new AuthAPI_ListUserResources_SharedResource$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_User$Type extends MessageType<AuthAPI_User> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.User", [
+            { no: 1, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<AuthAPI_User>): AuthAPI_User {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.login = "";
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_User>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_User): AuthAPI_User {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string login */ 1:
+                    message.login = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_User, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string login = 1; */
+        if (message.login !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.login);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.User
+ */
+export const AuthAPI_User = new AuthAPI_User$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListUsers$Type extends MessageType<AuthAPI_ListUsers> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListUsers", []);
+    }
+    create(value?: PartialMessage<AuthAPI_ListUsers>): AuthAPI_ListUsers {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListUsers>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListUsers): AuthAPI_ListUsers {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListUsers, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers
+ */
+export const AuthAPI_ListUsers = new AuthAPI_ListUsers$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListUsers_Request$Type extends MessageType<AuthAPI_ListUsers_Request> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListUsers.Request", []);
+    }
+    create(value?: PartialMessage<AuthAPI_ListUsers_Request>): AuthAPI_ListUsers_Request {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListUsers_Request>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListUsers_Request): AuthAPI_ListUsers_Request {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListUsers_Request, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Request
+ */
+export const AuthAPI_ListUsers_Request = new AuthAPI_ListUsers_Request$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AuthAPI_ListUsers_Response$Type extends MessageType<AuthAPI_ListUsers_Response> {
+    constructor() {
+        super("MiLaboratories.PL.API.AuthAPI.ListUsers.Response", [
+            { no: 1, name: "users", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => AuthAPI_User }
+        ]);
+    }
+    create(value?: PartialMessage<AuthAPI_ListUsers_Response>): AuthAPI_ListUsers_Response {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.users = [];
+        if (value !== undefined)
+            reflectionMergePartial<AuthAPI_ListUsers_Response>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AuthAPI_ListUsers_Response): AuthAPI_ListUsers_Response {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated MiLaboratories.PL.API.AuthAPI.User users */ 1:
+                    message.users.push(AuthAPI_User.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: AuthAPI_ListUsers_Response, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated MiLaboratories.PL.API.AuthAPI.User users = 1; */
+        for (let i = 0; i < message.users.length; i++)
+            AuthAPI_User.internalBinaryWrite(message.users[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers.Response
+ */
+export const AuthAPI_ListUsers_Response = new AuthAPI_ListUsers_Response$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class MiscAPI$Type extends MessageType<MiscAPI> {
     constructor() {
         super("MiLaboratories.PL.API.MiscAPI", []);
@@ -20405,6 +20727,7 @@ export const Platform = new ServiceType("MiLaboratories.PL.API.Platform", [
     { name: "MintSignature", options: { "google.api.http": { post: "/v1/auth/mint-signature", body: "*" } }, I: AuthAPI_MintSignature_Request, O: AuthAPI_MintSignature_Response },
     { name: "GetUserRoot", options: { "google.api.http": { post: "/v1/auth/user-root", body: "*" } }, I: AuthAPI_GetUserRoot_Request, O: AuthAPI_GetUserRoot_Response },
     { name: "ListUserResources", serverStreaming: true, options: {}, I: AuthAPI_ListUserResources_Request, O: AuthAPI_ListUserResources_Response },
+    { name: "ListUsers", options: {}, I: AuthAPI_ListUsers_Request, O: AuthAPI_ListUsers_Response },
     { name: "ListResourceTypes", options: { "google.api.http": { get: "/v1/resource-types" } }, I: MiscAPI_ListResourceTypes_Request, O: MiscAPI_ListResourceTypes_Response },
     { name: "Ping", options: { "google.api.http": { get: "/v1/ping" } }, I: MaintenanceAPI_Ping_Request, O: MaintenanceAPI_Ping_Response },
     { name: "License", options: { "google.api.http": { get: "/v1/license" } }, I: MaintenanceAPI_License_Request, O: MaintenanceAPI_License_Response }

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api_types.ts
@@ -417,8 +417,8 @@ export interface ResourceSchema {
  */
 export interface ResourceSchema_AccessFlags {
     /**
-     * Deny-list approach: default = allowed (true)
-     * Controllers set these to false to restrict non-controller roles (role='u', role='w')
+     * Allow-list approach: default = forbidden (false)
+     * Controllers set this to true allow non-controller roles (role='u', role='w')
      *
      * @generated from protobuf field: optional bool create_resource = 1
      */
@@ -428,21 +428,21 @@ export interface ResourceSchema_AccessFlags {
      *
      * @generated from protobuf field: optional bool read_fields = 2
      */
-    readFields?: boolean; // default: true (reads allowed)
+    readFields?: boolean; // default: false (reads denied)
     /**
      * @generated from protobuf field: optional bool write_fields = 3
      */
-    writeFields?: boolean; // default: true (writes allowed)
+    writeFields?: boolean; // default: false (writes denied)
     /**
      * IMPORTANT: read_kv=false with write_kv=true is a forbidden combination
      *
      * @generated from protobuf field: optional bool read_kv = 4
      */
-    readKv?: boolean; // if unset, falls back to read_fields
+    readKv?: boolean; // default: false (KV reads denied)
     /**
      * @generated from protobuf field: optional bool write_kv = 5
      */
-    writeKv?: boolean; // if unset, falls back to write_fields
+    writeKv?: boolean; // default: false (KV writes denied)
     /**
      * Per-field-type overrides (map: field_type → bool)
      * When defined for a field type, overrides resource-level flags
@@ -458,6 +458,13 @@ export interface ResourceSchema_AccessFlags {
     writeByFieldType: {
         [key: number]: boolean;
     };
+    /**
+     * Allows non-controller roles (role='u', role='w') to set error on the resource,
+     * marking it as failed and dropping it from recovery/deduplication indicies.
+     *
+     * @generated from protobuf field: optional bool set_error = 8
+     */
+    setError?: boolean; // default: true (allowed)
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.FieldSchema
@@ -1506,7 +1513,8 @@ class ResourceSchema_AccessFlags$Type extends MessageType<ResourceSchema_AccessF
             { no: 4, name: "read_kv", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 5, name: "write_kv", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
             { no: 6, name: "read_by_field_type", kind: "map", K: 13 /*ScalarType.UINT32*/, V: { kind: "scalar", T: 8 /*ScalarType.BOOL*/ } },
-            { no: 7, name: "write_by_field_type", kind: "map", K: 13 /*ScalarType.UINT32*/, V: { kind: "scalar", T: 8 /*ScalarType.BOOL*/ } }
+            { no: 7, name: "write_by_field_type", kind: "map", K: 13 /*ScalarType.UINT32*/, V: { kind: "scalar", T: 8 /*ScalarType.BOOL*/ } },
+            { no: 8, name: "set_error", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ResourceSchema_AccessFlags>): ResourceSchema_AccessFlags {
@@ -1542,6 +1550,9 @@ class ResourceSchema_AccessFlags$Type extends MessageType<ResourceSchema_AccessF
                     break;
                 case /* map<uint32, bool> write_by_field_type */ 7:
                     this.binaryReadMap7(message.writeByFieldType, reader, options);
+                    break;
+                case /* optional bool set_error */ 8:
+                    message.setError = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1608,6 +1619,9 @@ class ResourceSchema_AccessFlags$Type extends MessageType<ResourceSchema_AccessF
         /* map<uint32, bool> write_by_field_type = 7; */
         for (let k of globalThis.Object.keys(message.writeByFieldType))
             writer.tag(7, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).bool(message.writeByFieldType[k as any]).join();
+        /* optional bool set_error = 8; */
+        if (message.setError !== undefined)
+            writer.tag(8, WireType.Varint).bool(message.setError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -576,6 +576,15 @@ export interface components {
       nonce: string;
       /** Format: date-time */
       expiresAt: string;
+      /**
+       * @description Confidential-client secret for the IdP token exchange; absent for public clients.
+       *      Rationale: Google's OIDC does not support public clients — it requires a
+       *      client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+       *      gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+       *      leaving the server. So the backend holds the secret and forwards it here to the
+       *      desktop, which performs the token exchange as a confidential client.
+       */
+      clientSecret: string;
     };
     AuthAPI_BeginSSOLogin_Request: Record<string, never>;
     AuthAPI_BeginSSOLogin_Response: {
@@ -657,6 +666,7 @@ export interface components {
       groupsClaim: string;
       /** Format: enum */
       flowType: number;
+      accessType: string;
     };
     AuthAPI_ListMethods_TokenAuthMethod: Record<string, never>;
     AuthAPI_Login_BasicCredentials: {
@@ -957,14 +967,20 @@ export interface components {
       os: string;
       arch: string;
       /**
-       * @description Opt-in capabilities advertised by this server instance, used by
-       *      clients to pick between fast and fallback code paths without waiting
-       *      for a failed RPC.
+       * @description Opt-in capabilities advertised by this server instance. Two
+       *      client-side usage modes share this same wire field, decided
+       *      per-token by the client:
+       *        - Optimization hint. Client picks between a fast path and a
+       *          fallback without probing by trial-and-error; missing tokens
+       *          just cause the fallback to run (e.g. "treeFilter:v2").
+       *        - Install-time gate. Client refuses to install a block whose
+       *          manifest declares a required capability the server doesn't
+       *          advertise; missing tokens fail closed (e.g. "wasm:v1").
        *
        *      Each entry is an opaque token "<feature>:<version>" (e.g.
-       *      "loadSubtree:v1"). Unrecognized tokens are ignored by the client.
-       *      The field is unset on servers predating this mechanism, which the
-       *      client treats as "no optional capabilities advertised".
+       *      "treeFilter:v2"). The field is unset on servers predating this
+       *      mechanism, which the client treats as "no optional capabilities
+       *      advertised" — fallback for hints, fail-closed for gates.
        *
        *      All list see pl/platform/api/plapiserver/server_capabilities.go
        */
@@ -1063,8 +1079,8 @@ export interface components {
     };
     ResourceSchema_AccessFlags: {
       /**
-       * @description Deny-list approach: default = allowed (true)
-       *      Controllers set these to false to restrict non-controller roles (role='u', role='w')
+       * @description Allow-list approach: default = forbidden (false)
+       *      Controllers set this to true allow non-controller roles (role='u', role='w')
        */
       createResource: boolean;
       /** @description IMPORTANT: read_fields=false with write_fields=true is a forbidden combination */
@@ -1083,6 +1099,11 @@ export interface components {
       writeByFieldType: {
         [key: string]: boolean;
       };
+      /**
+       * @description Allows non-controller roles (role='u', role='w') to set error on the resource,
+       *      marking it as failed and dropping it from recovery/deduplication indicies.
+       */
+      setError: boolean;
     };
     ResourceType: {
       name: string;


### PR DESCRIPTION
## What

Re-syncs the vendored `plapi` proto definitions in `pl-client` with backend `main` and regenerates the gRPC and REST TypeScript clients.

New / changed API surface:
- **`ListUsers` RPC** (+ `User`, `ListUsers.Request/Response`) — lists user logins known to the server. This is the prerequisite for MILAB-6484 (admin opening other users' roots): it enables an optional user picker on top of the dirty text-input flow.
- **In-transaction `ListGrants`** (`list_grants` TX oneof, field 412 + `ListGrants.TxResponse`).
- **`AccessControl.set_error`** field.
- **SSO** `access_type` and `client_secret` fields.

## Why separate PR

The regenerated REST client (`proto-rest/plapi.ts`) carries a large, mostly-reordering diff driven by the backend's regenerated `openapi.yaml`. Isolating it here keeps the feature PR reviewable.

## Validation
- `pnpm build`, `tsc` type-check, and `oxlint` (0 warnings/errors) all pass for `pl-client`.
- Generated symbols verified present: `AuthAPI_ListUsers_*`, `listUsers()` client method, `setError`, `listGrants` TX, SSO `accessType`/`clientSecret`.

## Note
Generation followed the repo's `update-proto` pipeline (`protodep up` + `generate-grpc.sh` + `generate-rest.sh`); the rsync copy step was done manually since `rsync` is not installed locally (source verified byte-identical to `origin/main`).