### PR TITLE
fix: republish pl-drivers with from-pack-v2 local-tgz support

### DIFF
--- a/.changeset/pl-drivers-from-pack-v2-local-tgz.md
+++ b/.changeset/pl-drivers-from-pack-v2-local-tgz.md
@@ -1,0 +1,14 @@
+---
+"@milaboratories/pl-drivers": patch
+---
+
+Republish `pl-drivers` carrying the `from-pack-v2` frontend unpack support
+(`DownloadUrlDriver.getLocalTgz` + the `local-tgz` spec handling).
+
+This change landed in the facade work but was omitted from the
+`frompack-pointer-shape` changeset, so `pl-drivers` never got a version bump and
+the registry still serves the pre-facade `1.16.1` tarball (no `getLocalTgz`). The
+published `pl-middle-layer` calls `getLocalTgz` and pins `pl-drivers` exactly, so a
+from-pack-v2 block's frontend cannot be unpacked against the published SDK. Bumping
+`pl-drivers` republishes the current source and cascades a re-pin into
+`pl-middle-layer` and its dependents.


### PR DESCRIPTION
## Problem

The facade work added `DownloadUrlDriver.getLocalTgz` and the `local-tgz` frontend-spec handling to **`@milaboratories/pl-drivers`** (the from-pack-v2 UI unpack path), but this change was **omitted from the `frompack-pointer-shape` changeset**. As a result pl-drivers never got a version bump and was never republished — the registry still serves the pre-facade `1.16.1` tarball, which has no `getLocalTgz`.

Meanwhile the freshly published `@milaboratories/pl-middle-layer@1.64.38` **calls `getLocalTgz`** (`frontend_path.js`) and pins `pl-drivers` **exactly `1.16.1`**. So against the published SDK, unpacking a `from-pack-v2` block's frontend hits a pl-drivers that lacks the method — the facade's block-UI load path is broken on the registry SDK even though main's source is correct.

### Evidence
- main source `lib/node/pl-drivers` contains `getLocalTgz`; version still `1.16.1`.
- Published `pl-drivers@1.16.1` tarball: **no** `getLocalTgz` / `local-tgz`.
- Published `pl-middle-layer@1.64.38`: references `getLocalTgz` + `local-tgz`, `dependencies.@milaboratories/pl-drivers = 1.16.1`.
- The `Version packages` commit (`5a2d157c9`) bumped 13 packages; pl-drivers was the only changed-publishable facade package not among them.

## Fix

Add the missing changeset (`patch` on `@milaboratories/pl-drivers`, matching the sibling `frompack-pointer-shape` patch level). On merge this republishes pl-drivers with the current (correct) source and — via `updateInternalDependencies: "patch"` — cascades a re-pin into `pl-middle-layer` and its dependents, healing the published SDK.

Changeset-only; no source changes.