### PR TITLE
Structurer: stop marking software packages private

### DIFF
--- a/.changeset/software-not-private.md
+++ b/.changeset/software-not-private.md
@@ -1,0 +1,10 @@
+---
+'@platforma-sdk/block-tools': patch
+---
+
+Structurer: software packages must not be `private`. `pl-pkg` gates docker
+image auto-push on `!isPrivate`, so a private software package built its image
+but never pushed it — the published block then failed at runtime with a 404
+pulling that image. The structurer no longer generates `private` on software
+packages and now actively removes it on refresh, so a `structure refresh`
+heals any block that still has it.

--- a/tools/block-tools/src/structure/rules/software-package-json.ts
+++ b/tools/block-tools/src/structure/rules/software-package-json.ts
@@ -10,6 +10,7 @@
 
 import {
   ensureField,
+  removeField,
   ensureScript,
   ensureDevDeps,
   enforceAlphabeticalOrder,
@@ -46,7 +47,6 @@ export function softwarePackageJsonInitial(ctx: RunContext): Record<string, unkn
   const v = ctx.blockVars;
   return {
     name: `${v.facadeName}.software`,
-    private: true,
     type: "module",
     description: "Block Software",
     files: ["./dist/**/*"],
@@ -65,10 +65,11 @@ export function softwarePackageJsonInitial(ctx: RunContext): Record<string, unkn
 }
 
 export function softwarePackageJsonRules(): void {
-  // Controlled sibling — workspace-only, never npm-published. (Software still
-  // publishes runenv artifacts via `pl-pkg`, which is unaffected by `private`.)
-  // The `version` is kept (changesets-owned) so the packed template carries it.
-  ensureField("private", true);
+  // Software packages must never be private: `pl-pkg` gates docker image
+  // auto-push on `!isPrivate`, so a private software package builds its image
+  // but never pushes it — the block then 404s pulling it at runtime. Strip it
+  // so a `structure refresh` heals any block that has it.
+  removeField("private");
 
   ensureField("type", "module");
   ensureField("files", ["./dist/**/*"]);


### PR DESCRIPTION
pl-pkg gates docker image auto-push on !isPrivate, so a private software package built its image but never pushed it, and the published block 404'd pulling that image at runtime. Drop private from the software generator and stop asserting it in the refresh rule, so it is not re-added once removed from a block.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a runtime 404 regression where software packages were marked `private: true` in their `package.json`, causing `pl-pkg` to skip pushing the Docker image — the published block then failed to pull the image at runtime.

- Removes `private: true` from the `softwarePackageJsonInitial` generator so new blocks are no longer created with it.
- Drops the `ensureField(\"private\", true)` drift-corrector from `softwarePackageJsonRules` so the field is not re-added during `refresh` on existing blocks that have already had it removed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, two-line removal that directly unblocks Docker image pushes for software packages.

Both removals are correct: the initial generator no longer stamps new blocks with private, and the drift-corrector no longer re-adds it during refresh on existing blocks. The other rules in softwarePackageJsonRules (type, files, scripts, devDeps, ordering) are unchanged. No existing test covered software-package privacy, so no test regression is possible, and the changeset accurately describes the fix.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/rules/software-package-json.ts | Removes private: true from the initial generator and the ensureField("private", true) drift-corrector; the remaining rules are untouched and the file is structurally sound. |
| .changeset/software-not-private.md | New changeset entry correctly categorises the fix as a patch for @platforma-sdk/block-tools with an accurate description of the root cause and remediation. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Structurer as Structurer (block-tools)
    participant PkgJson as software/package.json
    participant PlPkg as pl-pkg build
    participant Registry as Docker Registry

    note over Structurer,Registry: Before fix — private: true prevents push
    Structurer->>PkgJson: "write { private: true, ... }"
    PlPkg->>PkgJson: read isPrivate
    PlPkg-->>Registry: "SKIP push (isPrivate === true)"
    Registry-->>PlPkg: (no image)
    note over Registry: Runtime block pulls → 404

    note over Structurer,Registry: After fix — no private field, push succeeds
    Structurer->>PkgJson: "write { type: module, ... } (no private)"
    PlPkg->>PkgJson: read isPrivate
    PlPkg->>Registry: "PUSH image (isPrivate === false)"
    Registry-->>PlPkg: 200 OK
    note over Registry: Runtime block pulls → success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Structurer as Structurer (block-tools)
    participant PkgJson as software/package.json
    participant PlPkg as pl-pkg build
    participant Registry as Docker Registry

    note over Structurer,Registry: Before fix — private: true prevents push
    Structurer->>PkgJson: "write { private: true, ... }"
    PlPkg->>PkgJson: read isPrivate
    PlPkg-->>Registry: "SKIP push (isPrivate === true)"
    Registry-->>PlPkg: (no image)
    note over Registry: Runtime block pulls → 404

    note over Structurer,Registry: After fix — no private field, push succeeds
    Structurer->>PkgJson: "write { type: module, ... } (no private)"
    PlPkg->>PkgJson: read isPrivate
    PlPkg->>Registry: "PUSH image (isPrivate === false)"
    Registry-->>PlPkg: 200 OK
    note over Registry: Runtime block pulls → success
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Structurer: stop marking software packag..."](https://github.com/milaboratory/platforma/commit/ffe135dcb3a855be263a36c42b7c1bb1bd6b1317) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40818515)</sub>

<!-- /greptile_comment -->