### PR TITLE
ci: run all platforma CI jobs on hz-ubuntu-dind

### DIFF
--- a/.github/workflows/_check-changesets.yaml
+++ b/.github/workflows/_check-changesets.yaml
@@ -17,6 +17,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # hz-ubuntu-dind has Node baked in the hostedtoolcache but not on PATH;
+      # set it up (cache hit on the baked 22.x) so `npx` is available.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Check changeset status
         id: check
         run: |

--- a/.github/workflows/_check-changesets.yaml
+++ b/.github/workflows/_check-changesets.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-changesets:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     outputs:
       has-pending: ${{ steps.check.outputs.has-pending }}
     steps:

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-pnpm-consistency:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
   # 1. Init
   # ──────────────────────────────────────────────
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
       current-version: ${{ steps.context.outputs.current-version }}
@@ -135,7 +135,7 @@ jobs:
   # 7. Notify
   # ──────────────────────────────────────────────
   notify:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     if: always()
     needs: [init, check-changesets, check-pnpm-consistency, test, publish]
     steps:

--- a/.github/workflows/merge-queue.yaml
+++ b/.github/workflows/merge-queue.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
       current-version: ${{ steps.context.outputs.current-version }}
@@ -38,7 +38,7 @@ jobs:
     secrets: inherit
 
   monitor-merge-queue:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     if: always()
     needs: [test]
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ jobs:
   # 1. Init
   # ──────────────────────────────────────────────
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
       current-version: ${{ steps.context.outputs.current-version }}
@@ -42,7 +42,7 @@ jobs:
   # 3. Notify
   # ──────────────────────────────────────────────
   notify:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     if: always()
     needs: [test]
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
       current-version: ${{ steps.context.outputs.current-version }}
@@ -42,7 +42,7 @@ jobs:
   debug:
     needs: [check-pnpm-consistency, test]
     if: ${{ failure() && contains(github.event.pull_request.labels.*.name, 'debug') }}
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     steps:
       - name: Interactive debug session (VS Code)
         uses: fawazahmed0/action-debug-vscode@main


### PR DESCRIPTION
Follow-up to #1713. Moves the **remaining light jobs** from `ubuntu-latest` to the self-hosted `hz-ubuntu-dind` runners, so the entire platforma pipeline runs on the Hetzner k3s fleet (full self-hosted control).

Flipped (9 jobs): `init` (pr/nightly/merge-queue/main), `notify` (nightly/main), `debug` (pr), `monitor-merge-queue`, `check-pnpm-consistency`, `check-changesets`. After this, every `runs-on` in platforma is `hz-ubuntu-dind`.

#1713 moved the heavy build/test jobs; this completes the switch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the migration of the entire platforma CI pipeline to the self-hosted `hz-ubuntu-dind` (Hetzner k3s Docker-in-Docker) runner fleet by switching the remaining 9 lightweight jobs that were still using GitHub-hosted `ubuntu-latest` runners.

- **9 jobs migrated** across 6 workflow files: `init` (pr/nightly/merge-queue/main), `notify` (nightly/main), `debug` (pr), `monitor-merge-queue`, `check-pnpm-consistency`, and `check-changesets`. No `ubuntu-latest` references remain in any workflow.
- **Security note**: The `debug` job in `pr.yaml` uses `fawazahmed0/action-debug-vscode@main` (unpinned) which now runs on self-hosted infrastructure — the blast radius of a supply-chain attack on that action is larger than when it ran on ephemeral GitHub-hosted VMs.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for all workflows except the `debug` job in `pr.yaml`, which opens a VS Code interactive tunnel via an unpinned third-party action now running on the self-hosted fleet.

All nine runner migrations are mechanical `ubuntu-latest` → `hz-ubuntu-dind` substitutions and carry no functional risk. The one concern is the `debug` job in `pr.yaml`: it uses `fawazahmed0/action-debug-vscode@main` without a commit SHA, and moving it from an ephemeral GitHub-hosted VM to a persistent self-hosted k3s runner means any upstream tampering with that action now executes inside cluster infrastructure rather than an isolated throwaway VM.

.github/workflows/pr.yaml — the `debug` job's use of an unpinned external action on a self-hosted runner deserves a second look before merging.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Supply-chain risk — unpinned third-party action on self-hosted runner** (`.github/workflows/pr.yaml`): `fawazahmed0/action-debug-vscode@main` resolves to whichever commit is currently at the tip of that repo's `main` branch. Any malicious push to that upstream repo would execute arbitrary code inside the `hz-ubuntu-dind` pod. This risk existed before but was bounded by GitHub-hosted VM isolation; on a self-hosted k3s runner the pod shares cluster network and ambient credentials, materially widening the blast radius.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr.yaml | Migrates `init` and `debug` jobs to `hz-ubuntu-dind`; the `debug` job uses the unpinned `fawazahmed0/action-debug-vscode@main` action, which now executes on self-hosted infrastructure with a larger blast radius than on GitHub-hosted VMs. |
| .github/workflows/main.yaml | Migrates `init` and `notify` jobs from `ubuntu-latest` to `hz-ubuntu-dind`; straightforward runner change, no logic altered. |
| .github/workflows/merge-queue.yaml | Migrates `init` and `monitor-merge-queue` jobs; `date -d` (GNU coreutils) used in the monitor job works correctly on the Ubuntu-based self-hosted runner. |
| .github/workflows/nightly.yaml | Migrates `init` and `notify` jobs from `ubuntu-latest` to `hz-ubuntu-dind`; no logic changes. |
| .github/workflows/_check-changesets.yaml | Migrates `check-changesets` reusable workflow job; no logic changes. |
| .github/workflows/_check.yaml | Migrates `check-pnpm-consistency` reusable workflow job; no logic changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph PR Workflow
        PR_init[init\nhz-ubuntu-dind] --> PR_test[test\nhz-ubuntu-dind]
        PR_cpc[check-pnpm-consistency\nhz-ubuntu-dind] --> PR_debug
        PR_test --> PR_debug[debug\nhz-ubuntu-dind\n⚠️ @main pin]
    end

    subgraph Main Workflow
        M_init[init\nhz-ubuntu-dind] --> M_test[test\nhz-ubuntu-dind]
        M_test --> M_publish[publish\nhz-ubuntu-dind]
        M_publish --> M_notify[notify\nhz-ubuntu-dind]
    end

    subgraph Merge Queue Workflow
        MQ_init[init\nhz-ubuntu-dind] --> MQ_test[test\nhz-ubuntu-dind]
        MQ_test --> MQ_monitor[monitor-merge-queue\nhz-ubuntu-dind]
    end

    subgraph Nightly Workflow
        N_init[init\nhz-ubuntu-dind] --> N_test[test\nhz-ubuntu-dind]
        N_test --> N_notify[notify\nhz-ubuntu-dind]
    end

    style PR_debug fill:#ffcccc,stroke:#cc0000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph PR Workflow
        PR_init[init\nhz-ubuntu-dind] --> PR_test[test\nhz-ubuntu-dind]
        PR_cpc[check-pnpm-consistency\nhz-ubuntu-dind] --> PR_debug
        PR_test --> PR_debug[debug\nhz-ubuntu-dind\n⚠️ @main pin]
    end

    subgraph Main Workflow
        M_init[init\nhz-ubuntu-dind] --> M_test[test\nhz-ubuntu-dind]
        M_test --> M_publish[publish\nhz-ubuntu-dind]
        M_publish --> M_notify[notify\nhz-ubuntu-dind]
    end

    subgraph Merge Queue Workflow
        MQ_init[init\nhz-ubuntu-dind] --> MQ_test[test\nhz-ubuntu-dind]
        MQ_test --> MQ_monitor[monitor-merge-queue\nhz-ubuntu-dind]
    end

    subgraph Nightly Workflow
        N_init[init\nhz-ubuntu-dind] --> N_test[test\nhz-ubuntu-dind]
        N_test --> N_notify[notify\nhz-ubuntu-dind]
    end

    style PR_debug fill:#ffcccc,stroke:#cc0000
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpr.yaml%3A48%0A**Unpinned%20third-party%20action%20on%20self-hosted%20runner**%0A%0A%60fawazahmed0%2Faction-debug-vscode%40main%60%20is%20pinned%20to%20a%20branch%20name%20rather%20than%20an%20immutable%20commit%20SHA.%20Any%20push%20to%20that%20upstream%20repo's%20%60main%60%20branch%20immediately%20becomes%20the%20code%20that%20executes%20inside%20your%20self-hosted%20k3s%20infrastructure.%20On%20ephemeral%20GitHub-hosted%20runners%20the%20blast%20radius%20of%20a%20compromised%20action%20is%20contained%20to%20that%20VM%3B%20on%20%60hz-ubuntu-dind%60%20the%20runner%20pod%20shares%20cluster%20network%20and%20credentials%2C%20making%20a%20supply-chain%20compromise%20substantially%20more%20impactful.%20Consider%20pinning%20to%20a%20specific%20SHA%20%28e.g.%20%60fawazahmed0%2Faction-debug-vscode%40%3Csha%3E%60%29%20or%20hosting%20a%20fork%20under%20the%20%60milaboratory%60%20org.%0A%0A&repo=milaboratory%2Fplatforma&pr=1729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/pr.yaml:48
**Unpinned third-party action on self-hosted runner**

`fawazahmed0/action-debug-vscode@main` is pinned to a branch name rather than an immutable commit SHA. Any push to that upstream repo's `main` branch immediately becomes the code that executes inside your self-hosted k3s infrastructure. On ephemeral GitHub-hosted runners the blast radius of a compromised action is contained to that VM; on `hz-ubuntu-dind` the runner pod shares cluster network and credentials, making a supply-chain compromise substantially more impactful. Consider pinning to a specific SHA (e.g. `fawazahmed0/action-debug-vscode@<sha>`) or hosting a fork under the `milaboratory` org.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run all platforma CI jobs on hz-ubun..."](https://github.com/milaboratory/platforma/commit/fe39689dff56ae8092286511bab17e14a0963893) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40907919)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->