### PR TITLE
chore: publish new-shape facades for ui-examples and enter-numbers

### DIFF
--- a/.changeset/publish-facade-blocks-spike.md
+++ b/.changeset/publish-facade-blocks-spike.md
@@ -1,0 +1,14 @@
+---
+"@milaboratories/milaboratories.ui-examples": patch
+"@milaboratories/milaboratories.test-enter-numbers": patch
+---
+
+Publish the new-shape facades for two in-monorepo test blocks so a real
+published version (carrying `BlockPointer` / `from-pack-v2`, slim deps) exists on
+the registry. `test-enter-numbers` had `private: true` removed so it can publish
+for the first time; `ui-examples` was already public but its latest published
+tarball still ships the pre-facade boilerplate shape, so this republishes it in
+the new shape.
+
+This enables the testing-framework self-verification route to pnpm-alias an older
+published version of these blocks beside the workspace version.

--- a/.changeset/publish-facade-blocks-spike.md
+++ b/.changeset/publish-facade-blocks-spike.md
@@ -1,6 +1,6 @@
 ---
-"@milaboratories/milaboratories.ui-examples": patch
-"@milaboratories/milaboratories.test-enter-numbers": patch
+"@milaboratories/milaboratories.ui-examples": minor
+"@milaboratories/milaboratories.test-enter-numbers": minor
 ---
 
 Publish the new-shape facades for two in-monorepo test blocks so a real

--- a/etc/blocks/enter-numbers/block/package.json
+++ b/etc/blocks/enter-numbers/block/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@milaboratories/milaboratories.test-enter-numbers",
   "version": "1.0.249",
-  "private": true,
   "files": [
     "dist",
     "block-pack"


### PR DESCRIPTION
## What

- Remove `private: true` from the `test-enter-numbers` block facade (`etc/blocks/enter-numbers/block/package.json`) so it can publish.
- Add a changeset bumping (patch) **`@milaboratories/milaboratories.ui-examples`** and **`@milaboratories/milaboratories.test-enter-numbers`**.

## Why

These two in-monorepo test blocks already carry the **new facade shape** in the workspace (`BlockPointer` / `from-pack-v2`, `exports`, slim `dependencies: {}`), but no new-shape version exists on the registry yet:

- Every published `ui-examples` version (1.3.50 → 1.3.58) still ships the **pre-facade boilerplate** (`blockSpec`, root `index.d.ts`, full SDK dep tree).
- `test-enter-numbers` was `private` and has **never** been published.

`.changeset/config.json` has `privatePackages: false`, so private packages are excluded from both versioning and publishing — removing `private` is what makes the first publish possible. On merge, the release pipeline (`main.yaml`) runs `changeset version` → `pnpm -r publish`, which publishes the new-shape facades (npm tarball + `block-tools publish` to the aux/dev block registry).

## Follow-up

This unblocks the testing-framework self-verification route: once these published versions exist, a test can **pnpm-alias an older published version beside the workspace version** and consume it via its standard `BlockPointer` (`addBlock(name, BlockPointer)`). That coexistence test lands in a follow-up PR, after the first publish.

## Verification

- `changeset status` → both packages bump at patch.
- `pnpm install --lockfile-only` → no lockfile change (`private` is not a dependency).
- `block-tools structure check --sdk-internal etc/blocks/enter-numbers` → `0 changes` (the structurer's facade rule does not manage `private`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two test block facades publishable by removing `private: true` from `enter-numbers/block/package.json` and adding a patch changeset for both `@milaboratories/milaboratories.test-enter-numbers` and `@milaboratories/milaboratories.ui-examples`. On merge, the release pipeline will produce the first published new-shape versions of these facades, unblocking a future testing-framework self-verification workflow.

- **`etc/blocks/enter-numbers/block/package.json`**: Drops `private: true` so `changeset version` / `pnpm -r publish` can pick up this package for the first time. The `prepublishOnly` script will invoke `block-tools publish` to the aux/dev S3 block registry alongside the npm publish.
- **`.changeset/publish-facade-blocks-spike.md`**: Adds a changeset that patches both `ui-examples` (already public, but last tarball carries pre-facade boilerplate) and `test-enter-numbers` (new to the registry).

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only code change is a one-line removal of `private: true`, and the changeset targets the aux/dev block registry, not production blocks.

Both changed files are minimal and mechanical: the package.json edit is a single field removal whose effect is fully controlled by the changeset pipeline, and the changeset file references the correct package names at patch level. The `prepublishOnly` script publishes to the aux/dev S3 registry, limiting blast radius. No logic, types, or runtime behaviour changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| etc/blocks/enter-numbers/block/package.json | Removes `private: true`; all other fields (exports, scripts, block metadata) are unchanged and match the new-shape facade pattern already used by ui-examples. |
| .changeset/publish-facade-blocks-spike.md | Patch changeset bumping both facade packages; package names match their respective package.json `name` fields exactly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer (merge)
    participant CI as main.yaml CI
    participant CS as changeset version
    participant NPM as npm registry
    participant S3 as aux/dev block registry (S3)

    Dev->>CI: merge PR
    CI->>CS: changeset version
    CS-->>CI: bump test-enter-numbers 1.0.249→1.0.250\nbump ui-examples 1.3.58→1.3.59
    CI->>NPM: pnpm -r publish (test-enter-numbers, first publish)
    CI->>NPM: pnpm -r publish (ui-examples, new-shape tarball)
    NPM-->>CI: published
    Note over CI,S3: prepublishOnly runs block-tools publish
    CI->>S3: block-tools publish test-enter-numbers → aux/dev
    CI->>S3: block-tools publish ui-examples → aux/dev
    S3-->>CI: registered
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer (merge)
    participant CI as main.yaml CI
    participant CS as changeset version
    participant NPM as npm registry
    participant S3 as aux/dev block registry (S3)

    Dev->>CI: merge PR
    CI->>CS: changeset version
    CS-->>CI: bump test-enter-numbers 1.0.249→1.0.250\nbump ui-examples 1.3.58→1.3.59
    CI->>NPM: pnpm -r publish (test-enter-numbers, first publish)
    CI->>NPM: pnpm -r publish (ui-examples, new-shape tarball)
    NPM-->>CI: published
    Note over CI,S3: prepublishOnly runs block-tools publish
    CI->>S3: block-tools publish test-enter-numbers → aux/dev
    CI->>S3: block-tools publish ui-examples → aux/dev
    S3-->>CI: registered
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump facades at minor instead of ..."](https://github.com/milaboratory/platforma/commit/df5efb9ea98a1dc12e8525acf9d0273bcd4f8e99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40928550)</sub>

<!-- /greptile_comment -->