### PR TITLE
test: OLD (registry-aliased) + NEW (workspace) facade of one block coexist

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@inquirer/prompts':
       specifier: ^7.0.1
       version: 7.0.1
+    '@milaboratories/milaboratories.test-enter-numbers-old':
+      specifier: npm:@milaboratories/milaboratories.test-enter-numbers@1.1.0
+      version: 1.1.0
     '@milaboratories/pframes-rs-node':
       specifier: 1.1.52
       version: 1.1.52
@@ -3769,6 +3772,9 @@ importers:
       '@milaboratories/milaboratories.test-enter-numbers':
         specifier: workspace:*
         version: link:../../etc/blocks/enter-numbers/block
+      '@milaboratories/milaboratories.test-enter-numbers-old':
+        specifier: 'catalog:'
+        version: '@milaboratories/milaboratories.test-enter-numbers@1.1.0'
       '@milaboratories/milaboratories.test-enter-numbers-v3':
         specifier: workspace:*
         version: link:../../etc/blocks/enter-numbers-v3/block
@@ -5373,6 +5379,9 @@ packages:
   '@milaboratories/helpers@1.14.2':
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
+
+  '@milaboratories/milaboratories.test-enter-numbers@1.1.0':
+    resolution: {integrity: sha512-tDtviGMdgl3AFGIUGtkF/8gD//arEEhvcnVElAt3657lgEM2vXMtxctJGcNBcF01v11W+HdegiSiA4IsrBNUXg==}
 
   '@milaboratories/pframes-rs-node@1.1.52':
     resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
@@ -10938,6 +10947,8 @@ snapshots:
   '@microsoft/tsdoc@0.15.1': {}
 
   '@milaboratories/helpers@1.14.2': {}
+
+  '@milaboratories/milaboratories.test-enter-numbers@1.1.0': {}
 
   '@milaboratories/pframes-rs-node@1.1.52(encoding@0.1.13)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -304,6 +304,9 @@ catalog:
 
   # Test
 
+  # OLD published version of the enter-numbers facade, pnpm-aliased so it can be
+  # installed beside the workspace (NEW) version of the same block.
+  "@milaboratories/milaboratories.test-enter-numbers-old": npm:@milaboratories/milaboratories.test-enter-numbers@1.1.0
   "vitest": &vitest-version ^4.1.3
   "@vitest/coverage-istanbul": *vitest-version
   "@faker-js/faker": ^9.2.0

--- a/tests/drivers-ml-blocks-integration/package.json
+++ b/tests/drivers-ml-blocks-integration/package.json
@@ -18,6 +18,7 @@
     "@milaboratories/milaboratories.test-download-file": "workspace:*",
     "@milaboratories/milaboratories.test-download-file.model": "workspace:*",
     "@milaboratories/milaboratories.test-enter-numbers": "workspace:*",
+    "@milaboratories/milaboratories.test-enter-numbers-old": "catalog:",
     "@milaboratories/milaboratories.test-enter-numbers-v3": "workspace:*",
     "@milaboratories/milaboratories.test-enter-numbers.model": "workspace:*",
     "@milaboratories/milaboratories.test-read-logs": "workspace:*",

--- a/tests/drivers-ml-blocks-integration/src/old-new-coexist.test.ts
+++ b/tests/drivers-ml-blocks-integration/src/old-new-coexist.test.ts
@@ -1,0 +1,78 @@
+// An OLD published version of a block (pnpm-aliased from the registry) and the
+// NEW workspace-source version of the SAME block coexist in one project, each
+// consumed via its own standard `BlockPointer` (from-pack-v2). Proves the
+// testing-framework migration mechanism (A-0094) and the Q-0006 question that a
+// single project can hold a registry-pinned and a workspace-source instance of
+// the same block at once.
+//
+// OLD: `npm:@milaboratories/milaboratories.test-enter-numbers@1.1.0` aliased as
+//      `...test-enter-numbers-old` — installed from the registry as a from-pack-v2
+//      pack (node_modules/.pnpm/...).
+// NEW: `@milaboratories/milaboratories.test-enter-numbers` — the workspace block.
+import { BlockPointer as enterNumbersNew } from "@milaboratories/milaboratories.test-enter-numbers";
+import { BlockPointer as enterNumbersOld } from "@milaboratories/milaboratories.test-enter-numbers-old";
+import { BlockPointer as sumNumbersSpec } from "@milaboratories/milaboratories.test-sum-numbers";
+import { test } from "vitest";
+import { withMl } from "./with-ml";
+import { awaitBlockDone, createProjectWatcher, outputRef } from "./test-helpers";
+import { BlockDumpArraySchemaUnified } from "./unified-state-schema";
+
+test(
+  "old (registry-aliased) + new (workspace) enter-numbers coexist",
+  { timeout: 30_000 },
+  async ({ expect }) => {
+    // Both pointers are from-pack-v2, but resolve to physically distinct packs:
+    // OLD from the registry tarball, NEW from the workspace checkout.
+    expect(enterNumbersOld.type).toBe("from-pack-v2");
+    expect(enterNumbersNew.type).toBe("from-pack-v2");
+    expect(enterNumbersOld.packUrl).not.toEqual(enterNumbersNew.packUrl);
+    expect(enterNumbersOld.packUrl).toContain(".pnpm");
+
+    await withMl(async (ml, workFolder) => {
+      const prjId = await ml.createProject({ label: "old+new coexist" });
+      await ml.openProject(prjId);
+      const prj = ml.getOpenedProject(prjId);
+
+      const oldId = await prj.addBlock("Enter (old, registry)", enterNumbersOld);
+      const newId = await prj.addBlock("Enter (new, workspace)", enterNumbersNew);
+      const sumId = await prj.addBlock("Sum", sumNumbersSpec);
+
+      const projectWatcher = await createProjectWatcher(ml, prj, {
+        workFolder,
+        validator: BlockDumpArraySchemaUnified,
+      });
+
+      // Three blocks coexist in one project — including two instances of the same
+      // block resolved from different sources (registry OLD + workspace NEW).
+      const overview0 = await prj.overview.awaitStableValue();
+      expect(overview0.blocks.length).toBe(3);
+      for (const block of overview0.blocks) {
+        expect(block.currentBlockPack).toBeDefined();
+      }
+
+      await prj.setBlockArgs(oldId, { numbers: [1, 2, 3] });
+      await prj.setBlockArgs(newId, { numbers: [10, 20] });
+      // Sum consumes the OLD (registry-aliased) block's output, so a green run
+      // proves the aliased OLD pack actually executes against the backend.
+      await prj.setBlockArgs(sumId, { sources: [outputRef(oldId, "numbers")] });
+
+      const overview1 = await prj.overview.awaitStableValue();
+      const findBlock = (id: string) => overview1.blocks.find((b) => b.id === id);
+      expect(findBlock(oldId)?.canRun).toBe(true);
+      expect(findBlock(newId)?.canRun).toBe(true);
+      expect(findBlock(sumId)?.canRun).toBe(true);
+
+      await prj.runBlock(sumId);
+      await awaitBlockDone(prj, sumId);
+
+      const sumState = await prj.getBlockState(sumId).getValue();
+      expect(sumState.outputs!["sum"]).toStrictEqual({
+        ok: true,
+        value: 6, // sum of the OLD block's [1, 2, 3]
+        stable: true,
+      });
+
+      await projectWatcher.abort();
+    });
+  },
+);


### PR DESCRIPTION
## What

Proves the testing-framework self-verification mechanism end-to-end: a **pnpm alias of an OLD published facade** coexists with the **workspace (NEW) version** of the same block in one project, each consumed via its standard `BlockPointer`.

- Catalog alias (`pnpm-workspace.yaml`): `"@milaboratories/milaboratories.test-enter-numbers-old": npm:@milaboratories/milaboratories.test-enter-numbers@1.1.0`.
- `tests/drivers-ml-blocks-integration` depends on it via `catalog:`.
- New test `src/old-new-coexist.test.ts`.

## Why

This is the empirical `[verify]` behind decision atom **A-0094** (old/new versions of one block present at once, consumed via the standard `from-pack-v2` `BlockPointer`) and answers **Q-0006** (can one project hold a registry-pinned and a workspace-source instance of the same block?).

Depends on the published versions from #1730 (`test-enter-numbers@1.1.0`, the first new-shape facade publish for this block).

## How it works

- **OLD** = `test-enter-numbers@1.1.0` installed from the registry as a `from-pack-v2` pack (`node_modules/.pnpm/...`).
- **NEW** = `@milaboratories/milaboratories.test-enter-numbers` = the workspace block (symlinked).
- Both export a `from-pack-v2` `BlockPointer`; the test asserts their `packUrl`s are physically distinct (registry tarball vs workspace checkout), adds both to one project plus a workspace `sum-numbers`, wires `sum` to consume the OLD block's output, runs against a real backend, and asserts `sum == 6` — so the aliased OLD pack genuinely executes, not just instantiates.

## Verification

```
✓ src/old-new-coexist.test.ts (1 test) — old (registry-aliased) + new (workspace) enter-numbers coexist
  Test Files  1 passed (1)
```

Run against a live backend (`run-platforma`). `types:check` and `formatter:check` both pass. The install initially 404'd until a stale pnpm metadata cache was cleared — confirming the alias genuinely resolves from the registry, not the workspace.

## Scope

Only the private `drivers-ml-blocks-integration` test package + a catalog entry — no publishable package changes, so no changeset. The `block-pack/manifest.json` `exports` resolution path remains out of scope (future work, per A-0094).
