### PR TITLE
MILAB-6484: add asUser impersonation option to pl-client

### DIFF
--- a/.changeset/milab-6484-asuser-impersonation.md
+++ b/.changeset/milab-6484-asuser-impersonation.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": minor
+---
+
+Add an `asUser` client config option (and `as-user` URL param) so an admin can open another user's root instead of their own. The backend authorizes impersonation by role and falls back to the caller's own root for regular users.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -106,6 +106,15 @@ export class PlClient {
     const conf =
       typeof configOrAddress === "string" ? plAddressToConfig(configOrAddress) : configOrAddress;
 
+    // An empty or whitespace-only asUser means "no impersonation"; normalize to undefined so a
+    // directly-constructed { asUser: "" } does not slip through as an empty login.
+    if (conf.asUser !== undefined && conf.asUser.trim() === "") conf.asUser = undefined;
+
+    // asUser (impersonation) and alternativeRoot both repoint the client root, so they cannot be
+    // combined. Validate here, before init() touches the network, so a misconfiguration fails fast.
+    if (conf.asUser !== undefined && conf.alternativeRoot !== undefined)
+      throw new Error("PlClient: asUser and alternativeRoot cannot be combined.");
+
     this.buildLLPlClient = async (
       shouldUseGzip: boolean,
       wireProtocol?: wireProtocol,
@@ -274,7 +283,20 @@ export class PlClient {
       this._ll = await this.buildLLPlClient(true, wireProtocol);
     }
 
-    const userRoot = await this.userResources.getUserRoot({ createIfNotExists: true });
+    // Resolve the client root. Normally the caller's own root; when `asUser` is set (admin impersonation),
+    // the target user's root instead. The backend authorizes impersonation by role and silently returns the
+    // caller's own root for non-admins, so no client-side role gate is needed here.
+    let userRoot: SignedResourceId;
+    if (this.conf.asUser === undefined) {
+      userRoot = await this.userResources.getUserRoot({ createIfNotExists: true });
+    } else {
+      const impersonatedRoot = await this.userResources.getUserRoot({ login: this.conf.asUser });
+      if (impersonatedRoot === undefined)
+        throw new Error(
+          `PlClient: cannot open root of user '${this.conf.asUser}': no root found (the user may have never logged in).`,
+        );
+      userRoot = impersonatedRoot;
+    }
 
     if (this.conf.alternativeRoot === undefined) {
       this._clientRoot = userRoot;

--- a/lib/node/pl-client/src/core/config.test.ts
+++ b/lib/node/pl-client/src/core/config.test.ts
@@ -73,6 +73,21 @@ test("should retain non-default port for https URL", () => {
   expect(config.ssl).toBe(true);
 });
 
+test("asUser is undefined when as-user param is absent", () => {
+  const conf = plAddressToConfig("http://127.0.0.1:6345");
+  expect(conf.asUser).toBeUndefined();
+});
+
+test("asUser is undefined when as-user param is empty", () => {
+  const conf = plAddressToConfig("http://127.0.0.1:6345/?as-user=");
+  expect(conf.asUser).toBeUndefined();
+});
+
+test("asUser is parsed from the as-user url param", () => {
+  const conf = plAddressToConfig("http://127.0.0.1:6345/?as-user=alice");
+  expect(conf.asUser).toEqual("alice");
+});
+
 test("should throw an error for grpc URL without an explicit port", () => {
   expect(() => plAddressToConfig("grpc://example.com")).toThrow(
     "Port must be specified explicitly for grpc: protocol.",

--- a/lib/node/pl-client/src/core/config.ts
+++ b/lib/node/pl-client/src/core/config.ts
@@ -16,6 +16,11 @@ export interface PlClientConfig {
    * client root. */
   alternativeRoot?: string;
 
+  /** Admin-only impersonation: if set, the client opens the root of the user with this login instead of the
+   * caller's own root. The backend authorizes this by role and silently falls back to the caller's own root for
+   * regular users, so it is safe without a client-side gate. Mutually exclusive with {@link alternativeRoot}. */
+  asUser?: string;
+
   /** If true, client will establish tls connection to the server, using default
    * CA of node instance. */
   // Not implementing custom ssl validation logic for now.
@@ -190,6 +195,7 @@ export function plAddressToConfig(
   return {
     hostAndPort: `${url.hostname}:${port}`,
     alternativeRoot: url.searchParams.get("alternative-root") ?? undefined,
+    asUser: url.searchParams.get("as-user") || undefined,
     ssl: url.protocol === "https:" || url.protocol === "tls:",
 
     wireProtocol: (url.searchParams.get("wire-protocol") as wireProtocol) ?? undefined,


### PR DESCRIPTION
implement vitaliis nits

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `asUser` impersonation option to `PlClient`, allowing an admin to open another user's root resource instead of their own. The backend handles authorization and silently falls back to the caller's own root for non-admins, so no client-side role gate is required.

- **`PlClientConfig.asUser`** — new optional field; also parsed from the `as-user` URL query parameter. Mutually exclusive with `alternativeRoot`; the constructor validates and throws early if both are set.
- **`PlClient.init()` root resolution** — branches on `asUser`: calls `getUserRoot({ login })` for impersonation (throws if no root found) vs. `getUserRoot({ createIfNotExists: true })` for the normal path.
- **`config.test.ts`** — three new tests cover URL-level `as-user` parsing, though constructor-level validations lack test coverage.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is small and self-contained, but the constructor directly mutates a caller-provided config object — a silent side-effect that can produce wrong state for any caller that reuses or re-reads the config after construction.

The core impersonation logic in init() is correct and the backend fallback is intentional. The concern is the constructor: when a PlClientConfig object is passed directly, conf.asUser = undefined modifies the caller's object in place. Any service that keeps a reference to its config and reads asUser after calling PlClient.init() will observe an unexpected mutation.

lib/node/pl-client/src/core/client.ts — the synchronous config mutation and the undetectable silent fallback when impersonation is not authorised both warrant a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/client.ts | Adds asUser impersonation in PlClient constructor and init(); mutates caller-provided config object in-place to normalise empty asUser, and adds mutual-exclusion guard with alternativeRoot. |
| lib/node/pl-client/src/core/config.ts | Adds asUser?: string to PlClientConfig interface and parses it from the as-user URL query parameter using || undefined to normalise empty values. |
| lib/node/pl-client/src/core/config.test.ts | Adds three tests covering URL-level asUser parsing. Missing coverage for constructor-level whitespace normalisation and asUser+alternativeRoot mutual exclusion. |
| .changeset/milab-6484-asuser-impersonation.md | Correct minor-version changeset for @milaboratories/pl-client. Description matches the PR scope. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant PlClient
    participant UserResources
    participant Backend

    Caller->>PlClient: PlClient.init(config, auth)
    PlClient->>PlClient: normalise asUser whitespace to undefined
    PlClient->>PlClient: guard asUser XOR alternativeRoot
    PlClient->>PlClient: init() build LLPlClient

    alt asUser undefined
        PlClient->>UserResources: getUserRoot createIfNotExists true
        UserResources->>Backend: getUserRoot RPC own user
        Backend-->>PlClient: SignedResourceId
    else asUser set
        PlClient->>UserResources: getUserRoot login asUser
        UserResources->>Backend: getUserRoot RPC target login
        Note over Backend: Non-admin silently returns caller root
        Backend-->>UserResources: SignedResourceId or undefined
        alt undefined
            PlClient-->>Caller: throw Error
        else found
            PlClient->>PlClient: "clientRoot = impersonatedRoot"
        end
    end

    PlClient-->>Caller: PlClient ready
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant PlClient
    participant UserResources
    participant Backend

    Caller->>PlClient: PlClient.init(config, auth)
    PlClient->>PlClient: normalise asUser whitespace to undefined
    PlClient->>PlClient: guard asUser XOR alternativeRoot
    PlClient->>PlClient: init() build LLPlClient

    alt asUser undefined
        PlClient->>UserResources: getUserRoot createIfNotExists true
        UserResources->>Backend: getUserRoot RPC own user
        Backend-->>PlClient: SignedResourceId
    else asUser set
        PlClient->>UserResources: getUserRoot login asUser
        UserResources->>Backend: getUserRoot RPC target login
        Note over Backend: Non-admin silently returns caller root
        Backend-->>UserResources: SignedResourceId or undefined
        alt undefined
            PlClient-->>Caller: throw Error
        else found
            PlClient->>PlClient: "clientRoot = impersonatedRoot"
        end
    end

    PlClient-->>Caller: PlClient ready
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fclient.ts%3A111%0A**Silent%20mutation%20of%20caller-provided%20config%20object**%0A%0AWhen%20%60configOrAddress%60%20is%20a%20%60PlClientConfig%60%20%28not%20a%20URL%20string%29%2C%20%60conf%60%20is%20the%20same%20object%20reference%20as%20the%20caller's%20value.%20Assigning%20%60conf.asUser%20%3D%20undefined%60%20here%20modifies%20the%20caller's%20object%20in-place%2C%20without%20any%20indication%20in%20the%20API%20that%20this%20happens.%20If%20a%20caller%20reuses%20or%20inspects%20its%20config%20after%20calling%20%60PlClient.init%28%7B%20...%2C%20asUser%3A%20%22%20%22%20%7D%2C%20auth%29%60%2C%20it%20will%20observe%20%60asUser%3A%20undefined%60%20unexpectedly.%20A%20defensive%20copy%20resolves%20this%20without%20changing%20behaviour%3A%20%60const%20conf%20%3D%20typeof%20configOrAddress%20%3D%3D%3D%20%22string%22%20%3F%20plAddressToConfig%28configOrAddress%29%20%3A%20%7B%20...configOrAddress%20%7D%3B%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fclient.ts%3A290-298%0A**Silent%20fallback%20makes%20impersonation%20failures%20invisible%20to%20callers**%0A%0AWhen%20the%20backend%20is%20not%20authorised%20for%20the%20requested%20%60asUser%60%20it%20silently%20returns%20the%20*caller's%20own*%20root.%20A%20non-admin%20who%20passes%20%60asUser%3A%20%22alice%22%60%20succeeds%20but%20ends%20up%20operating%20on%20their%20own%20data%20while%20believing%20they%20are%20on%20Alice's.%20Consider%20logging%20a%20warning%20or%20documenting%20clearly%20that%20the%20caller%20cannot%20tell%20whether%20impersonation%20was%20actually%20honoured.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fconfig.test.ts%3A76-89%0A**Constructor-level%20validations%20are%20untested**%0A%0AThe%20three%20new%20tests%20only%20exercise%20%60plAddressToConfig%60.%20Two%20constructor%20code%20paths%20have%20no%20coverage%3A%20%281%29%20whitespace-only%20normalisation%20for%20a%20directly-constructed%20config%20%28%60%7B%20asUser%3A%20%22%20%20%22%20%7D%60%20should%20become%20%60undefined%60%29%2C%20and%20%282%29%20the%20mutual-exclusion%20guard%20that%20throws%20when%20both%20%60asUser%60%20and%20%60alternativeRoot%60%20are%20set.%0A%0A&repo=milaboratory%2Fplatforma&pr=1733&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/node/pl-client/src/core/client.ts:111
**Silent mutation of caller-provided config object**

When `configOrAddress` is a `PlClientConfig` (not a URL string), `conf` is the same object reference as the caller's value. Assigning `conf.asUser = undefined` here modifies the caller's object in-place, without any indication in the API that this happens. If a caller reuses or inspects its config after calling `PlClient.init({ ..., asUser: " " }, auth)`, it will observe `asUser: undefined` unexpectedly. A defensive copy resolves this without changing behaviour: `const conf = typeof configOrAddress === "string" ? plAddressToConfig(configOrAddress) : { ...configOrAddress };`

### Issue 2 of 3
lib/node/pl-client/src/core/client.ts:290-298
**Silent fallback makes impersonation failures invisible to callers**

When the backend is not authorised for the requested `asUser` it silently returns the *caller's own* root. A non-admin who passes `asUser: "alice"` succeeds but ends up operating on their own data while believing they are on Alice's. Consider logging a warning or documenting clearly that the caller cannot tell whether impersonation was actually honoured.

### Issue 3 of 3
lib/node/pl-client/src/core/config.test.ts:76-89
**Constructor-level validations are untested**

The three new tests only exercise `plAddressToConfig`. Two constructor code paths have no coverage: (1) whitespace-only normalisation for a directly-constructed config (`{ asUser: "  " }` should become `undefined`), and (2) the mutual-exclusion guard that throws when both `asUser` and `alternativeRoot` are set.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6484: add asUser impersonation opt..."](https://github.com/milaboratory/platforma/commit/4eea3e6b51504245206fefc8e7959ec76fa892b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41297705)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->