### PR TITLE
MILAB-2668: tolerate old backends without sharing RPCs on connect

### DIFF
--- a/.changeset/milab-2668-old-backend-connect.md
+++ b/.changeset/milab-2668-old-backend-connect.md
@@ -1,0 +1,10 @@
+---
+"@milaboratories/pl-client": patch
+"@milaboratories/pl-tree": patch
+---
+
+Fix connecting to old backends that lack the sharing RPCs (MILAB-2668).
+
+pl-tree: shared-type-seed discovery in `SynchronizedTreeState` now treats an unimplemented `ListUserResources` route as "no shared resources" instead of letting the error propagate. On old backends the throw escaped `MiddleLayer.init` and failed the whole connection; discovery-backed features stay capability-gated in the UI, so an empty set is the correct degradation.
+
+pl-client: `isUnimplementedError` now also recognizes the "no route found" gRPC routing error (which carries no `UNIMPLEMENTED` code), so callers can detect a missing RPC on old backends.

--- a/lib/node/pl-client/src/core/errors.ts
+++ b/lib/node/pl-client/src/core/errors.ts
@@ -86,6 +86,8 @@ export function isUnimplementedError(err: unknown, nested: boolean = false): boo
   if (err === undefined || err === null) return false;
 
   if ((err as any).name == "RpcError" && (err as any).code == "UNIMPLEMENTED") return true;
+  if ((err as any).name == "RpcError" && String((err as any).message).includes("no route found"))
+    return true;
   if ((err as any).name == "RESTError" && (err as any).status.code == Code.UNIMPLEMENTED)
     return true;
   if ((err as any).cause !== undefined && !nested)

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -8,7 +8,11 @@ import type {
   TxOps,
 } from "@milaboratories/pl-client";
 import type { Filter } from "@milaboratories/pl-client";
-import { isUnauthenticated, isTimeoutOrCancelError } from "@milaboratories/pl-client";
+import {
+  isUnauthenticated,
+  isTimeoutOrCancelError,
+  isUnimplementedError,
+} from "@milaboratories/pl-client";
 import type { ExtendedResourceData } from "./state";
 import { PlTreeState, TreeStateUpdateError } from "./state";
 import type { PruningFunction, TraversalMode, TreeLoadingStat } from "./sync";
@@ -287,8 +291,14 @@ export class SynchronizedTreeState {
 
     const discovered = new Set<SignedResourceId>();
     for (const seed of this.sharedSeeds) {
-      // match by name only (permissive; ignores version, so it survives schema bumps)
-      const ids = await this.pl.userResources.listSharedResourcesByType(seed.resourceType.name);
+      let ids: SignedResourceId[];
+      try {
+        // match by name only (permissive; ignores version, so it survives schema bumps)
+        ids = await this.pl.userResources.listSharedResourcesByType(seed.resourceType.name);
+      } catch (e: unknown) {
+        if (isUnimplementedError(e)) continue;
+        throw e;
+      }
       for (const id of ids) discovered.add(id);
     }
 


### PR DESCRIPTION
## Problem

Connecting the desktop app to a **very old backend** (no sharing RPCs) fails outright:

```
ConnectRemoteError: Failed to connect to remote backend
  cause: RpcError: gRPC routing: method "/MiLaboratories.PL.API.Platform/ListUserResources": no route found
```

`MiddleLayer.init` builds the sharing discovery tree, and `SynchronizedTreeState.init` awaits a first `discover()` (a `ListUserResources` poll) before returning. On a backend without that route the `RpcError` propagates straight out of `init` and fails the whole connection — even though sharing is already correctly reported as unsupported (`sharingSupported` requires `crossTreeRefs:v1`).

## Fix

- **pl-tree**: `SynchronizedTreeState.discover()` now catches the per-seed `listSharedResourcesByType` call and, when the error is an unimplemented/missing route, treats that shared-type seed as **empty** (warns once) instead of throwing. Discovery-backed features are capability-gated in the UI, so an empty set is the correct degradation. Other errors still propagate.
- **pl-client**: `isUnimplementedError` now also recognizes the `"no route found"` gRPC routing error, which carries no `UNIMPLEMENTED` code — this is the predicate the guard relies on.

## Effect

Old backends connect again; sharing simply stays hidden there. Modern backends are unaffected (discovery works as before).

## Testing

- `@milaboratories/pl-tree` typecheck clean; do-pack succeeds.
- Runtime old-backend connect not yet re-verified after this change — worth a manual check against an old backend before merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tolerates old backends that are missing the sharing RPCs by catching `isUnimplementedError` per seed inside `SynchronizedTreeState.discover()` and treating missing routes as an empty discovered-root set, preventing the error from escaping `MiddleLayer.init`. It also extends `isUnimplementedError` in `pl-client` to recognise gRPC routing errors that carry `"no route found"` in their message instead of an `UNIMPLEMENTED` status code.

- **`pl-client/errors.ts`** — `isUnimplementedError` gains a second `RpcError` branch matching any message that includes `\"no route found\"`, covering old-backend routing errors that lack the standard `UNIMPLEMENTED` gRPC code.
- **`pl-tree/synchronized_tree.ts`** — `discover()` now wraps each `listSharedResourcesByType` call in a try/catch; an `isUnimplementedError` causes the loop to `continue` to the next seed (treating that seed as empty) while any other error still propagates. This makes the initial `discover()` in `init()` gracefully degrade on old backends rather than throwing.
- **Changeset** — both packages are patched at `patch` level with an accurate description.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly unblocks old-backend connections and modern backends are unaffected.

The core logic is sound: catching the missing-route error per seed and returning an empty discovered-root set is the right degradation. The only gaps are that the catch block emits no log and discover() will keep making the doomed RPC call on every poll cycle rather than short-circuiting. Neither gap affects correctness.

synchronized_tree.ts — the catch branch in discover() should log a warning and ideally memoize the seed-unavailable state to avoid repeated failing calls.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/errors.ts | Adds a message-substring guard to isUnimplementedError for the "no route found" gRPC routing error; the check is correct but lacks a code constraint that would make it narrower. |
| lib/node/pl-tree/src/synchronized_tree.ts | discover() now catches isUnimplementedError per seed and continues instead of throwing, fixing init() on old backends; missing log on the catch branch and no memoization to avoid repeated failing RPC calls. |
| .changeset/milab-2668-old-backend-connect.md | Changeset entry correctly marks both pl-client and pl-tree as patch releases and summarises the fix accurately. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant ML as MiddleLayer.init
    participant STS as SynchronizedTreeState.init
    participant D as discover()
    participant BE as Old Backend (no sharing RPCs)

    ML->>STS: init(pl, seeds, ops)
    STS->>D: discover()
    loop for each SharedTypeSeed
        D->>BE: listSharedResourcesByType(seed.resourceType.name)
        BE-->>D: RpcError("no route found")
        Note over D: isUnimplementedError(e) true, continue to next seed
    end
    D-->>STS: "discoveredRoots = [] (empty)"
    STS->>STS: refresh() skips empty seed set
    STS-->>ML: returns tree (connected, sharing hidden)

    Note over ML,BE: Modern backends: listSharedResourcesByType succeeds, discoveredRoots populated normally
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant ML as MiddleLayer.init
    participant STS as SynchronizedTreeState.init
    participant D as discover()
    participant BE as Old Backend (no sharing RPCs)

    ML->>STS: init(pl, seeds, ops)
    STS->>D: discover()
    loop for each SharedTypeSeed
        D->>BE: listSharedResourcesByType(seed.resourceType.name)
        BE-->>D: RpcError("no route found")
        Note over D: isUnimplementedError(e) true, continue to next seed
    end
    D-->>STS: "discoveredRoots = [] (empty)"
    STS->>STS: refresh() skips empty seed set
    STS-->>ML: returns tree (connected, sharing hidden)

    Note over ML,BE: Modern backends: listSharedResourcesByType succeeds, discoveredRoots populated normally
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fnode%2Fpl-tree%2Fsrc%2Fsynchronized_tree.ts%3A298-301%0A**Silent%20swallow%20with%20no%20log**%0A%0AThe%20PR%20description%20says%20the%20unimplemented%20error%20is%20%22warned%20once%22%2C%20but%20the%20catch%20block%20simply%20calls%20%60continue%60%20with%20no%20log%20statement.%20On%20an%20old%20backend%20every%20%60discover%28%29%60%20call%20%28fired%20every%20~3%20s%20from%20%60mainLoop%60%29%20will%20silently%20skip%20every%20shared%20seed%2C%20leaving%20no%20trace%20in%20the%20logs%20that%20discovery%20is%20being%20degraded.%20A%20single%20%60this.logger%3F.warn%28...%29%60%20on%20the%20first%20occurrence%20%28or%20even%20unconditionally%29%20would%20make%20this%20diagnosable%20without%20connecting%20a%20debugger.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fnode%2Fpl-tree%2Fsrc%2Fsynchronized_tree.ts%3A293-303%0A**Repeated%20failing%20RPC%20calls%20on%20every%20discovery%20cycle**%0A%0AAfter%20the%20first%20detection%20that%20a%20seed's%20RPC%20is%20missing%20%28%60isUnimplementedError%60%29%2C%20there%20is%20no%20memoization%3A%20%60mainLoop%60%20will%20call%20%60discover%28%29%60%20again%20every%20%60DISCOVERY_EVERY_N_REFRESHES%60%20iterations%20%28~3%20s%20default%29%2C%20which%20will%20attempt%20%60listSharedResourcesByType%60%2C%20receive%20%22no%20route%20found%22%2C%20catch%20it%2C%20and%20%60continue%60%20%E2%80%94%20indefinitely.%20The%20calls%20fail%20fast%20so%20impact%20is%20low%2C%20but%20setting%20a%20per-seed%20%28or%20per-tree%29%20flag%20on%20the%20first%20unimplemented%20catch%20and%20gating%20subsequent%20attempts%20on%20that%20flag%20would%20avoid%20the%20unnecessary%20traffic%20and%20keep%20the%20happy%20path%20clean.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Ferrors.ts%3A89-90%0A**Message-string%20detection%20without%20code%20check**%0A%0AThe%20new%20guard%20matches%20any%20%60RpcError%60%20whose%20message%20contains%20%60%22no%20route%20found%22%60%2C%20regardless%20of%20%60code%60.%20The%20existing%20gRPC%20routing%20behaviour%20in%20this%20codebase%20emits%20this%20string%20with%20what%20appears%20to%20be%20an%20%60INTERNAL%60%20code%2C%20but%20the%20match%20would%20also%20fire%20for%20an%20unrelated%20%60RpcError%60%20%28e.g.%20an%20application-level%20error%20whose%20message%20happens%20to%20include%20the%20phrase%29.%20Constraining%20to%20a%20specific%20code%20%28e.g.%20%60code%20%3D%3D%20%22INTERNAL%22%60%29%20in%20addition%20to%20the%20string%20would%20reduce%20the%20blast%20radius.%20This%20is%20narrow%20enough%20in%20practice%20to%20be%20acceptable%2C%20but%20worth%20documenting%20with%20an%20inline%20comment%20explaining%20the%20specific%20backend%20version%20behaviour%20it%20compensates%20for.%0A%0A&repo=milaboratory%2Fplatforma&pr=1735&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/node/pl-tree/src/synchronized_tree.ts:298-301
**Silent swallow with no log**

The PR description says the unimplemented error is "warned once", but the catch block simply calls `continue` with no log statement. On an old backend every `discover()` call (fired every ~3 s from `mainLoop`) will silently skip every shared seed, leaving no trace in the logs that discovery is being degraded. A single `this.logger?.warn(...)` on the first occurrence (or even unconditionally) would make this diagnosable without connecting a debugger.

### Issue 2 of 3
lib/node/pl-tree/src/synchronized_tree.ts:293-303
**Repeated failing RPC calls on every discovery cycle**

After the first detection that a seed's RPC is missing (`isUnimplementedError`), there is no memoization: `mainLoop` will call `discover()` again every `DISCOVERY_EVERY_N_REFRESHES` iterations (~3 s default), which will attempt `listSharedResourcesByType`, receive "no route found", catch it, and `continue` — indefinitely. The calls fail fast so impact is low, but setting a per-seed (or per-tree) flag on the first unimplemented catch and gating subsequent attempts on that flag would avoid the unnecessary traffic and keep the happy path clean.

### Issue 3 of 3
lib/node/pl-client/src/core/errors.ts:89-90
**Message-string detection without code check**

The new guard matches any `RpcError` whose message contains `"no route found"`, regardless of `code`. The existing gRPC routing behaviour in this codebase emits this string with what appears to be an `INTERNAL` code, but the match would also fire for an unrelated `RpcError` (e.g. an application-level error whose message happens to include the phrase). Constraining to a specific code (e.g. `code == "INTERNAL"`) in addition to the string would reduce the blast radius. This is narrow enough in practice to be acceptable, but worth documenting with an inline comment explaining the specific backend version behaviour it compensates for.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-2668: tolerate old backends withou..."](https://github.com/milaboratory/platforma/commit/effca5f3105ff650938ef44db0c382f001c8f257) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41636172)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->