### PR TITLE
fix: DeepReadonly/DeepMutable preserve branded primitive types

### DIFF
--- a/.changeset/deep-readonly-branded-types.md
+++ b/.changeset/deep-readonly-branded-types.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/helpers": patch
+---
+
+Fix `DeepReadonly` / `DeepMutable` mangling branded primitive types. The old `keyof T extends never` guard treated a branded string (`string & { [__brand] }`) as an object and mapped over its prototype keys, destroying the brand. The new implementation checks `Primitive | AnyFunction` first (branded primitives and functions pass through untouched), then recurses only into `object` types, leaving `unknown` and other non-object types intact. Union types are now handled correctly too.

--- a/lib/util/helpers/src/types/index.ts
+++ b/lib/util/helpers/src/types/index.ts
@@ -73,17 +73,21 @@ export type AwaitedStruct<O extends Record<string, unknown>> = {
   [P in keyof O]: Awaited<O[P]>;
 };
 
-export type DeepReadonly<T> = keyof T extends never
+export type DeepReadonly<T> = T extends Primitive | AnyFunction
   ? T
-  : { readonly [k in keyof T]: DeepReadonly<T[k]> };
+  : T extends object
+    ? { readonly [k in keyof T]: DeepReadonly<T[k]> }
+    : T;
 
 export type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
 };
 
-export type DeepMutable<T> = keyof T extends never
+export type DeepMutable<T> = T extends Primitive | AnyFunction
   ? T
-  : { -readonly [k in keyof T]: DeepMutable<T[k]> };
+  : T extends object
+    ? { -readonly [k in keyof T]: DeepMutable<T[k]> }
+    : T;
 
 export type Unionize<T extends Record<string, unknown>> = {
   [K in keyof T]: { key: K; value: T[K] };


### PR DESCRIPTION
## What

`DeepReadonly` and `DeepMutable` mangled branded primitive types. The old `keyof T extends never` guard treated a branded string (`string & { readonly [__brand]: B }`) as an object and mapped over its keys, destroying the brand — forcing consumers to strip and re-add ids as plain `string`.

## Fix

```ts
export type DeepReadonly<T> = T extends Primitive | AnyFunction
  ? T
  : { readonly [k in keyof T]: DeepReadonly<T[k]> };
```

A branded primitive still `extends Primitive`, so it passes through untouched with the brand intact. Same fix applied to `DeepMutable`.

Empty-key types still collapse to themselves (`[k in never]` → `{}`); primitives were already preserved by the homomorphic mapped type. Bonus: union types are now made readonly correctly (the old guard returned them unchanged).

Verified with type-level assertions covering branded types, plain primitives, empty objects, nested readonly enforcement, and functions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `DeepReadonly` and `DeepMutable` so they correctly preserve branded primitive types (e.g. `JsonString`, `IsoString`) by replacing the `keyof T extends never` guard with a `T extends Primitive | AnyFunction` distributive conditional check.

- **`DeepReadonly<T>` / `DeepMutable<T>`**: The guard was changed from `keyof T extends never ? T : { ...mapped }` to `T extends Primitive | AnyFunction ? T : { ...mapped }`. Branded strings (`string & { [__brand]: B }`) extend `Primitive`, so they now pass through untouched with the brand intact. As a bonus, union types are now handled distributively instead of returning the whole union unchanged.
- **`.changeset/deep-readonly-branded-types.md`**: Changeset entry added, correctly scoped to a patch for `@milaboratories/helpers`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a well-scoped, correct fix to two type aliases with no runtime impact.

The new `T extends Primitive | AnyFunction` guard is strictly more correct than `keyof T extends never`: it preserves branded primitives (e.g. `JsonString`, `IsoString`) that previously had their brand destroyed, and it handles union types distributively. No consumers of `DeepReadonly`/`DeepMutable` were found elsewhere in the repo or in the related repositories, so there is no breakage risk. The only gap noted is that `symbol` is absent from the `Primitive` definition, which is a pre-existing limitation not introduced here.

No files require special attention. The single-file change to `lib/util/helpers/src/types/index.ts` is straightforward and correct.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/util/helpers/src/types/index.ts | Core fix: DeepReadonly and DeepMutable guards changed from `keyof T extends never` to `T extends Primitive | AnyFunction` — correctly preserves branded primitives and fixes distributive behavior over union types |
| .changeset/deep-readonly-branded-types.md | New changeset entry for the patch fix to @milaboratories/helpers, accurately describing the problem and fix |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DeepReadonly&lt;T&gt; / DeepMutable&lt;T&gt;"] --> B{"T extends Primitive | AnyFunction?"}
    B -- "Yes (string, number, boolean, bigint, null, undefined, functions,\nand branded types like JsonString / IsoString)" --> C["Return T as-is\n(brand preserved)"]
    B -- "No (plain objects, arrays, class instances)" --> D["Map over keys:\n{ readonly [k in keyof T]: DeepReadonly&lt;T[k]&gt; }\nor\n{ -readonly [k in keyof T]: DeepMutable&lt;T[k]&gt; }"]
    D --> E["Recurse on each value type T[k]"]
    E --> B

    style C fill:#c8f7c5
    style D fill:#f7e8c5
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["DeepReadonly&lt;T&gt; / DeepMutable&lt;T&gt;"] --> B{"T extends Primitive | AnyFunction?"}
    B -- "Yes (string, number, boolean, bigint, null, undefined, functions,\nand branded types like JsonString / IsoString)" --> C["Return T as-is\n(brand preserved)"]
    B -- "No (plain objects, arrays, class instances)" --> D["Map over keys:\n{ readonly [k in keyof T]: DeepReadonly&lt;T[k]&gt; }\nor\n{ -readonly [k in keyof T]: DeepMutable&lt;T[k]&gt; }"]
    D --> E["Recurse on each value type T[k]"]
    E --> B

    style C fill:#c8f7c5
    style D fill:#f7e8c5
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alib%2Futil%2Fhelpers%2Fsrc%2Ftypes%2Findex.ts%3A1-5%0A**Missing%20%60symbol%60%20in%20%60Primitive%60%20passthrough**%0A%0A%60Primitive%60%20is%20defined%20as%20%60Nil%20%7C%20string%20%7C%20number%20%7C%20boolean%20%7C%20bigint%60%2C%20which%20omits%20%60symbol%60%20%E2%80%94%20a%20TypeScript%20primitive.%20A%20bare%20%60symbol%60%20or%20a%20symbol-branded%20type%20will%20fall%20through%20to%20the%20mapped-type%20branch%20and%20have%20%60Symbol.prototype%60%20methods%20wrapped%20in%20%60DeepReadonly%60%2F%60DeepMutable%60%20instead%20of%20passing%20through%20untouched.%20This%20was%20the%20same%20behaviour%20before%20this%20PR%2C%20but%20the%20new%20%60T%20extends%20Primitive%20%7C%20AnyFunction%60%20guard%20makes%20the%20intent%20explicit%2C%20and%20%60symbol%60%20is%20the%20one%20missing%20case.%20Adding%20%60symbol%60%20to%20%60Primitive%60%20would%20close%20the%20gap%20for%20completeness.%0A%0A&repo=milaboratory%2Fplatforma&pr=1736&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
lib/util/helpers/src/types/index.ts:1-5
**Missing `symbol` in `Primitive` passthrough**

`Primitive` is defined as `Nil | string | number | boolean | bigint`, which omits `symbol` — a TypeScript primitive. A bare `symbol` or a symbol-branded type will fall through to the mapped-type branch and have `Symbol.prototype` methods wrapped in `DeepReadonly`/`DeepMutable` instead of passing through untouched. This was the same behaviour before this PR, but the new `T extends Primitive | AnyFunction` guard makes the intent explicit, and `symbol` is the one missing case. Adding `symbol` to `Primitive` would close the gap for completeness.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: DeepReadonly/DeepMutable preserve b..."](https://github.com/milaboratory/platforma/commit/0e8ffb58464876980b9b63d6bb7a182b78a8b56e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42008058)</sub>

<!-- /greptile_comment -->