### PR TITLE
Only admins should be able to share projects to everyon

### DIFF
--- a/.changeset/small-bananas-mate.md
+++ b/.changeset/small-bananas-mate.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Only admins should be able to share projects to everyone

--- a/lib/node/pl-middle-layer/src/model/sharing_model.test.ts
+++ b/lib/node/pl-middle-layer/src/model/sharing_model.test.ts
@@ -16,7 +16,7 @@ test("canImpersonate: admin and controller only", () => {
   expect(canImpersonate(null)).toBe(false);
 });
 
-test("canGrantToEveryone includes USER but canImpersonate does not", () => {
-  expect(canGrantToEveryone(Role.USER)).toBe(true);
+test("canGrantToEveryone and canImpersonate does not include USER", () => {
+  expect(canGrantToEveryone(Role.USER)).toBe(false);
   expect(canImpersonate(Role.USER)).toBe(false);
 });

--- a/lib/node/pl-middle-layer/src/model/sharing_model.ts
+++ b/lib/node/pl-middle-layer/src/model/sharing_model.ts
@@ -51,7 +51,7 @@ export type ProjectFieldUuid = Branded<string, "ProjectFieldUuid">;
 
 /**
  * Whether a role may make a resource public (grant to everyone): true for controller,
- * admin, and user; false for workflow and unspecified. The middle layer carries no policy
+ * admin; false for workflow and unspecified. The middle layer carries no policy
  * of its own here — a crafted call still hits the backend's role + permission-ceiling gate.
  * `null` (no-auth mode) returns false.
  */
@@ -59,7 +59,6 @@ export function canGrantToEveryone(role: Role | null): boolean {
   switch (role) {
     case RoleEnum.CONTROLLER:
     case RoleEnum.ADMIN:
-    case RoleEnum.USER:
       return true;
     default:
       return false;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the \"share with everyone\" gate in `canGrantToEveryone` by removing `RoleEnum.USER`, so only `CONTROLLER` and `ADMIN` roles may make a resource public. The one-line change in `sharing_model.ts` is correct, but the accompanying test and two JSDoc comments were not updated to match.

- **`canGrantToEveryone` (`sharing_model.ts`)** — Predicate controlling whether a user's role permits share-to-everyone. `RoleEnum.USER` removed; now returns `true` only for `CONTROLLER` and `ADMIN`.
- **`canGrantToEveryone` JSDoc** — Still describes the old behaviour (\"true for controller, admin, and user\"). Needs updating.
- **`canImpersonate` JSDoc** — Describes the two predicates as intentionally asymmetric. That distinction is now gone and the comment is misleading.
- **`canShareWithEveryone` getter (`middle_layer.ts`)** — Correctly inherits the restriction with no code change needed.
- **Test in `sharing_model.test.ts`** — Explicitly asserts `canGrantToEveryone(Role.USER) === true`; will fail after the change.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The logic change is correct but the test suite will break — a companion test asserts the opposite of the new behaviour.

The one-line removal in canGrantToEveryone is exactly the right change, and canShareWithEveryone in middle_layer.ts picks it up automatically. However, the companion test explicitly asserts canGrantToEveryone(Role.USER) is true, so the test suite will fail. Two JSDoc comments also still describe the old USER-inclusive behaviour, creating confusion for future maintainers about the intended distinction between the two predicates.

sharing_model.test.ts — the failing assertion must be fixed before this can merge cleanly.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/model/sharing_model.ts | Removes RoleEnum.USER from canGrantToEveryone so only CONTROLLER and ADMIN may share with everyone; two JSDoc comments still reference the old USER-inclusive behaviour. |
| lib/node/pl-middle-layer/src/model/sharing_model.test.ts | Test 'canGrantToEveryone includes USER but canImpersonate does not' asserts canGrantToEveryone(Role.USER) is true — this assertion will now fail since USER was removed from the function. |
| .changeset/small-bananas-mate.md | Changelog entry correctly describes the intent: restrict share-to-everyone to admins only. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User triggers Share with Everyone] --> B{canShareWithEveryone}
    B --> C{serverCapabilities includes publicGrants:v1}
    C -- No --> D[UI hides share-with-all option]
    C -- Yes --> E{canGrantToEveryone role}
    E --> F{role?}
    F -- CONTROLLER --> G[Allowed]
    F -- ADMIN --> G
    F -- USER --> H[Denied - removed in this PR]
    F -- WORKFLOW / UNSPECIFIED / null --> H
    G --> I[shareProjects called with everyone:true]
    H --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User triggers Share with Everyone] --> B{canShareWithEveryone}
    B --> C{serverCapabilities includes publicGrants:v1}
    C -- No --> D[UI hides share-with-all option]
    C -- Yes --> E{canGrantToEveryone role}
    E --> F{role?}
    F -- CONTROLLER --> G[Allowed]
    F -- ADMIN --> G
    F -- USER --> H[Denied - removed in this PR]
    F -- WORKFLOW / UNSPECIFIED / null --> H
    G --> I[shareProjects called with everyone:true]
    H --> D
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fnode%2Fpl-middle-layer%2Fsrc%2Fmodel%2Fsharing_model.ts%3A52-57%0AThe%20JSDoc%20for%20%60canGrantToEveryone%60%20still%20says%20%22true%20for%20controller%2C%20admin%2C%20and%20user%22%20%E2%80%94%20the%20%60user%60%20entry%20is%20now%20stale%20after%20removing%20%60RoleEnum.USER%60%20from%20the%20switch.%20It%20also%20mentions%20%60canImpersonate%60%20being%20%22intentionally%20stricter%22%20than%20this%20predicate%2C%20but%20they%20are%20now%20equivalent.%0A%0A%60%60%60suggestion%0A%2F**%0A%20*%20Whether%20a%20role%20may%20make%20a%20resource%20public%20%28grant%20to%20everyone%29%3A%20true%20for%20controller%0A%20*%20and%20admin%20only%3B%20false%20for%20user%2C%20workflow%2C%20and%20unspecified.%20The%20middle%20layer%20carries%20no%0A%20*%20policy%20of%20its%20own%20here%20%E2%80%94%20a%20crafted%20call%20still%20hits%20the%20backend's%20role%20%2B%0A%20*%20permission-ceiling%20gate.%20%60null%60%20%28no-auth%20mode%29%20returns%20false.%0A%20*%2F%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fnode%2Fpl-middle-layer%2Fsrc%2Fmodel%2Fsharing_model.ts%3A69-75%0AThe%20%60canImpersonate%60%20JSDoc%20states%20it%20is%20%22intentionally%20stricter%20than%20%60canGrantToEveryone%60%2C%20which%20also%20returns%20true%20for%20a%20regular%20user%22.%20That%20asymmetry%20no%20longer%20exists%20%E2%80%94%20both%20functions%20now%20return%20%60true%60%20only%20for%20CONTROLLER%20and%20ADMIN.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20current%20parity.%0A%0A%60%60%60suggestion%0A%20*%20Whether%20a%20role%20may%20impersonate%20another%20user%3A%20open%2Fcreate%20another%20user's%20root%20and%20list%0A%20*%20the%20resources%20that%20user%20can%20access.%20Mirrors%20the%20backend's%20authorization%20rule%0A%20*%20%60util%2Fmisecurity%2Frole.go%60%20%60CanImpersonate%60%20%E2%80%94%20true%20for%20controller%20and%20admin%20only.%20This%20is%0A%20*%20the%20admin%20gate%20for%20the%20%22open%20another%20user's%20root%22%20feature.%20Both%20this%20predicate%20and%0A%20*%20%7B%40link%20canGrantToEveryone%7D%20now%20allow%20only%20controller%20and%20admin.%20%60null%60%20%28no-auth%0A%20*%20mode%29%20returns%20false.%0A%60%60%60%0A%0A&repo=milaboratory%2Fplatforma&pr=1737&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
lib/node/pl-middle-layer/src/model/sharing_model.ts:52-57
The JSDoc for `canGrantToEveryone` still says "true for controller, admin, and user" — the `user` entry is now stale after removing `RoleEnum.USER` from the switch. It also mentions `canImpersonate` being "intentionally stricter" than this predicate, but they are now equivalent.

```suggestion
/**
 * Whether a role may make a resource public (grant to everyone): true for controller
 * and admin only; false for user, workflow, and unspecified. The middle layer carries no
 * policy of its own here — a crafted call still hits the backend's role +
 * permission-ceiling gate. `null` (no-auth mode) returns false.
 */
```

### Issue 2 of 2
lib/node/pl-middle-layer/src/model/sharing_model.ts:69-75
The `canImpersonate` JSDoc states it is "intentionally stricter than `canGrantToEveryone`, which also returns true for a regular user". That asymmetry no longer exists — both functions now return `true` only for CONTROLLER and ADMIN. The comment should be updated to reflect the current parity.

```suggestion
 * Whether a role may impersonate another user: open/create another user's root and list
 * the resources that user can access. Mirrors the backend's authorization rule
 * `util/misecurity/role.go` `CanImpersonate` — true for controller and admin only. This is
 * the admin gate for the "open another user's root" feature. Both this predicate and
 * {@link canGrantToEveryone} now allow only controller and admin. `null` (no-auth
 * mode) returns false.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Only admins should be able to share proj..."](https://github.com/milaboratory/platforma/commit/9652e17ce6b41b8cf1b9e4a5ec9a9a66aff47091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42056961)</sub>

<!-- /greptile_comment -->