### PR TITLE
MILAB-6480: exec resource formulas — .resources({ onCPU, onGPU }) API + fluent chain

### DIFF
--- a/.changeset/resources-formula-api.md
+++ b/.changeset/resources-formula-api.md
@@ -31,6 +31,22 @@ builder.resources({
 
 - `onCPU` takes `{ cpu, ram }`; `onGPU` takes `{ cpu, ram, vram }` (vram is what makes it a GPU allocation, so it is required). Which blocks are present decides the mode.
 - Each dimension takes a static value (number / size string) or a data-driven `exec.formula` chain. A formula should end in `.staticFallback(...)` — the value used on backends that cannot evaluate formulas at run time.
-- The formula DSL is fluent-only: a formula starts from a leaf (`f.size`/`f.lineCount`/`f.gib`/…/`f.const`) and chains — `.plus`/`.minus`/`.times`/`.dividedBy` (÷, ceil)/`.dividedByFloor` (÷, truncating), bounds `.atLeast` (max)/`.atMost` (min)/`.between` (clamp), comparisons `.gt`/`.gte`/`.lt`/`.lte`, logic `.and`/`.or`/`.not`, multi-branch conditionals `f.when(cond, v).when(...).otherwise(default)`, and terminal `.staticFallback(...)`. The prefix operator constructors (`f.add`, `f.clamp`, `f.if`, …) are removed.
+- The formula DSL is **fluent-only**: a formula starts from a leaf (`f.size`/`f.lineCount`/`f.gib`/…/`f.const`) and chains. The prefix operator constructors (`f.add`, `f.clamp`, `f.if`, …) are removed. Chain methods:
+  - arithmetic: `.plus` / `.minus` / `.times` / `.dividedBy` (÷, ceiling) / `.dividedByFloor` (÷, truncating)
+  - bounds: `.atLeast` (max) / `.atMost` (min) / `.between(lo, hi)` (clamp)
+  - comparisons (produce a boolean — only valid inside a `when` branch): `.gt` / `.gte` / `.lt` / `.lte`
+  - logic: `.and` / `.or` / `.not`
+  - multi-branch conditional: `f.when(cond, value).when(cond2, value2).otherwise(default)` — compiles to a nested conditional; the first truthy branch wins. Only `.when` / `.otherwise` are exposed, so a bare boolean can never reach a quota.
+  - terminal: `.staticFallback(value)` — the value used on backends that cannot evaluate formulas at run time.
+
+  The AST op strings mirror these method names (`plus`/`dividedBy`/`between`/`when`/…), so a raw formula dump reads like the source.
+
+```go
+// conditional + comparison example: bucket RAM by input size, then pin a fallback
+ram: f.when(f.size("input").gt(f.gib(50)), f.gib(128)).
+       when(f.size("input").gt(f.gib(5)),  f.gib(64)).
+       otherwise(f.gib(16)).
+     staticFallback(f.gib(64))
+```
 - GPU/VRAM formulas compute VRAM from input metrics like RAM/CPU. `onGPU` alone errors at workflow render time on a GPU-less backend; the adaptive `onCPU`+`onGPU` form resolves against `exec.hasGpu` at workflow render time (no backend plan-selection needed).
 - Resource formulas remain CID-transparent (they do not affect exec deduplication). The static `.gpuMemory()` / `.cpu()` / `.mem()` setters are unchanged.

--- a/.changeset/resources-formula-api.md
+++ b/.changeset/resources-formula-api.md
@@ -14,7 +14,7 @@ f := exec.formula
 builder.resources({
     queue: "heavy",
     onCPU: {
-        cpu: f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16),
+        cpu: f.size("input").dividedBy(f.gib(4)).between(4, 16).staticFallback(16),
         ram: f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16)).staticFallback(f.gib(64)),
     },
 })
@@ -31,6 +31,6 @@ builder.resources({
 
 - `onCPU` takes `{ cpu, ram }`; `onGPU` takes `{ cpu, ram, vram }` (vram is what makes it a GPU allocation, so it is required). Which blocks are present decides the mode.
 - Each dimension takes a static value (number / size string) or a data-driven `exec.formula` chain. A formula should end in `.staticFallback(...)` — the value used on backends that cannot evaluate formulas at run time.
-- New fluent chain on every `exec.formula` node: `.per` (÷, ceil), `.times`, `.plus`, `.minus`, `.atLeast` (max), `.atMost` (min), `.between(lo, hi)` (clamp), `.staticFallback(...)`. The prefix constructors (`f.add`, `f.clamp`, `f.if`, …) remain for conditionals.
+- The formula DSL is fluent-only: a formula starts from a leaf (`f.size`/`f.lineCount`/`f.gib`/…/`f.const`) and chains — `.plus`/`.minus`/`.times`/`.dividedBy` (÷, ceil)/`.dividedByFloor` (÷, truncating), bounds `.atLeast` (max)/`.atMost` (min)/`.between` (clamp), comparisons `.gt`/`.gte`/`.lt`/`.lte`, logic `.and`/`.or`/`.not`, multi-branch conditionals `f.when(cond, v).when(...).otherwise(default)`, and terminal `.staticFallback(...)`. The prefix operator constructors (`f.add`, `f.clamp`, `f.if`, …) are removed.
 - GPU/VRAM formulas compute VRAM from input metrics like RAM/CPU. `onGPU` alone errors at workflow render time on a GPU-less backend; the adaptive `onCPU`+`onGPU` form resolves against `exec.hasGpu` at workflow render time (no backend plan-selection needed).
 - Resource formulas remain CID-transparent (they do not affect exec deduplication). The static `.gpuMemory()` / `.cpu()` / `.mem()` setters are unchanged.

--- a/.changeset/resources-formula-api.md
+++ b/.changeset/resources-formula-api.md
@@ -1,0 +1,36 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+exec resource formulas: replace the per-dimension setters with a single `.resources({ ... })` entry point, add a fluent formula chain, and add GPU/VRAM formulas.
+
+**BREAKING:** `exec.builder().memFormula(ast, { fallback })` and `.cpuFormula(ast, { fallback })` are removed. Declare RAM / CPU / GPU in one call instead:
+
+```go
+exec := import("@platforma-sdk/workflow-tengo:exec")
+f := exec.formula
+
+// CPU only (onCPU alone)
+builder.resources({
+    queue: "heavy",
+    onCPU: {
+        cpu: f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16),
+        ram: f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16)).staticFallback(f.gib(64)),
+    },
+})
+
+// GPU required (onGPU alone — runs only on a GPU node, errors fast otherwise)
+builder.resources({ onGPU: { cpu: ..., ram: ..., vram: ... } })
+
+// GPU preferred (both blocks — adaptive: onGPU when the backend has a GPU, else onCPU)
+builder.resources({
+    onCPU: { cpu: ..., ram: ... },
+    onGPU: { cpu: ..., ram: ..., vram: ... },
+})
+```
+
+- `onCPU` takes `{ cpu, ram }`; `onGPU` takes `{ cpu, ram, vram }` (vram is what makes it a GPU allocation, so it is required). Which blocks are present decides the mode.
+- Each dimension takes a static value (number / size string) or a data-driven `exec.formula` chain. A formula should end in `.staticFallback(...)` — the value used on backends that cannot evaluate formulas at run time.
+- New fluent chain on every `exec.formula` node: `.per` (÷, ceil), `.times`, `.plus`, `.minus`, `.atLeast` (max), `.atMost` (min), `.between(lo, hi)` (clamp), `.staticFallback(...)`. The prefix constructors (`f.add`, `f.clamp`, `f.if`, …) remain for conditionals.
+- GPU/VRAM formulas compute VRAM from input metrics like RAM/CPU. `onGPU` alone errors at workflow render time on a GPU-less backend; the adaptive `onCPU`+`onGPU` form resolves against `exec.hasGpu` at workflow render time (no backend plan-selection needed).
+- Resource formulas remain CID-transparent (they do not affect exec deduplication). The static `.gpuMemory()` / `.cpu()` / `.mem()` setters are unchanged.

--- a/sdk/workflow-tengo/src/exec/constants.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/constants.lib.tengo
@@ -18,15 +18,16 @@ RUNNER_EXECUTOR := "executor" // local binary execution
 
 // Field names for resource-formula exec inputs. The exec builder (.run())
 // writes these; the pure exec template (exec.tpl) reads them and evaluates the
-// formula. __memFormula__/__cpuFormula__ ride the META rail (CID-transparent);
-// __metric_lineCount__ rides a REGULAR input (file-derived, so it adds no CID
-// differentiation) and is deep-waited to final by the pure template's input
-// gate. The ephemeral exec impl does NOT read them — it just consumes the quota
-// the pure template already computed. Defined here so the cross-file contract
-// has one source of truth — a rename can't silently drift between the attach,
-// read, and validate sites.
+// formula. __memFormula__/__cpuFormula__/__gpuFormula__ ride the META rail
+// (CID-transparent); __metric_lineCount__ rides a REGULAR input (file-derived,
+// so it adds no CID differentiation) and is deep-waited to final by the pure
+// template's input gate. The ephemeral exec impl does NOT read them — it just
+// consumes the quota the pure template already computed. Defined here so the
+// cross-file contract has one source of truth — a rename can't silently drift
+// between the attach, read, and validate sites.
 META_INPUT_MEM_FORMULA := "__memFormula__"
 META_INPUT_CPU_FORMULA := "__cpuFormula__"
+META_INPUT_GPU_FORMULA := "__gpuFormula__"
 REGULAR_INPUT_LINE_COUNT := "__metric_lineCount__"
 
 export ll.toStrict({
@@ -47,5 +48,6 @@ export ll.toStrict({
 
 	META_INPUT_MEM_FORMULA: META_INPUT_MEM_FORMULA,
 	META_INPUT_CPU_FORMULA: META_INPUT_CPU_FORMULA,
+	META_INPUT_GPU_FORMULA: META_INPUT_GPU_FORMULA,
 	REGULAR_INPUT_LINE_COUNT: REGULAR_INPUT_LINE_COUNT
 })

--- a/sdk/workflow-tengo/src/exec/exec.tpl.tengo
+++ b/sdk/workflow-tengo/src/exec/exec.tpl.tengo
@@ -85,17 +85,18 @@ inputSchema := {
 	}
 }
 
-// Optional resource-formula inputs (attached by the exec builder when
-// memFormula/cpuFormula are used), evaluated by the body below. The formula ASTs
-// __memFormula__/__cpuFormula__ are JSON value resources on the META rail —
-// CID-transparent, yet readable as final in this pure body (same mechanism as
-// `quota`). __metric_lineCount__ is a COMPUTED map resource (fileName -> content
-// resource with that file's line count) on the REGULAR rail, so this pure
-// template's readiness gate deep-waits its per-file entries to final before the
-// body reads them. Keys come from execConstants so the attach/read/validate sites
-// share one source of truth. See analysis doc §4.
+// Optional resource-formula inputs (attached by the exec builder when a RAM /
+// CPU / VRAM formula is used), evaluated by the body below. The formula ASTs
+// __memFormula__/__cpuFormula__/__gpuFormula__ are JSON value resources on the
+// META rail — CID-transparent, yet readable as final in this pure body (same
+// mechanism as `quota`). __metric_lineCount__ is a COMPUTED map resource
+// (fileName -> content resource with that file's line count) on the REGULAR
+// rail, so this pure template's readiness gate deep-waits its per-file entries to
+// final before the body reads them. Keys come from execConstants so the
+// attach/read/validate sites share one source of truth. See analysis doc §4.
 inputSchema[execConstants.META_INPUT_MEM_FORMULA + ",?"] = "any"
 inputSchema[execConstants.META_INPUT_CPU_FORMULA + ",?"] = "any"
+inputSchema[execConstants.META_INPUT_GPU_FORMULA + ",?"] = "any"
 inputSchema[execConstants.REGULAR_INPUT_LINE_COUNT + ",?"] = "any"
 self.validateInputs(inputSchema)
 
@@ -118,7 +119,8 @@ self.body(func(inputs) {
 
 	memFormula := inputs[execConstants.META_INPUT_MEM_FORMULA]
 	cpuFormula := inputs[execConstants.META_INPUT_CPU_FORMULA]
-	if !is_undefined(memFormula) || !is_undefined(cpuFormula) {
+	gpuFormula := inputs[execConstants.META_INPUT_GPU_FORMULA]
+	if !is_undefined(memFormula) || !is_undefined(cpuFormula) || !is_undefined(gpuFormula) {
 		fileRefs := inputs.filesToAdd
 		lineCountMap := inputs[execConstants.REGULAR_INPUT_LINE_COUNT]
 		resolver := {
@@ -153,6 +155,11 @@ self.body(func(inputs) {
 		}
 		if !is_undefined(cpuFormula) {
 			quota.cpu = execFormula.evaluateResource(cpuFormula, resolver, "cpu")
+		}
+		if !is_undefined(gpuFormula) {
+			// VRAM bytes -> SizeUnit string (the quota's gpuMemory is a size string,
+			// parsed identically to ram). A positive integer is asserted, same as ram.
+			quota.gpuMemory = string(execFormula.evaluateResource(gpuFormula, resolver, "gpuMemory")) + "b"
 		}
 	}
 

--- a/sdk/workflow-tengo/src/exec/formula.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.lib.tengo
@@ -340,7 +340,7 @@ _node = func(ast, fallback) {
 	self.minus   = func(x) { return _node(_bin("sub", ast, x), fallback) }
 	self.atLeast = func(x) { return _node(_bin("max", ast, x), fallback) }
 	self.atMost  = func(x) { return _node(_bin("min", ast, x), fallback) }
-	self.between = func(lo, hi) { return _node({ op: "clamp", value: ast, lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
+	self.between = func(lo, hi) { return _node({ op: "clamp", value: _wrap(ast), lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
 	self.staticFallback = func(v) { return _node(ast, _staticValue(v)) }
 	return self
 }

--- a/sdk/workflow-tengo/src/exec/formula.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.lib.tengo
@@ -3,10 +3,13 @@
 // below) that flows through two phases across the exec boundary:
 //
 // WORKFLOW RENDER TIME (in exec.builder().run(), before the exec exists):
-//   1. The author composes a formula from the exported constructors
-//      (size/lineCount, gib/..., add/mul/clamp/if) OR the fluent chain
-//      (.per/.times/.plus/.between/... + .staticFallback). Both build the SAME
-//      AST — the chain is sugar. Bare ints auto-wrap to const.
+//   1. The author composes a formula by chaining off a leaf constructor
+//      (size/lineCount, gib/mib/..., const). The chain covers arithmetic
+//      (.plus/.minus/.times/.dividedBy/.dividedByFloor), bounds
+//      (.atLeast/.atMost/.between),
+//      comparisons (.gt/.gte/.lt/.lte), logic (.and/.or/.not) and multi-branch
+//      conditionals (f.when(cond, value).when(...).otherwise(default)).
+//      Bare ints auto-wrap to const.
 //   2. resolveAst() turns each { op: "metric", tag } into a concrete
 //      { op: "metricSum", files } via the builder's tag -> files map (an empty
 //      tag collapses to its { default }), and rejects lineCount on a non-text file.
@@ -31,9 +34,9 @@
 // FLUENT WRAPPERS: every constructor returns a chainable wrapper — a map
 //   { __isFormula__: true, __ast__: <plain AST>, __fallback__: <static?> } that
 //   also carries the chain methods. The plain AST is never contaminated: _wrap
-//   (used by every constructor when composing children) unwraps a wrapper back to
-//   its __ast__, so the tree stored and serialized is always plain maps. The
-//   builder reads a value with astOf()/fallbackOf(); the evaluator entry points
+//   (used by every method when composing children) unwraps a wrapper back to its
+//   __ast__, so the tree stored and serialized is always plain maps. The builder
+//   reads a value with astOf()/fallbackOf(); the evaluator entry points
 //   auto-unwrap, so passing a wrapper straight to resolveAst/evaluate/... works.
 //
 // Pure by design: this file walks data and knows nothing of the backend. That
@@ -71,7 +74,7 @@ _KNOWN_OPS := sets.fromSlice([
 ])
 
 // Comparison/logic ops. Rejected at the top level of a resource formula
-// (evaluateResource) — they are meaningful only inside f.if(...).
+// (evaluateResource) — they are meaningful only inside a f.when(...) branch.
 _BOOL_OPS := sets.fromSlice(["gt", "gte", "lt", "lte", "and", "or", "not"])
 
 // _unwrap strips a fluent wrapper down to its plain AST; a plain AST or an int
@@ -141,6 +144,8 @@ evaluate = func(node, resolver) {
 	if op == "div" {
 		b := evaluate(node.b, resolver)
 		ll.assert(b != 0, "exec.formula.evaluate: division by zero")
+		// integer (truncating) division; toward zero, which for the non-negative
+		// resource-metric domain (sizes, line counts) is floor.
 		return evaluate(node.a, resolver) / b
 	}
 	if op == "divCeil" {
@@ -179,20 +184,20 @@ evaluate = func(node, resolver) {
 // evaluateResource evaluates a formula destined for a resource quota (ram / cpu /
 // gpu) and asserts the result is usable: a positive integer. It first rejects a
 // comparison/logic op at the top level — Tengo's && / || return the deciding
-// OPERAND (an int), so a top-level f.and/f.or of ints would otherwise pass the
-// is_int check; comparisons and logic belong only inside f.if(...). The
-// positive-int check then catches a non-positive result (an f.sub that
+// OPERAND (an int), so a top-level .and/.or of ints would otherwise pass the
+// is_int check; comparisons and logic belong only inside a f.when(...) branch. The
+// positive-int check then catches a non-positive result (a .minus that
 // underflows, or a metric that floored to 0) BEFORE it reaches the quota as an
 // opaque "trueb" RAM string or a 0-core request. `label` ("ram" / "cpu" /
 // "gpuMemory") names the offending dimension.
 evaluateResource := func(node, resolver, label) {
 	node = _unwrap(node)
 	ll.assert(!sets.hasElement(_BOOL_OPS, node.op),
-		"exec resource formula (%s) must compute a number, but its top-level op is %q (a comparison/logic op). Use comparisons and logic only inside f.if(...).",
+		"exec resource formula (%s) must compute a number, but its top-level op is %q (a comparison/logic op). Use comparisons and logic only inside f.when(...).",
 		label, node.op)
 	v := evaluate(node, resolver)
 	ll.assert(is_int(v) && v > 0,
-		"exec resource formula (%s) must evaluate to a positive integer, got %v. If a metric can be zero or a subtraction can underflow, floor it with f.max(...) or f.between(...).",
+		"exec resource formula (%s) must evaluate to a positive integer, got %v. If a metric can be zero or a subtraction can underflow, floor it with .atLeast(...) or .between(...).",
 		label, v)
 	return v
 }
@@ -322,11 +327,14 @@ applyFormulaFallback := func(dims) {
 
 // ---- fluent wrapper factory ------------------------------------------------
 // _node wraps a plain AST in a chainable object. Every chain method returns a
-// NEW wrapper (immutable), carrying the accumulated { fallback } forward. The
-// arithmetic aliases read left-to-right — `f.size("x").times(12).plus(f.gib(8))`
-// composes mul(size, 12) then add(that, gib(8)). Bounds: .atLeast -> max,
-// .atMost -> min, .between(lo, hi) -> clamp. .staticFallback pins the value used
-// on backends that can't evaluate the formula.
+// NEW wrapper (immutable), carrying the accumulated { fallback } forward and
+// reading left-to-right — `f.size("x").times(12).plus(f.gib(8))` composes
+// mul(size, 12) then add(that, gib(8)). Arithmetic: .plus/.minus/.times ->
+// add/sub/mul; .dividedBy -> ceiling division, .dividedByFloor -> integer
+// (truncating) division. Bounds: .atLeast -> max, .atMost
+// -> min, .between(lo, hi) -> clamp. Comparisons (.gt/.gte/.lt/.lte) and logic
+// (.and/.or/.not) build boolean nodes for use inside a f.when(...) branch.
+// .staticFallback pins the value used on backends that can't evaluate the formula.
 _node := undefined
 _node = func(ast, fallback) {
 	self := {
@@ -334,14 +342,50 @@ _node = func(ast, fallback) {
 		__ast__:       ast,
 		__fallback__:  fallback
 	}
-	self.per     = func(x) { return _node(_bin("divCeil", ast, x), fallback) }
-	self.times   = func(x) { return _node(_bin("mul", ast, x), fallback) }
-	self.plus    = func(x) { return _node(_bin("add", ast, x), fallback) }
-	self.minus   = func(x) { return _node(_bin("sub", ast, x), fallback) }
-	self.atLeast = func(x) { return _node(_bin("max", ast, x), fallback) }
-	self.atMost  = func(x) { return _node(_bin("min", ast, x), fallback) }
-	self.between = func(lo, hi) { return _node({ op: "clamp", value: _wrap(ast), lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
+	self.plus      = func(x) { return _node(_bin("add", ast, x), fallback) }
+	self.minus     = func(x) { return _node(_bin("sub", ast, x), fallback) }
+	self.times     = func(x) { return _node(_bin("mul", ast, x), fallback) }
+	self.dividedBy      = func(x) { return _node(_bin("divCeil", ast, x), fallback) }
+	self.dividedByFloor = func(x) { return _node(_bin("div", ast, x), fallback) }
+	self.atLeast   = func(x) { return _node(_bin("max", ast, x), fallback) }
+	self.atMost    = func(x) { return _node(_bin("min", ast, x), fallback) }
+	self.between   = func(lo, hi) { return _node({ op: "clamp", value: _wrap(ast), lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
+	self.gt        = func(x) { return _node(_bin("gt", ast, x), fallback) }
+	self.gte       = func(x) { return _node(_bin("gte", ast, x), fallback) }
+	self.lt        = func(x) { return _node(_bin("lt", ast, x), fallback) }
+	self.lte       = func(x) { return _node(_bin("lte", ast, x), fallback) }
+	self.and       = func(x) { return _node(_bin("and", ast, x), fallback) }
+	self.or        = func(x) { return _node(_bin("or", ast, x), fallback) }
+	self.not       = func() { return _node({ op: "not", a: _wrap(ast) }, fallback) }
 	self.staticFallback = func(v) { return _node(ast, _staticValue(v)) }
+	return self
+}
+
+// _condBuilder accumulates when()-branches and folds them, right-to-left, into a
+// nested `if` AST on .otherwise(). It exposes ONLY .when / .otherwise — so a
+// conditional must be finished with .otherwise (there is no way to leak a
+// dangling boolean into a quota).
+_condBuilder := undefined
+_condBuilder = func(branches) {
+	self := {}
+	self.when = func(cond, value) {
+		// Copy `branches` before appending so sibling chains off the same builder
+		// never alias each other's branch list.
+		next := []
+		for br in branches { next = append(next, br) }
+		next = append(next, { cond: _wrap(cond), value: _wrap(value) })
+		return _condBuilder(next)
+	}
+	self.otherwise = func(dflt) {
+		node := _wrap(dflt)
+		i := len(branches) - 1
+		for i >= 0 {
+			b := branches[i]
+			node = { op: "if", cond: b.cond, then: b.value, "else": node }
+			i = i - 1
+		}
+		return _node(node, undefined)
+	}
 	return self
 }
 
@@ -365,30 +409,13 @@ export {
 
 	// const: a bare integer as a formula leaf (bytes / cores). Handy when a
 	// dimension is a plain number you still want to chain off of.
-	"const": func(n) { return _const(n) },
+	const: func(n) { return _const(n) },
 
-	add:     func(a, b) { return _node(_bin("add", a, b), undefined) },
-	sub:     func(a, b) { return _node(_bin("sub", a, b), undefined) },
-	mul:     func(a, b) { return _node(_bin("mul", a, b), undefined) },
-	div:     func(a, b) { return _node(_bin("div", a, b), undefined) },
-	// divCeil(a, b): ceiling of a/b. Assumes a >= 0 and b > 0 — the resource-metric
-	// domain (sizes, line counts, positive constants). A negative a (e.g. an
-	// underflowing f.sub) can be off by one; floor such inputs with f.max first.
-	divCeil: func(a, b) { return _node(_bin("divCeil", a, b), undefined) },
-
-	max:   func(a, b) { return _node(_bin("max", a, b), undefined) },
-	min:   func(a, b) { return _node(_bin("min", a, b), undefined) },
-	clamp: func(value, lo, hi) { return _node({ op: "clamp", value: _wrap(value), lo: _wrap(lo), hi: _wrap(hi) }, undefined) },
-
-	gt:  func(a, b) { return _node(_bin("gt", a, b), undefined) },
-	gte: func(a, b) { return _node(_bin("gte", a, b), undefined) },
-	lt:  func(a, b) { return _node(_bin("lt", a, b), undefined) },
-	lte: func(a, b) { return _node(_bin("lte", a, b), undefined) },
-	and: func(a, b) { return _node(_bin("and", a, b), undefined) },
-	or:  func(a, b) { return _node(_bin("or", a, b), undefined) },
-	not: func(a) { return _node({ op: "not", a: _wrap(a) }, undefined) },
-
-	"if": func(cond, then, els) { return _node({ op: "if", cond: _wrap(cond), then: _wrap(then), "else": _wrap(els) }, undefined) },
+	// when(cond, value): start a multi-branch conditional. Chain more .when(...)
+	// branches (evaluated in order), then finish with .otherwise(default). Compiles
+	// to a nested `if` — the first branch whose condition is truthy wins. Conditions
+	// come from the comparison/logic chain, e.g. f.size("input").gt(f.gib(1)).
+	when: func(cond, value) { return _condBuilder([]).when(cond, value) },
 
 	// ---- wrapper introspection (used by the exec builder) ------------------
 	// astOf: the plain AST behind a value (a wrapper -> its __ast__; a plain AST

--- a/sdk/workflow-tengo/src/exec/formula.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.lib.tengo
@@ -52,14 +52,17 @@ units := import(":units")
 
 // ---- AST node shapes -------------------------------------------------------
 // const:      { op: "const", value: <int> }
-// arithmetic: { op: "add"|"sub"|"mul"|"div"|"divCeil", a: <node>, b: <node> }
-// bounds:     { op: "max"|"min", a, b } | { op: "clamp", value, lo, hi }
+// arithmetic: { op: "plus"|"minus"|"times"|"dividedBy"|"dividedByFloor", a: <node>, b: <node> }
+//             ("dividedBy" is ceiling division; "dividedByFloor" is truncating)
+// bounds:     { op: "atLeast"|"atMost", a, b } | { op: "between", value, lo, hi }
 // compare:    { op: "gt"|"gte"|"lt"|"lte", a, b }
 // logic:      { op: "and"|"or", a, b } | { op: "not", a }
-// cond:       { op: "if", cond, then, else }
+// cond:       { op: "when", cond, then, else }
 // metric:     { op: "metric", metric: "size"|"lineCount", "tag,?": <string>, "default,?": <int> }
 //             (the builder later resolves "metric" -> "metricSum" with concrete files)
-// Note: if.cond and not.a may be const-wrapped if given a bare int; the
+// The op strings mirror the fluent chain method names (.plus/.dividedBy/.between/
+// .when/...), so a raw AST dump reads like the source formula.
+// Note: when.cond and not.a may be const-wrapped if given a bare int; the
 // evaluator treats any nonzero const as truthy.
 
 // Ops _wrap accepts as valid expression nodes. "metricSum" is builder-internal
@@ -67,10 +70,10 @@ units := import(":units")
 // never emits it directly.
 _KNOWN_OPS := sets.fromSlice([
 	"const", "metric", "metricSum",
-	"add", "sub", "mul", "div", "divCeil",
-	"max", "min", "clamp",
+	"plus", "minus", "times", "dividedBy", "dividedByFloor",
+	"atLeast", "atMost", "between",
 	"gt", "gte", "lt", "lte", "and", "or", "not",
-	"if"
+	"when"
 ])
 
 // Comparison/logic ops. Rejected at the top level of a resource formula
@@ -138,17 +141,17 @@ evaluate = func(node, resolver) {
 		return fn(node.files)
 	}
 
-	if op == "add" { return evaluate(node.a, resolver) + evaluate(node.b, resolver) }
-	if op == "sub" { return evaluate(node.a, resolver) - evaluate(node.b, resolver) }
-	if op == "mul" { return evaluate(node.a, resolver) * evaluate(node.b, resolver) }
-	if op == "div" {
+	if op == "plus"  { return evaluate(node.a, resolver) + evaluate(node.b, resolver) }
+	if op == "minus" { return evaluate(node.a, resolver) - evaluate(node.b, resolver) }
+	if op == "times" { return evaluate(node.a, resolver) * evaluate(node.b, resolver) }
+	if op == "dividedByFloor" {
 		b := evaluate(node.b, resolver)
 		ll.assert(b != 0, "exec.formula.evaluate: division by zero")
 		// integer (truncating) division; toward zero, which for the non-negative
 		// resource-metric domain (sizes, line counts) is floor.
 		return evaluate(node.a, resolver) / b
 	}
-	if op == "divCeil" {
+	if op == "dividedBy" {
 		b := evaluate(node.b, resolver)
 		ll.assert(b != 0, "exec.formula.evaluate: division by zero")
 		a := evaluate(node.a, resolver)
@@ -156,13 +159,13 @@ evaluate = func(node, resolver) {
 		return (a + b - 1) / b
 	}
 
-	if op == "max" { a := evaluate(node.a, resolver); b := evaluate(node.b, resolver); return a > b ? a : b }
-	if op == "min" { a := evaluate(node.a, resolver); b := evaluate(node.b, resolver); return a < b ? a : b }
-	if op == "clamp" {
+	if op == "atLeast" { a := evaluate(node.a, resolver); b := evaluate(node.b, resolver); return a > b ? a : b }
+	if op == "atMost"  { a := evaluate(node.a, resolver); b := evaluate(node.b, resolver); return a < b ? a : b }
+	if op == "between" {
 		v := evaluate(node.value, resolver)
 		lo := evaluate(node.lo, resolver)
 		hi := evaluate(node.hi, resolver)
-		ll.assert(lo <= hi, "exec.formula.clamp: lo (%v) must be <= hi (%v) — inverted bounds collapse every input to hi", lo, hi)
+		ll.assert(lo <= hi, "exec.formula.between: lo (%v) must be <= hi (%v) — inverted bounds collapse every input to hi", lo, hi)
 		if v < lo { v = lo }
 		if v > hi { v = hi }
 		return v
@@ -176,7 +179,7 @@ evaluate = func(node, resolver) {
 	if op == "or"  { return evaluate(node.a, resolver) || evaluate(node.b, resolver) }
 	if op == "not" { return !evaluate(node.a, resolver) }
 
-	if op == "if" { return evaluate(node.cond, resolver) ? evaluate(node.then, resolver) : evaluate(node["else"], resolver) }
+	if op == "when" { return evaluate(node.cond, resolver) ? evaluate(node.then, resolver) : evaluate(node["else"], resolver) }
 
 	ll.panic("exec.formula.evaluate: unknown op %q", op)
 }
@@ -270,7 +273,7 @@ referencedMetricFiles := func(resolvedNode) {
 				existing := is_undefined(acc[n.metric]) ? [] : acc[n.metric]
 				for fn in n.files { existing = append(existing, fn) }
 				// slices.unique dedups while preserving first-seen order (a file may be
-				// referenced by more than one metricSum node — e.g. an if cond and a
+				// referenced by more than one metricSum node — e.g. a when cond and a
 				// branch — but needs only one line-counter pre-exec).
 				acc[n.metric] = slices.unique(existing)
 			}
@@ -329,11 +332,11 @@ applyFormulaFallback := func(dims) {
 // _node wraps a plain AST in a chainable object. Every chain method returns a
 // NEW wrapper (immutable), carrying the accumulated { fallback } forward and
 // reading left-to-right — `f.size("x").times(12).plus(f.gib(8))` composes
-// mul(size, 12) then add(that, gib(8)). Arithmetic: .plus/.minus/.times ->
-// add/sub/mul; .dividedBy -> ceiling division, .dividedByFloor -> integer
-// (truncating) division. Bounds: .atLeast -> max, .atMost
-// -> min, .between(lo, hi) -> clamp. Comparisons (.gt/.gte/.lt/.lte) and logic
-// (.and/.or/.not) build boolean nodes for use inside a f.when(...) branch.
+// times(size, 12) then plus(that, gib(8)). Arithmetic: .plus/.minus/.times;
+// .dividedBy -> ceiling division, .dividedByFloor -> integer (truncating)
+// division. Bounds: .atLeast/.atMost/.between(lo, hi). Comparisons
+// (.gt/.gte/.lt/.lte) and logic (.and/.or/.not) build boolean nodes for use
+// inside a f.when(...) branch. Each method's op string equals its name.
 // .staticFallback pins the value used on backends that can't evaluate the formula.
 _node := undefined
 _node = func(ast, fallback) {
@@ -342,14 +345,14 @@ _node = func(ast, fallback) {
 		__ast__:       ast,
 		__fallback__:  fallback
 	}
-	self.plus      = func(x) { return _node(_bin("add", ast, x), fallback) }
-	self.minus     = func(x) { return _node(_bin("sub", ast, x), fallback) }
-	self.times     = func(x) { return _node(_bin("mul", ast, x), fallback) }
-	self.dividedBy      = func(x) { return _node(_bin("divCeil", ast, x), fallback) }
-	self.dividedByFloor = func(x) { return _node(_bin("div", ast, x), fallback) }
-	self.atLeast   = func(x) { return _node(_bin("max", ast, x), fallback) }
-	self.atMost    = func(x) { return _node(_bin("min", ast, x), fallback) }
-	self.between   = func(lo, hi) { return _node({ op: "clamp", value: _wrap(ast), lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
+	self.plus      = func(x) { return _node(_bin("plus", ast, x), fallback) }
+	self.minus     = func(x) { return _node(_bin("minus", ast, x), fallback) }
+	self.times     = func(x) { return _node(_bin("times", ast, x), fallback) }
+	self.dividedBy      = func(x) { return _node(_bin("dividedBy", ast, x), fallback) }
+	self.dividedByFloor = func(x) { return _node(_bin("dividedByFloor", ast, x), fallback) }
+	self.atLeast   = func(x) { return _node(_bin("atLeast", ast, x), fallback) }
+	self.atMost    = func(x) { return _node(_bin("atMost", ast, x), fallback) }
+	self.between   = func(lo, hi) { return _node({ op: "between", value: _wrap(ast), lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
 	self.gt        = func(x) { return _node(_bin("gt", ast, x), fallback) }
 	self.gte       = func(x) { return _node(_bin("gte", ast, x), fallback) }
 	self.lt        = func(x) { return _node(_bin("lt", ast, x), fallback) }
@@ -362,7 +365,7 @@ _node = func(ast, fallback) {
 }
 
 // _condBuilder accumulates when()-branches and folds them, right-to-left, into a
-// nested `if` AST on .otherwise(). It exposes ONLY .when / .otherwise — so a
+// nested `when` AST on .otherwise(). It exposes ONLY .when / .otherwise — so a
 // conditional must be finished with .otherwise (there is no way to leak a
 // dangling boolean into a quota).
 _condBuilder := undefined
@@ -381,7 +384,7 @@ _condBuilder = func(branches) {
 		i := len(branches) - 1
 		for i >= 0 {
 			b := branches[i]
-			node = { op: "if", cond: b.cond, then: b.value, "else": node }
+			node = { op: "when", cond: b.cond, then: b.value, "else": node }
 			i = i - 1
 		}
 		return _node(node, undefined)
@@ -413,7 +416,7 @@ export {
 
 	// when(cond, value): start a multi-branch conditional. Chain more .when(...)
 	// branches (evaluated in order), then finish with .otherwise(default). Compiles
-	// to a nested `if` — the first branch whose condition is truthy wins. Conditions
+	// to a nested `when` — the first branch whose condition is truthy wins. Conditions
 	// come from the comparison/logic chain, e.g. f.size("input").gt(f.gib(1)).
 	when: func(cond, value) { return _condBuilder([]).when(cond, value) },
 

--- a/sdk/workflow-tengo/src/exec/formula.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.lib.tengo
@@ -1,10 +1,12 @@
-// exec.formula — compute an exec's RAM/CPU from its input data instead of
+// exec.formula — compute an exec's RAM/CPU/GPU from its input data instead of
 // hardcoding it. A formula is a pure AST of plain maps (see "AST node shapes"
 // below) that flows through two phases across the exec boundary:
 //
-// BUILD TIME (in exec.builder().run(), before the exec exists):
+// WORKFLOW RENDER TIME (in exec.builder().run(), before the exec exists):
 //   1. The author composes a formula from the exported constructors
-//      (size/lineCount, gib/..., add/mul/clamp/if). Bare ints auto-wrap to const.
+//      (size/lineCount, gib/..., add/mul/clamp/if) OR the fluent chain
+//      (.per/.times/.plus/.between/... + .staticFallback). Both build the SAME
+//      AST — the chain is sugar. Bare ints auto-wrap to const.
 //   2. resolveAst() turns each { op: "metric", tag } into a concrete
 //      { op: "metricSum", files } via the builder's tag -> files map (an empty
 //      tag collapses to its { default }), and rejects lineCount on a non-text file.
@@ -23,7 +25,16 @@
 //      integer, and override the quota.
 //
 // FALLBACK: a backend that can't evaluate formulas uses a static value instead
-//   (applyFormulaFallback) — an explicit { fallback } or a static .mem()/.cpu().
+//   (applyFormulaFallback) — an explicit .staticFallback()/{ fallback } or a
+//   static request set on the same dimension.
+//
+// FLUENT WRAPPERS: every constructor returns a chainable wrapper — a map
+//   { __isFormula__: true, __ast__: <plain AST>, __fallback__: <static?> } that
+//   also carries the chain methods. The plain AST is never contaminated: _wrap
+//   (used by every constructor when composing children) unwraps a wrapper back to
+//   its __ast__, so the tree stored and serialized is always plain maps. The
+//   builder reads a value with astOf()/fallbackOf(); the evaluator entry points
+//   auto-unwrap, so passing a wrapper straight to resolveAst/evaluate/... works.
 //
 // Pure by design: this file walks data and knows nothing of the backend. That
 // resolver injection (step 4) keeps it import-free — and is why lineCount runs a
@@ -63,7 +74,15 @@ _KNOWN_OPS := sets.fromSlice([
 // (evaluateResource) — they are meaningful only inside f.if(...).
 _BOOL_OPS := sets.fromSlice(["gt", "gte", "lt", "lte", "and", "or", "not"])
 
+// _unwrap strips a fluent wrapper down to its plain AST; a plain AST or an int
+// passes through untouched. Applied at every evaluator entry point and by _wrap,
+// so the plain AST tree never contains a wrapper.
+_unwrap := func(x) {
+	return is_map(x) && !is_undefined(x.__isFormula__) ? x.__ast__ : x
+}
+
 _wrap := func(x) {
+	x = _unwrap(x)
 	if is_map(x) && !is_undefined(x.op) {
 		ll.assert(sets.hasElement(_KNOWN_OPS, x.op), "exec.formula: not a valid expression node (unknown op %v)", x.op)
 		return x
@@ -92,8 +111,22 @@ _metric := func(metricName, args) {
 	return node
 }
 
+// _staticValue extracts the constant behind a .staticFallback() argument: a bare
+// number/string passes through; a pure-const wrapper (e.g. f.gib(64)) yields its
+// integer byte value. Anything else is rejected — a fallback must be static.
+_staticValue := func(v) {
+	if is_map(v) && !is_undefined(v.__isFormula__) {
+		a := v.__ast__
+		ll.assert(is_map(a) && a.op == "const",
+			"exec.formula.staticFallback: expected a constant (a number, a size string, or a pure unit like f.gib(64)), got a formula")
+		return a.value
+	}
+	return v
+}
+
 evaluate := undefined
 evaluate = func(node, resolver) {
+	node = _unwrap(node)
 	op := node.op
 	if op == "const" { return node.value }
 	if op == "metricSum" {
@@ -143,27 +176,28 @@ evaluate = func(node, resolver) {
 	ll.panic("exec.formula.evaluate: unknown op %q", op)
 }
 
-// evaluateResource evaluates a formula destined for a resource quota (ram / cpu)
-// and asserts the result is usable: a positive integer. It first rejects a
+// evaluateResource evaluates a formula destined for a resource quota (ram / cpu /
+// gpu) and asserts the result is usable: a positive integer. It first rejects a
 // comparison/logic op at the top level — Tengo's && / || return the deciding
 // OPERAND (an int), so a top-level f.and/f.or of ints would otherwise pass the
 // is_int check; comparisons and logic belong only inside f.if(...). The
 // positive-int check then catches a non-positive result (an f.sub that
 // underflows, or a metric that floored to 0) BEFORE it reaches the quota as an
-// opaque "trueb" RAM string or a 0-core request. `label` ("ram" / "cpu") names
-// the offending dimension.
+// opaque "trueb" RAM string or a 0-core request. `label` ("ram" / "cpu" /
+// "gpuMemory") names the offending dimension.
 evaluateResource := func(node, resolver, label) {
+	node = _unwrap(node)
 	ll.assert(!sets.hasElement(_BOOL_OPS, node.op),
 		"exec resource formula (%s) must compute a number, but its top-level op is %q (a comparison/logic op). Use comparisons and logic only inside f.if(...).",
 		label, node.op)
 	v := evaluate(node, resolver)
 	ll.assert(is_int(v) && v > 0,
-		"exec resource formula (%s) must evaluate to a positive integer, got %v. If a metric can be zero or a subtraction can underflow, floor it with f.max(...) or f.clamp(...).",
+		"exec resource formula (%s) must evaluate to a positive integer, got %v. If a metric can be zero or a subtraction can underflow, floor it with f.max(...) or f.between(...).",
 		label, v)
 	return v
 }
 
-// ---- builder-time resolution helpers ---------------------------------------
+// ---- workflow-render-time resolution helpers -------------------------------
 
 // Line-oriented text extensions f.lineCount() supports, and the compression
 // suffixes it may carry. The line-counter binary infers the codec from the
@@ -192,6 +226,7 @@ _assertMetricCompatible := func(metric, fileName) {
 
 resolveAst := undefined
 resolveAst = func(node, tagMap, allFiles) {
+	node = _unwrap(node)
 	op := node.op
 	if op == "metric" {
 		files := is_undefined(node.tag) ? allFiles : (is_undefined(tagMap[node.tag]) ? [] : tagMap[node.tag])
@@ -221,6 +256,7 @@ resolveAst = func(node, tagMap, allFiles) {
 }
 
 referencedMetricFiles := func(resolvedNode) {
+	resolvedNode = _unwrap(resolvedNode)
 	acc := {}
 	walk := undefined
 	walk = func(n) {
@@ -243,36 +279,73 @@ referencedMetricFiles := func(resolvedNode) {
 	return acc
 }
 
-// applyFormulaFallback resolves the static ram/cpu to use when the backend
+// applyFormulaFallback resolves the static ram/cpu/gpu to use when the backend
 // cannot evaluate resource formulas at run time (no getBlobSize). `dims` is keyed
-// by dimension — { ram: { ast, fallback, static }, cpu: { ast, fallback, static } }
-// — where `ast` is the formula (if any), `static` the .mem()/.cpu() request (if
-// any), and `fallback` the { fallback } given on the formula. A formula dimension
-// needs SOME static value: a static request always wins (the formula won't run on
-// this backend) and doubles as the fallback, so `fallback` fills in only when no
-// static request was set; the sole error is a formula dimension with NEITHER.
-// Returns { ram, cpu, err } — err a message string or undefined; the caller asserts
-// err is undefined, then applies ram/cpu. (Field is `err`, not `error`: `error` is
-// a reserved word in Tengo.) The ram/cpu values are validated by the builder before
-// they reach here; this only picks among them.
+// by dimension — { ram: { ast, fallback, static }, cpu: {...}, gpu?: {...} } —
+// where `ast` is the formula (if any), `static` the static request (if any), and
+// `fallback` the .staticFallback()/{ fallback } given on the formula. A formula
+// dimension needs SOME static value: a static request always wins (the formula
+// won't run on this backend) and doubles as the fallback, so `fallback` fills in
+// only when no static request was set; the sole error is a formula dimension with
+// NEITHER. Returns { ram, cpu, gpu, err } — err a message string or undefined;
+// the caller asserts err is undefined, then applies ram/cpu/gpu. (Field is `err`,
+// not `error`: `error` is a reserved word in Tengo.) The values are validated by
+// the builder before they reach here; this only picks among them. The gpu
+// dimension is optional in `dims` (omitted when no GPU is in play); res.gpu is
+// then undefined and the caller leaves the quota's gpuMemory unset.
 applyFormulaFallback := func(dims) {
-	res := { ram: dims.ram.static, cpu: dims.cpu.static, err: undefined }
-	if !is_undefined(dims.ram.ast) && is_undefined(res.ram) {
+	gpu := is_undefined(dims.gpu) ? {} : dims.gpu
+	res := { ram: dims.ram.static, cpu: dims.cpu.static, gpu: gpu.static, err: undefined }
+	if !is_undefined(_unwrap(dims.ram.ast)) && is_undefined(res.ram) {
 		if is_undefined(dims.ram.fallback) {
-			res.err = "exec.builder: memFormula needs a static fallback on backends that can't evaluate resource formulas at run time. Provide { fallback: ... } on memFormula, set a static .mem(), or upgrade the backend."
+			res.err = "exec.builder: the RAM formula needs a static fallback on backends that can't evaluate resource formulas at run time. Provide .staticFallback(...) on the RAM formula, set a static ram, or upgrade the backend."
 			return res
 		}
 		res.ram = dims.ram.fallback
 	}
-	if !is_undefined(dims.cpu.ast) && is_undefined(res.cpu) {
+	if !is_undefined(_unwrap(dims.cpu.ast)) && is_undefined(res.cpu) {
 		if is_undefined(dims.cpu.fallback) {
-			res.err = "exec.builder: cpuFormula needs a static fallback on backends that can't evaluate resource formulas at run time. Provide { fallback: ... } on cpuFormula, set a static .cpu(), or upgrade the backend."
+			res.err = "exec.builder: the CPU formula needs a static fallback on backends that can't evaluate resource formulas at run time. Provide .staticFallback(...) on the CPU formula, set a static cpu, or upgrade the backend."
 			return res
 		}
 		res.cpu = dims.cpu.fallback
 	}
+	if !is_undefined(_unwrap(gpu.ast)) && is_undefined(res.gpu) {
+		if is_undefined(gpu.fallback) {
+			res.err = "exec.builder: the VRAM formula needs a static fallback on backends that can't evaluate resource formulas at run time. Provide .staticFallback(...) on the vram formula, set a static vram, or upgrade the backend."
+			return res
+		}
+		res.gpu = gpu.fallback
+	}
 	return res
 }
+
+// ---- fluent wrapper factory ------------------------------------------------
+// _node wraps a plain AST in a chainable object. Every chain method returns a
+// NEW wrapper (immutable), carrying the accumulated { fallback } forward. The
+// arithmetic aliases read left-to-right — `f.size("x").times(12).plus(f.gib(8))`
+// composes mul(size, 12) then add(that, gib(8)). Bounds: .atLeast -> max,
+// .atMost -> min, .between(lo, hi) -> clamp. .staticFallback pins the value used
+// on backends that can't evaluate the formula.
+_node := undefined
+_node = func(ast, fallback) {
+	self := {
+		__isFormula__: true,
+		__ast__:       ast,
+		__fallback__:  fallback
+	}
+	self.per     = func(x) { return _node(_bin("divCeil", ast, x), fallback) }
+	self.times   = func(x) { return _node(_bin("mul", ast, x), fallback) }
+	self.plus    = func(x) { return _node(_bin("add", ast, x), fallback) }
+	self.minus   = func(x) { return _node(_bin("sub", ast, x), fallback) }
+	self.atLeast = func(x) { return _node(_bin("max", ast, x), fallback) }
+	self.atMost  = func(x) { return _node(_bin("min", ast, x), fallback) }
+	self.between = func(lo, hi) { return _node({ op: "clamp", value: ast, lo: _wrap(lo), hi: _wrap(hi) }, fallback) }
+	self.staticFallback = func(v) { return _node(ast, _staticValue(v)) }
+	return self
+}
+
+_const := func(n) { ll.assert(is_int(n), "exec.formula: unit amount must be an integer"); return _node({ op: "const", value: n }, undefined) }
 
 export {
 	// size: total bytes of the referenced input files (blob size; no pre-exec).
@@ -280,38 +353,51 @@ export {
 	//   with N newlines reports N, so a final line without a trailing newline is
 	//   NOT counted. Requires a pre-exec line-counter pass, so it is supported
 	//   only for line-oriented text formats (see _LINECOUNT_OK above).
-	size:      func(...args) { return _metric("size", args) },
-	lineCount: func(...args) { return _metric("lineCount", args) },
+	size:      func(...args) { return _node(_metric("size", args), undefined) },
+	lineCount: func(...args) { return _node(_metric("lineCount", args), undefined) },
 
-	gib: func(n) { ll.assert(is_int(n), "exec.formula.gib: n must be an integer"); return { op: "const", value: n * units.GiB } },
-	mib: func(n) { ll.assert(is_int(n), "exec.formula.mib: n must be an integer"); return { op: "const", value: n * units.MiB } },
-	kib: func(n) { ll.assert(is_int(n), "exec.formula.kib: n must be an integer"); return { op: "const", value: n * units.KiB } },
-	gb:  func(n) { ll.assert(is_int(n), "exec.formula.gb: n must be an integer");  return { op: "const", value: n * units.GB } },
-	mb:  func(n) { ll.assert(is_int(n), "exec.formula.mb: n must be an integer");  return { op: "const", value: n * units.MB } },
-	kb:  func(n) { ll.assert(is_int(n), "exec.formula.kb: n must be an integer");  return { op: "const", value: n * units.KB } },
+	gib: func(n) { return _const(n * units.GiB) },
+	mib: func(n) { return _const(n * units.MiB) },
+	kib: func(n) { return _const(n * units.KiB) },
+	gb:  func(n) { return _const(n * units.GB) },
+	mb:  func(n) { return _const(n * units.MB) },
+	kb:  func(n) { return _const(n * units.KB) },
 
-	add:     func(a, b) { return _bin("add", a, b) },
-	sub:     func(a, b) { return _bin("sub", a, b) },
-	mul:     func(a, b) { return _bin("mul", a, b) },
-	div:     func(a, b) { return _bin("div", a, b) },
+	// const: a bare integer as a formula leaf (bytes / cores). Handy when a
+	// dimension is a plain number you still want to chain off of.
+	"const": func(n) { return _const(n) },
+
+	add:     func(a, b) { return _node(_bin("add", a, b), undefined) },
+	sub:     func(a, b) { return _node(_bin("sub", a, b), undefined) },
+	mul:     func(a, b) { return _node(_bin("mul", a, b), undefined) },
+	div:     func(a, b) { return _node(_bin("div", a, b), undefined) },
 	// divCeil(a, b): ceiling of a/b. Assumes a >= 0 and b > 0 — the resource-metric
 	// domain (sizes, line counts, positive constants). A negative a (e.g. an
 	// underflowing f.sub) can be off by one; floor such inputs with f.max first.
-	divCeil: func(a, b) { return _bin("divCeil", a, b) },
+	divCeil: func(a, b) { return _node(_bin("divCeil", a, b), undefined) },
 
-	max:   func(a, b) { return _bin("max", a, b) },
-	min:   func(a, b) { return _bin("min", a, b) },
-	clamp: func(value, lo, hi) { return { op: "clamp", value: _wrap(value), lo: _wrap(lo), hi: _wrap(hi) } },
+	max:   func(a, b) { return _node(_bin("max", a, b), undefined) },
+	min:   func(a, b) { return _node(_bin("min", a, b), undefined) },
+	clamp: func(value, lo, hi) { return _node({ op: "clamp", value: _wrap(value), lo: _wrap(lo), hi: _wrap(hi) }, undefined) },
 
-	gt:  func(a, b) { return _bin("gt", a, b) },
-	gte: func(a, b) { return _bin("gte", a, b) },
-	lt:  func(a, b) { return _bin("lt", a, b) },
-	lte: func(a, b) { return _bin("lte", a, b) },
-	and: func(a, b) { return _bin("and", a, b) },
-	or:  func(a, b) { return _bin("or", a, b) },
-	not: func(a) { return { op: "not", a: _wrap(a) } },
+	gt:  func(a, b) { return _node(_bin("gt", a, b), undefined) },
+	gte: func(a, b) { return _node(_bin("gte", a, b), undefined) },
+	lt:  func(a, b) { return _node(_bin("lt", a, b), undefined) },
+	lte: func(a, b) { return _node(_bin("lte", a, b), undefined) },
+	and: func(a, b) { return _node(_bin("and", a, b), undefined) },
+	or:  func(a, b) { return _node(_bin("or", a, b), undefined) },
+	not: func(a) { return _node({ op: "not", a: _wrap(a) }, undefined) },
 
-	"if": func(cond, then, els) { return { op: "if", cond: _wrap(cond), then: _wrap(then), "else": _wrap(els) } },
+	"if": func(cond, then, els) { return _node({ op: "if", cond: _wrap(cond), then: _wrap(then), "else": _wrap(els) }, undefined) },
+
+	// ---- wrapper introspection (used by the exec builder) ------------------
+	// astOf: the plain AST behind a value (a wrapper -> its __ast__; a plain AST
+	//   or int -> itself). fallbackOf: the .staticFallback() carried on a wrapper
+	//   (else undefined). isFormula: true for a wrapper or a plain AST node, false
+	//   for a bare number/string (i.e. a static request).
+	astOf:      func(x) { return _unwrap(x) },
+	fallbackOf: func(x) { return is_map(x) && !is_undefined(x.__isFormula__) ? x.__fallback__ : undefined },
+	isFormula:  func(x) { return is_map(x) && (!is_undefined(x.__isFormula__) || !is_undefined(x.op)) },
 
 	evaluateResource:      evaluateResource,
 	resolveAst:            resolveAst,

--- a/sdk/workflow-tengo/src/exec/formula.test.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.test.tengo
@@ -7,16 +7,16 @@ text := import("text")
 // wrapper to the plain AST these structural assertions compare against.
 
 TestFluentArithmetic := func() {
-	test.isEqual({ op: "add", a: { op: "const", value: 2 }, b: { op: "const", value: 3 } }, f.astOf(f.const(2).plus(3)))
-	test.isEqual({ op: "sub", a: { op: "const", value: 7 }, b: { op: "const", value: 2 } }, f.astOf(f.const(7).minus(2)))
-	test.isEqual({ op: "mul", a: { op: "const", value: 4 }, b: { op: "const", value: 5 } }, f.astOf(f.const(4).times(5)))
-	test.isEqual("divCeil", f.astOf(f.const(10).dividedBy(3)).op)
+	test.isEqual({ op: "plus", a: { op: "const", value: 2 }, b: { op: "const", value: 3 } }, f.astOf(f.const(2).plus(3)))
+	test.isEqual({ op: "minus", a: { op: "const", value: 7 }, b: { op: "const", value: 2 } }, f.astOf(f.const(7).minus(2)))
+	test.isEqual({ op: "times", a: { op: "const", value: 4 }, b: { op: "const", value: 5 } }, f.astOf(f.const(4).times(5)))
+	test.isEqual("dividedBy", f.astOf(f.const(10).dividedBy(3)).op)
 }
 
 TestFluentBounds := func() {
-	test.isEqual({ op: "clamp", value: { op: "const", value: 1 }, lo: { op: "const", value: 2 }, hi: { op: "const", value: 3 } }, f.astOf(f.const(1).between(2, 3)))
-	test.isEqual("max", f.astOf(f.const(1).atLeast(2)).op)
-	test.isEqual("min", f.astOf(f.const(9).atMost(4)).op)
+	test.isEqual({ op: "between", value: { op: "const", value: 1 }, lo: { op: "const", value: 2 }, hi: { op: "const", value: 3 } }, f.astOf(f.const(1).between(2, 3)))
+	test.isEqual("atLeast", f.astOf(f.const(1).atLeast(2)).op)
+	test.isEqual("atMost", f.astOf(f.const(9).atMost(4)).op)
 }
 
 TestFluentComparisonsAndLogic := func() {
@@ -38,8 +38,8 @@ TestFluentComparisonsAndLogic := func() {
 TestFluentChainComposesLeftToRight := func() {
 	// size/4GiB (ceil) bounded to [4,16] — the canonical CPU-cores shape.
 	node := f.astOf(f.size("reads").dividedBy(f.gib(4)).between(4, 16))
-	test.isEqual("clamp", node.op)
-	test.isEqual("divCeil", node.value.op)
+	test.isEqual("between", node.op)
+	test.isEqual("dividedBy", node.value.op)
 	test.isEqual("metric", node.value.a.op)             // size("reads")
 	test.isEqual(4 * 1073741824, node.value.b.value)    // 4 GiB divisor
 	test.isEqual({ op: "const", value: 4 }, node.lo)
@@ -64,7 +64,7 @@ TestFluentMetricNodes := func() {
 
 TestWhenSingleBranch := func() {
 	node := f.astOf(f.when(f.const(5).gt(2), 1).otherwise(0))
-	test.isEqual("if", node.op)
+	test.isEqual("when", node.op)
 	test.isEqual("gt", node.cond.op)
 	test.isEqual({ op: "const", value: 1 }, node.then)
 	test.isEqual({ op: "const", value: 0 }, node["else"])
@@ -76,9 +76,9 @@ TestWhenMultiBranchNestsInOrder := func() {
 	node := f.astOf(f.when(f.size("reads").gt(f.gib(10)), f.gib(64)).
 		when(f.size("reads").gt(f.gib(1)), f.gib(32)).
 		otherwise(f.gib(16)))
-	test.isEqual("if", node.op)
+	test.isEqual("when", node.op)
 	test.isEqual(64 * 1073741824, node.then.value)      // first branch value
-	test.isEqual("if", node["else"].op)                 // nested second branch
+	test.isEqual("when", node["else"].op)                 // nested second branch
 	test.isEqual(32 * 1073741824, node["else"].then.value)
 	test.isEqual(16 * 1073741824, node["else"]["else"].value) // default
 }
@@ -139,7 +139,7 @@ TestEvaluateDividedByExactAndInexact := func() {
 
 TestFluentDividedByFloorTruncates := func() {
 	// .dividedByFloor -> truncating integer division (contrast .dividedBy = ceiling).
-	test.isEqual("div", f.astOf(f.const(10).dividedByFloor(3)).op)
+	test.isEqual("dividedByFloor", f.astOf(f.const(10).dividedByFloor(3)).op)
 	test.isEqual(3, f._internal.evaluate(f.const(10).dividedByFloor(3), _fakeResolver))  // 10/3 -> 3
 	test.isEqual(4, f._internal.evaluate(f.const(10).dividedBy(3), _fakeResolver))       // 10/3 -> 4
 	test.isEqual(0, f._internal.evaluate(f.const(2).dividedByFloor(3), _fakeResolver))   // 2/3 -> 0
@@ -211,7 +211,7 @@ TestResolveRecursesInPlace := func() {
 	allFiles := ["r1.fastq", "r2.fastq"]
 	// size("reads")*4 + lineCount("reads")
 	resolved := f.resolveAst(f.size("reads").times(4).plus(f.lineCount("reads")), tagMap, allFiles)
-	test.isEqual("add", resolved.op)
+	test.isEqual("plus", resolved.op)
 	test.isEqual("metricSum", resolved.a.a.op)   // size("reads") inside mul
 	test.isEqual("size", resolved.a.a.metric)
 	test.isEqual({ op: "const", value: 4 }, resolved.a.b)
@@ -225,7 +225,7 @@ TestResolveRecursesIntoBetweenAndWhen := func() {
 
 	// .between -> clamp: metric resolves in `value`, bounds preserved.
 	resolvedClamp := f.resolveAst(f.size("reads").between(f.gib(1), f.gib(4)), tagMap, allFiles)
-	test.isEqual("clamp", resolvedClamp.op)
+	test.isEqual("between", resolvedClamp.op)
 	test.isEqual("metricSum", resolvedClamp.value.op)
 	test.isEqual(["r1.fastq", "r2.fastq"], resolvedClamp.value.files)
 	test.isEqual(1073741824, resolvedClamp.lo.value)
@@ -234,7 +234,7 @@ TestResolveRecursesIntoBetweenAndWhen := func() {
 	// f.when(...).otherwise(...) -> if: metric inside the condition resolves.
 	resolvedIf := f.resolveAst(
 		f.when(f.lineCount("reads").gt(100), f.gib(16)).otherwise(f.gib(8)), tagMap, allFiles)
-	test.isEqual("if", resolvedIf.op)
+	test.isEqual("when", resolvedIf.op)
 	test.isEqual("metricSum", resolvedIf.cond.a.op)
 	test.isEqual("lineCount", resolvedIf.cond.a.metric)
 	test.isEqual(16 * 1073741824, resolvedIf.then.value)
@@ -298,7 +298,7 @@ TestResolveLineCountBz2AndZstAccepted := func() {
 TestStaticFallbackCaptured := func() {
 	node := f.size("a").times(2).staticFallback(f.gib(64))
 	test.isEqual(64 * 1073741824, f.fallbackOf(node))
-	test.isEqual("mul", f.astOf(node).op)                // fallback does not alter the AST
+	test.isEqual("times", f.astOf(node).op)                // fallback does not alter the AST
 	test.isTrue(is_undefined(f.fallbackOf(f.size("a")))) // none set -> undefined
 	test.isEqual(8, f.fallbackOf(f.size("a").dividedBy(4).staticFallback(8)))
 	test.isEqual("16GiB", f.fallbackOf(f.size("a").dividedBy(4).staticFallback("16GiB")))

--- a/sdk/workflow-tengo/src/exec/formula.test.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.test.tengo
@@ -2,34 +2,36 @@ test := import(":test")
 f := import(":exec.formula")
 text := import("text")
 
+// Constructors return a chainable wrapper; f.astOf(...) unwraps it to the plain
+// AST these assertions compare against.
 TestFormulaConstructors := func() {
-	test.isEqual({ op: "add", a: { op: "const", value: 2 }, b: { op: "const", value: 3 } }, f.add(2, 3))
-	test.isEqual({ op: "clamp", value: { op: "const", value: 1 }, lo: { op: "const", value: 2 }, hi: { op: "const", value: 3 } }, f.clamp(1, 2, 3))
-	test.isEqual("divCeil", f.divCeil(10, 3).op)
+	test.isEqual({ op: "add", a: { op: "const", value: 2 }, b: { op: "const", value: 3 } }, f.astOf(f.add(2, 3)))
+	test.isEqual({ op: "clamp", value: { op: "const", value: 1 }, lo: { op: "const", value: 2 }, hi: { op: "const", value: 3 } }, f.astOf(f.clamp(1, 2, 3)))
+	test.isEqual("divCeil", f.astOf(f.divCeil(10, 3)).op)
 }
 
 TestFormulaAutoWrap := func() {
-	node := f.mul(f.size("reads"), 4)
+	node := f.astOf(f.mul(f.size("reads"), 4))
 	test.isEqual("mul", node.op)
 	test.isEqual("metric", node.a.op)
 	test.isEqual({ op: "const", value: 4 }, node.b)
 }
 
 TestFormulaUnits := func() {
-	test.isEqual({ op: "const", value: 16 * 1073741824 }, f.gib(16))
-	test.isEqual({ op: "const", value: 256 * 1048576 }, f.mib(256))
-	test.isEqual({ op: "const", value: 2 * 1000000000 }, f.gb(2))
+	test.isEqual({ op: "const", value: 16 * 1073741824 }, f.astOf(f.gib(16)))
+	test.isEqual({ op: "const", value: 256 * 1048576 }, f.astOf(f.mib(256)))
+	test.isEqual({ op: "const", value: 2 * 1000000000 }, f.astOf(f.gb(2)))
 }
 
 TestFormulaMetricNodes := func() {
-	test.isEqual({ op: "metric", metric: "size" }, f.size())
-	test.isEqual({ op: "metric", metric: "size", tag: "reads" }, f.size("reads"))
-	test.isEqual({ op: "metric", metric: "size", tag: "ref", default: 0 }, f.size("ref", { default: 0 }))
-	test.isEqual("lineCount", f.lineCount("reads").metric)
+	test.isEqual({ op: "metric", metric: "size" }, f.astOf(f.size()))
+	test.isEqual({ op: "metric", metric: "size", tag: "reads" }, f.astOf(f.size("reads")))
+	test.isEqual({ op: "metric", metric: "size", tag: "ref", default: 0 }, f.astOf(f.size("ref", { default: 0 })))
+	test.isEqual("lineCount", f.astOf(f.lineCount("reads")).metric)
 }
 
 TestFormulaConditional := func() {
-	node := f["if"](f.gt(f.size(), 100), f.gib(16), f.gib(8))
+	node := f.astOf(f["if"](f.gt(f.size(), 100), f.gib(16), f.gib(8)))
 	test.isEqual("if", node.op)
 	test.isEqual("gt", node.cond.op)
 	test.isEqual(16 * 1073741824, node.then.value)
@@ -37,7 +39,7 @@ TestFormulaConditional := func() {
 }
 
 TestFormulaLogic := func() {
-	node := f.not(f.lt(1, 2))
+	node := f.astOf(f.not(f.lt(1, 2)))
 	test.isEqual("not", node.op)
 	test.isEqual("lt", node.a.op)
 }
@@ -252,16 +254,16 @@ TestFallbackStaticRequestWins := func() {
 }
 
 TestFallbackMissingMemFallbackErrors := func() {
-	// memFormula present, no fallback, backend can't evaluate => error naming mem.
+	// RAM formula present, no fallback, backend can't evaluate => error naming RAM.
 	res := f.applyFormulaFallback({ ram: { ast: f.size() }, cpu: {} })
-	test.isTrue(!is_undefined(res.err), "missing memFormula fallback must error")
-	test.isTrue(text.contains(res.err, "memFormula"))
+	test.isTrue(!is_undefined(res.err), "missing RAM formula fallback must error")
+	test.isTrue(text.contains(res.err, "RAM formula"))
 }
 
 TestFallbackMissingCpuFallbackErrors := func() {
 	res := f.applyFormulaFallback({ ram: {}, cpu: { ast: f.size() } })
-	test.isTrue(!is_undefined(res.err), "missing cpuFormula fallback must error")
-	test.isTrue(text.contains(res.err, "cpuFormula"))
+	test.isTrue(!is_undefined(res.err), "missing CPU formula fallback must error")
+	test.isTrue(text.contains(res.err, "CPU formula"))
 }
 
 TestFallbackNoFormulasIsPassthrough := func() {
@@ -355,4 +357,77 @@ TestResolveLineCountBz2Accepted := func() {
 	// The builder must strip .bz2 and accept the line-oriented base extension.
 	resolved := f.resolveAst(f.lineCount("reads"), { "reads": ["r1.fastq.bz2"] }, ["r1.fastq.bz2"])
 	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["r1.fastq.bz2"] }, resolved)
+}
+
+// ---- fluent chain + wrapper introspection ----------------------------------
+// The chain methods are sugar: they must build the SAME AST as the equivalent
+// prefix constructors, so the evaluator/resolver code paths stay identical.
+
+TestFluentChainMatchesPrefixAst := func() {
+	// cpu: divCeil(size, gib(4)) clamped to [4, 16]
+	chain  := f.size("input").per(f.gib(4)).between(4, 16)
+	prefix := f.clamp(f.divCeil(f.size("input"), f.gib(4)), 4, 16)
+	test.isEqual(f.astOf(prefix), f.astOf(chain))
+
+	// ram: size*12 + gib(8), floored at gib(16)
+	chain2  := f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16))
+	prefix2 := f.max(f.add(f.mul(f.size("input"), 12), f.gib(8)), f.gib(16))
+	test.isEqual(f.astOf(prefix2), f.astOf(chain2))
+
+	// .minus / .atMost complete the alias set (sub / min)
+	chain3  := f.size("input").minus(f.gib(1)).atMost(f.gib(8))
+	prefix3 := f.min(f.sub(f.size("input"), f.gib(1)), f.gib(8))
+	test.isEqual(f.astOf(prefix3), f.astOf(chain3))
+}
+
+TestFluentChainEvaluates := func() {
+	// The chain AST resolves + evaluates through the normal resolver: size("a")=100.
+	// divCeil(100, 40)=3 -> clamp to [4, 16] -> 4. resolveAst first, exactly as the
+	// builder does (metric -> metricSum) before the evaluator runs.
+	resolved := f.resolveAst(f.size("a").per(40).between(4, 16), { "a": ["a"] }, ["a"])
+	test.isEqual(4, f.evaluateResource(resolved, _fakeResolver, "cpu"))
+}
+
+TestStaticFallbackCaptured := func() {
+	// .staticFallback pins the value; fallbackOf reads it, astOf ignores it.
+	// A pure-unit wrapper (f.gib) is accepted and yields its byte value.
+	node := f.size("a").times(2).staticFallback(f.gib(64))
+	test.isEqual(64 * 1073741824, f.fallbackOf(node))
+	test.isEqual("mul", f.astOf(node).op)               // fallback does not alter the AST
+	test.isTrue(is_undefined(f.fallbackOf(f.size("a")))) // no fallback set -> undefined
+
+	// a bare number / string passes through unchanged
+	test.isEqual(8, f.fallbackOf(f.size("a").per(4).staticFallback(8)))
+	test.isEqual("16GiB", f.fallbackOf(f.size("a").per(4).staticFallback("16GiB")))
+}
+
+TestIsFormulaDiscriminatesStaticFromFormula := func() {
+	// isFormula distinguishes a data-driven value (wrapper or plain AST) from a
+	// static request (bare number / string). This is exactly how .resources()
+	// decides whether a dimension is a formula or a static request.
+	test.isTrue(f.isFormula(f.size("input")))               // wrapper
+	test.isTrue(f.isFormula(f.size("input").per(f.gib(4)))) // chained wrapper
+	test.isTrue(f.isFormula({ op: "const", value: 4 }))     // plain AST node
+	test.isFalse(f.isFormula(4))                            // static cores
+	test.isFalse(f.isFormula("16GiB"))                      // static size string
+}
+
+TestFallbackGpuDimension := func() {
+	// applyFormulaFallback now handles an optional gpu dimension symmetrically to
+	// ram/cpu: static wins, else the fallback, else an error naming VRAM.
+	ok := f.applyFormulaFallback({
+		ram: { ast: f.size(), fallback: "16GiB" },
+		cpu: { static: 4 },
+		gpu: { ast: f.size(), fallback: "48GiB" }
+	})
+	test.isEqual("48GiB", ok.gpu)
+	test.isTrue(is_undefined(ok.err))
+
+	missing := f.applyFormulaFallback({
+		ram: { static: "16GiB" },
+		cpu: { static: 4 },
+		gpu: { ast: f.size() }
+	})
+	test.isTrue(!is_undefined(missing.err), "missing VRAM fallback must error")
+	test.isTrue(text.contains(missing.err, "VRAM"))
 }

--- a/sdk/workflow-tengo/src/exec/formula.test.tengo
+++ b/sdk/workflow-tengo/src/exec/formula.test.tengo
@@ -2,46 +2,85 @@ test := import(":test")
 f := import(":exec.formula")
 text := import("text")
 
-// Constructors return a chainable wrapper; f.astOf(...) unwraps it to the plain
-// AST these assertions compare against.
-TestFormulaConstructors := func() {
-	test.isEqual({ op: "add", a: { op: "const", value: 2 }, b: { op: "const", value: 3 } }, f.astOf(f.add(2, 3)))
-	test.isEqual({ op: "clamp", value: { op: "const", value: 1 }, lo: { op: "const", value: 2 }, hi: { op: "const", value: 3 } }, f.astOf(f.clamp(1, 2, 3)))
-	test.isEqual("divCeil", f.astOf(f.divCeil(10, 3)).op)
+// The DSL is fluent-only: every formula is built by chaining off a leaf
+// constructor (size/lineCount, gib/..., const). f.astOf(...) unwraps a chain
+// wrapper to the plain AST these structural assertions compare against.
+
+TestFluentArithmetic := func() {
+	test.isEqual({ op: "add", a: { op: "const", value: 2 }, b: { op: "const", value: 3 } }, f.astOf(f.const(2).plus(3)))
+	test.isEqual({ op: "sub", a: { op: "const", value: 7 }, b: { op: "const", value: 2 } }, f.astOf(f.const(7).minus(2)))
+	test.isEqual({ op: "mul", a: { op: "const", value: 4 }, b: { op: "const", value: 5 } }, f.astOf(f.const(4).times(5)))
+	test.isEqual("divCeil", f.astOf(f.const(10).dividedBy(3)).op)
 }
 
-TestFormulaAutoWrap := func() {
-	node := f.astOf(f.mul(f.size("reads"), 4))
-	test.isEqual("mul", node.op)
-	test.isEqual("metric", node.a.op)
-	test.isEqual({ op: "const", value: 4 }, node.b)
+TestFluentBounds := func() {
+	test.isEqual({ op: "clamp", value: { op: "const", value: 1 }, lo: { op: "const", value: 2 }, hi: { op: "const", value: 3 } }, f.astOf(f.const(1).between(2, 3)))
+	test.isEqual("max", f.astOf(f.const(1).atLeast(2)).op)
+	test.isEqual("min", f.astOf(f.const(9).atMost(4)).op)
 }
 
-TestFormulaUnits := func() {
+TestFluentComparisonsAndLogic := func() {
+	test.isEqual("gt",  f.astOf(f.const(5).gt(2)).op)
+	test.isEqual("gte", f.astOf(f.const(5).gte(5)).op)
+	test.isEqual("lt",  f.astOf(f.const(1).lt(2)).op)
+	test.isEqual("lte", f.astOf(f.const(2).lte(2)).op)
+
+	andNode := f.astOf(f.const(5).gte(5).and(f.const(2).lte(9)))
+	test.isEqual("and", andNode.op)
+	test.isEqual("gte", andNode.a.op)
+	test.isEqual("lte", andNode.b.op)
+
+	notNode := f.astOf(f.const(1).lt(2).not())
+	test.isEqual("not", notNode.op)
+	test.isEqual("lt", notNode.a.op)
+}
+
+TestFluentChainComposesLeftToRight := func() {
+	// size/4GiB (ceil) bounded to [4,16] — the canonical CPU-cores shape.
+	node := f.astOf(f.size("reads").dividedBy(f.gib(4)).between(4, 16))
+	test.isEqual("clamp", node.op)
+	test.isEqual("divCeil", node.value.op)
+	test.isEqual("metric", node.value.a.op)             // size("reads")
+	test.isEqual(4 * 1073741824, node.value.b.value)    // 4 GiB divisor
+	test.isEqual({ op: "const", value: 4 }, node.lo)
+	test.isEqual({ op: "const", value: 16 }, node.hi)
+}
+
+TestFluentUnits := func() {
 	test.isEqual({ op: "const", value: 16 * 1073741824 }, f.astOf(f.gib(16)))
 	test.isEqual({ op: "const", value: 256 * 1048576 }, f.astOf(f.mib(256)))
 	test.isEqual({ op: "const", value: 2 * 1000000000 }, f.astOf(f.gb(2)))
+	test.isEqual({ op: "const", value: 7 }, f.astOf(f.const(7)))
 }
 
-TestFormulaMetricNodes := func() {
+TestFluentMetricNodes := func() {
 	test.isEqual({ op: "metric", metric: "size" }, f.astOf(f.size()))
 	test.isEqual({ op: "metric", metric: "size", tag: "reads" }, f.astOf(f.size("reads")))
 	test.isEqual({ op: "metric", metric: "size", tag: "ref", default: 0 }, f.astOf(f.size("ref", { default: 0 })))
 	test.isEqual("lineCount", f.astOf(f.lineCount("reads")).metric)
 }
 
-TestFormulaConditional := func() {
-	node := f.astOf(f["if"](f.gt(f.size(), 100), f.gib(16), f.gib(8)))
+// ---- conditional builder: f.when(...).when(...).otherwise(...) --------------
+
+TestWhenSingleBranch := func() {
+	node := f.astOf(f.when(f.const(5).gt(2), 1).otherwise(0))
 	test.isEqual("if", node.op)
 	test.isEqual("gt", node.cond.op)
-	test.isEqual(16 * 1073741824, node.then.value)
-	test.isEqual(8 * 1073741824, node["else"].value)
+	test.isEqual({ op: "const", value: 1 }, node.then)
+	test.isEqual({ op: "const", value: 0 }, node["else"])
 }
 
-TestFormulaLogic := func() {
-	node := f.astOf(f.not(f.lt(1, 2)))
-	test.isEqual("not", node.op)
-	test.isEqual("lt", node.a.op)
+TestWhenMultiBranchNestsInOrder := func() {
+	// when(c1,v1).when(c2,v2).otherwise(d) -> if(c1, v1, if(c2, v2, d))
+	// (trailing-dot continuation — Tengo inserts a semicolon before a leading dot)
+	node := f.astOf(f.when(f.size("reads").gt(f.gib(10)), f.gib(64)).
+		when(f.size("reads").gt(f.gib(1)), f.gib(32)).
+		otherwise(f.gib(16)))
+	test.isEqual("if", node.op)
+	test.isEqual(64 * 1073741824, node.then.value)      // first branch value
+	test.isEqual("if", node["else"].op)                 // nested second branch
+	test.isEqual(32 * 1073741824, node["else"].then.value)
+	test.isEqual(16 * 1073741824, node["else"]["else"].value) // default
 }
 
 // fake resolver: size sums a fixed per-file table, lineCount sums another
@@ -60,43 +99,79 @@ _fakeResolver := {
 	}
 }
 
-TestFormulaEvaluateArithmetic := func() {
-	test.isEqual(7, f._internal.evaluate(f.add(3, 4), _fakeResolver))
-	test.isEqual(3, f._internal.evaluate(f.div(10, 3), _fakeResolver))      // truncating
-	test.isEqual(4, f._internal.evaluate(f.divCeil(10, 3), _fakeResolver))  // ceiling
-	test.isEqual(20, f._internal.evaluate(f.mul(f.sub(7, 2), 4), _fakeResolver))
+TestEvaluateArithmetic := func() {
+	test.isEqual(7, f._internal.evaluate(f.const(3).plus(4), _fakeResolver))
+	test.isEqual(4, f._internal.evaluate(f.const(10).dividedBy(3), _fakeResolver))  // ceiling
+	test.isEqual(20, f._internal.evaluate(f.const(7).minus(2).times(4), _fakeResolver))
 }
 
-TestFormulaEvaluateBoundsAndCond := func() {
-	test.isEqual(5, f._internal.evaluate(f.clamp(2, 5, 10), _fakeResolver))   // raised to lo
-	test.isEqual(10, f._internal.evaluate(f.clamp(99, 5, 10), _fakeResolver)) // capped to hi
-	test.isEqual(8, f._internal.evaluate(f.max(8, 3), _fakeResolver))
-	test.isEqual(1, f._internal.evaluate(f["if"](f.gt(5, 2), 1, 0), _fakeResolver))
-	test.isEqual(0, f._internal.evaluate(f["if"](f.lt(5, 2), 1, 0), _fakeResolver))
+TestEvaluateBoundsAndConditional := func() {
+	test.isEqual(5, f._internal.evaluate(f.const(2).between(5, 10), _fakeResolver))    // raised to lo
+	test.isEqual(10, f._internal.evaluate(f.const(99).between(5, 10), _fakeResolver))  // capped to hi
+	test.isEqual(8, f._internal.evaluate(f.const(8).atLeast(3), _fakeResolver))
+	test.isEqual(3, f._internal.evaluate(f.const(3).atMost(8), _fakeResolver))
+	test.isEqual(1, f._internal.evaluate(f.when(f.const(5).gt(2), 1).otherwise(0), _fakeResolver))
+	test.isEqual(0, f._internal.evaluate(f.when(f.const(5).lt(2), 1).otherwise(0), _fakeResolver))
 }
 
-TestEvaluateResourceAcceptsPositiveInt := func() {
-	// evaluateResource returns the evaluated value unchanged for a valid resource
-	// formula (a positive integer). The rejection path (a bool or non-positive
-	// result) goes through ll.assert, which is terminal in Tengo, so it cannot be
-	// exercised from a unit test — only the accepted contract is checked here.
-	test.isEqual(1073741824, f.evaluateResource(f.gib(1), _fakeResolver, "ram"))
-	test.isEqual(3, f.evaluateResource(f.add(2, 1), _fakeResolver, "cpu"))
-	test.isEqual(350, f.evaluateResource({ op: "metricSum", metric: "size", files: ["a", "b"] }, _fakeResolver, "ram"))
+TestWhenMultiBranchEvaluatesSelectsFirstMatch := func() {
+	// A chained 3-way conditional: >10 GiB -> 64, >1 GiB -> 32, else 16. Evaluating
+	// the SAME chain against three inputs exercises each branch — the FIRST truthy
+	// .when wins (the nested-if order), and .otherwise is the fall-through.
+	bucket := func(bytes) {
+		node := f.when(f.size("x").gt(f.gib(10)), f.gib(64)).
+			when(f.size("x").gt(f.gib(1)), f.gib(32)).
+			otherwise(f.gib(16))
+		resolver := { size: func(files) { return bytes }, lineCount: func(files) { return 0 } }
+		return f.evaluateResource(f.resolveAst(node, { "x": ["file"] }, ["file"]), resolver, "ram")
+	}
+	test.isEqual(64 * 1073741824, bucket(20 * 1073741824))  // first .when
+	test.isEqual(32 * 1073741824, bucket(5 * 1073741824))   // second .when
+	test.isEqual(16 * 1073741824, bucket(100))              // otherwise
 }
 
-TestFormulaEvaluateMetricSum := func() {
+TestEvaluateDividedByExactAndInexact := func() {
+	test.isEqual(3, f._internal.evaluate(f.const(9).dividedBy(3), _fakeResolver))  // exact -> not rounded up
+	test.isEqual(1, f._internal.evaluate(f.const(1).dividedBy(1), _fakeResolver))
+	test.isEqual(0, f._internal.evaluate(f.const(0).dividedBy(3), _fakeResolver))
+	test.isEqual(4, f._internal.evaluate(f.const(7).dividedBy(2), _fakeResolver))  // inexact -> ceil
+}
+
+TestFluentDividedByFloorTruncates := func() {
+	// .dividedByFloor -> truncating integer division (contrast .dividedBy = ceiling).
+	test.isEqual("div", f.astOf(f.const(10).dividedByFloor(3)).op)
+	test.isEqual(3, f._internal.evaluate(f.const(10).dividedByFloor(3), _fakeResolver))  // 10/3 -> 3
+	test.isEqual(4, f._internal.evaluate(f.const(10).dividedBy(3), _fakeResolver))       // 10/3 -> 4
+	test.isEqual(0, f._internal.evaluate(f.const(2).dividedByFloor(3), _fakeResolver))   // 2/3 -> 0
+}
+
+TestEvaluateBetweenInRange := func() {
+	test.isEqual(7, f._internal.evaluate(f.const(7).between(5, 10), _fakeResolver))
+	test.isEqual(5, f._internal.evaluate(f.const(5).between(5, 10), _fakeResolver))
+	test.isEqual(10, f._internal.evaluate(f.const(10).between(5, 10), _fakeResolver))
+}
+
+TestEvaluateLogic := func() {
+	test.isTrue(f._internal.evaluate(f.const(5).gte(5).and(f.const(2).lte(9)), _fakeResolver))
+	test.isFalse(f._internal.evaluate(f.const(1).gt(2).or(f.const(1).lt(2).not()), _fakeResolver))
+	test.isFalse(f._internal.evaluate(f.const(5).not(), _fakeResolver))  // !nonzero
+	test.isTrue(f._internal.evaluate(f.const(0).not(), _fakeResolver))   // !0
+}
+
+TestEvaluateMetricSum := func() {
 	node := { op: "metricSum", metric: "size", files: ["a", "b"] }
 	test.isEqual(350, f._internal.evaluate(node, _fakeResolver))
 	lc := { op: "metricSum", metric: "lineCount", files: ["a"] }
 	test.isEqual(9, f._internal.evaluate(lc, _fakeResolver))
 }
 
-TestFormulaEvaluateLogic := func() {
-	test.isEqual(3, f._internal.evaluate(f.min(3, 8), _fakeResolver))
-	test.isTrue(f._internal.evaluate(f.and(f.gte(5, 5), f.lte(2, 9)), _fakeResolver))
-	test.isFalse(f._internal.evaluate(f.or(f.gt(1, 2), f.not(f.lt(1, 2))), _fakeResolver))
+TestEvaluateResourceAcceptsPositiveInt := func() {
+	test.isEqual(1073741824, f.evaluateResource(f.gib(1), _fakeResolver, "ram"))
+	test.isEqual(3, f.evaluateResource(f.const(2).plus(1), _fakeResolver, "cpu"))
+	test.isEqual(350, f.evaluateResource({ op: "metricSum", metric: "size", files: ["a", "b"] }, _fakeResolver, "ram"))
 }
+
+// ---- resolveAst / referencedMetricFiles ------------------------------------
 
 TestResolveTagsToFiles := func() {
 	tagMap := { "reads": ["r1.fastq.gz", "r2.fastq.gz"], "ref": ["ref.fasta"] }
@@ -125,118 +200,119 @@ TestResolveDefaultSubstitution := func() {
 	test.isEqual({ op: "const", value: 0 }, resolved)
 }
 
-TestReferencedMetricFiles := func() {
-	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
-	formula := f.add(f.mul(f.size("reads"), 4), f.lineCount("reads"))
-	resolved := f.resolveAst(formula, tagMap, ["r1.fastq", "r2.fastq"])
-	refs := f.referencedMetricFiles(resolved)
-	test.isEqual(["r1.fastq", "r2.fastq"], refs.lineCount)
-	test.isTrue(is_undefined(refs.size), "size must not require pre-exec")
-}
-
-TestResolveLineCountCompressionAccepted := func() {
-	// .fastq.gz: compression suffix stripped -> ext "fastq" is line-oriented -> accepted, no panic
-	resolved := f.resolveAst(f.lineCount("reads"), { "reads": ["r1.fastq.gz"] }, ["r1.fastq.gz"])
-	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["r1.fastq.gz"] }, resolved)
-}
-
-TestResolveLineCountUppercaseExtensionAccepted := func() {
-	// Extension matching is case-insensitive: .FASTQ / .TXT are valid line-oriented
-	// formats (the line-counter binary reads them raw and counts '\n'). A lowercase
-	// compression suffix is still stripped first, so .FASTQ.gz is accepted too.
-	upper := f.resolveAst(f.lineCount("reads"), { "reads": ["READS.FASTQ"] }, ["READS.FASTQ"])
-	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["READS.FASTQ"] }, upper)
-
-	upperBase := f.resolveAst(f.lineCount("reads"), { "reads": ["reads.FASTQ.gz"] }, ["reads.FASTQ.gz"])
-	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["reads.FASTQ.gz"] }, upperBase)
-}
-
-TestResolveLineCountUppercaseCompressionAccepted := func() {
-	// Compression suffix matching is case-insensitive too: .GZ / .Zst strip just
-	// like .gz / .zst, leaving a line-oriented base extension. The line-counter
-	// binary likewise lowercases the suffix before decompressing, so the count is
-	// correct (small-binaries case-insensitive release).
-	gz := f.resolveAst(f.lineCount("reads"), { "reads": ["reads.fastq.GZ"] }, ["reads.fastq.GZ"])
-	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["reads.fastq.GZ"] }, gz)
-
-	zst := f.resolveAst(f.lineCount("reads"), { "reads": ["reads.fasta.Zst"] }, ["reads.fasta.Zst"])
-	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["reads.fasta.Zst"] }, zst)
+TestResolveDefaultNotCarriedWhenTagHasFiles := func() {
+	tagMap := { "reads": ["r1.fastq"] }
+	resolved := f.resolveAst(f.size("reads", { default: 7 }), tagMap, ["r1.fastq"])
+	test.isEqual({ op: "metricSum", metric: "size", files: ["r1.fastq"] }, resolved)
 }
 
 TestResolveRecursesInPlace := func() {
 	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
 	allFiles := ["r1.fastq", "r2.fastq"]
-	// add(mul(size("reads"), 4), lineCount("reads"))
-	resolved := f.resolveAst(f.add(f.mul(f.size("reads"), 4), f.lineCount("reads")), tagMap, allFiles)
+	// size("reads")*4 + lineCount("reads")
+	resolved := f.resolveAst(f.size("reads").times(4).plus(f.lineCount("reads")), tagMap, allFiles)
 	test.isEqual("add", resolved.op)
 	test.isEqual("metricSum", resolved.a.a.op)   // size("reads") inside mul
 	test.isEqual("size", resolved.a.a.metric)
 	test.isEqual({ op: "const", value: 4 }, resolved.a.b)
 	test.isEqual("metricSum", resolved.b.op)     // lineCount("reads")
 	test.isEqual("lineCount", resolved.b.metric)
-	test.isEqual(["r1.fastq", "r2.fastq"], resolved.b.files)
 }
 
-// Note on panic-path coverage: the formula's rejection contracts (lineCount on
-// an unsupported extension, a tag with no files and no { default }, division by
-// zero, _wrap on a non-node) all go through ll.assert / ll.panic, which are
-// terminal in Tengo (no recover / try-catch — see pframes/table-builder.test.tengo).
-// They cannot be exercised from a unit test and are instead verified by reading.
-// The tests below cover the non-panic behavior those same code paths produce.
-
-TestResolveRecursesIntoClampAndIf := func() {
-	// resolveAst must recurse through the non-binary node shapes — clamp
-	// (value/lo/hi) and if (cond/then/else) — not just the binary a/b shape of
-	// add/mul. It resolves embedded metrics while copying the other fields through.
+TestResolveRecursesIntoBetweenAndWhen := func() {
 	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
 	allFiles := ["r1.fastq", "r2.fastq"]
 
-	resolvedClamp := f.resolveAst(f.clamp(f.size("reads"), f.gib(1), f.gib(4)), tagMap, allFiles)
+	// .between -> clamp: metric resolves in `value`, bounds preserved.
+	resolvedClamp := f.resolveAst(f.size("reads").between(f.gib(1), f.gib(4)), tagMap, allFiles)
 	test.isEqual("clamp", resolvedClamp.op)
-	test.isEqual("metricSum", resolvedClamp.value.op)            // size("reads") resolved in `value`
+	test.isEqual("metricSum", resolvedClamp.value.op)
 	test.isEqual(["r1.fastq", "r2.fastq"], resolvedClamp.value.files)
-	test.isEqual(1073741824, resolvedClamp.lo.value)             // 1 GiB lo bound preserved
-	test.isEqual(4 * 1073741824, resolvedClamp.hi.value)         // 4 GiB hi bound preserved
+	test.isEqual(1073741824, resolvedClamp.lo.value)
+	test.isEqual(4 * 1073741824, resolvedClamp.hi.value)
 
-	resolvedIf := f.resolveAst(f["if"](f.gt(f.lineCount("reads"), 100), f.gib(16), f.gib(8)), tagMap, allFiles)
+	// f.when(...).otherwise(...) -> if: metric inside the condition resolves.
+	resolvedIf := f.resolveAst(
+		f.when(f.lineCount("reads").gt(100), f.gib(16)).otherwise(f.gib(8)), tagMap, allFiles)
 	test.isEqual("if", resolvedIf.op)
-	test.isEqual("metricSum", resolvedIf.cond.a.op)              // lineCount("reads") inside the gt cond
+	test.isEqual("metricSum", resolvedIf.cond.a.op)
 	test.isEqual("lineCount", resolvedIf.cond.a.metric)
 	test.isEqual(16 * 1073741824, resolvedIf.then.value)
 	test.isEqual(8 * 1073741824, resolvedIf["else"].value)
 }
 
-TestReferencedMetricFilesTraversesClampAndIf := func() {
-	// lineCount files nested inside clamp / if must still be discovered (they
-	// require a pre-exec); size must still be excluded (computed inline via
-	// getBlobSize, no pre-exec needed). Exercises the walk through both shapes.
+TestReferencedMetricFiles := func() {
 	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
-	allFiles := ["r1.fastq", "r2.fastq"]
-	formula := f["if"](
-		f.gt(f.size("reads"), 1000),
-		f.clamp(f.lineCount("reads"), f.mib(512), f.gib(2)),
-		f.gib(1))
-	resolved := f.resolveAst(formula, tagMap, allFiles)
+	formula := f.size("reads").times(4).plus(f.lineCount("reads"))
+	resolved := f.resolveAst(formula, tagMap, ["r1.fastq", "r2.fastq"])
 	refs := f.referencedMetricFiles(resolved)
-	test.isEqual(["r1.fastq", "r2.fastq"], refs.lineCount)        // found inside clamp inside if
+	test.isEqual(["r1.fastq", "r2.fastq"], refs.lineCount)
 	test.isTrue(is_undefined(refs.size), "size must not require pre-exec")
 }
 
-TestResolveDefaultNotCarriedWhenTagHasFiles := func() {
-	// When a tag HAS files, the metric resolves to metricSum and the { default }
-	// is DROPPED — the resolver computes the metric from the files, so a carried
-	// default would be dead data. default only matters on the empty-tag path
-	// (TestResolveDefaultSubstitution), where it becomes a const instead.
-	tagMap := { "reads": ["r1.fastq"] }
-	resolved := f.resolveAst(f.size("reads", { default: 7 }), tagMap, ["r1.fastq"])
-	test.isEqual({ op: "metricSum", metric: "size", files: ["r1.fastq"] }, resolved)
+TestReferencedMetricFilesTraversesWhenAndBetween := func() {
+	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
+	allFiles := ["r1.fastq", "r2.fastq"]
+	formula := f.when(
+		f.size("reads").gt(1000),
+		f.lineCount("reads").between(f.mib(512), f.gib(2))).otherwise(f.gib(1))
+	resolved := f.resolveAst(formula, tagMap, allFiles)
+	refs := f.referencedMetricFiles(resolved)
+	test.isEqual(["r1.fastq", "r2.fastq"], refs.lineCount)  // found inside branch value.s .between
+	test.isTrue(is_undefined(refs.size), "size must not require pre-exec")
 }
 
-// ---- applyFormulaFallback (builder-time, !hasBlobSize gate) ----------------
-// The exec builder calls this when the backend lacks getBlobSize support, so a
-// formula cannot be evaluated. Pure (no backend), so both branches — "use the
-// fallback" and "no fallback => error" — are unit-testable here. The live
-// !hasBlobSize path is otherwise unreachable from a unit test.
+TestReferencedMetricFilesDedupesRepeatedFile := func() {
+	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
+	allFiles := ["r1.fastq", "r2.fastq"]
+	formula := f.lineCount("reads").plus(f.lineCount("reads").times(2))
+	resolved := f.resolveAst(formula, tagMap, allFiles)
+	refs := f.referencedMetricFiles(resolved)
+	test.isEqual(["r1.fastq", "r2.fastq"], refs.lineCount)  // each file once, not duplicated
+}
+
+// ---- lineCount format compatibility (resolveAst -> _assertMetricCompatible) --
+
+TestResolveLineCountCompressionAccepted := func() {
+	resolved := f.resolveAst(f.lineCount("reads"), { "reads": ["r1.fastq.gz"] }, ["r1.fastq.gz"])
+	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["r1.fastq.gz"] }, resolved)
+}
+
+TestResolveLineCountUppercaseAccepted := func() {
+	upper := f.resolveAst(f.lineCount("reads"), { "reads": ["READS.FASTQ"] }, ["READS.FASTQ"])
+	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["READS.FASTQ"] }, upper)
+
+	gz := f.resolveAst(f.lineCount("reads"), { "reads": ["reads.fastq.GZ"] }, ["reads.fastq.GZ"])
+	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["reads.fastq.GZ"] }, gz)
+}
+
+TestResolveLineCountBz2AndZstAccepted := func() {
+	bz2 := f.resolveAst(f.lineCount("reads"), { "reads": ["r1.fastq.bz2"] }, ["r1.fastq.bz2"])
+	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["r1.fastq.bz2"] }, bz2)
+	zst := f.resolveAst(f.lineCount("reads"), { "reads": ["reads.fasta.Zst"] }, ["reads.fasta.Zst"])
+	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["reads.fasta.Zst"] }, zst)
+}
+
+// ---- wrapper introspection --------------------------------------------------
+
+TestStaticFallbackCaptured := func() {
+	node := f.size("a").times(2).staticFallback(f.gib(64))
+	test.isEqual(64 * 1073741824, f.fallbackOf(node))
+	test.isEqual("mul", f.astOf(node).op)                // fallback does not alter the AST
+	test.isTrue(is_undefined(f.fallbackOf(f.size("a")))) // none set -> undefined
+	test.isEqual(8, f.fallbackOf(f.size("a").dividedBy(4).staticFallback(8)))
+	test.isEqual("16GiB", f.fallbackOf(f.size("a").dividedBy(4).staticFallback("16GiB")))
+}
+
+TestIsFormulaDiscriminatesStaticFromFormula := func() {
+	test.isTrue(f.isFormula(f.size("input")))                    // wrapper
+	test.isTrue(f.isFormula(f.size("input").dividedBy(f.gib(4)))) // chained wrapper
+	test.isTrue(f.isFormula({ op: "const", value: 4 }))          // plain AST node
+	test.isFalse(f.isFormula(4))                                 // static cores
+	test.isFalse(f.isFormula("16GiB"))                           // static size string
+}
+
+// ---- applyFormulaFallback (builder-time, !hasBlobSize gate) -----------------
 
 TestFallbackAppliesWhenNoStaticRequest := func() {
 	res := f.applyFormulaFallback({ ram: { ast: f.size(), fallback: "16GiB" }, cpu: { ast: f.size(), fallback: 8 } })
@@ -246,15 +322,13 @@ TestFallbackAppliesWhenNoStaticRequest := func() {
 }
 
 TestFallbackStaticRequestWins := func() {
-	// A static .mem()/.cpu() already set => the fallback must NOT override it.
 	res := f.applyFormulaFallback({ ram: { ast: f.size(), fallback: "16GiB", static: "64GiB" }, cpu: { ast: f.size(), fallback: 8, static: 16 } })
 	test.isEqual("64GiB", res.ram)
 	test.isEqual(16, res.cpu)
 	test.isTrue(is_undefined(res.err))
 }
 
-TestFallbackMissingMemFallbackErrors := func() {
-	// RAM formula present, no fallback, backend can't evaluate => error naming RAM.
+TestFallbackMissingRamFallbackErrors := func() {
 	res := f.applyFormulaFallback({ ram: { ast: f.size() }, cpu: {} })
 	test.isTrue(!is_undefined(res.err), "missing RAM formula fallback must error")
 	test.isTrue(text.contains(res.err, "RAM formula"))
@@ -266,155 +340,7 @@ TestFallbackMissingCpuFallbackErrors := func() {
 	test.isTrue(text.contains(res.err, "CPU formula"))
 }
 
-TestFallbackNoFormulasIsPassthrough := func() {
-	// No formulas => ram/cpu pass through untouched, no error.
-	res := f.applyFormulaFallback({ ram: { static: "4GiB" }, cpu: { static: 2 } })
-	test.isEqual("4GiB", res.ram)
-	test.isEqual(2, res.cpu)
-	test.isTrue(is_undefined(res.err))
-}
-
-TestFallbackOnlyMemFormula := func() {
-	// memFormula with fallback, no cpuFormula => cpu stays whatever was passed.
-	res := f.applyFormulaFallback({ ram: { ast: f.size(), fallback: "2GiB" }, cpu: { static: 4 } })
-	test.isEqual("2GiB", res.ram)
-	test.isEqual(4, res.cpu)
-	test.isTrue(is_undefined(res.err))
-}
-
-TestFallbackStaticServesAsImplicitFallback := func() {
-	// A formula with NO explicit { fallback } but a static .mem()/.cpu() already
-	// set: the static request doubles as the old-backend fallback, so there is
-	// no error (a required { fallback } that the static value overrides anyway
-	// would be dead config). Errors only when neither static nor fallback exists.
-	res := f.applyFormulaFallback({ ram: { ast: f.size(), static: "64GiB" }, cpu: { ast: f.size(), static: 16 } })
-	test.isEqual("64GiB", res.ram)
-	test.isEqual(16, res.cpu)
-	test.isTrue(is_undefined(res.err))
-}
-
-// ============================================================================
-// Added by deep-dive review (2026-06-03): coverage for documented-but-untested
-// evaluator contracts, a non-binary clamp branch, the referencedMetricFiles
-// dedup loop, .bz2 acceptance, and the and/or-vs-bool result-guard boundary.
-// ============================================================================
-
-TestFormulaDivCeilExactDivision := func() {
-	// divCeil is (a+b-1)/b; an EXACT division must not round up (off-by-one guard).
-	// The pre-existing suite only covers the inexact case divCeil(10,3)=4.
-	test.isEqual(3, f._internal.evaluate(f.divCeil(9, 3), _fakeResolver))   // exact -> 3, not 4
-	test.isEqual(2, f._internal.evaluate(f.divCeil(6, 3), _fakeResolver))   // exact -> 2
-	test.isEqual(1, f._internal.evaluate(f.divCeil(1, 1), _fakeResolver))   // exact -> 1
-	test.isEqual(0, f._internal.evaluate(f.divCeil(0, 3), _fakeResolver))   // 0 -> 0
-	test.isEqual(4, f._internal.evaluate(f.divCeil(7, 2), _fakeResolver))   // inexact -> 4
-}
-
-TestFormulaClampValueInRange := func() {
-	// The passthrough branch: a value already within [lo,hi] returns unchanged.
-	// Existing suite covers only the raise-to-lo and cap-to-hi branches.
-	test.isEqual(7, f._internal.evaluate(f.clamp(7, 5, 10), _fakeResolver))    // in range -> unchanged
-	test.isEqual(5, f._internal.evaluate(f.clamp(5, 5, 10), _fakeResolver))    // on lo boundary
-	test.isEqual(10, f._internal.evaluate(f.clamp(10, 5, 10), _fakeResolver))  // on hi boundary
-}
-
-TestFormulaIfNotTruthyIntCondition := func() {
-	// formula.lib documents: "the evaluator treats any nonzero const as truthy" for
-	// if.cond / not.a given a bare int. Every existing if/not test feeds a comparison
-	// (already a bool); this pins the documented truthy-int contract.
-	test.isEqual(10, f._internal.evaluate(f["if"](1, 10, 20), _fakeResolver))  // nonzero -> then
-	test.isEqual(20, f._internal.evaluate(f["if"](0, 10, 20), _fakeResolver))  // zero -> else
-	test.isFalse(f._internal.evaluate(f.not(5), _fakeResolver))                // !nonzero -> false
-	test.isTrue(f._internal.evaluate(f.not(0), _fakeResolver))                 // !0 -> true
-}
-
-TestFormulaLogicOpsOfIntsReturnInt := func() {
-	// Tengo && / || yield the deciding OPERAND, not a coerced bool, so f.and/f.or of
-	// integer operands evaluate to an INTEGER at the evaluate() level (f.gt/f.lt/f.not
-	// yield a bool). Because that int would otherwise slip past evaluateResource's
-	// `is_int(v) && v > 0` check, evaluateResource now rejects comparison/logic ops
-	// structurally at the top level — they belong only inside f.if(...). That
-	// reject is an ll.assert panic (terminal in Tengo, not assertable here); this test
-	// pins the underlying evaluate() operand semantics the guard protects against.
-	test.isTrue(is_int(f._internal.evaluate(f.or(1, 0), _fakeResolver)))    // 1 || 0 -> 1 (int)
-	test.isTrue(is_int(f._internal.evaluate(f.and(2, 3), _fakeResolver)))   // 2 && 3 -> 3 (int)
-	test.isFalse(is_int(f._internal.evaluate(f.gt(5, 2), _fakeResolver)))   // 5 > 2 -> true (bool)
-}
-
-TestReferencedMetricFilesDedupesRepeatedFile := func() {
-	// referencedMetricFiles must collapse a file referenced by lineCount more than once
-	// (e.g. once in a condition and once in a branch) to a single pre-exec. Existing
-	// tests reference each file exactly once, leaving the dedup loop unexercised.
-	tagMap := { "reads": ["r1.fastq", "r2.fastq"] }
-	allFiles := ["r1.fastq", "r2.fastq"]
-	formula := f.add(f.lineCount("reads"), f.mul(f.lineCount("reads"), 2))
-	resolved := f.resolveAst(formula, tagMap, allFiles)
-	refs := f.referencedMetricFiles(resolved)
-	test.isEqual(["r1.fastq", "r2.fastq"], refs.lineCount)   // each file once, not duplicated
-}
-
-TestResolveLineCountBz2Accepted := func() {
-	// .bz2 is a supported compression suffix, but only .gz/.zst were covered.
-	// The builder must strip .bz2 and accept the line-oriented base extension.
-	resolved := f.resolveAst(f.lineCount("reads"), { "reads": ["r1.fastq.bz2"] }, ["r1.fastq.bz2"])
-	test.isEqual({ op: "metricSum", metric: "lineCount", files: ["r1.fastq.bz2"] }, resolved)
-}
-
-// ---- fluent chain + wrapper introspection ----------------------------------
-// The chain methods are sugar: they must build the SAME AST as the equivalent
-// prefix constructors, so the evaluator/resolver code paths stay identical.
-
-TestFluentChainMatchesPrefixAst := func() {
-	// cpu: divCeil(size, gib(4)) clamped to [4, 16]
-	chain  := f.size("input").per(f.gib(4)).between(4, 16)
-	prefix := f.clamp(f.divCeil(f.size("input"), f.gib(4)), 4, 16)
-	test.isEqual(f.astOf(prefix), f.astOf(chain))
-
-	// ram: size*12 + gib(8), floored at gib(16)
-	chain2  := f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16))
-	prefix2 := f.max(f.add(f.mul(f.size("input"), 12), f.gib(8)), f.gib(16))
-	test.isEqual(f.astOf(prefix2), f.astOf(chain2))
-
-	// .minus / .atMost complete the alias set (sub / min)
-	chain3  := f.size("input").minus(f.gib(1)).atMost(f.gib(8))
-	prefix3 := f.min(f.sub(f.size("input"), f.gib(1)), f.gib(8))
-	test.isEqual(f.astOf(prefix3), f.astOf(chain3))
-}
-
-TestFluentChainEvaluates := func() {
-	// The chain AST resolves + evaluates through the normal resolver: size("a")=100.
-	// divCeil(100, 40)=3 -> clamp to [4, 16] -> 4. resolveAst first, exactly as the
-	// builder does (metric -> metricSum) before the evaluator runs.
-	resolved := f.resolveAst(f.size("a").per(40).between(4, 16), { "a": ["a"] }, ["a"])
-	test.isEqual(4, f.evaluateResource(resolved, _fakeResolver, "cpu"))
-}
-
-TestStaticFallbackCaptured := func() {
-	// .staticFallback pins the value; fallbackOf reads it, astOf ignores it.
-	// A pure-unit wrapper (f.gib) is accepted and yields its byte value.
-	node := f.size("a").times(2).staticFallback(f.gib(64))
-	test.isEqual(64 * 1073741824, f.fallbackOf(node))
-	test.isEqual("mul", f.astOf(node).op)               // fallback does not alter the AST
-	test.isTrue(is_undefined(f.fallbackOf(f.size("a")))) // no fallback set -> undefined
-
-	// a bare number / string passes through unchanged
-	test.isEqual(8, f.fallbackOf(f.size("a").per(4).staticFallback(8)))
-	test.isEqual("16GiB", f.fallbackOf(f.size("a").per(4).staticFallback("16GiB")))
-}
-
-TestIsFormulaDiscriminatesStaticFromFormula := func() {
-	// isFormula distinguishes a data-driven value (wrapper or plain AST) from a
-	// static request (bare number / string). This is exactly how .resources()
-	// decides whether a dimension is a formula or a static request.
-	test.isTrue(f.isFormula(f.size("input")))               // wrapper
-	test.isTrue(f.isFormula(f.size("input").per(f.gib(4)))) // chained wrapper
-	test.isTrue(f.isFormula({ op: "const", value: 4 }))     // plain AST node
-	test.isFalse(f.isFormula(4))                            // static cores
-	test.isFalse(f.isFormula("16GiB"))                      // static size string
-}
-
 TestFallbackGpuDimension := func() {
-	// applyFormulaFallback now handles an optional gpu dimension symmetrically to
-	// ram/cpu: static wins, else the fallback, else an error naming VRAM.
 	ok := f.applyFormulaFallback({
 		ram: { ast: f.size(), fallback: "16GiB" },
 		cpu: { static: 4 },
@@ -423,11 +349,20 @@ TestFallbackGpuDimension := func() {
 	test.isEqual("48GiB", ok.gpu)
 	test.isTrue(is_undefined(ok.err))
 
-	missing := f.applyFormulaFallback({
-		ram: { static: "16GiB" },
-		cpu: { static: 4 },
-		gpu: { ast: f.size() }
-	})
+	missing := f.applyFormulaFallback({ ram: { static: "16GiB" }, cpu: { static: 4 }, gpu: { ast: f.size() } })
 	test.isTrue(!is_undefined(missing.err), "missing VRAM fallback must error")
 	test.isTrue(text.contains(missing.err, "VRAM"))
 }
+
+TestFallbackNoFormulasIsPassthrough := func() {
+	res := f.applyFormulaFallback({ ram: { static: "4GiB" }, cpu: { static: 2 } })
+	test.isEqual("4GiB", res.ram)
+	test.isEqual(2, res.cpu)
+	test.isTrue(is_undefined(res.err))
+}
+
+// Note on panic-path coverage: the rejection contracts (lineCount on an
+// unsupported extension, an empty tag with no { default }, a top-level
+// comparison reaching a quota, _wrap on a non-node) all go through ll.assert /
+// ll.panic, which are terminal in Tengo (no recover) — they cannot be exercised
+// from a unit test and are verified by reading + the e2e formula_reject tpl.

--- a/sdk/workflow-tengo/src/exec/gpu.test.tengo
+++ b/sdk/workflow-tengo/src/exec/gpu.test.tengo
@@ -43,3 +43,66 @@ Test_gpu_override := func() {
 
 	test.isTrue(ll.methodExists(b, "run"), "gpuMemory() override should return valid builder")
 }
+
+f := exec.formula
+
+Test_resources_cpu_only := func() {
+	b := exec.builder().
+		cmd("test").
+		resources({
+			queue: "heavy",
+			onCPU: {
+				cpu: f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16),
+				ram: f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16)).staticFallback(f.gib(64))
+			}
+		})
+
+	test.isTrue(ll.methodExists(b, "run"), "resources({onCPU}) should return a valid builder")
+}
+
+Test_resources_static_values := func() {
+	b := exec.builder().
+		cmd("test").
+		resources({ onCPU: { cpu: 4, ram: "16GiB" } })
+
+	test.isTrue(ll.methodExists(b, "run"), "resources() with static cpu/ram should return a valid builder")
+}
+
+Test_resources_adaptive := func() {
+	// onCPU + onGPU is adaptive at workflow render time; the chain stays valid on both
+	// GPU-capable and GPU-less backends (exec.hasGpu picks the block).
+	b := exec.builder().
+		cmd("test").
+		resources({
+			queue: "heavy",
+			onCPU: {
+				cpu: f.const(4).staticFallback(4),
+				ram: f.size("input").times(12).atLeast(f.gib(16)).staticFallback(f.gib(64))
+			},
+			onGPU: {
+				cpu: 4,
+				ram: f.size("input").times(6).plus(f.gib(2)).between(f.gib(8), f.gib(32)).staticFallback(f.gib(32)),
+				vram: f.size("input").times(8).plus(f.gib(2)).between(f.gib(6), f.gib(48)).staticFallback(f.gib(48))
+			}
+		})
+
+	test.isTrue(ll.methodExists(b, "run"), "resources({onCPU, onGPU}) should return a valid builder")
+}
+
+Test_resources_gpu_required := func() {
+	// onGPU alone asserts a GPU-capable backend at workflow render time; only exercise it
+	// where one is advertised, else the assertion is the correct behavior.
+	if exec.hasGpu {
+		b := exec.builder().
+			cmd("test").
+			resources({
+				onGPU: {
+					cpu: f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16),
+					ram: f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16)).staticFallback(f.gib(64)),
+					vram: f.size("input").times(8).plus(f.gib(2)).between(f.gib(6), f.gib(48)).staticFallback(f.gib(48))
+				}
+			})
+
+		test.isTrue(ll.methodExists(b, "run"), "resources({onGPU}) should return a valid builder")
+	}
+}

--- a/sdk/workflow-tengo/src/exec/gpu.test.tengo
+++ b/sdk/workflow-tengo/src/exec/gpu.test.tengo
@@ -52,7 +52,7 @@ Test_resources_cpu_only := func() {
 		resources({
 			queue: "heavy",
 			onCPU: {
-				cpu: f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16),
+				cpu: f.size("input").dividedBy(f.gib(4)).between(4, 16).staticFallback(16),
 				ram: f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16)).staticFallback(f.gib(64))
 			}
 		})
@@ -97,7 +97,7 @@ Test_resources_gpu_required := func() {
 			cmd("test").
 			resources({
 				onGPU: {
-					cpu: f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16),
+					cpu: f.size("input").dividedBy(f.gib(4)).between(4, 16).staticFallback(16),
 					ram: f.size("input").times(12).plus(f.gib(8)).atLeast(f.gib(16)).staticFallback(f.gib(64)),
 					vram: f.size("input").times(8).plus(f.gib(2)).between(f.gib(6), f.gib(48)).staticFallback(f.gib(48))
 				}

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -499,7 +499,7 @@ builder := func() {
 		 *   - static: a number (cores, or bytes for ram/vram) or a size string
 		 *     ("16GiB"). Enters the exec as-is.
 		 *   - formula: an `exec.formula` chain — e.g.
-		 *       f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16)
+		 *       f.size("input").dividedBy(f.gib(4)).between(4, 16).staticFallback(16)
 		 *     Evaluated at run time from input-file metrics (size / line count).
 		 *     A formula SHOULD end in .staticFallback(...) — the value used on
 		 *     backends that cannot evaluate formulas (no getBlobSize); without it

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -37,11 +37,12 @@ lineCounterSoft := assets.importSoftware("@platforma-open/milaboratories.softwar
 // the enclosing function).
 _lineCountResource := undefined
 
-// _assertValidCpuRequest / _assertValidMemRequest hold the single definition of a
-// valid CPU / RAM request, so .cpu()/.mem() and the memFormula/cpuFormula
-// { fallback } (which substitutes for a static request on backends that cannot
-// evaluate formulas) all enforce the same contract. `ctx` prefixes the message so
-// the error names the offending setter.
+// _assertValidCpuRequest / _assertValidMemRequest / _assertValidGpuRequest hold
+// the single definition of a valid CPU / RAM / VRAM request, so the static
+// setters (.cpu()/.mem()/.gpuMemory()), the .resources({...}) dimensions, and
+// the formula .staticFallback() (which substitutes for a static request on
+// backends that cannot evaluate formulas) all enforce the same contract. `ctx`
+// prefixes the message so the error names the offending setter.
 _assertValidCpuRequest := func(amount, ctx) {
 	validation.assertType(amount, "number", ctx + ": amount of cores must be a number")
 	ll.assert(amount > 0, ctx + ": amount of cores should be greater than 0")
@@ -49,6 +50,13 @@ _assertValidCpuRequest := func(amount, ctx) {
 _assertValidMemRequest := func(amount, ctx) {
 	validation.assertType(amount, ["or", "number", "string"], ctx + ": RAM amount should be a number or string")
 	ll.assert(is_string(amount) || amount >= 16 * units.MiB, ctx + ": amount in bytes should be at least 16MiB")
+}
+// A VRAM request is a size string ("16GiB") or a number of bytes. The static
+// .gpuMemory() takes a string; a formula .staticFallback() may resolve to a
+// number of bytes (e.g. f.gib(48)) — both are accepted, mirroring _assertValidMemRequest.
+_assertValidGpuRequest := func(amount, ctx) {
+	validation.assertType(amount, ["or", "number", "string"], ctx + ": VRAM amount must be a number of bytes or a size string like '16GiB'")
+	ll.assert(is_string(amount) || amount > 0, ctx + ": VRAM amount in bytes should be greater than 0")
 }
 
 /**
@@ -84,11 +92,16 @@ builder := func() {
 	ramRequest := undefined
 	gpuMemory := undefined
 
-	// resource-formula builder state (memFormula / cpuFormula / addFile tags)
+	// resource-formula builder state (ram / cpu / vram formulas + addFile tags).
+	// Set by .resources({ ... }); each *FormulaAst holds a plain formula AST and
+	// each *FormulaFallback the static value used on backends that can't evaluate
+	// formulas at run time (see analysis doc §4).
 	memFormulaAst := undefined
 	memFormulaFallback := undefined
 	cpuFormulaAst := undefined
 	cpuFormulaFallback := undefined
+	gpuFormulaAst := undefined
+	gpuFormulaFallback := undefined
 	fileTags := {}   // fileName -> tag (for f.size("tag") / f.lineCount("tag") aggregation)
 
 	commandName := ""
@@ -477,18 +490,41 @@ builder := func() {
 		},
 
 		/**
-		 * Sets a resource formula that computes the RAM request from input file
-		 * metrics (size / line count) at run time on the backend.
+		 * Declares the exec's compute resources in one call. This is the primary
+		 * way to request RAM / CPU / GPU — replacing the older per-dimension
+		 * formula setters.
 		 *
-		 * Requires a backend with getBlobSize support. On older backends the
-		 * formula is skipped and a static RAM request is used instead: the
-		 * `{ fallback: ... }` value, or — if none is given — a static `.mem()`
-		 * set on the same builder. One of the two must be present (else an error).
+		 * Each dimension takes EITHER a static value or a data-driven FORMULA:
+		 *   - static: a number (cores, or bytes for ram/vram) or a size string
+		 *     ("16GiB"). Enters the exec as-is.
+		 *   - formula: an `exec.formula` chain — e.g.
+		 *       f.size("input").per(f.gib(4)).between(4, 16).staticFallback(16)
+		 *     Evaluated at run time from input-file metrics (size / line count).
+		 *     A formula SHOULD end in .staticFallback(...) — the value used on
+		 *     backends that cannot evaluate formulas (no getBlobSize); without it
+		 *     such a backend errors. A formula must evaluate to a positive integer;
+		 *     floor it with .between(...) / .atLeast(...) if a metric can be zero.
 		 *
-		 * The formula must evaluate to a positive integer number of bytes. A
-		 * non-positive or non-integer result (e.g. a top-level comparison, or an
-		 * f.sub that underflows) is rejected at run time — floor it with f.max /
-		 * f.clamp if a metric can be zero.
+		 * Shapes (config map). Two parallel blocks, onCPU and onGPU, describe the
+		 * CPU-node and GPU-node allocations; which are present decides the mode:
+		 *   // CPU only (the common case) — onCPU alone
+		 *   .resources({ queue: "heavy", onCPU: { cpu: <cpu>, ram: <ram> } })
+		 *
+		 *   // GPU required — onGPU alone; runs only on a GPU node (errors fast if
+		 *   // the backend has none)
+		 *   .resources({ queue: "heavy", onGPU: { cpu: <cpu>, ram: <ram>, vram: <vram> } })
+		 *
+		 *   // GPU preferred — both blocks; adaptive: the onGPU allocation is used
+		 *   // when the backend has a GPU (exec.hasGpu, decided here at workflow render time),
+		 *   // else the onCPU allocation.
+		 *   .resources({
+		 *       queue: "heavy",
+		 *       onCPU: { cpu: <cpu>, ram: <ram> },
+		 *       onGPU: { cpu: <cpu>, ram: <ram>, vram: <vram> }
+		 *   })
+		 *
+		 * onCPU takes { cpu, ram }; onGPU takes { cpu, ram, vram } (vram is what
+		 * makes it a GPU allocation, so it is required there).
 		 *
 		 * NOTE: resource formulas are CID-transparent — they do NOT participate in
 		 * exec deduplication. Two execs identical except for their formula dedup to
@@ -497,70 +533,109 @@ builder := func() {
 		 * serviceFields support; on a backend without it the formula instead
 		 * enters the exec CID — evaluation is still correct, only dedup is lost.)
 		 *
-		 * @param ast - a formula node produced via exec.formula
-		 * @param opts: { fallback?: number | string } - static RAM used when the
-		 *        backend lacks getBlobSize support.
-		 *
+		 * @param spec: {
+		 *     queue?: string,
+		 *     onCPU?: { cpu, ram: <static | formula> },
+		 *     onGPU?: { cpu, ram, vram: <static | formula> }
+		 *   }
 		 * @return builder
 		 */
-		memFormula: func(ast, ...opts) {
-			ll.assert(is_map(ast) && !is_undefined(ast.op), "exec.builder.memFormula: expected a formula node from exec.formula")
-			memFormulaAst = ast
-			if len(opts) > 0 && ll.isMap(opts[0]) {
-				for k, _ in opts[0] {
-					ll.assert(k == "fallback", "exec.builder.memFormula: unknown option %q (only { fallback } is supported)", k)
-				}
-				if !is_undefined(opts[0].fallback) {
-					_assertValidMemRequest(opts[0].fallback, "exec.builder.memFormula fallback")
-					memFormulaFallback = opts[0].fallback
+		resources: func(spec) {
+			ll.assert(ll.isMap(spec), "exec.builder.resources: expected a config map")
+			allowed := { queue: true, onCPU: true, onGPU: true }
+			for k, _ in spec {
+				ll.assert(!is_undefined(allowed[k]), "exec.builder.resources: unknown key %q (allowed: queue, onCPU, onGPU)", k)
+			}
+			hasCPU := !is_undefined(spec.onCPU)
+			hasGPU := !is_undefined(spec.onGPU)
+			ll.assert(hasCPU || hasGPU, "exec.builder.resources: provide onCPU and/or onGPU")
+
+			if !is_undefined(spec.queue) {
+				validation.assertType(spec.queue, "string", "exec.builder.resources: queue must be a string")
+				queue = spec.queue
+			}
+
+			// Per-dimension setters: a formula (exec.formula chain / AST) sets the
+			// *FormulaAst + its .staticFallback(); a bare number/string is a static
+			// request. Closure-assign the builder's resource state directly.
+			setCpu := func(v, ctx) {
+				if execFormula.isFormula(v) {
+					cpuFormulaAst = execFormula.astOf(v)
+					fb := execFormula.fallbackOf(v)
+					if !is_undefined(fb) { _assertValidCpuRequest(fb, ctx + " cpu fallback"); cpuFormulaFallback = fb }
+				} else {
+					_assertValidCpuRequest(v, ctx + " cpu")
+					cpuRequest = v
 				}
 			}
-			return self
-		},
+			setRam := func(v, ctx) {
+				if execFormula.isFormula(v) {
+					memFormulaAst = execFormula.astOf(v)
+					fb := execFormula.fallbackOf(v)
+					if !is_undefined(fb) { _assertValidMemRequest(fb, ctx + " ram fallback"); memFormulaFallback = fb }
+				} else {
+					_assertValidMemRequest(v, ctx + " ram")
+					ramRequest = v
+				}
+			}
+			setVram := func(v, ctx) {
+				if execFormula.isFormula(v) {
+					gpuFormulaAst = execFormula.astOf(v)
+					fb := execFormula.fallbackOf(v)
+					if !is_undefined(fb) { _assertValidGpuRequest(fb, ctx + " vram fallback"); gpuFormulaFallback = fb }
+				} else {
+					_assertValidGpuRequest(v, ctx + " vram")
+					gpuMemory = v
+				}
+			}
 
-		/**
-		 * Sets a resource formula that computes the CPU request from input file
-		 * metrics (size / line count) at run time on the backend.
-		 *
-		 * Requires a backend with getBlobSize support. On older backends the
-		 * formula is skipped and a static CPU request is used instead: the
-		 * `{ fallback: ... }` value, or — if none is given — a static `.cpu()`
-		 * set on the same builder. One of the two must be present (else an error).
-		 *
-		 * The formula must evaluate to a positive integer number of cores. A
-		 * non-positive or non-integer result is rejected at run time — floor it
-		 * with f.max / f.clamp if a metric can be zero.
-		 *
-		 * NOTE: resource formulas are CID-transparent — they do NOT participate in
-		 * exec deduplication. Two execs identical except for their formula dedup to
-		 * one run (and one allocation); vary a real input (an arg or file) if you
-		 * need them to allocate separately. (Transparency requires backend
-		 * serviceFields support; on a backend without it the formula instead
-		 * enters the exec CID — evaluation is still correct, only dedup is lost.)
-		 *
-		 * @param ast - a formula node produced via exec.formula
-		 * @param opts: { fallback?: number } - static CPU used when the backend
-		 *        lacks getBlobSize support.
-		 *
-		 * @return builder
-		 */
-		cpuFormula: func(ast, ...opts) {
-			ll.assert(is_map(ast) && !is_undefined(ast.op), "exec.builder.cpuFormula: expected a formula node from exec.formula")
-			cpuFormulaAst = ast
-			if len(opts) > 0 && ll.isMap(opts[0]) {
-				for k, _ in opts[0] {
-					ll.assert(k == "fallback", "exec.builder.cpuFormula: unknown option %q (only { fallback } is supported)", k)
+			assertKeys := func(block, name, allowVram) {
+				ll.assert(ll.isMap(block), "exec.builder.resources.%s: expected a map", name)
+				for k, _ in block {
+					ok := k == "cpu" || k == "ram" || (allowVram && k == "vram")
+					ll.assert(ok, "exec.builder.resources.%s: unknown key %q (allowed: %s)", name, k, allowVram ? "cpu, ram, vram" : "cpu, ram")
 				}
-				if !is_undefined(opts[0].fallback) {
-					_assertValidCpuRequest(opts[0].fallback, "exec.builder.cpuFormula fallback")
-					cpuFormulaFallback = opts[0].fallback
+				ll.assert(!is_undefined(block.cpu) && !is_undefined(block.ram),
+					"exec.builder.resources.%s: cpu and ram are required", name)
+				if allowVram {
+					ll.assert(!is_undefined(block.vram),
+						"exec.builder.resources.%s: vram is required (it is what makes this a GPU allocation)", name)
 				}
+			}
+
+			if hasCPU { assertKeys(spec.onCPU, "onCPU", false) }
+			if hasGPU { assertKeys(spec.onGPU, "onGPU", true) }
+
+			// Mode from which blocks are present:
+			//   onGPU alone            -> GPU required (fail fast if no GPU support)
+			//   onCPU + onGPU          -> adaptive: onGPU when the backend has a GPU, else onCPU
+			//   onCPU alone            -> CPU only
+			// The GPU-vs-CPU choice is resolved HERE, at workflow render time, via
+			// exec.hasGpu — no backend-side plan selection is involved.
+			useGPU := hasGPU && (!hasCPU || feats.hasGpu)
+			if hasGPU && !hasCPU {
+				ll.assert(feats.hasGpu,
+					"exec.builder.resources: onGPU was set without onCPU (GPU required), but this backend has no GPU support (exec.hasGpu is false). Add an onCPU block for an adaptive CPU fallback, or run on a GPU-enabled backend.")
+			}
+
+			if useGPU {
+				g := spec.onGPU
+				setCpu(g.cpu, "resources.onGPU")
+				setRam(g.ram, "resources.onGPU")
+				setVram(g.vram, "resources.onGPU")
+			} else {
+				c := spec.onCPU
+				setCpu(c.cpu, "resources.onCPU")
+				setRam(c.ram, "resources.onCPU")
 			}
 			return self
 		},
 
 		/**
 		 * Requests GPU resources from the underlying executor.
+		 *
+		 * Prefer .resources({ onGPU: { ... } }) for new code; this static setter
+		 * remains for direct/UI-driven VRAM requests.
 		 *
 		 * @param args: ...string - optional minimum VRAM size string (e.g. "16GiB").
 		 *              No args means any GPU with default 1GiB minimum VRAM.
@@ -1235,9 +1310,10 @@ builder := func() {
 			// builder() factory itself (see _lineCountResource). That is a plain
 			// recursive function call within :exec — no import of :pt or any
 			// metrics module — so there is no import cycle.
-			hasFormula := !is_undefined(memFormulaAst) || !is_undefined(cpuFormulaAst)
+			hasFormula := !is_undefined(memFormulaAst) || !is_undefined(cpuFormulaAst) || !is_undefined(gpuFormulaAst)
 			resolvedMem := undefined
 			resolvedCpu := undefined
+			resolvedGpu := undefined
 			lineCountMapResource := undefined
 
 			if hasFormula {
@@ -1252,18 +1328,21 @@ builder := func() {
 				canEvaluateFormulas := feats.hasBlobSize
 				if !canEvaluateFormulas {
 					// Backend can't evaluate formulas (no getBlobSize). Each formula
-					// dimension falls back to its { fallback }, or to a static
-					// .mem()/.cpu() if no { fallback } was given; error only when a
-					// dimension has neither. Pure decision, unit-tested in exec.formula
+					// dimension falls back to its .staticFallback(), or to a static
+					// request if none was given; error only when a dimension has
+					// neither. Pure decision, unit-tested in exec.formula
 					// (applyFormulaFallback).
 					fb := execFormula.applyFormulaFallback({
 						ram: { ast: memFormulaAst, fallback: memFormulaFallback, static: ramRequest },
-						cpu: { ast: cpuFormulaAst, fallback: cpuFormulaFallback, static: cpuRequest }
+						cpu: { ast: cpuFormulaAst, fallback: cpuFormulaFallback, static: cpuRequest },
+						gpu: { ast: gpuFormulaAst, fallback: gpuFormulaFallback, static: gpuMemory }
 					})
 					ll.assert(is_undefined(fb.err), fb.err)
 					ramRequest = fb.ram
 					cpuRequest = fb.cpu
+					gpuMemory = fb.gpu
 					if is_int(ramRequest) { ramRequest = string(ramRequest) + "b" }
+					if is_int(gpuMemory) { gpuMemory = string(gpuMemory) + "b" }
 				} else {
 					tagMap := {}
 					for fileName, tag in fileTags {
@@ -1283,6 +1362,11 @@ builder := func() {
 						refs := execFormula.referencedMetricFiles(resolvedCpu)
 						if !is_undefined(refs.lineCount) { sets.add(neededLineCount, refs.lineCount...) }
 					}
+					if !is_undefined(gpuFormulaAst) {
+						resolvedGpu = execFormula.resolveAst(gpuFormulaAst, tagMap, allFiles)
+						refs := execFormula.referencedMetricFiles(resolvedGpu)
+						if !is_undefined(refs.lineCount) { sets.add(neededLineCount, refs.lineCount...) }
+					}
 
 					if len(neededLineCount) > 0 {
 						perFile := {}
@@ -1299,16 +1383,18 @@ builder := func() {
 				cpu: cpuRequest,
 				ram: ramRequest
 			}
-			if !is_undefined(gpuMemory) {
-				// A cpuFormula/memFormula satisfies this requirement just like a static
-				// .cpu()/.mem(): it provides an explicit request, computed at run time
-				// (the ephemeral impl overrides the quota before allocation; gpuMemory is
-				// forwarded alongside), and the { fallback } covers no-getBlobSize backends.
-				// Without this, gpuMemory + a formula would wrongly assert on hasBlobSize
+			if !is_undefined(gpuMemory) || !is_undefined(gpuFormulaAst) {
+				// A cpu/ram formula satisfies this requirement just like a static
+				// request: it provides an explicit value, computed at run time (the
+				// ephemeral impl overrides the quota before allocation; gpuMemory is
+				// forwarded alongside), and the fallback covers no-getBlobSize backends.
+				// Without this, a GPU + a formula would wrongly assert on hasBlobSize
 				// backends (where ramRequest/cpuRequest stay undefined) yet pass on older ones.
-				ll.assert(!is_undefined(cpuRequest) || !is_undefined(cpuFormulaAst), "exec.builder: cpu() or cpuFormula() is required when gpuMemory() is set. GPU nodes vary in CPU capacity and cost; please provide an explicit CPU request.")
-				ll.assert(!is_undefined(ramRequest) || !is_undefined(memFormulaAst), "exec.builder: mem() or memFormula() is required when gpuMemory() is set. GPU nodes vary in RAM capacity and cost; please provide an explicit RAM request.")
-				quotaData.gpuMemory = gpuMemory
+				ll.assert(!is_undefined(cpuRequest) || !is_undefined(cpuFormulaAst), "exec.builder: a cpu request is required when a GPU is requested. GPU nodes vary in CPU capacity and cost; please provide an explicit CPU request.")
+				ll.assert(!is_undefined(ramRequest) || !is_undefined(memFormulaAst), "exec.builder: a ram request is required when a GPU is requested. GPU nodes vary in RAM capacity and cost; please provide an explicit RAM request.")
+				// A VRAM formula computes gpuMemory at run time (in exec.tpl); leave the
+				// static quota's gpuMemory unset in that case, exactly as ram/cpu do.
+				if !is_undefined(gpuMemory) { quotaData.gpuMemory = gpuMemory }
 			}
 			metaExecInputs := {
 				quota: smart.createJsonResource(quotaData)
@@ -1332,6 +1418,7 @@ builder := func() {
 			// Populated only on the canEvaluateFormulas path above.
 			if !is_undefined(resolvedMem) { metaExecInputs[execConstants.META_INPUT_MEM_FORMULA] = smart.createJsonResource(resolvedMem) }
 			if !is_undefined(resolvedCpu) { metaExecInputs[execConstants.META_INPUT_CPU_FORMULA] = smart.createJsonResource(resolvedCpu) }
+			if !is_undefined(resolvedGpu) { metaExecInputs[execConstants.META_INPUT_GPU_FORMULA] = smart.createJsonResource(resolvedGpu) }
 			if !is_undefined(lineCountMapResource) { pureExecInputs[execConstants.REGULAR_INPUT_LINE_COUNT] = lineCountMapResource }
 
 			// We add monetization only if it's enabled
@@ -1525,9 +1612,10 @@ export ll.toStrict({
 	builder: builder,
 
 	// True when at least one backend runner advertises GPU availability.
-	// Gate .gpuMemory() calls in blocks that have a CPU fallback path:
-	//   if exec.hasGpu { builder = builder.gpuMemory("16GiB") }
-	// Calling .gpuMemory() against a backend without GPU produces a permanent error.
+	// .resources({ onCPU, onGPU }) reads this at workflow render time to choose the
+	// onGPU allocation vs the onCPU fallback, so blocks rarely need it directly. It
+	// also backs the GPU-required guard: onGPU without onCPU (or a static
+	// .gpuMemory()) on a GPU-less backend is a permanent error.
 	hasGpu: feats.hasGpu,
 	formula: execFormula
 })

--- a/sdk/workflow-tengo/src/exec/index.lib.tengo
+++ b/sdk/workflow-tengo/src/exec/index.lib.tengo
@@ -53,10 +53,11 @@ _assertValidMemRequest := func(amount, ctx) {
 }
 // A VRAM request is a size string ("16GiB") or a number of bytes. The static
 // .gpuMemory() takes a string; a formula .staticFallback() may resolve to a
-// number of bytes (e.g. f.gib(48)) — both are accepted, mirroring _assertValidMemRequest.
+// number of bytes (e.g. f.gib(48)) — both are accepted, mirroring _assertValidMemRequest,
+// including the 16MiB floor that catches a bytes-where-GiB-was-meant mistake.
 _assertValidGpuRequest := func(amount, ctx) {
 	validation.assertType(amount, ["or", "number", "string"], ctx + ": VRAM amount must be a number of bytes or a size string like '16GiB'")
-	ll.assert(is_string(amount) || amount > 0, ctx + ": VRAM amount in bytes should be greater than 0")
+	ll.assert(is_string(amount) || amount >= 16 * units.MiB, ctx + ": VRAM amount in bytes should be at least 16MiB (did you pass bytes instead of GiB?)")
 }
 
 /**
@@ -558,34 +559,51 @@ builder := func() {
 			// Per-dimension setters: a formula (exec.formula chain / AST) sets the
 			// *FormulaAst + its .staticFallback(); a bare number/string is a static
 			// request. Closure-assign the builder's resource state directly.
+			// Each setter is authoritative for its dimension: a formula clears any
+			// static request left from a prior .cpu()/.mem()/.gpuMemory() (or an earlier
+			// .resources()), and a static value clears any prior formula AST + fallback.
+			// Without this, a reused/reconfigured builder could keep stale state and let
+			// a leftover formula override a later static value (or vice versa) at finalize.
 			setCpu := func(v, ctx) {
 				if execFormula.isFormula(v) {
 					cpuFormulaAst = execFormula.astOf(v)
+					cpuFormulaFallback = undefined
 					fb := execFormula.fallbackOf(v)
 					if !is_undefined(fb) { _assertValidCpuRequest(fb, ctx + " cpu fallback"); cpuFormulaFallback = fb }
+					cpuRequest = undefined
 				} else {
 					_assertValidCpuRequest(v, ctx + " cpu")
 					cpuRequest = v
+					cpuFormulaAst = undefined
+					cpuFormulaFallback = undefined
 				}
 			}
 			setRam := func(v, ctx) {
 				if execFormula.isFormula(v) {
 					memFormulaAst = execFormula.astOf(v)
+					memFormulaFallback = undefined
 					fb := execFormula.fallbackOf(v)
 					if !is_undefined(fb) { _assertValidMemRequest(fb, ctx + " ram fallback"); memFormulaFallback = fb }
+					ramRequest = undefined
 				} else {
 					_assertValidMemRequest(v, ctx + " ram")
 					ramRequest = v
+					memFormulaAst = undefined
+					memFormulaFallback = undefined
 				}
 			}
 			setVram := func(v, ctx) {
 				if execFormula.isFormula(v) {
 					gpuFormulaAst = execFormula.astOf(v)
+					gpuFormulaFallback = undefined
 					fb := execFormula.fallbackOf(v)
 					if !is_undefined(fb) { _assertValidGpuRequest(fb, ctx + " vram fallback"); gpuFormulaFallback = fb }
+					gpuMemory = undefined
 				} else {
 					_assertValidGpuRequest(v, ctx + " vram")
 					gpuMemory = v
+					gpuFormulaAst = undefined
+					gpuFormulaFallback = undefined
 				}
 			}
 
@@ -627,6 +645,11 @@ builder := func() {
 				c := spec.onCPU
 				setCpu(c.cpu, "resources.onCPU")
 				setRam(c.ram, "resources.onCPU")
+				// CPU-only mode: clear any GPU/VRAM state left from a prior .gpuMemory()
+				// or an earlier GPU-shaped .resources() so this spec doesn't leak a GPU request.
+				gpuMemory = undefined
+				gpuFormulaAst = undefined
+				gpuFormulaFallback = undefined
 			}
 			return self
 		},

--- a/tests/workflow-tengo/src/exec/formula.test.ts
+++ b/tests/workflow-tengo/src/exec/formula.test.ts
@@ -3,7 +3,7 @@ import { tplTest } from "@platforma-sdk/test";
 import * as env from "../env";
 
 /**
- * End-to-end proof that resource formulas (memFormula / cpuFormula) are
+ * End-to-end proof that resource formulas (RAM / CPU) are
  * evaluated at runtime against a LIVE backend, and that the line-counter
  * sub-exec actually runs.
  *
@@ -76,7 +76,7 @@ async function libraryFileHandle(
  *   lineCount — the line-counter sub-exec runs and its count flows into RAM.
  *   multi     — two files under one tag: size sums both blobs and lineCount sums
  *               both counts (metric map has 2 entries → exercises the aggregate
- *               map + the impl's wildcard await), and divCeil rounds up.
+ *               map + the impl's wildcard await), and .dividedBy (ceil) rounds up.
  */
 const fileCases = [
   {
@@ -93,9 +93,9 @@ const fileCases = [
   },
   {
     mode: "multi",
-    // cpu = divCeil(2*lineCount, 50); ceiling of 84/50 = 2 (truncating div = 1).
-    // Robust to a ±1 newline-vs-line ambiguity in the counter: divCeil(86,50)=2 too.
-    desc: "ram = 1GiB + 2*fileSize, cpu = divCeil(2*lineCount, 50) (multi-file aggregation)",
+    // cpu = ceil(2*lineCount / 50); ceiling of 84/50 = 2 (truncating div = 1).
+    // Robust to a ±1 newline-vs-line ambiguity in the counter: ceil(86/50)=2 too.
+    desc: "ram = 1GiB + 2*fileSize, cpu = ceil(2*lineCount / 50) (multi-file aggregation)",
     expectedRam: 1 * GIB + 2 * FIXTURE_BYTES,
     expectedCpu: Math.ceil((2 * FIXTURE_NEWLINES) / 50),
   },
@@ -141,7 +141,7 @@ for (const tc of fileCases) {
  * a different slice of the evaluator wires through the ephemeral impl:
  *   formula_const — the constant-arithmetic plumbing (builder → pure template →
  *                   ephemeral impl eval → quota override), independent of files.
- *   formula_ops   — non-arithmetic ops (clamp, comparison, conditional) evaluate
+ *   formula_ops   — non-arithmetic ops (.between, comparison, conditional) evaluate
  *                   against the real evaluator, not just the unit-test resolver.
  */
 const constCases = [
@@ -153,7 +153,7 @@ const constCases = [
   },
   {
     template: "exec.run.formula_ops",
-    desc: "ram = 4GiB (clamp caps 8GiB→4GiB), cpu = 2 (if/gt selects)",
+    desc: "ram = 4GiB (.between caps 8GiB→4GiB), cpu = 2 (.when/.gt selects)",
     expectedRam: 4 * GIB,
     expectedCpu: 2,
   },
@@ -302,20 +302,20 @@ const rejectCases = [
   {
     mode: "negative",
     needsFile: false,
-    pattern: /\(ram\) must evaluate to a positive integer/, // result underflows to negative (f.sub)
-    desc: "memFormula underflow (negative) rejected, names ram",
+    pattern: /\(ram\) must evaluate to a positive integer/, // result underflows to negative (.minus)
+    desc: "RAM formula underflow (negative) rejected, names ram",
   },
   {
     mode: "zero",
     needsFile: false,
     pattern: /\(ram\) must evaluate to a positive integer/, // result is an unfloored 0
-    desc: "memFormula = 0 (unfloored) rejected, names ram",
+    desc: "RAM formula = 0 (unfloored) rejected, names ram",
   },
   {
     mode: "boolCpu",
     needsFile: false,
     pattern: /\(cpu\) must compute a number/, // top-level comparison rejected structurally
-    desc: "cpuFormula = comparison (bool) rejected, names cpu",
+    desc: "CPU formula = comparison (bool) rejected, names cpu",
   },
   {
     mode: "bam",
@@ -367,7 +367,7 @@ for (const tc of rejectCases) {
 /**
  * Formula CID-transparency direct proof. The resolved formula ASTs ride the META
  * input rail, so they are EXCLUDED from the exec CID. Render the SAME exec twice
- * (identical software/arg/no files), differing ONLY in the memFormula value
+ * (identical software/arg/no files), differing ONLY in the RAM formula value
  * (2 GiB vs 4 GiB). Because the formula does NOT affect the CID, the two renders
  * share one CID and dedup to a single allocation: the memGib=4 render dedups to
  * the memGib=2 render, so BOTH read back 2 GiB. (If the formula ever leaked into
@@ -378,7 +378,7 @@ for (const tc of rejectCases) {
  * constant ",cid" arg suffix so the two renders differ ONLY by formula.
  */
 tplTest.concurrent(
-  "formula-cid-transparent: changing the memFormula dedups to one allocation",
+  "formula-cid-transparent: changing the RAM formula dedups to one allocation",
   async ({ helper, expect }) => {
     const readRam = async (memGib: number) => {
       const result = await helper.renderTemplate(

--- a/tests/workflow-tengo/src/exec/formula.test.ts
+++ b/tests/workflow-tengo/src/exec/formula.test.ts
@@ -320,8 +320,14 @@ const rejectCases = [
   {
     mode: "bam",
     needsFile: true,
-    pattern: /lineCount is not supported for file/, // unsupported lineCount format, rejected at builder time
-    desc: "f.lineCount() on a .bam file rejected at builder time",
+    pattern: /lineCount is not supported for file/, // unsupported lineCount format, rejected at workflow render time
+    desc: "f.lineCount() on a .bam file rejected at workflow render time",
+  },
+  {
+    mode: "gpuRequired",
+    needsFile: false,
+    pattern: /no GPU support/, // onGPU without onCPU on a GPU-less backend -> fail fast at workflow render time
+    desc: "resources({ onGPU }) alone fails fast on a GPU-less backend",
   },
 ] as const;
 
@@ -331,10 +337,11 @@ for (const tc of rejectCases) {
     async ({ helper, expect, driverKit }) => {
       const handle = tc.needsFile ? await libraryFileHandle(driverKit) : undefined;
 
-      // The render must fail. Positive-integer-guard rejections surface when the awaited
-      // output resolves (the ephemeral impl panics in evaluateResource); the format-guard
-      // rejection fails the render directly (builder-time assert). Wrapping
-      // render + await in one thunk catches both timings.
+      // The render must fail. Positive-integer-guard rejections surface at run time,
+      // when the awaited output resolves (the ephemeral impl panics in
+      // evaluateResource); the format guard and the GPU-required guard fail the
+      // render directly (a workflow-render-time assert). Wrapping render + await in
+      // one thunk catches both timings.
       await expect(async () => {
         const result = await helper.renderTemplate(
           false,

--- a/tests/workflow-tengo/src/exec/run/formula_bz2.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_bz2.tpl.tengo
@@ -32,7 +32,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},bz2").
 		addFile("reads.fastq.bz2", inputFile, { tag: "reads" }).
-		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024)), cpu: f.add(1, 1) } }).
+		resources({ onCPU: { ram: f.lineCount("reads").times(1024).plus(f.mib(512)), cpu: f.const(1).plus(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_bz2.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_bz2.tpl.tengo
@@ -32,8 +32,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},bz2").
 		addFile("reads.fastq.bz2", inputFile, { tag: "reads" }).
-		memFormula(f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024))).
-		cpuFormula(f.add(1, 1)).
+		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024)), cpu: f.add(1, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_cid.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_cid.tpl.tengo
@@ -29,8 +29,7 @@ self.body(func(inputs) {
 		inHeavyQueue().
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},cid").
-		memFormula(f.gib(inputs.memGib)).
-		cpuFormula(f.add(2, 1)).
+		resources({ onCPU: { ram: f.gib(inputs.memGib), cpu: f.add(2, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_cid.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_cid.tpl.tengo
@@ -29,7 +29,7 @@ self.body(func(inputs) {
 		inHeavyQueue().
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},cid").
-		resources({ onCPU: { ram: f.gib(inputs.memGib), cpu: f.add(2, 1) } }).
+		resources({ onCPU: { ram: f.gib(inputs.memGib), cpu: f.const(2).plus(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_cid_files.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_cid_files.tpl.tengo
@@ -30,7 +30,7 @@ self.body(func(inputs) {
 		argWithVar("{system.ram.bytes},{system.cpu},cidfiles").
 		addFile("a.txt", fileA, { tag: "a" }).
 		addFile("b.txt", fileB, { tag: "b" }).
-		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount(inputs.whichTag), 1024)), cpu: f.add(1, 1) } }).
+		resources({ onCPU: { ram: f.lineCount(inputs.whichTag).times(1024).plus(f.mib(512)), cpu: f.const(1).plus(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_cid_files.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_cid_files.tpl.tengo
@@ -30,8 +30,7 @@ self.body(func(inputs) {
 		argWithVar("{system.ram.bytes},{system.cpu},cidfiles").
 		addFile("a.txt", fileA, { tag: "a" }).
 		addFile("b.txt", fileB, { tag: "b" }).
-		memFormula(f.add(f.mib(512), f.mul(f.lineCount(inputs.whichTag), 1024))).
-		cpuFormula(f.add(1, 1)).
+		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount(inputs.whichTag), 1024)), cpu: f.add(1, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_cid_metric.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_cid_metric.tpl.tengo
@@ -28,9 +28,9 @@ self.body(func(inputs) {
 
 	memAst := undefined
 	if mode == "size" {
-		memAst = f.add(f.size("reads"), f.gib(deltaGib))
+		memAst = f.size("reads").plus(f.gib(deltaGib))
 	} else if mode == "lineCount" {
-		memAst = f.add(f.mul(f.lineCount("reads"), 1024), f.gib(deltaGib))
+		memAst = f.lineCount("reads").times(1024).plus(f.gib(deltaGib))
 	} else {
 		ll.panic("formula_cid_metric: unknown mode %v", mode)
 	}
@@ -40,7 +40,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},cidmetric-" + mode).
 		addFile("input.txt", inputFile, { tag: "reads" }).
-		resources({ onCPU: { ram: memAst, cpu: f.add(2, 1) } }).
+		resources({ onCPU: { ram: memAst, cpu: f.const(2).plus(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_cid_metric.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_cid_metric.tpl.tengo
@@ -40,8 +40,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},cidmetric-" + mode).
 		addFile("input.txt", inputFile, { tag: "reads" }).
-		memFormula(memAst).
-		cpuFormula(f.add(2, 1)).
+		resources({ onCPU: { ram: memAst, cpu: f.add(2, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_const.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_const.tpl.tengo
@@ -20,8 +20,7 @@ self.body(func(inputs) {
 		inHeavyQueue().
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu}").
-		memFormula(f.gib(2)).
-		cpuFormula(f.add(2, 1)).
+		resources({ onCPU: { ram: f.gib(2), cpu: f.add(2, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_const.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_const.tpl.tengo
@@ -20,7 +20,7 @@ self.body(func(inputs) {
 		inHeavyQueue().
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu}").
-		resources({ onCPU: { ram: f.gib(2), cpu: f.add(2, 1) } }).
+		resources({ onCPU: { ram: f.gib(2), cpu: f.const(2).plus(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_gz.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_gz.tpl.tengo
@@ -33,7 +33,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},gz").
 		addFile("reads.fastq.GZ", inputFile, { tag: "reads" }).
-		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024)), cpu: f.add(1, 1) } }).
+		resources({ onCPU: { ram: f.lineCount("reads").times(1024).plus(f.mib(512)), cpu: f.const(1).plus(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_gz.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_gz.tpl.tengo
@@ -33,8 +33,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},gz").
 		addFile("reads.fastq.GZ", inputFile, { tag: "reads" }).
-		memFormula(f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024))).
-		cpuFormula(f.add(1, 1)).
+		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024)), cpu: f.add(1, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_limits.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_limits.tpl.tengo
@@ -61,8 +61,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu}," + mode).
 		addFile("input.txt", inputFile, { tag: "reads" }).
-		memFormula(memAst).
-		cpuFormula(cpuAst).
+		resources({ onCPU: { ram: memAst, cpu: cpuAst } }).
 		saveStdoutContent()
 
 	// Second file under the same tag, to exercise multi-file metric aggregation.

--- a/tests/workflow-tengo/src/exec/run/formula_limits.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_limits.tpl.tengo
@@ -33,20 +33,20 @@ self.body(func(inputs) {
 	cpuAst := undefined
 	if mode == "size" {
 		// 1 GiB + size("reads") bytes ; 2 + 1 = 3 cores
-		memAst = f.add(f.gib(1), f.size("reads"))
-		cpuAst = f.add(2, 1)
+		memAst = f.size("reads").plus(f.gib(1))
+		cpuAst = f.const(2).plus(1)
 	} else if mode == "lineCount" {
 		// 512 MiB + lineCount("reads") * 1024 bytes ; 1 + 1 = 2 cores
-		memAst = f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024))
-		cpuAst = f.add(1, 1)
+		memAst = f.lineCount("reads").times(1024).plus(f.mib(512))
+		cpuAst = f.const(1).plus(1)
 	} else if mode == "multi" {
 		// Two files share tag "reads": size("reads") sums BOTH blob sizes, and
 		// lineCount("reads") sums BOTH line counts — so the line-count metric map
 		// carries two entries, exercising _aggregateLineCountMap and the impl's
 		// wildcard await over more than one per-file count. divCeil proves ceiling
 		// division: with 2*42=84 lines, divCeil(84, 50) = 2 (truncating div = 1).
-		memAst = f.add(f.gib(1), f.size("reads"))
-		cpuAst = f.divCeil(f.lineCount("reads"), 50)
+		memAst = f.size("reads").plus(f.gib(1))
+		cpuAst = f.lineCount("reads").dividedBy(50)
 	} else {
 		ll.panic("formula_limits: unknown mode %v", mode)
 	}

--- a/tests/workflow-tengo/src/exec/run/formula_ops.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_ops.tpl.tengo
@@ -25,7 +25,7 @@ self.body(func(inputs) {
 		inHeavyQueue().
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},ops").
-		resources({ onCPU: { ram: f.clamp(f.gib(8), f.gib(1), f.gib(4)), cpu: f["if"](f.gt(f.gib(8), f.gib(4)), 2, 1) } }).
+		resources({ onCPU: { ram: f.gib(8).between(f.gib(1), f.gib(4)), cpu: f.when(f.gib(8).gt(f.gib(4)), 2).otherwise(1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_ops.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_ops.tpl.tengo
@@ -25,8 +25,7 @@ self.body(func(inputs) {
 		inHeavyQueue().
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},ops").
-		memFormula(f.clamp(f.gib(8), f.gib(1), f.gib(4))).
-		cpuFormula(f["if"](f.gt(f.gib(8), f.gib(4)), 2, 1)).
+		resources({ onCPU: { ram: f.clamp(f.gib(8), f.gib(1), f.gib(4)), cpu: f["if"](f.gt(f.gib(8), f.gib(4)), 2, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_reject.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_reject.tpl.tengo
@@ -2,9 +2,9 @@
  * Negative-path resource-formula templates: each `mode` builds a formula that
  * MUST be rejected, proving the guards actually fire end-to-end.
  *
- *   negative     — memFormula underflows (f.sub) to a negative byte count -> rejected (ram), at run time
- *   zero         — memFormula evaluates to exactly 0                       -> rejected (ram), at run time
- *   boolCpu      — cpuFormula is a top-level comparison (a bool)           -> rejected (cpu), at run time
+ *   negative     — the RAM formula underflows (.minus) to a negative byte count -> rejected (ram), at run time
+ *   zero         — the RAM formula evaluates to exactly 0                       -> rejected (ram), at run time
+ *   boolCpu      — the CPU formula is a top-level comparison (a bool)           -> rejected (cpu), at run time
  *   bam          — f.lineCount() on a .bam file (unsupported format)       -> rejected at workflow render time
  *   gpuRequired  — resources({ onGPU }) with NO onCPU on a GPU-less backend -> rejected at workflow render time (fail fast)
  *
@@ -44,20 +44,20 @@ self.body(func(inputs) {
 
 	if mode == "negative" {
 		// 1 GiB - 2 GiB underflows to a negative byte count -> rejected (ram).
-		b = b.resources({ onCPU: { ram: f.sub(f.gib(1), f.gib(2)), cpu: f.add(1, 1) } })
+		b = b.resources({ onCPU: { ram: f.gib(1).minus(f.gib(2)), cpu: f.const(1).plus(1) } })
 	} else if mode == "zero" {
 		// 1 GiB - 1 GiB = 0 -> a zero RAM request is rejected (ram).
-		b = b.resources({ onCPU: { ram: f.sub(f.gib(1), f.gib(1)), cpu: f.add(1, 1) } })
+		b = b.resources({ onCPU: { ram: f.gib(1).minus(f.gib(1)), cpu: f.const(1).plus(1) } })
 	} else if mode == "boolCpu" {
 		// A top-level comparison evaluates to a bool, not an int -> rejected (cpu).
-		b = b.resources({ onCPU: { ram: f.gib(1), cpu: f.gt(f.gib(8), f.gib(4)) } })
+		b = b.resources({ onCPU: { ram: f.gib(1), cpu: f.gib(8).gt(f.gib(4)) } })
 	} else if mode == "bam" {
 		// f.lineCount() on a .bam file: the builder's format check rejects it before
 		// any pre-exec runs. The file content is irrelevant — the guard keys off the
 		// extension — so we reuse the standard text fixture under a .bam name.
 		inputFile := file.importFile(inputs.file).file
 		b = b.addFile("reads.bam", inputFile, { tag: "reads" }).
-			resources({ onCPU: { ram: f.add(f.mib(512), f.lineCount("reads")), cpu: f.add(1, 1) } })
+			resources({ onCPU: { ram: f.lineCount("reads").plus(f.mib(512)), cpu: f.const(1).plus(1) } })
 	} else if mode == "gpuRequired" {
 		// onGPU with NO onCPU means "GPU required". On a backend without GPU support
 		// (exec.hasGpu is false) resources() must fail fast at workflow render time — there is

--- a/tests/workflow-tengo/src/exec/run/formula_reject.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_reject.tpl.tengo
@@ -1,17 +1,21 @@
 /**
  * Negative-path resource-formula templates: each `mode` builds a formula that
- * MUST be rejected, proving the run-time guards actually fire end-to-end.
+ * MUST be rejected, proving the guards actually fire end-to-end.
  *
- *   negative — memFormula underflows (f.sub) to a negative byte count -> rejected (ram)
- *   zero     — memFormula evaluates to exactly 0                       -> rejected (ram)
- *   boolCpu  — cpuFormula is a top-level comparison (a bool)           -> rejected (cpu)
- *   bam      — f.lineCount() on a .bam file (unsupported format)       -> rejected at builder time
+ *   negative     — memFormula underflows (f.sub) to a negative byte count -> rejected (ram), at run time
+ *   zero         — memFormula evaluates to exactly 0                       -> rejected (ram), at run time
+ *   boolCpu      — cpuFormula is a top-level comparison (a bool)           -> rejected (cpu), at run time
+ *   bam          — f.lineCount() on a .bam file (unsupported format)       -> rejected at workflow render time
+ *   gpuRequired  — resources({ onGPU }) with NO onCPU on a GPU-less backend -> rejected at workflow render time (fail fast)
  *
  * The positive-integer result guard lives in the ephemeral impl
- * (exec.formula.evaluateResource); the format-compatibility guard lives
- * in the builder (resolveAst -> _assertMetricCompatible). Both surface to the
- * test as a render failure (the impl panic propagates to the awaited output;
- * the builder panic fails the render directly).
+ * (exec.formula.evaluateResource); the format-compatibility guard and the
+ * GPU-required guard live in the builder (resolveAst -> _assertMetricCompatible;
+ * resources() -> feats.hasGpu). Both surface to the test as a render failure (the
+ * impl panic propagates to the awaited output; the workflow-render-time panic
+ * fails the render directly). NOTE: gpuRequired only fails as intended on a
+ * backend WITHOUT GPU support (exec.hasGpu is false) — the case the test suite
+ * runs against.
  *
  * The ",reject-<mode>" arg suffix keeps each failing exec CID-distinct — formula
  * meta inputs are CID-transparent, so identical args would otherwise dedup the
@@ -40,21 +44,27 @@ self.body(func(inputs) {
 
 	if mode == "negative" {
 		// 1 GiB - 2 GiB underflows to a negative byte count -> rejected (ram).
-		b = b.memFormula(f.sub(f.gib(1), f.gib(2))).cpuFormula(f.add(1, 1))
+		b = b.resources({ onCPU: { ram: f.sub(f.gib(1), f.gib(2)), cpu: f.add(1, 1) } })
 	} else if mode == "zero" {
 		// 1 GiB - 1 GiB = 0 -> a zero RAM request is rejected (ram).
-		b = b.memFormula(f.sub(f.gib(1), f.gib(1))).cpuFormula(f.add(1, 1))
+		b = b.resources({ onCPU: { ram: f.sub(f.gib(1), f.gib(1)), cpu: f.add(1, 1) } })
 	} else if mode == "boolCpu" {
 		// A top-level comparison evaluates to a bool, not an int -> rejected (cpu).
-		b = b.memFormula(f.gib(1)).cpuFormula(f.gt(f.gib(8), f.gib(4)))
+		b = b.resources({ onCPU: { ram: f.gib(1), cpu: f.gt(f.gib(8), f.gib(4)) } })
 	} else if mode == "bam" {
 		// f.lineCount() on a .bam file: the builder's format check rejects it before
 		// any pre-exec runs. The file content is irrelevant — the guard keys off the
 		// extension — so we reuse the standard text fixture under a .bam name.
 		inputFile := file.importFile(inputs.file).file
 		b = b.addFile("reads.bam", inputFile, { tag: "reads" }).
-			memFormula(f.add(f.mib(512), f.lineCount("reads"))).
-			cpuFormula(f.add(1, 1))
+			resources({ onCPU: { ram: f.add(f.mib(512), f.lineCount("reads")), cpu: f.add(1, 1) } })
+	} else if mode == "gpuRequired" {
+		// onGPU with NO onCPU means "GPU required". On a backend without GPU support
+		// (exec.hasGpu is false) resources() must fail fast at workflow render time — there is
+		// no CPU fallback to degrade to. This proves the fail-fast guard fires end-to-end.
+		// Values are irrelevant — the fail-fast assert fires in resources() before any
+		// formula is evaluated — so keep them static.
+		b = b.resources({ onGPU: { cpu: 4, ram: "16GiB", vram: "16GiB" } })
 	} else {
 		ll.panic("formula_reject: unknown mode %v", mode)
 	}

--- a/tests/workflow-tengo/src/exec/run/formula_zst.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_zst.tpl.tengo
@@ -31,8 +31,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},zst").
 		addFile("reads.fastq.zst", inputFile, { tag: "reads" }).
-		memFormula(f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024))).
-		cpuFormula(f.add(1, 1)).
+		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024)), cpu: f.add(1, 1) } }).
 		saveStdoutContent().
 		run()
 

--- a/tests/workflow-tengo/src/exec/run/formula_zst.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/formula_zst.tpl.tengo
@@ -31,7 +31,7 @@ self.body(func(inputs) {
 		software(sw).
 		argWithVar("{system.ram.bytes},{system.cpu},zst").
 		addFile("reads.fastq.zst", inputFile, { tag: "reads" }).
-		resources({ onCPU: { ram: f.add(f.mib(512), f.mul(f.lineCount("reads"), 1024)), cpu: f.add(1, 1) } }).
+		resources({ onCPU: { ram: f.lineCount("reads").times(1024).plus(f.mib(512)), cpu: f.const(1).plus(1) } }).
 		saveStdoutContent().
 		run()
 


### PR DESCRIPTION
Redesigns the exec resource-formula API in the `workflow-tengo` SDK, plus a matching rewrite of the `clonotype-space` UMAP block (block change lives in its own repo/PR).

## Key files
- sdk/workflow-tengo/src/exec/formula.test.tengo
- sdk/workflow-tengo/src/exec/formula.lib.tengo

## What changed

**New front door — `builder.resources({ ... })`** with two parallel blocks; the mode is inferred from which are present:

```go
exec := import("@platforma-sdk/workflow-tengo:exec")
f := exec.formula

// CPU only (onCPU alone)
.resources({ queue: "heavy", onCPU: { cpu: <cpu>, ram: <ram> } })

// GPU required (onGPU alone — runs only on a GPU node, fails fast at workflow render time otherwise)
.resources({ onGPU: { cpu: <cpu>, ram: <ram>, vram: <vram> } })

// GPU preferred (both — adaptive: onGPU when the backend has a GPU, else onCPU)
.resources({ onCPU: { cpu, ram }, onGPU: { cpu, ram, vram } })
```

- `onCPU` takes `{ cpu, ram }`; `onGPU` takes `{ cpu, ram, vram }` (vram is what makes it a GPU allocation, so it's required there).
- Each dimension takes a static value (number / size string) or a data-driven `exec.formula` chain ending in `.staticFallback(...)` (the value used on backends that can't evaluate formulas at run time).
- The GPU-vs-CPU choice is resolved at **workflow render time** via `exec.hasGpu` — no backend plan-selection involved. `onGPU` alone on a GPU-less backend errors immediately (fail fast).

**Fluent formula chain** on every `exec.formula` node: `.per` (÷, ceil), `.times`, `.plus`, `.minus`, `.atLeast` (max), `.atMost` (min), `.between(lo, hi)` (clamp), `.staticFallback(...)`. The prefix constructors (`f.add`, `f.clamp`, `f.if`, …) remain for conditionals.

**GPU/VRAM formulas** — new `__gpuFormula__` meta input + VRAM evaluation in `exec.tpl`. Resource formulas stay CID-transparent.

## Breaking

Removes the imperative `.memFormula()` / `.cpuFormula()` builder methods (shipped in 6.6.x). The static `.cpu()` / `.mem()` / `.gpuMemory()` setters are unchanged. Only in-repo consumer was `clonotype-space`, migrated separately.

## Tests

- Unit (`pl-tengo test`): 204 pass — fluent-chain-equals-prefix-AST, `isFormula`/`astOf`/`fallbackOf`, GPU fallback dimension, and `resources()` smoke tests (CPU / static / adaptive / GPU-required).
- Integration (`formula_*.tpl` + `formula.test.ts`): 10 templates migrated to `onCPU`/`onGPU`; added a `gpuRequired` reject-case proving `onGPU`-alone fails fast on a GPU-less backend.

## Note for reviewers

`faf4a63a6` was accidentally pushed straight to `main`, reverted there (`a01e228c7`), and this branch reapplies it via `8bbf418ba` so the change lands through review. The PR diff is exactly the intended work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR redesigns the exec resource-formula API in the `workflow-tengo` SDK: the per-dimension `.memFormula()`/`.cpuFormula()` methods are removed in favour of a single `.resources({ onCPU, onGPU })` entry point, a fluent chain DSL replaces the old prefix constructors, GPU/VRAM formula support is added via a new `__gpuFormula__` META input, and all AST op names are renamed to match the fluent method names (`add→plus`, `clamp→between`, `if→when`, etc.).

- **New `.resources({ onCPU?, onGPU? })` API**: mode is inferred from which blocks are present — CPU-only, GPU-required (fail-fast at workflow render time), or adaptive (resolved via `feats.hasGpu`). Each dimension accepts a static value or a fluent formula chain ending in `.staticFallback(...)`.
- **Fluent formula DSL (`_node` + `_condBuilder`)**: immutable, chainable wrapper carrying the plain AST and an optional static fallback; the underlying AST tree stays wrapper-free through `_unwrap`/`_wrap` at every composition boundary.
- **GPU formula evaluation in `exec.tpl`**: the resolved VRAM AST rides the META rail (`__gpuFormula__`) and is evaluated at run time, producing a bytes-string for `quota.gpuMemory`.

**Key touched terms:**
- **exec formula** — Pure AST representing a data-driven resource computation. Op names renamed to mirror fluent method names.
- **fluent wrapper (`_node`)** — New chainable `{ __isFormula__, __ast__, __fallback__ }` map replacing prefix constructors.
- **`_condBuilder`** — New immutable accumulator for `when().otherwise()` multi-branch conditionals.
- **`resources()`** — New unified builder entry point (`{ onCPU?, onGPU? }`), replacing `.memFormula()`/`.cpuFormula()`.
- **`staticFallback`** — New terminal chain method pinning the static value for no-`hasBlobSize` backends.
- **`__gpuFormula__`** — New CID-transparent META rail input carrying the resolved VRAM AST to `exec.tpl`.
- **`_assertValidGpuRequest`** — VRAM validator, now requires `>= 16 MiB` (consistent with the RAM floor).
- **`feats.hasGpu` / `exec.hasGpu`** — Backend GPU feature flag, now drives `onCPU`/`onGPU` mode selection at workflow render time.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the change introduces a well-bounded new API with no mutations to existing exec CID semantics, all new code paths are tested unit and end-to-end, and the breaking removal of the old formula setters is limited to one in-repo consumer already migrated separately.

The fluent wrapper is immutable by construction, _unwrap/_wrap are applied consistently at every composition boundary, the GPU formula path in exec.tpl mirrors the well-tested RAM path exactly, validation floors are consistent across all three dimensions, and the fail-fast GPU-required guard is integration-tested. No logical gaps were found.

No files require special attention. The two suggestions are cosmetic comment fixes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/exec/formula.lib.tengo | Core formula DSL rewrite: adds _node fluent wrapper, _condBuilder, _staticValue, _unwrap; renames all AST ops; evaluateResource/resolveAst/applyFormulaFallback extended for GPU dimension. Logic and immutability handling are correct. |
| sdk/workflow-tengo/src/exec/index.lib.tengo | Adds resources() builder method with onCPU/onGPU mode inference, _assertValidGpuRequest (16 MiB floor), gpuFormulaAst/Fallback state, and GPU assertion in run(). Adaptive GPU/CPU selection via feats.hasGpu is correct. |
| sdk/workflow-tengo/src/exec/exec.tpl.tengo | Adds __gpuFormula__ optional META input and evaluates it at run time, producing quota.gpuMemory as a Nb byte string consistent with the existing RAM formula pattern. |
| sdk/workflow-tengo/src/exec/constants.lib.tengo | Adds META_INPUT_GPU_FORMULA constant keeping the cross-file attach/read/validate contract in one source of truth. |
| sdk/workflow-tengo/src/exec/formula.test.tengo | Comprehensive unit tests: fluent chain structure, all arithmetic/bounds/logic/conditional ops, evaluateResource, resolveAst, referencedMetricFiles, staticFallback, isFormula, applyFormulaFallback including new GPU dimension. |
| sdk/workflow-tengo/src/exec/gpu.test.tengo | Unit tests for resources() covering CPU-only, static values, adaptive onCPU+onGPU, and GPU-required shapes. |
| tests/workflow-tengo/src/exec/run/formula_reject.tpl.tengo | Adds gpuRequired reject-case (onGPU without onCPU on a GPU-less backend), migrates other modes to new resources({onCPU}) syntax. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Author
    participant Builder as exec.builder resources()
    participant Feats as feats.hasGpu
    participant Resolver as resolveAst
    participant META as META rail __gpuFormula__
    participant Template as exec.tpl run time
    participant Evaluator as evaluateResource

    Author->>Builder: resources onCPU onGPU spec
    Builder->>Feats: read hasGpu flag
    Feats-->>Builder: true or false
    Builder->>Builder: choose onGPU or onCPU block
    Builder->>Resolver: resolveAst gpuFormulaAst tagMap allFiles
    Resolver-->>Builder: resolved AST metric to metricSum
    Builder->>META: attach resolvedGpu as __gpuFormula__ JSON resource
    Note over META: CID-transparent META rail

    Template->>META: read __gpuFormula__
    Template->>Evaluator: evaluateResource gpuFormula resolver gpuMemory
    Evaluator-->>Template: positive integer bytes
    Template->>Template: "quota.gpuMemory = string bytes + b"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Author
    participant Builder as exec.builder resources()
    participant Feats as feats.hasGpu
    participant Resolver as resolveAst
    participant META as META rail __gpuFormula__
    participant Template as exec.tpl run time
    participant Evaluator as evaluateResource

    Author->>Builder: resources onCPU onGPU spec
    Builder->>Feats: read hasGpu flag
    Feats-->>Builder: true or false
    Builder->>Builder: choose onGPU or onCPU block
    Builder->>Resolver: resolveAst gpuFormulaAst tagMap allFiles
    Resolver-->>Builder: resolved AST metric to metricSum
    Builder->>META: attach resolvedGpu as __gpuFormula__ JSON resource
    Note over META: CID-transparent META rail

    Template->>META: read __gpuFormula__
    Template->>Evaluator: evaluateResource gpuFormula resolver gpuMemory
    Evaluator-->>Template: positive integer bytes
    Template->>Template: "quota.gpuMemory = string bytes + b"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["MILAB-6480: full info about new fluent A..."](https://github.com/milaboratory/platforma/commit/4499369a22fb6aa253c1252892dbddf4f3bb1e30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42333181)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->