### PR TITLE
MILAB-6497: fix release binary upload env var for software build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -98,7 +98,7 @@ jobs:
         env:
           NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL: ${{ secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL }}
+          PL_RELEASE_BINARY_UPLOAD_URL: ${{ secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL }}
         run: pnpm run ci:build:release
 
       - name: Security scan


### PR DESCRIPTION
## Problem

The `main` release build (job **publish** → **Build for publish (full, non-local)**) fails:

\`\`\`
error: no storage URL is set for registry platforma-open
error: 'registry.storageURL' of package 'phead-lines' is empty. Set it as command option,
       in 'package.json' file or via environment variable 'PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL'
Failed: @platforma-open/milaboratories.software-ptexter#build
\`\`\`

Failing run: https://github.com/milaboratory/platforma/actions/runs/28955554910/job/85913770051

## Root cause

Introduced by `a6f7e3e71` (MILAB-6497), which moved `lib/ptexter` and `lib/ptabler/software` off `pl-pkg` to `block-tools software build` and dropped `prepublishOnly`. Binary upload to the `platforma-open` registry now happens **inside the turbo `build` task** during `ci:build:release`.

In release mode the upload URL is resolved from `PL_RELEASE_BINARY_UPLOAD_URL`, which is the registry upload var whitelisted in both packages' `turbo.json` `env` lists. But the workflow step still set the legacy `PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL` — not in any build-task allowlist, so **turbo strict env mode strips it** before the build runs. The `platforma-open` registry then has no `storageURL` and the build aborts.

This only surfaces on the `main` release build; PR CI runs `ci:build:local` (dev/local), which uses the built-in midev target.

## Fix

Rename the env var in the **Build for publish** step to `PL_RELEASE_BINARY_UPLOAD_URL` — the var the release code path reads and that turbo already passes through. Same secret value, only the key changes. The `Publish packages (public)` step is left untouched (packages still on `pl-pkg prepublish` upload there, outside turbo).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken `main` branch release build by correcting the environment variable name used in the \"Build for publish\" GitHub Actions step. The build was failing because turbo's strict env mode was stripping `PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL` — which is not in any turbo task `env` allowlist — before the `build` task ran, leaving the `platforma-open` registry without a `storageURL`.

- **Env var rename in CI**: The `Build for publish (full, non-local)` step now sets `PL_RELEASE_BINARY_UPLOAD_URL` (whitelisted in `lib/ptexter/turbo.json` and `lib/ptabler/software/turbo.json`) instead of the old `PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL`. Both variables point to the same secret value.
- **\"Publish packages (public)\" step untouched**: That step still uses `PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL`, which is correct because `pl-pkg prepublish` runs outside turbo and reads the legacy variable name.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line env var rename that directly unblocks a broken release build with no side effects on other steps.

The rename is mechanically correct: `PL_RELEASE_BINARY_UPLOAD_URL` is explicitly listed in the turbo task `env` allowlists for both `lib/ptexter` and `lib/ptabler/software`, and the code that reads it (`package-info.ts`) already uses this exact name. The "Publish packages (public)" step, which legitimately still uses the legacy name outside turbo, is untouched. The same secret backs both variables, so no credential changes are needed.

No files require special attention. The single changed line in `.github/workflows/main.yaml` is straightforward and well-supported by existing turbo allowlist entries and code.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/main.yaml | Single-line env var rename from `PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL` to `PL_RELEASE_BINARY_UPLOAD_URL` in the "Build for publish" step; the secret source and all other steps are unchanged. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Turbo as Turbo (strict env)
    participant Build as block-tools software build
    participant Registry as platforma-open registry

    GH->>Turbo: ci:build:release env: PL_RELEASE_BINARY_UPLOAD_URL (new)
    Note over Turbo: Env allowlist check: PL_RELEASE_BINARY_UPLOAD_URL is in turbo.json
    Turbo->>Build: PL_RELEASE_BINARY_UPLOAD_URL passed through
    Build->>Registry: Upload binary using storageURL

    Note over GH,Registry: Before fix: PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL not in allowlist, Turbo strips it, registry storageURL empty, build fails
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Turbo as Turbo (strict env)
    participant Build as block-tools software build
    participant Registry as platforma-open registry

    GH->>Turbo: ci:build:release env: PL_RELEASE_BINARY_UPLOAD_URL (new)
    Note over Turbo: Env allowlist check: PL_RELEASE_BINARY_UPLOAD_URL is in turbo.json
    Turbo->>Build: PL_RELEASE_BINARY_UPLOAD_URL passed through
    Build->>Registry: Upload binary using storageURL

    Note over GH,Registry: Before fix: PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL not in allowlist, Turbo strips it, registry storageURL empty, build fails
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6497: fix release binary upload en..."](https://github.com/milaboratory/platforma/commit/7bd1f3c65e2a8a4894f26c5b5ed6ff7ff611bd26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42758202)</sub>

<!-- /greptile_comment -->