### PR TITLE
MILAB-6497: pass AWS credentials through turbo software build

### DIFF
--- a/.changeset/software-publish-aws-creds.md
+++ b/.changeset/software-publish-aws-creds.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.software-ptexter": patch
+"@platforma-open/milaboratories.software-ptabler": patch
+"@platforma-sdk/block-tools": patch
+---
+
+Fix release publishing: declare `AWS_*`/`PL_AWS_*` in the `build`/`do-pack` `passThroughEnv` of the ptexter and ptabler `turbo.json`, and in the structurer's root `turbo.json` template (`build`) so generated block repos get them too. The S3 upload now runs inside the turbo-cached `build` task under strict env mode, which strips any env var not declared in `env`/`passThroughEnv`. The AWS credentials set by CI were being stripped, so the package builder's S3 storage driver could not load credentials and publish failed with "Could not load credentials from any providers". Uses `passThroughEnv` (not `env`) because session tokens rotate per run and must not enter the cache key.

--- a/lib/ptabler/software/turbo.json
+++ b/lib/ptabler/software/turbo.json
@@ -17,7 +17,8 @@
         "PL_RELEASE_DOCKER_PULL_URL",
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
-      ]
+      ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
     },
     "do-pack": {
       "env": [
@@ -35,7 +36,8 @@
         "PL_RELEASE_DOCKER_PULL_URL",
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
-      ]
+      ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
     }
   }
 }

--- a/lib/ptexter/turbo.json
+++ b/lib/ptexter/turbo.json
@@ -17,7 +17,8 @@
         "PL_RELEASE_DOCKER_PULL_URL",
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
-      ]
+      ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
     },
     "do-pack": {
       "env": [
@@ -35,7 +36,8 @@
         "PL_RELEASE_DOCKER_PULL_URL",
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
-      ]
+      ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
     }
   }
 }

--- a/tools/block-tools/src/structure/templates/static/root/turbo.json
+++ b/tools/block-tools/src/structure/templates/static/root/turbo.json
@@ -26,6 +26,7 @@
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
       ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"]
     },
     "build:dev": {


### PR DESCRIPTION
## Problem

Release publishing still failed after #1742, now with a different error:

```
error: failed to init storage driver from URL: credentials given to package builder do not have access to S3 bucket 'milab-euce1-prod-pkgs-s3-platforma-registry': CredentialsProviderError: ... Could not load credentials from any providers
```

#1742 fixed the missing upload URL, so publish now gets far enough to open the S3 storage driver — which then can't find AWS credentials.

## Cause

The software S3 upload runs inside the turbo-cached `build` task under **strict env mode**, which strips any env var not declared in `env`/`passThroughEnv`. CI exports `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`/`AWS_REGION` on the step, but none of them were declared for `build`/`do-pack`, so the AWS SDK credential chain came up empty. (Docker push works because docker creds come from `~/.docker/config.json`, not env.) The `mark-stable` task already declares `passThroughEnv: ["PL_REGISTRY", "AWS_*"]` — the publish path was just missing the same.

## Fix

Add `AWS_*` / `PL_AWS_*` to `passThroughEnv` on `build` + `do-pack` in:
- `lib/ptexter/turbo.json`
- `lib/ptabler/software/turbo.json`
- `tools/block-tools/.../templates/static/root/turbo.json` (generated block repos)

`passThroughEnv`, not `env`: session tokens rotate every run and must not enter the turbo cache key.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a release-publishing failure caused by AWS credentials being stripped inside the turbo-cached `build` and `do-pack` tasks. Because those tasks run under turbo's strict env mode, any env var not explicitly declared in `env` or `passThroughEnv` is invisible to the process — the AWS SDK credential chain was coming up empty when the S3 storage driver was opened.

- Adds `passThroughEnv: ["AWS_*", "PL_AWS_*"]` to `build` and `do-pack` in `lib/ptexter/turbo.json` and `lib/ptabler/software/turbo.json`, and to `build` in the block-tools root template, so generated block repos inherit the same fix.
- Correctly uses `passThroughEnv` rather than `env` to keep rotating session tokens out of the turbo cache key, consistent with the existing `mark-stable` task pattern.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to config-only turbo.json files and directly addresses the identified credential-stripping failure.

Three turbo.json files receive a single well-reasoned addition: AWS credential env vars are placed in passThroughEnv (not env), which is the correct field to keep rotating session tokens out of the cache key while still making them visible to the build process. The pattern is already established by the existing mark-stable task. The changeset correctly tracks all three affected packages. No logic, types, or runtime code is modified.

No files require special attention. The only pre-existing asymmetry (mark-stable in the block-tools template missing PL_AWS_* while the new build entry includes it) predates this PR and is not introduced by these changes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ptabler/software/turbo.json | Adds passThroughEnv: ["AWS_*", "PL_AWS_*"] to both build and do-pack tasks so AWS credentials are available during S3 uploads without entering the cache key. |
| lib/ptexter/turbo.json | Identical change to ptabler: passThroughEnv added to build and do-pack for AWS credential pass-through. |
| tools/block-tools/src/structure/templates/static/root/turbo.json | Adds passThroughEnv to the build task only; do-pack in this template carries no env config and does not perform S3 uploads. The mark-stable task's pre-existing omission of PL_AWS_* predates this PR. |
| .changeset/software-publish-aws-creds.md | Changeset file listing ptexter, ptabler software, and block-tools as patch bumps with a clear explanation of the root cause and fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CI["CI Step\nAWS_ACCESS_KEY_ID\nAWS_SECRET_ACCESS_KEY\nAWS_SESSION_TOKEN\nAWS_REGION"] -->|exports env vars| Turbo["Turbo Build Runner\nstrict env mode"]
    Turbo -->|passThroughEnv: AWS_*, PL_AWS_*| Build["build task\nptexter / ptabler / generated blocks"]
    Turbo -->|passThroughEnv: AWS_*, PL_AWS_*| DoPack["do-pack task\nptexter / ptabler"]
    Build --> S3Upload["S3 Storage Driver\nopens with credentials ✓"]
    DoPack --> S3Upload2["S3 Storage Driver\nopens with credentials ✓"]
    S3Upload --> Registry["Package Registry\nS3 Bucket"]
    S3Upload2 --> Registry

    subgraph Before["Before (broken)"]
        CI2["CI Step\nAWS env vars"] -->|stripped by turbo| Build2["build / do-pack"]
        Build2 --> Fail["Could not load credentials\nfrom any providers ✗"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    CI["CI Step\nAWS_ACCESS_KEY_ID\nAWS_SECRET_ACCESS_KEY\nAWS_SESSION_TOKEN\nAWS_REGION"] -->|exports env vars| Turbo["Turbo Build Runner\nstrict env mode"]
    Turbo -->|passThroughEnv: AWS_*, PL_AWS_*| Build["build task\nptexter / ptabler / generated blocks"]
    Turbo -->|passThroughEnv: AWS_*, PL_AWS_*| DoPack["do-pack task\nptexter / ptabler"]
    Build --> S3Upload["S3 Storage Driver\nopens with credentials ✓"]
    DoPack --> S3Upload2["S3 Storage Driver\nopens with credentials ✓"]
    S3Upload --> Registry["Package Registry\nS3 Bucket"]
    S3Upload2 --> Registry

    subgraph Before["Before (broken)"]
        CI2["CI Step\nAWS env vars"] -->|stripped by turbo| Build2["build / do-pack"]
        Build2 --> Fail["Could not load credentials\nfrom any providers ✗"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6497: pass AWS credentials through..."](https://github.com/milaboratory/platforma/commit/45706c3f87a47bf1f29a4bbc45da50d519d60b13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42955141)</sub>

<!-- /greptile_comment -->