### PR TITLE
fix(block-tools): build workflow calls build:release, not removed build script

### DIFF
--- a/.changeset/structurer-build-script-name.md
+++ b/.changeset/structurer-build-script-name.md
@@ -1,0 +1,13 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Fix the generated build workflow calling a removed script. The root
+`package.json` rules deliberately drop the bare `build` script (a developer
+must pick a scenario flavor), but the `build.tpl.yaml` workflow template still
+invoked `build-script-name: 'build'`, so refreshed blocks failed CI with
+`ERR_PNPM_NO_SCRIPT: Missing script: build`.
+
+Point the two build legs at the right flavors: PR/merge-queue validation uses
+`build:dev-local`, and the publish leg uses `build:release` via
+`build-before-publish-script-name`.

--- a/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
+++ b/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
@@ -37,6 +37,11 @@ describe("root CI workflows (fixed, generated)", () => {
     // Shared constants.
     expect(build).toContain("team-id: 'ciplopen'");
     expect(build).toContain("test: true");
+    // No bare `build` script exists (root-package-json removes it), so both
+    // build legs must name scenario flavors: PR/test validates locally, the
+    // publish leg builds the release channel.
+    expect(build).toContain("build-script-name: 'build:dev-local'");
+    expect(build).toContain("build-before-publish-script-name: 'build:release'");
     // The reusable-workflow pins — the whole point of engine-owning the file.
     expect(build).toContain(
       "uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4",

--- a/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
@@ -25,7 +25,8 @@ jobs:
       app-name: '${appName}'
       app-name-slug: '${appNameSlug}'
       node-version: '20.x'
-      build-script-name: 'build'
+      build-script-name: 'build:dev-local'
+      build-before-publish-script-name: 'build:release'
       pnpm-recursive-build: false
 
       test: true


### PR DESCRIPTION
## Problem

The structurer's root `package.json` rules deliberately `removeScript("build")` / `removeScript("build:dev")` — a developer must pick a scenario flavor (`build:dev-local`, `build:release`, …). But `build.tpl.yaml` still generated `build-script-name: 'build'`, so every block refreshed with block-tools 2.12.0 gets a CI that calls a script that no longer exists:

```
ERR_PNPM_NO_SCRIPT  Missing script: build
Command "build" not found.
```

Seen in the wild: [rarefaction PR #32 CI](https://github.com/platforma-open/rarefaction/actions/runs/29013932735/job/86104518919?pr=32).

## Fix

The reusable `node-simple-pnpm.yaml` workflow has two build legs:
- **PR / merge-queue validation** → `build-script-name`
- **publish** → `build-before-publish-script-name` (falls back to `build-script-name`)

Wire each to the right flavor:

```yaml
build-script-name: 'build:dev-local'          # PR builds validate locally
build-before-publish-script-name: 'build:release'  # publish builds the release channel
```

PR builds must **not** run the release channel (remote software upload); they validate with `build:dev-local`. Only the publish leg builds `build:release`. Added test assertions so the template can't silently regress.

## Note

Blocks already generated with the broken template pick this up on their next `structure refresh`.