### PR TITLE
fix(block-tools): run generated block CI on Hetzner runner

### DIFF
--- a/.changeset/structurer-hetzner-runner.md
+++ b/.changeset/structurer-hetzner-runner.md
@@ -1,0 +1,13 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Run the generated block `build.yaml` workflow on the Hetzner CI runner.
+
+The `build.tpl.yaml` template hard-coded `ubuntu-latest`, so every structurer
+refresh reverted blocks already migrated to Hetzner back to GitHub-hosted
+runners. Bake the Hetzner setup into the template: `runs-on: hz-ubuntu-dind`
+for the `init` job, `gha-runner-label: hz-ubuntu-dind` for the reusable
+workflow, and the `HZ_CI_*` turbo/cache S3 credentials in the secrets env.
+Matches the manual migration in `clonotype-enrichment` and
+`sequence-embeddings` byte-for-byte.

--- a/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch: {}
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     steps:
       - uses: milaboratory/github-ci/actions/context/init@v4
         with:
@@ -25,6 +25,7 @@ jobs:
       app-name: '${appName}'
       app-name-slug: '${appNameSlug}'
       node-version: '20.x'
+      gha-runner-label: hz-ubuntu-dind
       build-script-name: 'build:dev-local'
       build-before-publish-script-name: 'build:release'
       pnpm-recursive-build: false
@@ -57,6 +58,15 @@ jobs:
 
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
           "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
+
+          "HZ_CI_TURBO_S3_BUCKET": ${{ toJSON(vars.HZ_CI_TURBO_S3_BUCKET) }},
+          "HZ_CI_TURBO_S3_ENDPOINT": ${{ toJSON(vars.HZ_CI_TURBO_S3_ENDPOINT) }},
+          "HZ_CI_TURBO_S3_REGION": ${{ toJSON(vars.HZ_CI_TURBO_S3_REGION) }},
+          "HZ_CI_TURBO_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_ACCESS_KEY) }},
+          "HZ_CI_TURBO_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_SECRET_KEY) }},
+          "HZ_CI_CACHE_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_ACCESS_KEY) }},
+          "HZ_CI_CACHE_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_SECRET_KEY) }},
+
           "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }


### PR DESCRIPTION
## What

The structurer's `build.tpl.yaml` (a `fixed`, engine-owned template — the single source for every standalone block's `build.yaml`) hard-coded `ubuntu-latest`. Every refresh therefore reverted blocks already migrated to the Hetzner CI runner back to GitHub-hosted runners.

This bakes the Hetzner setup into the template:
- `init` job: `runs-on: hz-ubuntu-dind`
- reusable workflow input: `gha-runner-label: hz-ubuntu-dind`
- `secrets.env`: the 7 `HZ_CI_*` turbo/cache S3 credentials

## Verification

Matched byte-for-byte against the two manual migrations already in the wild:
- `platforma-open/clonotype-enrichment` (commit `d8f4ffc`)
- `platforma-open/sequence-embeddings` (commit `f9f3f15`)

Both apply the identical delta (same `vars.`/`secrets.` split, same ordering, same surrounding blanks) and neither touches `turbo.json` — the `HZ_CI_*` vars are consumed by turbo's remote-cache backend directly, not via `passThroughEnv`. The `build-script-name` flavors (`build:dev-local` / `build:release`) are unchanged from the previous fix.

`etc/blocks/*` are unaffected (sdk-internal, skip root CI), so no `check-blocks` refresh is needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `build.tpl.yaml` — the structurer's engine-owned template that is the single source for every generated standalone-block `build.yaml` — so that refreshing a block no longer silently reverts it from the Hetzner self-hosted runner back to GitHub-hosted `ubuntu-latest`.

- **`init` job runner**: switched from `ubuntu-latest` to `hz-ubuntu-dind` (Hetzner Docker-in-Docker runner).
- **Reusable-workflow input**: `gha-runner-label: hz-ubuntu-dind` is now passed to `milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4`, which propagates the label to all its internal jobs (build, test, publish, notify, …).
- **Hetzner turbo/cache credentials**: 7 `HZ_CI_*` entries are added to the `secrets.env` JSON object — the 3 non-sensitive config values (`BUCKET`, `ENDPOINT`, `REGION`) sourced from `vars.*` and the 4 credential values (`ACCESS_KEY`/`SECRET_KEY` for both turbo and cache) sourced from `secrets.*` — matching the pattern of manual migrations already in production.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two targeted lines and seven env entries in a YAML template, verified byte-for-byte against two already-deployed manual migrations.

The change is narrow: two runner references and seven HZ_CI_* env entries in the generated-workflow template. The gha-runner-label input exists and defaults to ubuntu-latest in the upstream reusable workflow, so passing hz-ubuntu-dind is a well-supported override. The vars/secrets split (bucket/endpoint/region as vars, access/secret keys as secrets) is the correct pattern and mirrors what is already live in production block repos.

No files require special attention. The only substantive file is build.tpl.yaml, and its changes are straightforward runner-label and credential additions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml | Runner switched to hz-ubuntu-dind in the init job and via gha-runner-label; 7 HZ_CI_* env entries added with correct vars/secrets split matching existing manual migrations. |
| .changeset/structurer-hetzner-runner.md | Patch-level changeset for @platforma-sdk/block-tools with accurate description of the template fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Structurer as block-tools structurer
    participant Tpl as build.tpl.yaml (template)
    participant Gen as build.yaml (generated)
    participant Init as init job<br/>(hz-ubuntu-dind)
    participant Reusable as node-simple-pnpm.yaml@v4<br/>(milaboratory/github-ci)

    Structurer->>Tpl: reads fixed template
    Structurer->>Gen: renders build.yaml (substitutes appName, appNameSlug)
    Note over Gen: runs-on: hz-ubuntu-dind (init)<br/>gha-runner-label: hz-ubuntu-dind (run)<br/>HZ_CI_* in secrets.env

    Gen->>Init: triggers on push/PR/merge_group
    Init->>Reusable: "calls with gha-runner-label=hz-ubuntu-dind + secrets.env (HZ_CI_* + AWS_CI_* + …)"
    Reusable->>Reusable: all internal jobs run on hz-ubuntu-dind (build, test, publish, notify, …)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Structurer as block-tools structurer
    participant Tpl as build.tpl.yaml (template)
    participant Gen as build.yaml (generated)
    participant Init as init job<br/>(hz-ubuntu-dind)
    participant Reusable as node-simple-pnpm.yaml@v4<br/>(milaboratory/github-ci)

    Structurer->>Tpl: reads fixed template
    Structurer->>Gen: renders build.yaml (substitutes appName, appNameSlug)
    Note over Gen: runs-on: hz-ubuntu-dind (init)<br/>gha-runner-label: hz-ubuntu-dind (run)<br/>HZ_CI_* in secrets.env

    Gen->>Init: triggers on push/PR/merge_group
    Init->>Reusable: "calls with gha-runner-label=hz-ubuntu-dind + secrets.env (HZ_CI_* + AWS_CI_* + …)"
    Reusable->>Reusable: all internal jobs run on hz-ubuntu-dind (build, test, publish, notify, …)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(block-tools): run generated block CI..."](https://github.com/milaboratory/platforma/commit/00f95013da967d2c98b89817aa280092c22c672f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43014629)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->