### PR TITLE
feat(pl-cli): add admin user list against live backend

### DIFF
--- a/.changeset/pl-cli-admin-user-list.md
+++ b/.changeset/pl-cli-admin-user-list.md
@@ -1,0 +1,6 @@
+---
+"@platforma-sdk/pl-cli": minor
+"@milaboratories/pl-client": minor
+---
+
+Add `pl-cli admin user-list`: lists all known users' logins from a live server (admin-authenticated), CSV by default (`--format text|json` also supported). Adds `PlClient.listUsers()`.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -18,6 +18,7 @@ import type { PlDriver, PlDriverDefinition } from "./driver";
 import type {
   MaintenanceAPI_Ping_Response,
   MaintenanceAPI_License_Response,
+  AuthAPI_User,
 } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import { MaintenanceAPI_Ping_Response_Compression } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import * as tp from "node:timers/promises";
@@ -190,6 +191,11 @@ export class PlClient {
 
   public async license(): Promise<MaintenanceAPI_License_Response> {
     return await this.ll.license();
+  }
+
+  /** Lists the users known to the server (login only on the wire). See {@link LLPlClient.listUsers}. */
+  public async listUsers(): Promise<AuthAPI_User[]> {
+    return await this.ll.listUsers();
   }
 
   /**

--- a/tools/pl-cli/src/cli.ts
+++ b/tools/pl-cli/src/cli.ts
@@ -5,6 +5,7 @@ import projectDuplicateCommand from "./cmd/project/duplicate";
 import projectRenameCommand from "./cmd/project/rename";
 import projectDeleteCommand from "./cmd/project/delete";
 import adminCopyProjectCommand from "./cmd/admin/copy-project";
+import adminUserListCommand from "./cmd/admin/user-list";
 
 export function buildProgram(): Command {
   const program = new Command();
@@ -22,6 +23,7 @@ export function buildProgram(): Command {
     "Admin operations (requires controller credentials)",
   );
   admin.addCommand(adminCopyProjectCommand());
+  admin.addCommand(adminUserListCommand());
   program.addCommand(admin);
 
   return program;

--- a/tools/pl-cli/src/cmd-opts.ts
+++ b/tools/pl-cli/src/cmd-opts.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from "commander";
+import type { OutputFormat } from "./output";
 
 /** Add one or more groups of options to a command, preserving group order. */
 export function addOptions(cmd: Command, ...optionGroups: Option[][]): Command {
@@ -8,11 +9,13 @@ export function addOptions(cmd: Command, ...optionGroups: Option[][]): Command {
   return cmd;
 }
 
-export const GlobalOptions = (): Option[] => [
+export const GlobalOptions = (formatDefault: OutputFormat = "text"): Option[] => [
   new Option("-a, --address <url>", "Platforma server address")
     .env("PL_ADDRESS")
     .makeOptionMandatory(),
-  new Option("-f, --format <format>", "Output format").choices(["text", "json"]).default("text"),
+  new Option("-f, --format <format>", "Output format")
+    .choices(["text", "json", "csv"])
+    .default(formatDefault),
 ];
 
 export const UserAuthOptions = (): Option[] => [

--- a/tools/pl-cli/src/cmd-opts.ts
+++ b/tools/pl-cli/src/cmd-opts.ts
@@ -9,12 +9,15 @@ export function addOptions(cmd: Command, ...optionGroups: Option[][]): Command {
   return cmd;
 }
 
-export const GlobalOptions = (formatDefault: OutputFormat = "text"): Option[] => [
+export const GlobalOptions = (
+  formatDefault: OutputFormat = "text",
+  allowedFormats: OutputFormat[] = ["text", "json"],
+): Option[] => [
   new Option("-a, --address <url>", "Platforma server address")
     .env("PL_ADDRESS")
     .makeOptionMandatory(),
   new Option("-f, --format <format>", "Output format")
-    .choices(["text", "json", "csv"])
+    .choices(allowedFormats)
     .default(formatDefault),
 ];
 

--- a/tools/pl-cli/src/cmd/admin/user-list.ts
+++ b/tools/pl-cli/src/cmd/admin/user-list.ts
@@ -8,7 +8,7 @@ export default function adminUserListCommand(): Command {
     "List all known users' logins from a live server. Requires admin/controller credentials.",
   );
 
-  addOptions(cmd, GlobalOptions("csv"), AdminAuthOptions());
+  addOptions(cmd, GlobalOptions("csv", ["text", "json", "csv"]), AdminAuthOptions());
 
   cmd.action(async (flags) => {
     const pl = await connectClient(flags);

--- a/tools/pl-cli/src/cmd/admin/user-list.ts
+++ b/tools/pl-cli/src/cmd/admin/user-list.ts
@@ -1,0 +1,30 @@
+import { Command } from "commander";
+import { connectClient } from "../../base_command";
+import { addOptions, GlobalOptions, AdminAuthOptions } from "../../cmd-opts";
+import { outputJson, outputText, outputCsv } from "../../output";
+
+export default function adminUserListCommand(): Command {
+  const cmd = new Command("user-list").description(
+    "List all known users' logins from a live server. Requires admin/controller credentials.",
+  );
+
+  addOptions(cmd, GlobalOptions("csv"), AdminAuthOptions());
+
+  cmd.action(async (flags) => {
+    const pl = await connectClient(flags);
+    try {
+      const logins = (await pl.listUsers()).map((u) => u.login).sort();
+      if (flags.format === "json") outputJson(logins);
+      else if (flags.format === "text") outputText(logins.join("\n"));
+      else
+        outputCsv(
+          ["login"],
+          logins.map((l) => [l]),
+        );
+    } finally {
+      await pl.close();
+    }
+  });
+
+  return cmd;
+}

--- a/tools/pl-cli/src/output.ts
+++ b/tools/pl-cli/src/output.ts
@@ -1,4 +1,4 @@
-export type OutputFormat = "text" | "json";
+export type OutputFormat = "text" | "json" | "csv";
 
 /** Outputs a line of text to stdout. */
 export function outputText(message: string): void {
@@ -8,6 +8,13 @@ export function outputText(message: string): void {
 /** Outputs data as formatted JSON to stdout. */
 export function outputJson(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
+}
+
+/** Outputs a header row + data rows as RFC-4180-ish CSV to stdout. */
+export function outputCsv(headers: string[], rows: string[][]): void {
+  const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  const lines = [headers, ...rows].map((r) => r.map(esc).join(","));
+  console.log(lines.join("\n"));
 }
 
 /** Formats a table as aligned text columns. */

--- a/tools/pl-cli/src/output.ts
+++ b/tools/pl-cli/src/output.ts
@@ -12,7 +12,7 @@ export function outputJson(data: unknown): void {
 
 /** Outputs a header row + data rows as RFC-4180-ish CSV to stdout. */
 export function outputCsv(headers: string[], rows: string[][]): void {
-  const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  const esc = (v: string) => (/[",\r\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
   const lines = [headers, ...rows].map((r) => r.map(esc).join(","));
   console.log(lines.join("\n"));
 }


### PR DESCRIPTION
Adds `pl-cli admin user list`, which calls the live `AuthAPI.ListUsers` RPC with admin credentials and prints each known user's login — the live alternative to the offline `pl-db-cli user list` (no server downtime, no RocksDB access). Output defaults to CSV (a `login` header + sorted rows) to seed the migration provisioning CSV; `--format text|json` also supported. Adds a one-method `listUsers()` wrapper to `LLPlClient`/`PlClient` (previously only on the generated low-level client) and an `outputCsv` helper + `csv` format choice. Login-only: email + login metadata are not on the wire (backend enrichment is a separate follow-up).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `pl-cli admin user-list`, a live alternative to the offline `pl-db-cli user list` that calls `AuthAPI.ListUsers` with admin credentials and prints each user's login. Output defaults to CSV (suitable for migration provisioning), with `--format text|json` also available.

- **`PlClient.listUsers()`** — new public wrapper on the high-level client that delegates directly to `LLPlClient.listUsers()` and returns `AuthAPI_User[]`; gRPC-only constraint inherited from the lower layer.
- **`GlobalOptions` parameterization** — the format option factory now accepts `formatDefault` and `allowedFormats`, so `user-list` can advertise `csv` as its default without leaking the choice to other commands.
- **`outputCsv` helper** — new RFC 4180-compatible CSV renderer in `output.ts`, with correct quoting for `"`, `,`, `\r`, and `\n`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive, the admin-auth path is correctly wired, and cleanup is guarded by try/finally.

The new command is a straightforward read-only RPC call with admin credentials; the GlobalOptions refactor correctly preserves the behaviour of all existing callers; and the CSV helper handles the full RFC 4180 quoting surface (quote, comma, CR, LF). No existing functionality is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/pl-cli/src/cmd/admin/user-list.ts | New command: calls pl.listUsers(), sorts logins, and outputs CSV/text/JSON; cleanup via try/finally is correct. |
| lib/node/pl-client/src/core/client.ts | Adds PlClient.listUsers() wrapping ll.listUsers(); consistent with ping/license pattern but note that userResources.listUsers() also exists. |
| tools/pl-cli/src/cmd-opts.ts | GlobalOptions() parameterized with formatDefault and allowedFormats; existing callers use defaults and are unaffected. |
| tools/pl-cli/src/output.ts | outputCsv added with RFC 4180 quoting (covers quote, comma, CR, LF); OutputFormat union extended with "csv". |
| tools/pl-cli/src/cli.ts | Registers adminUserListCommand under the admin subcommand; straightforward wiring. |
| .changeset/pl-cli-admin-user-list.md | Minor bump for both pl-cli and pl-client packages; description matches the changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as pl-cli (user-list.ts)
    participant CC as connectClient
    participant PC as PlClient
    participant LL as LLPlClient
    participant gRPC as gRPC (AuthAPI)

    CLI->>CC: connectClient(flags)
    CC->>PC: createAdminPlConnection(adminUser, adminPassword)
    PC-->>CLI: PlClient instance

    CLI->>PC: pl.listUsers()
    PC->>LL: ll.listUsers()
    LL->>gRPC: "AuthAPI.ListUsers({})"
    gRPC-->>LL: "AuthAPI_ListUsers_Response { users[] }"
    LL-->>PC: AuthAPI_User[]
    PC-->>CLI: AuthAPI_User[]

    CLI->>CLI: ".map(u => u.login).sort()"

    alt "format === json"
        CLI->>CLI: outputJson(logins)
    else "format === text"
        CLI->>CLI: outputText(logins.join(newline))
    else "format === csv (default)"
        CLI->>CLI: "outputCsv([login], logins.map(l => [l]))"
    end

    CLI->>PC: pl.close()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as pl-cli (user-list.ts)
    participant CC as connectClient
    participant PC as PlClient
    participant LL as LLPlClient
    participant gRPC as gRPC (AuthAPI)

    CLI->>CC: connectClient(flags)
    CC->>PC: createAdminPlConnection(adminUser, adminPassword)
    PC-->>CLI: PlClient instance

    CLI->>PC: pl.listUsers()
    PC->>LL: ll.listUsers()
    LL->>gRPC: "AuthAPI.ListUsers({})"
    gRPC-->>LL: "AuthAPI_ListUsers_Response { users[] }"
    LL-->>PC: AuthAPI_User[]
    PC-->>CLI: AuthAPI_User[]

    CLI->>CLI: ".map(u => u.login).sort()"

    alt "format === json"
        CLI->>CLI: outputJson(logins)
    else "format === text"
        CLI->>CLI: outputText(logins.join(newline))
    else "format === csv (default)"
        CLI->>CLI: "outputCsv([login], logins.map(l => [l]))"
    end

    CLI->>PC: pl.close()
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Allow configuring allowed formats in glo..."](https://github.com/milaboratory/platforma/commit/35339d60fbf991e0809a0ac90d5e763a4d0f251f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43035200)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->