### PR TITLE
MILAB-6497: pass docker build/push knobs through ptabler/ptexter software build

### DIFF
--- a/.changeset/ptabler-ptexter-docker-env-passthrough.md
+++ b/.changeset/ptabler-ptexter-docker-env-passthrough.md
@@ -1,0 +1,19 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+"@platforma-open/milaboratories.software-ptexter": patch
+"@platforma-sdk/block-tools": patch
+---
+
+Fix software `build`: pass the docker-control knobs (`PL_DOCKER_BUILD`,
+`PL_DOCKER_NO_BUILD`, `PL_DOCKER_AUTOPUSH`, `PL_DOCKER_NO_AUTOPUSH`,
+`PL_DOCKER_REGISTRY_PUSH_TO`) through the `build`/`do-pack` tasks of the ptabler
+and ptexter `turbo.json`, and add the build/autopush toggles to the structurer's
+root `turbo.json` template so generated block repos inherit them too. When these
+packages moved from `pl-pkg build` to `block-tools software build`, their
+package-level `turbo.json` overrode the root task's `passThroughEnv` with only
+`AWS_*`/`PL_AWS_*`, so under turbo strict env mode the docker knobs were stripped.
+Consumers building the monorepo in CI (e.g. the `pl` monorepo test job) then had
+no way to disable the docker build or redirect the push, and `block-tools software
+build` fell back to its CI default of pushing to the public
+`containers.pl-open.science` registry — failing with `unauthorized` on runners
+without push credentials.

--- a/lib/ptabler/software/turbo.json
+++ b/lib/ptabler/software/turbo.json
@@ -18,7 +18,15 @@
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
       ],
-      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
+      "passThroughEnv": [
+        "AWS_*",
+        "PL_AWS_*",
+        "PL_DOCKER_REGISTRY_PUSH_TO",
+        "PL_DOCKER_BUILD",
+        "PL_DOCKER_NO_BUILD",
+        "PL_DOCKER_AUTOPUSH",
+        "PL_DOCKER_NO_AUTOPUSH"
+      ]
     },
     "do-pack": {
       "env": [
@@ -37,7 +45,15 @@
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
       ],
-      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
+      "passThroughEnv": [
+        "AWS_*",
+        "PL_AWS_*",
+        "PL_DOCKER_REGISTRY_PUSH_TO",
+        "PL_DOCKER_BUILD",
+        "PL_DOCKER_NO_BUILD",
+        "PL_DOCKER_AUTOPUSH",
+        "PL_DOCKER_NO_AUTOPUSH"
+      ]
     }
   }
 }

--- a/lib/ptexter/turbo.json
+++ b/lib/ptexter/turbo.json
@@ -18,7 +18,15 @@
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
       ],
-      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
+      "passThroughEnv": [
+        "AWS_*",
+        "PL_AWS_*",
+        "PL_DOCKER_REGISTRY_PUSH_TO",
+        "PL_DOCKER_BUILD",
+        "PL_DOCKER_NO_BUILD",
+        "PL_DOCKER_AUTOPUSH",
+        "PL_DOCKER_NO_AUTOPUSH"
+      ]
     },
     "do-pack": {
       "env": [
@@ -37,7 +45,15 @@
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
       ],
-      "passThroughEnv": ["AWS_*", "PL_AWS_*"]
+      "passThroughEnv": [
+        "AWS_*",
+        "PL_AWS_*",
+        "PL_DOCKER_REGISTRY_PUSH_TO",
+        "PL_DOCKER_BUILD",
+        "PL_DOCKER_NO_BUILD",
+        "PL_DOCKER_AUTOPUSH",
+        "PL_DOCKER_NO_AUTOPUSH"
+      ]
     }
   }
 }

--- a/tools/block-tools/src/structure/templates/static/root/turbo.json
+++ b/tools/block-tools/src/structure/templates/static/root/turbo.json
@@ -26,7 +26,14 @@
         "PL_RELEASE_BINARY_UPLOAD_URL",
         "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
       ],
-      "passThroughEnv": ["AWS_*", "PL_AWS_*"],
+      "passThroughEnv": [
+        "AWS_*",
+        "PL_AWS_*",
+        "PL_DOCKER_BUILD",
+        "PL_DOCKER_NO_BUILD",
+        "PL_DOCKER_AUTOPUSH",
+        "PL_DOCKER_NO_AUTOPUSH"
+      ],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"]
     },
     "build:dev": {


### PR DESCRIPTION
When ptabler and ptexter moved from `pl-pkg build` to `block-tools software build` (MILAB-6497), their package-level `turbo.json` overrode the root `build`/`do-pack` task `passThroughEnv` with only `AWS_*`/`PL_AWS_*`. Under turbo **strict env mode** that strips the docker-control knobs the root turbo.json passes through:

- `PL_DOCKER_BUILD`
- `PL_DOCKER_NO_BUILD`
- `PL_DOCKER_AUTOPUSH`
- `PL_DOCKER_NO_AUTOPUSH`
- `PL_DOCKER_REGISTRY_PUSH_TO`

So any consumer building the monorepo in CI (e.g. the `pl` repo `monorepo tests (s3)` job) can no longer disable the docker build or redirect the push. `block-tools software build` then falls back to its CI default — build **and push** a docker image to the public `containers.pl-open.science` registry — and fails with `unauthorized` on runners without push credentials. This currently breaks the pl monorepo test job on `main` and every pl PR.

## Changes
- `lib/ptabler/software/turbo.json`, `lib/ptexter/turbo.json`: add the docker knobs to `build`/`do-pack` `passThroughEnv`.
- `tools/block-tools/src/structure/templates/static/root/turbo.json`: add the build/autopush toggles so generated block repos inherit them.

## Companion
Paired with pl PR that sets `PL_DOCKER_NO_BUILD=true` on the `monorepo tests (s3)` job. Both are needed: this PR makes the knob effective, the pl PR sets it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores the docker-control environment variables (`PL_DOCKER_BUILD`, `PL_DOCKER_NO_BUILD`, `PL_DOCKER_AUTOPUSH`, `PL_DOCKER_NO_AUTOPUSH`, `PL_DOCKER_REGISTRY_PUSH_TO`) through the Turbo `passThroughEnv` for ptabler, ptexter, and the block-tools generated-repo template after the packages' package-level `turbo.json` overrides were stripping them under Turbo strict env mode.

- **`lib/ptabler/software/turbo.json` and `lib/ptexter/turbo.json`**: Both `build` and `do-pack` tasks now declare all five docker knobs in `passThroughEnv`, matching what the monorepo root `turbo.json` already provides for other packages.
- **`tools/block-tools/src/structure/templates/static/root/turbo.json`**: The `build` task gains the four toggle vars in `passThroughEnv`; `PL_DOCKER_REGISTRY_PUSH_TO` is intentionally left out of `passThroughEnv` because it was already listed in `env`. The `do-pack` task is unchanged and still has no docker vars defined, unlike the monorepo root pattern.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The ptabler and ptexter fixes are correct and match the monorepo root pattern exactly. The template change is correct for `build` but leaves `do-pack` without docker knobs, creating a latent trap for future generated-repo software packages.

The two package fixes unblock the broken CI job and are straightforwardly correct. The one gap is the template's `do-pack` task, which has no docker vars in `passThroughEnv` — the monorepo root has all five docker vars there, but the generated-repo template does not. No currently-known generated block repo triggers this gap today, making it a forward-looking concern rather than an active breakage.

tools/block-tools/src/structure/templates/static/root/turbo.json — the `do-pack` task lacks docker-control vars that the monorepo root `turbo.json` provides, which could silently affect future software packages in generated block repos.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ptabler/software/turbo.json | Correctly adds all five docker-control knobs to `passThroughEnv` for both `build` and `do-pack` tasks, matching the root monorepo `turbo.json` pattern. |
| lib/ptexter/turbo.json | Identical fix as ptabler — adds all five docker-control knobs to `passThroughEnv` for `build` and `do-pack`; content of this file is an exact copy of `lib/ptabler/software/turbo.json`. |
| tools/block-tools/src/structure/templates/static/root/turbo.json | Adds four docker-toggle vars to `build.passThroughEnv` (correct); `PL_DOCKER_REGISTRY_PUSH_TO` is already in `build.env` so intentionally excluded. However, the `do-pack` task receives no docker vars at all, unlike the monorepo root `turbo.json`, leaving a latent gap for future generated-repo software packages. |
| .changeset/ptabler-ptexter-docker-env-passthrough.md | Accurate changeset entry; correctly tags all three affected packages as `patch`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CI["CI Runner\n(e.g. pl monorepo tests s3)"]
    ENV["Docker control env vars\nPL_DOCKER_BUILD / PL_DOCKER_NO_BUILD\nPL_DOCKER_AUTOPUSH / PL_DOCKER_NO_AUTOPUSH\nPL_DOCKER_REGISTRY_PUSH_TO"]

    CI --> ENV

    subgraph "Before this PR (broken)"
        ROOT_OLD["Root turbo.json\npassThroughEnv: docker knobs ✓"]
        PKG_OLD["ptabler/ptexter turbo.json\nextends //\npassThroughEnv: AWS_* only"]
        STRIP["Turbo strict mode\nSTRIPS docker knobs"]
        FAIL["block-tools software build\nFallback: push to containers.pl-open.science\n→ unauthorized ✗"]
        ROOT_OLD --> PKG_OLD --> STRIP --> FAIL
    end

    subgraph "After this PR (fixed)"
        ROOT_NEW["Root turbo.json\npassThroughEnv: docker knobs ✓"]
        PKG_NEW["ptabler/ptexter turbo.json\nextends //\npassThroughEnv: AWS_* + docker knobs ✓"]
        PASS["Turbo strict mode\npasses docker knobs through ✓"]
        OK["block-tools software build\nPL_DOCKER_NO_BUILD=true respected\n→ skips docker build ✓"]
        ROOT_NEW --> PKG_NEW --> PASS --> OK
    end

    subgraph "Template (block-tools)"
        TMPL_BUILD["build task\npassThroughEnv: + 4 toggle vars ✓\nenv: PL_DOCKER_REGISTRY_PUSH_TO ✓"]
        TMPL_PACK["do-pack task\nno passThroughEnv ⚠"]
    end

    ENV --> ROOT_OLD
    ENV --> ROOT_NEW
    ENV --> TMPL_BUILD
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    CI["CI Runner\n(e.g. pl monorepo tests s3)"]
    ENV["Docker control env vars\nPL_DOCKER_BUILD / PL_DOCKER_NO_BUILD\nPL_DOCKER_AUTOPUSH / PL_DOCKER_NO_AUTOPUSH\nPL_DOCKER_REGISTRY_PUSH_TO"]

    CI --> ENV

    subgraph "Before this PR (broken)"
        ROOT_OLD["Root turbo.json\npassThroughEnv: docker knobs ✓"]
        PKG_OLD["ptabler/ptexter turbo.json\nextends //\npassThroughEnv: AWS_* only"]
        STRIP["Turbo strict mode\nSTRIPS docker knobs"]
        FAIL["block-tools software build\nFallback: push to containers.pl-open.science\n→ unauthorized ✗"]
        ROOT_OLD --> PKG_OLD --> STRIP --> FAIL
    end

    subgraph "After this PR (fixed)"
        ROOT_NEW["Root turbo.json\npassThroughEnv: docker knobs ✓"]
        PKG_NEW["ptabler/ptexter turbo.json\nextends //\npassThroughEnv: AWS_* + docker knobs ✓"]
        PASS["Turbo strict mode\npasses docker knobs through ✓"]
        OK["block-tools software build\nPL_DOCKER_NO_BUILD=true respected\n→ skips docker build ✓"]
        ROOT_NEW --> PKG_NEW --> PASS --> OK
    end

    subgraph "Template (block-tools)"
        TMPL_BUILD["build task\npassThroughEnv: + 4 toggle vars ✓\nenv: PL_DOCKER_REGISTRY_PUSH_TO ✓"]
        TMPL_PACK["do-pack task\nno passThroughEnv ⚠"]
    end

    ENV --> ROOT_OLD
    ENV --> ROOT_NEW
    ENV --> TMPL_BUILD
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fblock-tools%2Fsrc%2Fstructure%2Ftemplates%2Fstatic%2Froot%2Fturbo.json%3A43-46%0A**Template%20%60do-pack%60%20missing%20docker%20knobs**%0A%0AThe%20%60build%60%20task%20in%20the%20template%20now%20correctly%20receives%20the%20four%20docker-toggle%20vars%2C%20but%20the%20%60do-pack%60%20task%20has%20no%20%60passThroughEnv%60%20at%20all%20%28not%20even%20%60AWS_*%60%2F%60PL_AWS_*%60%29.%20The%20root%20%60turbo.json%60%20of%20this%20monorepo%20gives%20%60do-pack%60%20all%20five%20docker%20vars%3B%20the%20template%20diverges%20from%20that%20pattern.%20Any%20software%20package%20added%20to%20a%20generated%20block%20repo%20that%20overrides%20%60do-pack%60%20in%20its%20own%20%60turbo.json%60%20%28the%20exact%20pattern%20that%20broke%20ptabler%2Fptexter%29%20will%20start%20from%20a%20root%20with%20no%20docker%20vars%20defined%20%E2%80%94%20so%20it%20inherits%20nothing%20useful%20and%20will%20face%20the%20same%20CI%20failure%20this%20PR%20is%20fixing%2C%20just%20in%20a%20harder-to-diagnose%20location.%0A%0A&repo=milaboratory%2Fplatforma&pr=1747&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/block-tools/src/structure/templates/static/root/turbo.json:43-46
**Template `do-pack` missing docker knobs**

The `build` task in the template now correctly receives the four docker-toggle vars, but the `do-pack` task has no `passThroughEnv` at all (not even `AWS_*`/`PL_AWS_*`). The root `turbo.json` of this monorepo gives `do-pack` all five docker vars; the template diverges from that pattern. Any software package added to a generated block repo that overrides `do-pack` in its own `turbo.json` (the exact pattern that broke ptabler/ptexter) will start from a root with no docker vars defined — so it inherits nothing useful and will face the same CI failure this PR is fixing, just in a harder-to-diagnose location.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pass docker build/push knobs throug..."](https://github.com/milaboratory/platforma/commit/02f8b54afbc13756a6ec89e6a04438482aac580a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43060144)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->