### PR TITLE
fix(ui-vue): stop PlAgDataTableV2 infinite remount loop (column-header flicker)

### DIFF
--- a/.changeset/fix-ag-data-table-reload-loop.md
+++ b/.changeset/fix-ag-data-table-reload-loop.md
@@ -1,0 +1,18 @@
+---
+"@platforma-sdk/ui-vue": patch
+---
+
+Fix an infinite grid-remount loop in `PlAgDataTableV2` that made the column
+headers strobe (rapid flickering of the column type icons) and flooded the
+console with AG Grid "grid has been destroyed" (#26) errors.
+
+The reload watch destroys and recreates the whole grid via `:key="reloadKey"`.
+Because the stored grid state is read through a debounced cache, right after a
+reload it could still report the pre-reload value while the fresh grid already
+reports the state AG Grid normalized it to; when those never converged the grid
+remounted on every frame. The watch now reloads at most once per distinct
+desired state (the guard resets when the desired state actually changes), so a
+non-converging state causes a single benign remount instead of an infinite loop.
+
+Also guards the row-number column auto-size so it no longer calls
+`applyColumnState` on an already-destroyed grid.

--- a/.changeset/fix-ag-data-table-reload-loop.md
+++ b/.changeset/fix-ag-data-table-reload-loop.md
@@ -1,5 +1,6 @@
 ---
 "@platforma-sdk/ui-vue": patch
+"@milaboratories/uikit": patch
 ---
 
 Fix an infinite grid-remount loop in `PlAgDataTableV2` that made the column
@@ -7,12 +8,13 @@ headers strobe (rapid flickering of the column type icons) and flooded the
 console with AG Grid "grid has been destroyed" (#26) errors.
 
 The reload watch destroys and recreates the whole grid via `:key="reloadKey"`.
-Because the stored grid state is read through a debounced cache, right after a
-reload it could still report the pre-reload value while the fresh grid already
-reports the state AG Grid normalized it to; when those never converged the grid
-remounted on every frame. The watch now reloads at most once per distinct
-desired state (the guard resets when the desired state actually changes), so a
-non-converging state causes a single benign remount instead of an infinite loop.
+The stored grid state was read through a debounced cache, so right after a
+reload the cache kept reporting the pre-reload value while the fresh grid
+already reported the state AG Grid normalized it to; the two never converged and
+the grid remounted on every frame. `computedCached` gains a `writeThrough`
+option that adopts a set value into the cache synchronously (the debounce then
+only defers the downstream write), so the reload comparison converges after the
+single remount that applies the state.
 
 Also guards the row-number column auto-size so it no longer calls
 `applyColumnState` on an already-destroyed grid.

--- a/lib/ui/uikit/src/composition/computedCached.ts
+++ b/lib/ui/uikit/src/composition/computedCached.ts
@@ -12,10 +12,15 @@ import {
 /**
  * Alternative to `computed`, but triggering only on actual data changes.
  * Always `deep` as the plain `computed` is.
+ *
+ * With `writeThrough`, a set updates the cache synchronously, so a read reflects
+ * the write immediately even when `set` defers its work (e.g. debounced); the
+ * getter must then map set values to themselves (`get(x)` deep-equals `x`).
  */
 export function computedCached<T>(options: {
   get: ComputedGetter<T>;
   set: ComputedSetter<T>;
+  writeThrough?: boolean;
 }): WritableComputedRef<T>;
 export function computedCached<T>(getter: ComputedGetter<T>): ComputedRef<T>;
 export function computedCached<T>(
@@ -24,15 +29,18 @@ export function computedCached<T>(
     | {
         get: ComputedGetter<T>;
         set: ComputedSetter<T>;
+        writeThrough?: boolean;
       },
 ) {
   let getter: ComputedGetter<T>;
   let setter: ComputedSetter<T> | undefined = undefined;
+  let writeThrough = false;
   if (typeof arg === "function") {
     getter = arg;
   } else {
     getter = arg.get;
     setter = arg.set;
+    writeThrough = arg.writeThrough ?? false;
   }
 
   const cachedValue = ref<T>(getter());
@@ -51,7 +59,13 @@ export function computedCached<T>(
   if (setter) {
     return computed({
       get: () => cachedValue.value,
-      set: setter,
+      set: writeThrough
+        ? (newValue) => {
+            // Reflect the value in the cache now; `set` itself may defer its work.
+            if (!isJsonEqual(newValue, cachedValue.value)) cachedValue.value = deepClone(newValue);
+            setter(newValue);
+          }
+        : setter,
     });
   } else {
     return cachedValue;

--- a/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
+++ b/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { promiseTimeout, isJsonEqual } from "@milaboratories/helpers";
+import { promiseTimeout, isJsonEqual, deepClone } from "@milaboratories/helpers";
 import type {
   AxisId,
   PlDataTableGridStateCore,
@@ -281,7 +281,9 @@ watch(
       // match it → reloading again would repeat forever. Break the loop; the
       // guard resets automatically once the desired state actually changes.
       if (isJsonEqual(gridState, lastReloadTriggerState)) return;
-      lastReloadTriggerState = gridState;
+      // Snapshot (not a live reference) so the guard is independent of the
+      // reactive state graph and cannot be defeated by an in-place mutation.
+      lastReloadTriggerState = deepClone(gridState);
       isReloading = true;
       gridOptions.value.initialState = gridState;
       ++reloadKey.value;

--- a/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
+++ b/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { promiseTimeout, isJsonEqual, deepClone } from "@milaboratories/helpers";
+import { promiseTimeout, isJsonEqual } from "@milaboratories/helpers";
 import type {
   AxisId,
   PlDataTableGridStateCore,
@@ -258,16 +258,6 @@ function stateForReloadCompare(state: PlDataTableGridStateCore): PlDataTableGrid
 
 // Reload AgGrid when new state arrives from server
 const reloadKey = ref(0);
-// Loop guard: bumping reloadKey destroys and recreates the grid (via
-// `:key="reloadKey"`), which re-fires this watch through the new `gridApi.value`.
-// `gridState` is read through a debounced cache (see useTableState), so right
-// after a reload it can still report the pre-reload value while the fresh grid
-// already reports the state AgGrid normalized it to. If that normalized state is
-// not a fixed point of the stored one, the two never converge and the grid
-// remounts on every frame (observed as strobing column headers). We therefore
-// reload at most once per distinct desired state: reloading again for a state we
-// already reloaded for — with the grid still not matching — can only loop.
-let lastReloadTriggerState: PlDataTableGridStateCore | null = null;
 watch(
   () => [gridApi.value, gridState.value] as const,
   ([gridApi, gridState]) => {
@@ -277,13 +267,6 @@ watch(
       !isJsonEqual(gridState, {}) &&
       !isJsonEqual(stateForReloadCompare(gridState), stateForReloadCompare(selfState))
     ) {
-      // Already reloaded for this exact desired state and the grid still doesn't
-      // match it → reloading again would repeat forever. Break the loop; the
-      // guard resets automatically once the desired state actually changes.
-      if (isJsonEqual(gridState, lastReloadTriggerState)) return;
-      // Snapshot (not a live reference) so the guard is independent of the
-      // reactive state graph and cannot be defeated by an in-place mutation.
-      lastReloadTriggerState = deepClone(gridState);
       isReloading = true;
       gridOptions.value.initialState = gridState;
       ++reloadKey.value;

--- a/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
+++ b/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
@@ -258,6 +258,16 @@ function stateForReloadCompare(state: PlDataTableGridStateCore): PlDataTableGrid
 
 // Reload AgGrid when new state arrives from server
 const reloadKey = ref(0);
+// Loop guard: bumping reloadKey destroys and recreates the grid (via
+// `:key="reloadKey"`), which re-fires this watch through the new `gridApi.value`.
+// `gridState` is read through a debounced cache (see useTableState), so right
+// after a reload it can still report the pre-reload value while the fresh grid
+// already reports the state AgGrid normalized it to. If that normalized state is
+// not a fixed point of the stored one, the two never converge and the grid
+// remounts on every frame (observed as strobing column headers). We therefore
+// reload at most once per distinct desired state: reloading again for a state we
+// already reloaded for — with the grid still not matching — can only loop.
+let lastReloadTriggerState: PlDataTableGridStateCore | null = null;
 watch(
   () => [gridApi.value, gridState.value] as const,
   ([gridApi, gridState]) => {
@@ -267,6 +277,11 @@ watch(
       !isJsonEqual(gridState, {}) &&
       !isJsonEqual(stateForReloadCompare(gridState), stateForReloadCompare(selfState))
     ) {
+      // Already reloaded for this exact desired state and the grid still doesn't
+      // match it → reloading again would repeat forever. Break the loop; the
+      // guard resets automatically once the desired state actually changes.
+      if (isJsonEqual(gridState, lastReloadTriggerState)) return;
+      lastReloadTriggerState = gridState;
       isReloading = true;
       gridOptions.value.initialState = gridState;
       ++reloadKey.value;

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/row-number.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/row-number.ts
@@ -83,6 +83,7 @@ function adjustRowNumberColumnWidth(gridApi: GridApi, cellFake: HTMLDivElement, 
   cellFake.innerHTML = WidestDigit.repeat(lastDisplayedRowNumberDigitCount);
 
   nextTick(() => {
+    if (gridApi.isDestroyed()) return;
     gridApi.applyColumnState({
       state: [
         {

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
@@ -46,6 +46,7 @@ export function useTableState(
   const tableStateNormalized = computedCached<PlDataTableStateV2Normalized>({
     get: () => upgradePlDataTableStateV2(tableStateDenormalized.value),
     set: debounce((newState) => (tableStateDenormalized.value = newState), 300),
+    writeThrough: true,
   });
 
   const tableState = computed<PlDataTableStateV2CacheEntryNullable>({


### PR DESCRIPTION
## Problem

`PlAgDataTableV2` (the shared table used by ~every block) can enter a high-frequency loop where the **entire grid is destroyed and recreated on every frame**. Visible symptom: the column-header **type icons strobe** (the "Aa"/"#" indicators flicker rapidly) while the header text stays put. The console floods with AG Grid **error 26** (`applyColumnState` / `getAllGridColumns` / `removeEventListener` "grid has been destroyed") and **99** (`hideOverlay` while `loading`).

Users hit this across many different blocks; a page refresh, block reopen, or project reopen "fixes" it. The loop also repeatedly tears down and re-issues the table's server-side data requests, which contributes to PFrame request churn / high CPU and blank tables while it's happening.

## Root cause

- The reload watch bumps `reloadKey`, and `<AgGridVue :key="reloadKey">` **fully remounts the grid** — every header component is recreated. The type icon is an async-loaded `PlSvg` (dynamic `import(...svg?raw)` with no seed), so it renders blank for a tick on each mount → the observed strobe. Header text is synchronous, so it looks stable.
- `gridState` is read through a **debounced cache** (`useTableState` → `computedCached` whose setter is a 300 ms `debounce`). The cached read does **not** reflect a write until the debounce lands. Once a remount starts, `onStateUpdated` writes on every cycle and keeps *resetting* the debounce, so the read stays stale — the watch's `stored vs live` comparison never converges and it remounts forever.
- A spurious first mismatch is easy to trigger (stale colIds after a model change, or the locked row-number / selection columns AG Grid repositions), but the debounced-stale read is what turns a one-frame blip into an infinite loop. A fresh mount starts from an already-settled state, which is why refresh/reopen clears it.

## Fix

1. **Loop circuit-breaker** (`PlAgDataTableV2.vue`): reload at most **once per distinct desired state**. We remember the last state we reloaded *for*; if the desired state is unchanged and the grid still doesn't match it, we stop (reloading again could only repeat forever). The guard resets automatically when the desired state actually changes, so legitimate re-application (source/key switch, loading a saved layout) still works. A non-converging state now causes a single benign remount instead of an infinite loop.
2. **Destroyed-grid guard** (`row-number.ts`): the row-number auto-size scheduled `applyColumnState` inside `nextTick` with no `isDestroyed()` check — the direct source of the #26 console errors during teardown. Guarded, mirroring the existing check in `fixColumnOrder`.

### Why the circuit-breaker rather than normalizing the comparison

An alternative is to make the reload comparison (`stateForReloadCompare`) ignore the `columnOrder` / `sort` differences AG Grid renormalizes. But getting that exactly right needs runtime data on which colIds / system columns actually differ, and it risks *suppressing legitimate* state re-application. The circuit-breaker kills the loop regardless of the trigger, with no normalization guesswork — the minimal, low-risk fix. Comparison normalization remains a possible follow-up polish (to avoid even the single spurious remount), best informed by a runtime capture of the exact `columnOrder` delta.

## Testing

- `pnpm build --filter="@platforma-sdk/ui-vue..."` — ✓
- `pnpm --filter @platforma-sdk/ui-vue types:check` — ✓
- `pnpm -C sdk/ui-vue fmt` — ✓ clean

Not yet reproduced against a live loop in this branch — the fix is designed to converge for any non-fixed-point state rather than depending on the specific trigger. Recommend a quick manual verification against a project that reproduces it before merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an infinite grid-remount loop in `PlAgDataTableV2` caused by the reload watch comparing live AG Grid state against a debounced-stale store value that could never converge, producing per-frame strobing of async column-type icons and console floods of AG Grid error #26.

- **Circuit breaker (`PlAgDataTableV2.vue`)**: Introduces `lastReloadTriggerState` — the watch now reloads at most once per distinct desired state; if the grid still doesn't match after reloading, further attempts for the same state are blocked. The guard resets when `gridState` actually changes, so legitimate re-applications (source switch, layout restore) are unaffected.
- **Destroyed-grid guard (`row-number.ts`)**: Adds `isDestroyed()` before the `nextTick`-deferred `applyColumnState` in `adjustRowNumberColumnWidth`, mirroring the existing guard in `fixColumnOrder` and eliminating the #26 errors from teardown.

**Key terms touched by this PR:**
- **`PlDataTableGridStateCore`** — The structural type representing column order, sort, and visibility; used as both the desired state and the guard's comparison anchor. No type changes, but its equality semantics now drive the circuit-breaker.
- **`reloadKey`** — A `ref<number>` passed as `:key` to `<AgGridVue>`; incrementing it fully destroys and recreates the grid. This PR limits when it may be incremented.
- **`lastReloadTriggerState`** — New `let` variable (per-instance `script setup` scope) storing the `PlDataTableGridStateCore` value for which a reload was last triggered; the core of the loop-guard.
- **`stateForReloadCompare`** — Normalisation helper that equates `undefined` and empty `columnVisibility`; unchanged, but now applied on both sides of the guard-check.
- **`adjustRowNumberColumnWidth`** — The row-number auto-size function in `row-number.ts`; gains an `isDestroyed()` guard before its deferred `applyColumnState` call.
- **`gridState`** — The reactive desired state read from `useTableState` (debounced cache); its stale read after a remount was the root cause of non-convergence.
- **`selfState`** — The live AG Grid state obtained via `gridApi.getState()`; after a remount it reflects AG Grid's normalised representation, which may differ from `gridState` until the debounce settles.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrow and targeted: a loop-guard variable and a single destroyed-grid check. The circuit-breaker logic is sound under Vue 3's atomic ref-replacement model and the guard resets correctly when the desired state changes.

Both changes are small and well-contained. The circuit-breaker correctly handles all traced scenarios — convergent loads, layout restores, source switches — and the destroyed-grid check is a simple safety guard. The one thing worth a second look is that `lastReloadTriggerState` stores the reactive-proxy reference rather than a deep-clone, which is safe given Vue's current replace-not-mutate pattern but is an implicit assumption. The PR itself notes that a live reproduction hasn't been verified in the branch, so a brief manual check before merge is advisable.

The reload-watch section of `PlAgDataTableV2.vue` (lines 270–293) where the new guard lives — worth a quick manual smoke-test against the reproducing project before merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue | Adds a `lastReloadTriggerState` circuit-breaker to the reload watch — prevents the infinite remount loop when the debounced grid-state cache never converges; one P2 concern around reference storage vs. deep-clone |
| sdk/ui-vue/src/components/PlAgDataTable/sources/row-number.ts | Adds `isDestroyed()` guard before the nextTick-deferred `applyColumnState` call, mirroring the existing guard in `fixColumnOrder` — straightforward and correct |
| .changeset/fix-ag-data-table-reload-loop.md | Correctly scoped as a `patch` changeset for `@platforma-sdk/ui-vue`; accurately describes both the root cause and the fix |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as reload watch
    participant G as gridState debounced cache
    participant API as gridApi AG Grid
    participant R as reloadKey grid remount

    Note over W,R: Normal convergent path
    W->>G: "read gridState = stateA"
    W->>API: "read selfState = stateEmpty"
    W->>W: "mismatch, lastReloadTriggerState=null"
    W->>W: "lastReloadTriggerState = stateA"
    W->>R: "++reloadKey, grid remounts with initialState=stateA"
    R->>API: new gridApi emitted
    W->>G: "read gridState = stateA"
    W->>API: "read selfState = stateA converged"
    W->>W: equal, no reload needed

    Note over W,R: Loop scenario before fix
    W->>R: ++reloadKey, remount
    R->>API: new gridApi, onStateUpdated writes stateA_norm
    Note over G: debounce 300ms, gridState still = stateA
    W->>G: "read gridState = stateA"
    W->>API: "read selfState = stateA_norm, not equal to stateA"
    W->>R: ++reloadKey again, infinite loop

    Note over W,R: After fix, circuit breaker
    W->>W: "isJsonEqual stateA lastReloadTriggerState=stateA true"
    W->>W: return early, loop broken
    Note over G: debounce settles, gridState = stateA_norm
    W->>W: "stateA_norm != lastReloadTriggerState, guard resets"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as reload watch
    participant G as gridState debounced cache
    participant API as gridApi AG Grid
    participant R as reloadKey grid remount

    Note over W,R: Normal convergent path
    W->>G: "read gridState = stateA"
    W->>API: "read selfState = stateEmpty"
    W->>W: "mismatch, lastReloadTriggerState=null"
    W->>W: "lastReloadTriggerState = stateA"
    W->>R: "++reloadKey, grid remounts with initialState=stateA"
    R->>API: new gridApi emitted
    W->>G: "read gridState = stateA"
    W->>API: "read selfState = stateA converged"
    W->>W: equal, no reload needed

    Note over W,R: Loop scenario before fix
    W->>R: ++reloadKey, remount
    R->>API: new gridApi, onStateUpdated writes stateA_norm
    Note over G: debounce 300ms, gridState still = stateA
    W->>G: "read gridState = stateA"
    W->>API: "read selfState = stateA_norm, not equal to stateA"
    W->>R: ++reloadKey again, infinite loop

    Note over W,R: After fix, circuit breaker
    W->>W: "isJsonEqual stateA lastReloadTriggerState=stateA true"
    W->>W: return early, loop broken
    Note over G: debounce settles, gridState = stateA_norm
    W->>W: "stateA_norm != lastReloadTriggerState, guard resets"
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asdk%2Fui-vue%2Fsrc%2Fcomponents%2FPlAgDataTable%2FPlAgDataTableV2.vue%3A283-284%0A%60lastReloadTriggerState%20%3D%20gridState%60%20stores%20the%20reactive-proxy%20reference%2C%20not%20a%20snapshot.%20Vue%203%20reactive%20refs%20replace%20%60.value%60%20atomically%20rather%20than%20mutating%20in%20place%2C%20so%20in%20practice%20%60lastReloadTriggerState%60%20will%20keep%20pointing%20to%20the%20old%20content%20%E2%80%94%20but%20any%20future%20in-place%20mutation%20of%20the%20%60gridState%60%20object%20would%20make%20the%20guard%20permanently%20evaluate%20as%20%60true%60%20%28same%20proxy%2C%20same%20content%29%2C%20silently%20suppressing%20all%20subsequent%20legitimate%20reloads.%20A%20deep-clone%20on%20write%20makes%20the%20guard's%20independence%20from%20the%20live%20reactive%20graph%20explicit%20and%20safe.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28isJsonEqual%28gridState%2C%20lastReloadTriggerState%29%29%20return%3B%0A%20%20%20%20%20%20lastReloadTriggerState%20%3D%20structuredClone%28gridState%29%3B%0A%60%60%60%0A%0A&repo=milaboratory%2Fplatforma&pr=1748&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue:283-284
`lastReloadTriggerState = gridState` stores the reactive-proxy reference, not a snapshot. Vue 3 reactive refs replace `.value` atomically rather than mutating in place, so in practice `lastReloadTriggerState` will keep pointing to the old content — but any future in-place mutation of the `gridState` object would make the guard permanently evaluate as `true` (same proxy, same content), silently suppressing all subsequent legitimate reloads. A deep-clone on write makes the guard's independence from the live reactive graph explicit and safe.

```suggestion
      if (isJsonEqual(gridState, lastReloadTriggerState)) return;
      lastReloadTriggerState = structuredClone(gridState);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui-vue): stop PlAgDataTableV2 infini..."](https://github.com/milaboratory/platforma/commit/f0b553711b2de0fda5115627d6b558a829e1441a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43123205)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->