### PR TITLE
polars-pf version bump

### DIFF
--- a/.changeset/fair-cities-ask.md
+++ b/.changeset/fair-cities-ask.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+---
+
+polars-pf version bump

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.53
+polars-pf==1.1.54
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^2.0.1
       version: 2.0.1
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.10.6
-      version: 1.10.6
+      specifier: 1.11.1
+      version: 1.11.1
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -2499,7 +2499,7 @@ importers:
         version: link:../../../tools/ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.6
+        version: 1.11.1
       '@types/archiver':
         specifier: 'catalog:'
         version: 6.0.3
@@ -3300,7 +3300,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.6
+        version: 1.11.1
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../../tools/block-tools
@@ -3309,7 +3309,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.10.6
+        version: 1.11.1
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../tools/block-tools
@@ -5869,6 +5869,9 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0':
     resolution: {integrity: sha512-nEM4eEj7pFT6yi+P5028qtgK5v9A9H0XdVHDtrKX7xW5Jipc1RIliOEU3gzaH0E7UAzPFQGSqShlwakRcGXwdQ==}
 
+  '@platforma-open/milaboratories.runenv-python-3.12.10-pgen@0.2.0':
+    resolution: {integrity: sha512-+4pEVwRZaBAm0716NoNdK9cfF4E7jtsRUpcAWYCuPbbZJ3Q7bgfgq8bEhcck8No97l9jWN2rAeJegA9UQy5FgQ==}
+
   '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.7.0':
     resolution: {integrity: sha512-nChTh2Fk9KW1yLfqDb1Bb1BBDQRNoZZ2jRMLH76wEa3l0g1ZHG52wCkwzXz6fztvru0Em52PH4KdENp4hUTNMw==}
 
@@ -5878,14 +5881,14 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0':
     resolution: {integrity: sha512-CSLEjBYUdHDf66QAfgQ9jo+MoW63Wr0ygdIncJE2siO2jMUzYCqgCNd8bMjaMfZa3YBC9bHca3Cjxbp4VYc54A==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0':
-    resolution: {integrity: sha512-Z9OIHbWfq0OsTUvmJIK6HBm8qLIli5xxHlGsiNx012YU69snwgi2edioMjUQ1vr5eWPA/9+Xs8Ih9z+aWbmUpQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0':
+    resolution: {integrity: sha512-PRGkgsVY08tQvoucU8fJmeCF+x9XjiHHjNTbxWqddqx2EZpiUvmylkxtU8i8xJW13cesAI+xHv3NsVUXQaRDqA==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.20':
-    resolution: {integrity: sha512-A2+SYW2loIWrf33zbRjWimjsLx5scEOTL2VnTxlBQmuSWyxR1jjm711yaS+F76WoAMTBpaLbmwgO1WUP2cVAvg==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.21':
+    resolution: {integrity: sha512-64E3Dammowcqe8TvNmW2gCbQ8PtLjcH/YynOIGulmFtX129npMQkMyAYBpSCCI5YZRRi/Ya4Cx78QxYwla/4wQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.6':
-    resolution: {integrity: sha512-cAGuQ49mcagJsOPRb3EalJq8B5ADBeITrkCrnpattC7U2SjM+PkR60eqtt41CneaQZNP4DHjSGVNA8sKHSn+CA==}
+  '@platforma-open/milaboratories.runenv-python-3@1.11.1':
+    resolution: {integrity: sha512-PF56vtTzpcn+Zv7URNbcsZ3u4tYed35CiAQ+eArKJjPKE4o5a9UBE7ur3QS3u/f75LU1KIeLgM2xR99Jtuu6Cg==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -11409,28 +11412,31 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0': {}
 
+  '@platforma-open/milaboratories.runenv-python-3.12.10-pgen@0.2.0': {}
+
   '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.7.0': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.6': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.1.0': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.20': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.21': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.10.6':
+  '@platforma-open/milaboratories.runenv-python-3@1.11.1':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.20
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.21
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5
       '@platforma-open/milaboratories.runenv-python-3.12.10-humanness': 0.2.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-parapred': 1.1.0
+      '@platforma-open/milaboratories.runenv-python-3.12.10-pgen': 0.2.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.7.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.6
       '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': 1.1.0
-      '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': 0.1.0
+      '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': 0.2.0
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -299,7 +299,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.1.1
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.10.6
+  "@platforma-open/milaboratories.runenv-python-3": 1.11.1
 
   "shx": ^0.4.0
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `polars-pf` from `1.1.53` to `1.1.54` in the ptabler software requirements and upgrades the `runenv-python-3` catalog dependency from `1.10.6` to `1.11.1`, which also pulls in a new `pgen@0.2.0` extension and updates `torch-cuda` to `0.2.0`.

- **`polars-pf` patch bump** (`1.1.53 → 1.1.54`) in `lib/ptabler/software/src/requirements.txt` with a corresponding `patch` changeset for `@platforma-open/milaboratories.software-ptabler`.
- **`runenv-python-3` minor bump** (`1.10.6 → 1.11.1`) applied globally via the pnpm catalog, updating the base runtime (`1.3.20 → 1.3.21`), adding `pgen@0.2.0`, and upgrading `torch-cuda` (`0.1.0 → 0.2.0`).
- Three workspace packages consume `runenv-python-3` from the catalog: `software-ptabler`, `software-ptexter`, and `package-builder-lib`; only `software-ptabler` has a changeset entry.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Python dependency and runtime bumps are self-contained; the main risk is that software-ptexter is rebuilt against a newer runtime without a version bump signalling that to consumers.

The polars-pf and runenv-python-3 bumps are straightforward, but the runenv-python-3 catalog change silently rebuilds software-ptexter with the updated runtime while omitting a changeset for it. Consumers relying on reproducible releases of that package would get a new artifact under the old version number.

.changeset/fair-cities-ask.md — consider whether @platforma-open/milaboratories.software-ptexter also needs an entry given the shared catalog bump.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/fair-cities-ask.md | Changeset records only software-ptabler but the runenv-python-3 catalog bump also rebuilds software-ptexter with no version entry |
| lib/ptabler/software/src/requirements.txt | Bumps polars-pf from 1.1.53 to 1.1.54; all other Python dependencies remain unchanged |
| pnpm-workspace.yaml | Catalog entry for runenv-python-3 bumped from 1.10.6 to 1.11.1 |
| pnpm-lock.yaml | Lock file updated to reflect new runenv-python-3@1.11.1 and its changed transitive deps (new pgen@0.2.0, torch-cuda 0.1.0→0.2.0, python-3.12.10 1.3.20→1.3.21) |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    WS["pnpm-workspace.yaml\nrunenv-python-3: 1.10.6 → 1.11.1"]

    WS --> PTA["lib/ptabler/software\n@platforma-open/milaboratories.software-ptabler\n✅ changeset: patch"]
    WS --> PTX["lib/ptexter\n@platforma-open/milaboratories.software-ptexter\n⚠️ no changeset"]
    WS --> PBL["lib/node/package-builder-lib\n(internal build tool, no publish)"]

    PTA --> REQ["requirements.txt\npolars-pf 1.1.53 → 1.1.54"]

    subgraph runenv["runenv-python-3@1.11.1 (was 1.10.6)"]
        CORE["runenv-python-3.12.10\n1.3.20 → 1.3.21"]
        PGEN["runenv-python-3.12.10-pgen\n0.2.0 NEW"]
        TORCH["runenv-python-3.12.10-torch-cuda\n0.1.0 → 0.2.0"]
    end

    WS --> CORE
    WS --> PGEN
    WS --> TORCH
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    WS["pnpm-workspace.yaml\nrunenv-python-3: 1.10.6 → 1.11.1"]

    WS --> PTA["lib/ptabler/software\n@platforma-open/milaboratories.software-ptabler\n✅ changeset: patch"]
    WS --> PTX["lib/ptexter\n@platforma-open/milaboratories.software-ptexter\n⚠️ no changeset"]
    WS --> PBL["lib/node/package-builder-lib\n(internal build tool, no publish)"]

    PTA --> REQ["requirements.txt\npolars-pf 1.1.53 → 1.1.54"]

    subgraph runenv["runenv-python-3@1.11.1 (was 1.10.6)"]
        CORE["runenv-python-3.12.10\n1.3.20 → 1.3.21"]
        PGEN["runenv-python-3.12.10-pgen\n0.2.0 NEW"]
        TORCH["runenv-python-3.12.10-torch-cuda\n0.1.0 → 0.2.0"]
    end

    WS --> CORE
    WS --> PGEN
    WS --> TORCH
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.changeset%2Ffair-cities-ask.md%3A1-5%0A**Missing%20changeset%20for%20%60software-ptexter%60**%0A%0A%60lib%2Fptexter%60%20%28%60%40platforma-open%2Fmilaboratories.software-ptexter%60%29%20also%20has%20%60runenv-python-3%60%20bumped%20from%20%601.10.6%60%20to%20%601.11.1%60%20via%20the%20catalog%20change%2C%20but%20no%20changeset%20entry%20exists%20for%20it.%20Because%20%60runenv-python-3%60%20is%20bundled%20into%20the%20published%20software%20artifact%20at%20build%20time%20%28not%20just%20a%20JS%20devDependency%29%2C%20the%20built%20output%20for%20%60software-ptexter%60%20will%20change%20without%20a%20corresponding%20version%20increment%20%E2%80%94%20consumers%20won't%20see%20a%20new%20release%20signalling%20the%20runtime%20update.%0A%0A&repo=milaboratory%2Fplatforma&pr=1749&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/fair-cities-ask.md:1-5
**Missing changeset for `software-ptexter`**

`lib/ptexter` (`@platforma-open/milaboratories.software-ptexter`) also has `runenv-python-3` bumped from `1.10.6` to `1.11.1` via the catalog change, but no changeset entry exists for it. Because `runenv-python-3` is bundled into the published software artifact at build time (not just a JS devDependency), the built output for `software-ptexter` will change without a corresponding version increment — consumers won't see a new release signalling the runtime update.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["polars-pf version bump"](https://github.com/milaboratory/platforma/commit/26f1dbb7232605524dfc4e0a6bf3f13375657a12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43242335)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->