### PR TITLE
MILAB-6611: pt: size ptabler CPU/RAM from input data via exec.formula

### DIFF
--- a/.changeset/pt-resource-formulas.md
+++ b/.changeset/pt-resource-formulas.md
@@ -4,7 +4,7 @@
 
 pt: size the ptabler run's CPU and RAM from the input data volume by default. When a block does not set an explicit `.cpu()`/`.mem()`, the `pt` runner now requests resources via `exec.formula` derived from the total input blob size (`f.size()`):
 
-- `ram = clamp(2 GiB + 4 × size, 2 GiB, 64 GiB)` (fallback 4 GiB)
-- `cpu = clamp(2 + size / 16 GiB, 2, 8)` (fallback 2)
+- `ram = between(2 GiB + 4 × size, 2 GiB, 64 GiB)` (fallback 4 GiB)
+- `cpu = between(2 + size / 16 GiB, 2, 8)` (fallback 2)
 
 An explicit `.cpu()`/`.mem()` still wins. Both dimensions carry a `.staticFallback`, so the run also resolves on backends that cannot evaluate resource formulas (no `getBlobSize`). Sizing is deliberately moderate because ptabler runs Polars in lazy + streaming mode with disk spill (`--spill-dir`), so peak RAM is a modest multiple of the input rather than the whole dataset.

--- a/.changeset/pt-resource-formulas.md
+++ b/.changeset/pt-resource-formulas.md
@@ -1,0 +1,10 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+---
+
+pt: size the ptabler run's CPU and RAM from the input data volume by default. When a block does not set an explicit `.cpu()`/`.mem()`, the `pt` runner now requests resources via `exec.formula` derived from the total input blob size (`f.size()`):
+
+- `ram = clamp(2 GiB + 4 × size, 2 GiB, 64 GiB)` (fallback 4 GiB)
+- `cpu = clamp(2 + size / 16 GiB, 2, 8)` (fallback 2)
+
+An explicit `.cpu()`/`.mem()` still wins. Both dimensions carry a `.staticFallback`, so the run also resolves on backends that cannot evaluate resource formulas (no `getBlobSize`). Sizing is deliberately moderate because ptabler runs Polars in lazy + streaming mode with disk spill (`--spill-dir`), so peak RAM is a modest multiple of the input rather than the whole dataset.

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -861,7 +861,7 @@ workflow := func() {
 		 * Sets the number of CPUs to request from the underlying executor (i.e. Google/AWS Batch, PBS, Slurm, etc.).
 		 *
 		 * If not set, the CPU request is sized from the input data volume:
-		 * `clamp(2 + size / 16 GiB, 2, 8)`. Setting an explicit value overrides this.
+		 * `between(2 + size / 16 GiB, 2, 8)`. Setting an explicit value overrides this.
 		 *
 		 * @param amount: number - number of cores requested for command.
 		 */
@@ -880,7 +880,7 @@ workflow := func() {
 		 *                                    120 * units.GiB
 		 *
 		 * If not set, the RAM request is sized from the input data volume:
-		 * `clamp(2 GiB + 4 × size, 2 GiB, 64 GiB)`. Setting an explicit value overrides this.
+		 * `between(2 GiB + 4 × size, 2 GiB, 64 GiB)`. Setting an explicit value overrides this.
 		 *
 		 * @return builder
 		 */

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -860,6 +860,9 @@ workflow := func() {
 		/**
 		 * Sets the number of CPUs to request from the underlying executor (i.e. Google/AWS Batch, PBS, Slurm, etc.).
 		 *
+		 * If not set, the CPU request is sized from the input data volume:
+		 * `clamp(2 + size / 16 GiB, 2, 8)`. Setting an explicit value overrides this.
+		 *
 		 * @param amount: number - number of cores requested for command.
 		 */
 		cpu: func(amount) {
@@ -875,6 +878,9 @@ workflow := func() {
 		 *                                    Ki, KiB, Mi, MiB, Gi, GiB for base-2 sizes (powers of 1024)
 		 *                                  when operating with bytes, you may use 'units' package for convenience:
 		 *                                    120 * units.GiB
+		 *
+		 * If not set, the RAM request is sized from the input data volume:
+		 * `clamp(2 GiB + 4 × size, 2 GiB, 64 GiB)`. Setting an explicit value overrides this.
 		 *
 		 * @return builder
 		 */

--- a/sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo
+++ b/sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo
@@ -41,12 +41,35 @@ self.body(func(inputs) {
         arg("--frame-dir").arg(inFramesFolder).
         arg("--spill-dir").arg(spillFolder).
         writeFile("workflow_sc.json", workflowJsonStruct);
-    if !is_undefined(cpu) {
-        ptCmd.cpu(cpu)
+    // Size the ptabler (Polars) run from the total input data volume, unless the
+    // block author set an explicit cpu/mem (an explicit request always wins).
+    // ptabler runs Polars in lazy + streaming mode with disk spill (--spill-dir),
+    // so peak RAM stays a modest multiple of the input size rather than the whole
+    // dataset. f.size() sums the stored (parquet) blob size of all input files via
+    // getBlobSize (a metadata read, no pre-exec). Both dimensions carry a
+    // .staticFallback so the run also resolves on backends that cannot evaluate
+    // resource formulas (no getBlobSize).
+    //     ram = clamp(2 GiB + 4 * size, 2 GiB, 64 GiB)
+    //     cpu = clamp(2 + size / 16 GiB, 2, 8)
+    f := exec.formula
+    ramReq := mem
+    if is_undefined(ramReq) {
+        ramReq = f.size({ default: 0 }).times(4).plus(f.gib(2)).
+            between(f.gib(2), f.gib(64)).
+            staticFallback("4GiB")
     }
-    if !is_undefined(mem) {
-        ptCmd.mem(mem)
+    cpuReq := cpu
+    if is_undefined(cpuReq) {
+        cpuReq = f.size({ default: 0 }).dividedByFloor(f.gib(16)).plus(f.const(2)).
+            between(f.const(2), f.const(8)).
+            staticFallback(2)
     }
+    ptCmd.resources({
+        onCPU: {
+            cpu: cpuReq,
+            ram: ramReq
+        }
+    })
     if !is_undefined(inputCache) {
         ptCmd.cacheInputs(inputCache)
     }

--- a/sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo
+++ b/sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo
@@ -49,8 +49,8 @@ self.body(func(inputs) {
     // getBlobSize (a metadata read, no pre-exec). Both dimensions carry a
     // .staticFallback so the run also resolves on backends that cannot evaluate
     // resource formulas (no getBlobSize).
-    //     ram = clamp(2 GiB + 4 * size, 2 GiB, 64 GiB)
-    //     cpu = clamp(2 + size / 16 GiB, 2, 8)
+    //     ram = between(2 GiB + 4 * size, 2 GiB, 64 GiB)
+    //     cpu = between(2 + size / 16 GiB, 2, 8)
     f := exec.formula
     ramReq := mem
     if is_undefined(ramReq) {


### PR DESCRIPTION
## What

Size the `pt` (ptabler / Polars) run's CPU and RAM from the input data volume by default, using `exec.formula`. Applied in `pt/workflow-run.tpl.tengo` — the single exec builder call in `pt/`.

When a block does **not** set an explicit `.cpu()` / `.mem()`, the runner now requests:

```
ram = between(2 GiB + 4 × f.size(), 2 GiB, 64 GiB)   fallback 4 GiB
cpu = between(2 + f.size() / 16 GiB, 2, 8)           fallback 2
```

An explicit `.cpu()` / `.mem()` still wins (unchanged). Both dimensions carry a `.staticFallback`, so the run also resolves on backends that cannot evaluate resource formulas (no `getBlobSize`).

## Why these numbers

`f.size()` sums the stored (parquet) blob size of all input files. The sizing is deliberately **moderate** because ptabler runs Polars in **lazy + streaming** mode (`collect_all(engine="streaming")`) with **disk spill** (`--spill-dir` → DuckDB sort + PFrame reads). Peak RAM is therefore a modest multiple of the input rather than the whole dataset; the 4× covers parquet→in-memory expansion plus a small operation working set, and spill handles the tail. CPU scales gently and caps low because Polars parallelizes internally and `pt` is only ever used on the medium/light queues.

## Impact

Affects the default resources for all `pt` runs (~50 call sites across blocks). Real-world usage is medium (48) / light (2) — no heavy/ui-tasks — so there is no regression against a large queue default; medium's ~1 GiB default becomes `≥ 2 GiB + 4×input`, and light requests are capped to the light limit anyway.

Not runtime-validated in isolation (needs a live backend, same as other resource formulas); relies on the monorepo CI here. Tengo build + full unit suite (201 pass / 0 fail) are green.

## Changes

- `sdk/workflow-tengo/src/pt/workflow-run.tpl.tengo` — formula sizing
- `sdk/workflow-tengo/src/pt/index.lib.tengo` — doc notes on `.cpu()`/`.mem()` defaults
- `.changeset/pt-resource-formulas.md` — `minor`
