### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/bright-donuts-yell.md
+++ b/.changeset/bright-donuts-yell.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+"@platforma-sdk/workflow-tengo": patch
+---
+
+PFrames bump

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.54
+polars-pf==1.1.55
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,14 +28,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.52
-      version: 1.1.52
+      specifier: 1.1.55
+      version: 1.1.55
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.52
-      version: 1.1.52
+      specifier: 1.1.55
+      version: 1.1.55
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.52
-      version: 1.1.52
+      specifier: 1.1.55
+      version: 1.1.55
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^2.0.1
       version: 2.0.1
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.11.1
-      version: 1.11.1
+      specifier: 1.11.2
+      version: 1.11.2
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -2348,7 +2348,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2499,7 +2499,7 @@ importers:
         version: link:../../../tools/ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.11.1
+        version: 1.11.2
       '@types/archiver':
         specifier: 'catalog:'
         version: 6.0.3
@@ -2526,10 +2526,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.52(encoding@0.1.13)
+        version: 1.1.55(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -3012,10 +3012,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.52(encoding@0.1.13)
+        version: 1.1.55(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3300,7 +3300,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.11.1
+        version: 1.11.2
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../../tools/block-tools
@@ -3309,7 +3309,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.11.1
+        version: 1.11.2
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../tools/block-tools
@@ -3664,7 +3664,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.52
+        version: 1.1.55
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5387,18 +5387,18 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.52':
-    resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
+  '@milaboratories/pframes-rs-node@1.1.55':
+    resolution: {integrity: sha512-TbudDPMixADLyVr5UsiXhf+zq7YCJA3osFrzDn7Lr5aeyorCjiXDkVOGKpID7GkkssuVsNpPXtoGdA71Y2tLjQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
-    resolution: {integrity: sha512-yVfcyLztgj5UAffj30se5G4MwxkIOFVWPHY1tZZ8zLhQQzx95R/e1toAqq3FLV7y6kpJovwmLusbefgKw9Ejcg==}
+  '@milaboratories/pframes-rs-serv@1.1.55':
+    resolution: {integrity: sha512-cGByUULBA/JiwyFEBZrVNOEbnbrMPWWHCWLprRKlVWlmDMaRmsVft/tFpnle46BhDZWpoWbaKEZ8NGOtGqDCXw==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52':
-    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
+  '@milaboratories/pframes-rs-wasip2@1.1.55':
+    resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52':
-    resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
+  '@milaboratories/pframes-rs-wasm@1.1.55':
+    resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.2
@@ -5884,11 +5884,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0':
     resolution: {integrity: sha512-PRGkgsVY08tQvoucU8fJmeCF+x9XjiHHjNTbxWqddqx2EZpiUvmylkxtU8i8xJW13cesAI+xHv3NsVUXQaRDqA==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.21':
-    resolution: {integrity: sha512-64E3Dammowcqe8TvNmW2gCbQ8PtLjcH/YynOIGulmFtX129npMQkMyAYBpSCCI5YZRRi/Ya4Cx78QxYwla/4wQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.22':
+    resolution: {integrity: sha512-8cFlOrT4lTSb/uz/T8CUYoJWhqFAheOVycne7HmMIsXPdeyF23iV0q9rV4w9bKSg+ER8qzkmSrxT/G8bF68oyA==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.11.1':
-    resolution: {integrity: sha512-PF56vtTzpcn+Zv7URNbcsZ3u4tYed35CiAQ+eArKJjPKE4o5a9UBE7ur3QS3u/f75LU1KIeLgM2xR99Jtuu6Cg==}
+  '@platforma-open/milaboratories.runenv-python-3@1.11.2':
+    resolution: {integrity: sha512-0mwC1U40h8tXp9qoA0eaVMgg2QWyQtJySRv58z/Hj8ILflLjsqBzfaTV9NvtA5Nt5Y61vfjizzTKsZdsVFcOHw==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -10999,18 +10999,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.52(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.55(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.52
+      '@milaboratories/pframes-rs-serv': 1.1.55
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
+  '@milaboratories/pframes-rs-serv@1.1.55':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -11019,12 +11019,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.55': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/pframes-rs-wasip2': 1.1.55
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11422,11 +11422,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.21': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.22': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.11.1':
+  '@platforma-open/milaboratories.runenv-python-3@1.11.2':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.21
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.22
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -254,9 +254,9 @@ catalog:
 
   "@milaboratories/tengo-tester": ^1.6.4
   # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
-  "@milaboratories/pframes-rs-node": 1.1.52
-  "@milaboratories/pframes-rs-wasip2": 1.1.52
-  "@milaboratories/pframes-rs-wasm": 1.1.52
+  "@milaboratories/pframes-rs-node": 1.1.55
+  "@milaboratories/pframes-rs-wasip2": 1.1.55
+  "@milaboratories/pframes-rs-wasm": 1.1.55
 
   "quickjs-emscripten": 0.31.0
 
@@ -299,7 +299,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.1.1
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.11.1
+  "@platforma-open/milaboratories.runenv-python-3": 1.11.2
 
   "shx": ^0.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -253,7 +253,10 @@ catalog:
   "winston": ^3.17.0
 
   "@milaboratories/tengo-tester": ^1.6.4
-  # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts.
+  # When bumping, also update `REQUIRES_PFRAMES_VERSION` in lib/model/common/src/flags/block_flags.ts
+  # in case the changes are not backward-compatible. When adding new functionality - bump pframes-rs
+  # and then `REQUIRES_PFRAMES_VERSION` after a week or two, to give the users time to update desktop
+  # before SDK starts requiring a newer version of desktop.
   "@milaboratories/pframes-rs-node": 1.1.55
   "@milaboratories/pframes-rs-wasip2": 1.1.55
   "@milaboratories/pframes-rs-wasm": 1.1.55


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the PFrames Rust engine packages (`pframes-rs-*`) from 1.1.52 → 1.1.55, the Python `polars-pf` binding from 1.1.54 → 1.1.55, and the Python 3 runtime environment (`runenv-python-3`) from 1.11.1 → 1.11.2 — keeping the JS, WASM, wasip2, and Python-side pframes packages in sync.

- **pframes-rs-node / wasip2 / wasm / serv 1.1.52 → 1.1.55**: catalog and lock-file entries updated; new integrity hashes in `pnpm-lock.yaml`.
- **polars-pf 1.1.54 → 1.1.55**: Python requirements updated in `lib/ptabler/software/src/requirements.txt`.
- **runenv-python-3 1.11.1 → 1.11.2**: catalog and lock-file entries updated, pulling in a new `runenv-python-3.12.10` (1.3.21 → 1.3.22).
- **`REQUIRES_PFRAMES_VERSION` in `lib/model/common/src/flags/block_flags.ts` not updated**: the comment in `pnpm-workspace.yaml` explicitly instructs updating this constant on every pframes bump; it remains at `1_001_031` (v1.1.31) despite packages now being at 1.1.55.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Mostly mechanical version bumps; the one concern is the compatibility-guard constant that was left behind.

All package version changes are straightforward and the lock file is consistently updated. The only non-trivial gap is that REQUIRES_PFRAMES_VERSION in block_flags.ts was not updated alongside the pframes packages, even though the comment next to the catalog entries explicitly requires it. That constant is stamped into every compiled block and checked by the desktop app's middle layer, so leaving it at v1.1.31 while shipping v1.1.55 packages means the compatibility fence is softer than intended.

lib/model/common/src/flags/block_flags.ts — REQUIRES_PFRAMES_VERSION needs to be bumped to match the new pframes-rs version.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Bumps pframes-rs-* packages from 1.1.52 → 1.1.55 and runenv-python-3 from 1.11.1 → 1.11.2 in the catalog; REQUIRES_PFRAMES_VERSION in block_flags.ts was not updated as required by the inline comment. |
| lib/ptabler/software/src/requirements.txt | Bumps polars-pf from 1.1.54 → 1.1.55, keeping the Python package version in sync with the Rust pframes packages. |
| pnpm-lock.yaml | Lock file updated to reflect new resolutions and integrity hashes for all bumped packages; mechanically consistent with catalog changes. |
| .changeset/bright-donuts-yell.md | Changeset marks patch bumps for software-ptabler, pf-spec-driver, pf-driver, and workflow-tengo; pl-model-common is absent, consistent with REQUIRES_PFRAMES_VERSION being left unchanged. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm-workspace.yaml catalog\npframes-rs-* 1.1.52 → 1.1.55\nrunenv-python-3 1.11.1 → 1.11.2"] --> B["pnpm-lock.yaml\nnew integrity hashes"]
    A --> C["lib/ptabler/software/src/requirements.txt\npolars-pf 1.1.54 → 1.1.55"]
    A --> D[".changeset/bright-donuts-yell.md\npatch: software-ptabler, pf-spec-driver, pf-driver, workflow-tengo"]
    A -->|"comment says: also update"| E["lib/model/common/src/flags/block_flags.ts\nREQUIRES_PFRAMES_VERSION = 1_001_031\n⚠️ NOT updated"]
    E -->|"read by"| F["sdk/model/src/block_model.ts\nstamps requiresPFramesVersion on blocks"]
    E -->|"read by"| G["lib/node/pl-middle-layer\ndeclares desktop app capability"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["pnpm-workspace.yaml catalog\npframes-rs-* 1.1.52 → 1.1.55\nrunenv-python-3 1.11.1 → 1.11.2"] --> B["pnpm-lock.yaml\nnew integrity hashes"]
    A --> C["lib/ptabler/software/src/requirements.txt\npolars-pf 1.1.54 → 1.1.55"]
    A --> D[".changeset/bright-donuts-yell.md\npatch: software-ptabler, pf-spec-driver, pf-driver, workflow-tengo"]
    A -->|"comment says: also update"| E["lib/model/common/src/flags/block_flags.ts\nREQUIRES_PFRAMES_VERSION = 1_001_031\n⚠️ NOT updated"]
    E -->|"read by"| F["sdk/model/src/block_model.ts\nstamps requiresPFramesVersion on blocks"]
    E -->|"read by"| G["lib/node/pl-middle-layer\ndeclares desktop app capability"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apnpm-workspace.yaml%3A254-260%0A**%60REQUIRES_PFRAMES_VERSION%60%20not%20updated%20after%20bump**%0A%0AThe%20inline%20comment%20on%20line%20255%20of%20%60pnpm-workspace.yaml%60%20explicitly%20states%3A%20*%22When%20bumping%2C%20also%20update%20%60REQUIRES_PFRAMES_VERSION%60%20in%20%60lib%2Fmodel%2Fcommon%2Fsrc%2Fflags%2Fblock_flags.ts%60.%22*%20The%20packages%20were%20bumped%20from%201.1.52%20%E2%86%92%201.1.55%2C%20but%20%60REQUIRES_PFRAMES_VERSION%60%20is%20still%20%601_001_031%60%20%28encoding%20v1.1.31%29.%20%60block_model.ts%60%20reads%20this%20constant%20and%20stamps%20%60requiresPFramesVersion%60%20on%20every%20block%2C%20and%20%60middle_layer.ts%60%20uses%20it%20to%20declare%20what%20the%20desktop%20app%20supports.%20Leaving%20it%20at%201.1.31%20means%20blocks%20built%20against%20the%20new%20pframes%20SDK%20won't%20reject%20loading%20on%20desktop%20apps%20that%20still%20ship%20pframes%201.1.31%E2%80%931.1.54%2C%20which%20defeats%20the%20compatibility%20guard%20this%20flag%20was%20designed%20to%20enforce.%0A%0A&repo=milaboratory%2Fplatforma&pr=1752&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-workspace.yaml:254-260
**`REQUIRES_PFRAMES_VERSION` not updated after bump**

The inline comment on line 255 of `pnpm-workspace.yaml` explicitly states: *"When bumping, also update `REQUIRES_PFRAMES_VERSION` in `lib/model/common/src/flags/block_flags.ts`."* The packages were bumped from 1.1.52 → 1.1.55, but `REQUIRES_PFRAMES_VERSION` is still `1_001_031` (encoding v1.1.31). `block_model.ts` reads this constant and stamps `requiresPFramesVersion` on every block, and `middle_layer.ts` uses it to declare what the desktop app supports. Leaving it at 1.1.31 means blocks built against the new pframes SDK won't reject loading on desktop apps that still ship pframes 1.1.31–1.1.54, which defeats the compatibility guard this flag was designed to enforce.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/milaboratory/platforma/commit/d65b1908f38d876c83bc40165ed364f8dbcbc728) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44080523)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->