### PR TITLE
fix: release nameable Branded for cross-package dts emit

### DIFF
--- a/.changeset/release-helpers-brand-nameability.md
+++ b/.changeset/release-helpers-brand-nameability.md
@@ -1,0 +1,16 @@
+---
+"@milaboratories/helpers": patch
+---
+
+Release the nameable string-key `Branded` fix. The brand key was changed from a
+`unique symbol` to a plain string literal (`{ readonly __brand: B }`) in the new
+column access work so branded types stay nameable during cross-package `.d.ts`
+emit. That source change shipped in #1739, but `@milaboratories/helpers@1.14.3`
+was published before it merged, so the fix never reached consumers.
+
+Without this, any package that lets a `Branded`-based id (e.g. the
+`ColumnUniversalId` union: `LocalPObjectId | GlobalPObjectId | ColumnFilteredId |
+ColumnDiscoveredId | ColumnOverriddenId`) flow into an inferred exported type
+fails declaration emit with TS4023 ("has or is using name '__brand' ... but
+cannot be named"). Bumping helpers republishes the fix and cascades to
+pl-model-common / model / ui-vue.


### PR DESCRIPTION
## Problem

Packages that let a `Branded`-based id (e.g. the `ColumnUniversalId` union: `LocalPObjectId | GlobalPObjectId | ColumnFilteredId | ColumnDiscoveredId | ColumnOverriddenId`) flow into an inferred exported type fail declaration emit with:

```
error TS4023: Exported variable 'platforma' has or is using name '__brand'
from external module ".../@milaboratories/helpers/dist/types/brand" but cannot be named.
```

This blocks any block migrating to the released new column access SDK (model 1.80.0) from building its `.d.ts` (type-check passes; the failure is declaration-emit only).

## Root cause

The fix already exists in source: `helpers/src/types/brand.ts` changed the brand key from a `unique symbol` to a plain string literal (`{ readonly __brand: B }`) so branded types stay nameable during cross-package dts emit — committed with the new column access work (#1739).

But `@milaboratories/helpers@1.14.3` was published on 2026-07-06, before #1739 merged (2026-07-14), and #1739 carried no changeset for helpers. So the fix never reached npm — consumers still resolve the `unique symbol` brand.

## Fix

Adds a changeset bumping `@milaboratories/helpers` (patch) to release the already-committed fix. `changeset status` confirms it cascades to pl-model-common / model / ui-vue and their dependents.

Verified locally: patching only the resolved helpers `brand.d.ts` to the string-key form makes a 1.80.0-migrated block's model build succeed.