### PR TITLE
fix(ui-vue): distinct labels in PlTableFiltersV2 filter picker

### DIFF
--- a/.changeset/table-filter-distinct-labels.md
+++ b/.changeset/table-filter-distinct-labels.md
@@ -1,0 +1,10 @@
+---
+"@platforma-sdk/ui-vue": patch
+---
+
+PlTableFiltersV2: derive column option labels with `deriveDistinctLabels`
+(matching the table header) instead of the raw `Label` annotation. Columns that
+share a base label but differ by trace — e.g. a multi-axis abundance column
+split per sample — now show distinct labels ("Number Of Reads / <sample>") in
+the filter picker instead of collapsing to identical entries. Axes are left
+untouched (they are already unique).

--- a/sdk/ui-vue/src/components/PlTableFilters/PlTableFiltersV2.vue
+++ b/sdk/ui-vue/src/components/PlTableFilters/PlTableFiltersV2.vue
@@ -4,6 +4,7 @@ import type {
   PlDataTableFiltersWithMeta,
   PFrameHandle,
   PTableColumnId,
+  PColumnSpec,
 } from "@platforma-sdk/model";
 import {
   Annotation,
@@ -13,6 +14,7 @@ import {
   getUniqueSourceValuesWithLabels,
   extractPObjectId,
   getPTableColumnId,
+  deriveDistinctLabels,
 } from "@platforma-sdk/model";
 import { computed, ref } from "vue";
 import { PlBtnGhost, PlSlideModal, usePlBlockPageTitleTeleportTarget } from "@milaboratories/uikit";
@@ -65,10 +67,22 @@ const onUpdateFilters = (_value: PlAdvancedFilter) => {
 };
 
 const options = computed<PlAdvancedFilterItem[]>(() => {
+  const columnEntries: { idx: number; spec: PColumnSpec }[] = [];
+  props.columns.forEach((col, idx) => {
+    if (col.type === "column") columnEntries.push({ idx, spec: col.spec });
+  });
+  const distinctLabelByIdx = new Map<number, string>();
+  deriveDistinctLabels(
+    columnEntries.map((e) => e.spec),
+    {},
+  ).forEach((label, i) => distinctLabelByIdx.set(columnEntries[i].idx, label));
+
   return props.columns.map((col, idx) => {
     const id = getPTableColumnId(col);
     const label =
-      readAnnotation(col.spec, Annotation.Label)?.trim() ?? `Unlabeled ${col.type} ${idx}`;
+      distinctLabelByIdx.get(idx)?.trim() ||
+      readAnnotation(col.spec, Annotation.Label)?.trim() ||
+      `Unlabeled ${col.type} ${idx}`;
     const alphabet =
       readDomain(col.spec, Domain.Alphabet) ?? readAnnotation(col.spec, Annotation.Alphabet);
     return {


### PR DESCRIPTION
## Problem

In the table's "Manage Filters" picker (`PlTableFiltersV2`), columns that share a base label but differ only by trace — e.g. a multi-axis abundance column split per sample — all render as the same base label ("Number Of Reads", repeated), while the table *header* shows the distinguished label ("Number Of Reads / <sample>"). This makes such columns indistinguishable in the filter picker.

## Cause

The picker derived each option's label from the raw `Label` annotation:

```ts
const label = readAnnotation(col.spec, Annotation.Label)?.trim() ?? …
```

The table header instead uses `deriveDistinctLabels`, which appends the distinguishing trace element (the per-sample split), so the two disagree.

## Fix

Derive the picker's option labels with `deriveDistinctLabels` (same as the header). Only column entries are derived (axes are already unique); narrowing on `col.type === "column"` keeps their specs typed as `PColumnSpec` with no cast. Falls back to the `Label` annotation then the `Unlabeled …` placeholder.

Verified in a block: per-sample abundance columns now show "Number Of Reads / <sample>" in the filter picker, matching the header.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX bug in `PlTableFiltersV2` where columns sharing a base label but differing by trace (e.g., per-sample abundance columns) all appeared identically in the filter picker. The fix calls `deriveDistinctLabels` on column-type entries — matching the algorithm the table header already uses — so the picker labels now include distinguishing trace elements like "Number Of Reads / \<sample\>".

- `PlTableFiltersV2.vue`: Collects `column`-type entries, derives their labels via `deriveDistinctLabels(specs, {})`, and maps results back to original indices; axis entries continue to use the raw `Label` annotation.
- The filter picker receives only `PColumnSpec` (no linker paths or qualifications context), unlike the table header's `deriveAllLabels`. Columns only distinguishable via linker or qualification context will not benefit from this fix, but that is outside the stated scope.
- **Key terms touched**: `PColumnSpec` — flat column-specification type passed to `deriveDistinctLabels` as a plain `PObjectSpec` entry. `PTableColumnSpec` — discriminated union narrowed on `type === \"column\"` to extract typed `PColumnSpec`. `deriveDistinctLabels` — minimization algorithm reading `Annotation.Trace` and `Annotation.Label` to produce the shortest unique label set. `Annotation.Label` — raw label annotation, now a dead-code path for column entries. `Trace` — JSON-encoded derivation lineage stored in `Annotation.Trace`; the distinguishing element for per-sample columns.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to the filter picker's label derivation and does not touch state management, filter logic, or any shared utilities — only the display label computation in one computed property.

For the primary use case (labeled columns with distinct traces), the fix works correctly. The only concern is that the `readAnnotation` fallback and the unique `Unlabeled ${type} ${idx}` placeholder are unreachable for column entries, because `deriveDistinctLabels` always emits a truthy string — including its own "Unlabeled" when a column has neither a label annotation nor a trace. Multiple such columns would show as the generic "Unlabeled" instead of the formerly distinct "Unlabeled column 0 / 1 / …". This scenario is uncommon in practice but represents a small regression.

The only changed logic is in `sdk/ui-vue/src/components/PlTableFilters/PlTableFiltersV2.vue`; the changeset file needs no attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlTableFilters/PlTableFiltersV2.vue | Replaces raw `Label` annotation lookup with `deriveDistinctLabels` for column-type entries in the filter picker option list, matching the table header behavior; axis entries unchanged. Minor issue: the `readAnnotation` fallback and the unique `Unlabeled ${type} ${idx}` placeholder are unreachable for column entries because `deriveDistinctLabels` always returns a truthy string. |
| .changeset/table-filter-distinct-labels.md | Patch-level changeset entry for `@platforma-sdk/ui-vue` describing the filter picker label fix; accurate and complete. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Vue as PlTableFiltersV2.vue
    participant Filter as options computed
    participant DDL as deriveDistinctLabels()
    participant RA as readAnnotation()

    Vue->>Filter: compute options (props.columns)
    Filter->>Filter: "filter col.type === "column" → columnEntries[]"
    Filter->>DDL: "deriveDistinctLabels(columnEntries.map(e => e.spec), {})"
    DDL-->>Filter: string[] (one label per column entry)
    Filter->>Filter: "build distinctLabelByIdx Map<idx, label>"

    loop props.columns (all entries)
        alt "type === "column""
            Filter->>Filter: distinctLabelByIdx.get(idx)?.trim() → label
        else "type === "axis""
            Filter->>RA: readAnnotation(col.spec, Annotation.Label)
            RA-->>Filter: "label | undefined"
            Filter->>Filter: label ?? "Unlabeled axis N"
        end
        Filter->>Filter: "push { id, label, spec, alphabet }"
    end
    Filter-->>Vue: PlAdvancedFilterItem[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Vue as PlTableFiltersV2.vue
    participant Filter as options computed
    participant DDL as deriveDistinctLabels()
    participant RA as readAnnotation()

    Vue->>Filter: compute options (props.columns)
    Filter->>Filter: "filter col.type === "column" → columnEntries[]"
    Filter->>DDL: "deriveDistinctLabels(columnEntries.map(e => e.spec), {})"
    DDL-->>Filter: string[] (one label per column entry)
    Filter->>Filter: "build distinctLabelByIdx Map<idx, label>"

    loop props.columns (all entries)
        alt "type === "column""
            Filter->>Filter: distinctLabelByIdx.get(idx)?.trim() → label
        else "type === "axis""
            Filter->>RA: readAnnotation(col.spec, Annotation.Label)
            RA-->>Filter: "label | undefined"
            Filter->>Filter: label ?? "Unlabeled axis N"
        end
        Filter->>Filter: "push { id, label, spec, alphabet }"
    end
    Filter-->>Vue: PlAdvancedFilterItem[]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asdk%2Fui-vue%2Fsrc%2Fcomponents%2FPlTableFilters%2FPlTableFiltersV2.vue%3A83-85%0A**%22Unlabeled%22%20fallback%20is%20unreachable%20for%20column-type%20entries**%0A%0AFor%20a%20%60column%60-type%20entry%2C%20%60distinctLabelByIdx.get%28idx%29%60%20is%20always%20defined%20%28every%20column%20entry%20is%20added%20to%20the%20map%2C%20and%20%60deriveDistinctLabels%60%20always%20returns%20a%20non-empty%20string%20%E2%80%94%20falling%20back%20to%20%60%22Unlabeled%22%60%20internally%20when%20no%20label%2Ftrace%20is%20present%29.%20Because%20%60%22Unlabeled%22%60%20is%20truthy%2C%20the%20%60%7C%7C%60%20chain%20stops%20there%20and%20the%20final%20%60%60%20Unlabeled%20%24%7Bcol.type%7D%20%24%7Bidx%7D%20%60%60%20placeholder%20is%20never%20reached%20for%20column%20entries.%20This%20means%20multiple%20unlabeled%2Fno-trace%20columns%20all%20receive%20%60%22Unlabeled%22%60%20instead%20of%20the%20previously%20distinct%20%60%22Unlabeled%20column%200%22%60%2C%20%60%22Unlabeled%20column%201%22%60%2C%20etc.%20The%20second%20%60readAnnotation%60%20call%20is%20also%20unreachable%20for%20columns%2C%20since%20%60deriveDistinctLabels%60%20already%20incorporates%20the%20%60Label%60%20annotation.%0A%0A&repo=milaboratory%2Fplatforma&pr=1754&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
sdk/ui-vue/src/components/PlTableFilters/PlTableFiltersV2.vue:83-85
**"Unlabeled" fallback is unreachable for column-type entries**

For a `column`-type entry, `distinctLabelByIdx.get(idx)` is always defined (every column entry is added to the map, and `deriveDistinctLabels` always returns a non-empty string — falling back to `"Unlabeled"` internally when no label/trace is present). Because `"Unlabeled"` is truthy, the `||` chain stops there and the final `` Unlabeled ${col.type} ${idx} `` placeholder is never reached for column entries. This means multiple unlabeled/no-trace columns all receive `"Unlabeled"` instead of the previously distinct `"Unlabeled column 0"`, `"Unlabeled column 1"`, etc. The second `readAnnotation` call is also unreachable for columns, since `deriveDistinctLabels` already incorporates the `Label` annotation.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui-vue): distinct labels in PlTableF..."](https://github.com/milaboratory/platforma/commit/92db3a05bcfa165db4073562580a2e973a405392) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44149233)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->