### PR TITLE
MILAB-6621: fix block update crash when args() returns undefined

### DIFF
--- a/.changeset/mixcr-clonotyping-update-undefined-args.md
+++ b/.changeset/mixcr-clonotyping-update-undefined-args.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Fix block update/staging crash when a block's `args()` returns `undefined`.
+
+When updating a block pack (`update-block-pack`) or deriving initial storage, the middle layer re-ran the new model's `args()` and wrote the result to `currentArgs` unconditionally as long as derivation didn't throw. A model that legitimately returns `undefined` from `args()` (the standard "inputs incomplete/invalid" contract, e.g. `if (!Valid.safeParse(data).success) return undefined`) produced `undefined` with no error, and `createJsonFieldValue(undefined)` threw `ERR_INVALID_ARG_TYPE` (`Buffer.from(undefined)`), aborting the update. Now an `undefined` value is treated like a derivation failure: `currentArgs` is cleared and the update completes, matching the existing behaviour in `initializeBlock`.

--- a/etc/blocks/enter-numbers-v3/model/src/index.ts
+++ b/etc/blocks/enter-numbers-v3/model/src/index.ts
@@ -45,6 +45,12 @@ export const platforma = BlockModelV3.create(dataModel)
     if (data.numbers.length === 0) {
       throw new Error("Numbers are required!");
     }
+    // Test sentinel: args() returns undefined (without throwing) to exercise the
+    // "derivation succeeds but value is undefined" contract used by real blocks
+    // (e.g. `if (!Valid.safeParse(data).success) return undefined`).
+    if (data.numbers.length === 1 && data.numbers[0] === 777) {
+      return undefined;
+    }
     return { numbers: data.numbers.toSorted() };
   })
 

--- a/lib/node/pl-middle-layer/src/mutator/project-v3.test.ts
+++ b/lib/node/pl-middle-layer/src/mutator/project-v3.test.ts
@@ -553,3 +553,70 @@ test("v3 blocks: migrateBlockPack assigns author marker", async () => {
     });
   });
 });
+
+// Regression: MILAB-6621. Updating a block whose args() returns undefined (the
+// standard "inputs incomplete/invalid" contract, e.g. `if (!Valid.safeParse(data).success)
+// return undefined`) must not crash. Previously applyStorageAndDeriveArgs passed the
+// undefined value straight to createJsonFieldValue -> Buffer.from(undefined) -> ERR_INVALID_ARG_TYPE,
+// aborting the update-block-pack task (reported by AstraZeneca on mixcr-clonotyping 2.14 -> 2.20).
+// The sentinel input [777] makes the enter-numbers-v3 model's args() return undefined without throwing.
+test("v3 blocks: migrateBlockPack does not crash when args() returns undefined", async () => {
+  const quickJs = await getQuickJS();
+
+  await TestHelpers.withTempRoot(async (pl) => {
+    const prj = await pl.withWriteTx("CreatingProject", async (tx) => {
+      const prjRef = await createProject(tx);
+      tx.createField(field(tx.clientRoot, "prj"), "Dynamic", prjRef);
+      await tx.commit();
+      return await toGlobalResourceId(prjRef);
+    });
+
+    // Add block and set the sentinel state: args() returns undefined (no error).
+    await pl.withWriteTx("AddBlock", async (tx) => {
+      const mut = await ProjectMutator.load(new ProjectHelper(quickJs), tx, prj);
+      mut.addBlock(
+        { id: "enter1", label: "Enter Numbers V3", renderingMode: "Heavy" },
+        {
+          storageMode: "fromModel",
+          blockPack: await TestBPPreparer.prepare(BPSpecEnterV3),
+        },
+      );
+      mut.setStates([
+        {
+          modelAPIVersion: 2,
+          blockId: "enter1",
+          payload: { operation: "update-block-data", value: { numbers: [777] } },
+        },
+      ]);
+      mut.save();
+      await tx.commit();
+    });
+
+    // Update the block pack — re-derives args from storage. Must NOT throw even though
+    // args() returns undefined (previously crashed inside createJsonFieldValue).
+    await pl.withWriteTx("MigrateBlockPack", async (tx) => {
+      const mut = await ProjectMutator.load(new ProjectHelper(quickJs), tx, prj);
+      mut.migrateBlockPack("enter1", await TestBPPreparer.prepare(BPSpecEnterV3));
+      mut.save();
+      await tx.commit();
+    });
+
+    // Verify: currentArgs cleared (args() undefined), storage preserved, prerunArgs still derived.
+    await poll(pl, async (tx) => {
+      const prjR = await tx.get(prj);
+
+      const currentArgsField = prjR.data.fields.find(
+        (f) => f.name === projectFieldName("enter1", "currentArgs"),
+      );
+      expect(currentArgsField).toBeUndefined();
+
+      const blockStorage = await prjR.get(projectFieldName("enter1", "blockStorage"));
+      const storageData = JSON.parse(Buffer.from(blockStorage.data.data!).toString());
+      expect(storageData.__data).toStrictEqual({ numbers: [777] });
+
+      const currentPrerunArgs = await prjR.get(projectFieldName("enter1", "currentPrerunArgs"));
+      const prerunData = JSON.parse(Buffer.from(currentPrerunArgs.data.data!).toString());
+      expect(prerunData).toStrictEqual({ evenNumbers: [] });
+    });
+  });
+});

--- a/lib/node/pl-middle-layer/src/mutator/project.ts
+++ b/lib/node/pl-middle-layer/src/mutator/project.ts
@@ -769,7 +769,9 @@ export class ProjectMutator {
       blockConfig,
       initialStorageJson,
     );
-    if (!deriveArgsResult.error) {
+    // args() legitimately returns undefined when inputs are incomplete/invalid;
+    // treat that like a derivation failure and clear the field (never JSON-encode undefined).
+    if (!deriveArgsResult.error && deriveArgsResult.value !== undefined) {
       this.setBlockFieldObj(
         blockId,
         "currentArgs",
@@ -1408,7 +1410,9 @@ export class ProjectMutator {
       }
 
       const deriveArgsResult = this.projectHelper.deriveArgsFromStorage(newConfig, storageJson);
-      if (!deriveArgsResult.error) {
+      // args() legitimately returns undefined when inputs are incomplete/invalid;
+      // treat that like a derivation failure and clear the field (never JSON-encode undefined).
+      if (!deriveArgsResult.error && deriveArgsResult.value !== undefined) {
         this.setBlockFieldObj(
           blockId,
           "currentArgs",


### PR DESCRIPTION
## Problem

Updating a block pack (`update-block-pack`) crashed with:

```
TaskError.update-block-pack: The first argument must be of type string or an
instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
  at Buffer.from (node:buffer)
  at ProjectMutator.createJsonFieldValue (pl-middle-layer/dist/mutator/project.js)
  at applyStorageAndDeriveArgs (…)
```

Reported by AstraZeneca upgrading **mixcr-clonotyping 2.14.0 → 2.20.0**, and reproduced end-to-end (configured + computed 2.14.0 block, update to 2.20.0).

## Root cause

`migrateBlockPack` (and the initial-storage path) re-derive args by running the new model's `args()` against the migrated storage, then write the result to `currentArgs` whenever derivation didn't *error*. But `args()` legitimately returns `undefined` when inputs are incomplete/invalid — the standard block contract, e.g. mixcr-clonotyping:

```ts
if (!BlockArgsValid.safeParse(data).success) return undefined;
```

`deriveArgsFromStorage` then returns `{ value: undefined }` with no error, and `createJsonFieldValue(undefined)` → `Buffer.from(JSON.stringify(undefined))` = `Buffer.from(undefined)` → `ERR_INVALID_ARG_TYPE`, aborting the update. On 2.20.0 the migrated preset shape fails the new `BlockArgsValid`, so `args()` returns `undefined` rather than throwing.

Two derive sites checked only `.error` (not `.value`), while `initializeBlock` and `setStates` already guard `value !== undefined` — an inconsistency.

## Fix

Guard both sites (`initial-storage` path and `applyStorageAndDeriveArgs`) with `&& deriveArgsResult.value !== undefined`, treating an undefined value like a derivation failure and clearing `currentArgs`. The update now completes and the block lands in the normal "needs configuration" state instead of crashing.

## Test

Adds a regression test in `project-v3.test.ts`: an `enter-numbers-v3` sentinel input makes `args()` return `undefined` (without throwing), and `migrateBlockPack` must not crash — `currentArgs` is cleared, storage preserved, `prerunArgs` still derived.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in `update-block-pack` and `resetToInitialStorage` when a block's `args()` legitimately returns `undefined` (the standard "inputs incomplete/invalid" contract). The two affected call sites checked only `.error` on the result of `deriveArgsFromStorage`, so a `{ value: undefined, error: undefined }` result fell through to `createJsonFieldValue(undefined)` → `Buffer.from(undefined)` → `ERR_INVALID_ARG_TYPE`.

- **`project.ts`**: Both `resetToInitialStorage` and `applyStorageAndDeriveArgs` now guard with `&& deriveArgsResult.value !== undefined`, matching the pattern already used in `setStates` (line 838) and `addBlock` (line 1126).
- **`enter-numbers-v3/model/src/index.ts`**: Adds a test sentinel — input `[777]` makes `args()` return `undefined` without throwing — to represent the real-world block contract (e.g. `if (!Valid.safeParse(data).success) return undefined`).
- **`project-v3.test.ts`**: Regression test confirms `migrateBlockPack` completes without throwing, `currentArgs` is cleared, storage is preserved, and `currentPrerunArgs` is still derived correctly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal two-line guard that brings two call sites in line with the already-correct behavior in the rest of the mutator.

Both fixed paths now mirror the existing `setStates` and `addBlock` patterns exactly. The regression test exercises the precise failure scenario (sentinel `[777]` → `args()` returns `undefined` → `migrateBlockPack`) and verifies the three expected post-conditions. No unrelated behavior is changed.

No files require special attention. The `enter-numbers-v3` sentinel is clearly commented and isolated to a test-only block.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/mutator/project.ts | Adds `value !== undefined` guard to two `deriveArgsFromStorage` call sites (`resetToInitialStorage` and `applyStorageAndDeriveArgs`) that previously skipped only on `.error`, aligning them with the existing pattern in `setStates` and `addBlock`. |
| lib/node/pl-middle-layer/src/mutator/project-v3.test.ts | Adds a regression test for MILAB-6621: sets block storage to the `[777]` sentinel, calls `migrateBlockPack`, and asserts `currentArgs` is cleared, storage is preserved, and `currentPrerunArgs` is still derived correctly. |
| etc/blocks/enter-numbers-v3/model/src/index.ts | Adds a test sentinel in `args()`: input `[777]` returns `undefined` without throwing, exercising the "inputs incomplete/invalid" contract that real blocks (e.g. mixcr-clonotyping) use. |
| .changeset/mixcr-clonotyping-update-undefined-args.md | Patch-level changeset for `@milaboratories/pl-middle-layer` documenting the undefined-args crash fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[migrateBlockPack / resetToInitialStorage] --> B[applyStorageAndDeriveArgs]
    B --> C[deriveArgsFromStorage]
    C --> D{deriveArgsResult}

    D -->|.error set| E[deleteBlockFields currentArgs]
    D -->|.value === undefined - new guard| E
    D -->|no error AND value !== undefined| F[setBlockFieldObj currentArgs]

    C2[setStates / addBlock - already correct] --> D2{derivedArgsResult}
    D2 -->|error OR undefined| G[skip / delete currentArgs]
    D2 -->|value !== undefined| H[setBlockField currentArgs]

    style E fill:#f9c74f
    style F fill:#90be6d
    style G fill:#f9c74f
    style H fill:#90be6d
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[migrateBlockPack / resetToInitialStorage] --> B[applyStorageAndDeriveArgs]
    B --> C[deriveArgsFromStorage]
    C --> D{deriveArgsResult}

    D -->|.error set| E[deleteBlockFields currentArgs]
    D -->|.value === undefined - new guard| E
    D -->|no error AND value !== undefined| F[setBlockFieldObj currentArgs]

    C2[setStates / addBlock - already correct] --> D2{derivedArgsResult}
    D2 -->|error OR undefined| G[skip / delete currentArgs]
    D2 -->|value !== undefined| H[setBlockField currentArgs]

    style E fill:#f9c74f
    style F fill:#90be6d
    style G fill:#f9c74f
    style H fill:#90be6d
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6621: fix block update crash when ..."](https://github.com/milaboratory/platforma/commit/6b8c259ae3c93ad7e3a40e3df43e54a3d8804293) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44150466)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->