### PR TITLE
MILAB-6497: fix release docker descriptors pointing at quay pull URL

### DIFF
--- a/.changeset/docker-release-pull-registry.md
+++ b/.changeset/docker-release-pull-registry.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Fix release docker descriptors embedding the quay push target as the pull address. Release channel now defaults the embedded pull address to the built-in `containers.pl-open.science` registry (the GA-fronted pull proxy), independent of the push target. `PL_RELEASE_DOCKER_PULL_URL` / `PL_DOCKER_REGISTRY` still override. Dev channel is unchanged (pull still follows push, one ECR host).

--- a/tools/block-tools/src/cmd/software/run-build.test.ts
+++ b/tools/block-tools/src/cmd/software/run-build.test.ts
@@ -127,14 +127,14 @@ describe("runBuild orchestration", () => {
     ]);
   });
 
-  it("dev docker build targets the built-in dev registry; release does not", async () => {
+  it("dev docker build targets the built-in dev registry; release the production registry", async () => {
     const dev = await run({ channel: "dev", variant: "docker", location: "remote" });
     expect(dev.spies.buildDockerImages).toHaveBeenCalledWith(
       expect.objectContaining({ registry: defaults.DEV_DOCKER_REGISTRY }),
     );
     const rel = await run({ channel: "release", variant: "docker", location: "remote" });
     expect(rel.spies.buildDockerImages).toHaveBeenCalledWith(
-      expect.objectContaining({ registry: undefined }),
+      expect.objectContaining({ registry: defaults.DOCKER_REGISTRY }),
     );
   });
 
@@ -166,11 +166,26 @@ describe("runBuild orchestration", () => {
       });
     });
 
-    it("release override targets the configured release registry, no built-in default", async () => {
-      expect(await dockerAddresses(releaseRemote)).toEqual({ pull: undefined, push: undefined });
+    it("release pull defaults to the built-in registry, independent of the push target", async () => {
+      // No push override: nothing pushed, pull embeds the built-in production registry.
+      expect(await dockerAddresses(releaseRemote)).toEqual({
+        pull: defaults.DOCKER_REGISTRY,
+        push: undefined,
+      });
+      // Push to quay, but the descriptor still embeds containers.pl-open.science (GA-fronted proxy).
+      // quay is not reachable from corporate deployments, so pull must NOT inherit the push target.
       process.env.PL_RELEASE_DOCKER_PUSH_URL = "quay.io/org/repo";
       expect(await dockerAddresses(releaseRemote)).toEqual({
-        pull: "quay.io/org/repo",
+        pull: defaults.DOCKER_REGISTRY,
+        push: "quay.io/org/repo",
+      });
+    });
+
+    it("PL_RELEASE_DOCKER_PULL_URL overrides the built-in release pull default", async () => {
+      process.env.PL_RELEASE_DOCKER_PUSH_URL = "quay.io/org/repo";
+      process.env.PL_RELEASE_DOCKER_PULL_URL = "cdn.example/release";
+      expect(await dockerAddresses(releaseRemote)).toEqual({
+        pull: "cdn.example/release",
         push: "quay.io/org/repo",
       });
     });

--- a/tools/block-tools/src/cmd/software/run-build.ts
+++ b/tools/block-tools/src/cmd/software/run-build.ts
@@ -134,7 +134,10 @@ function parsePushTarget(raw: string): { registry: string; autoLogin: boolean } 
 }
 
 // Docker push target + the pull address embedded in the descriptor. Precedence flag > channel env >
-// dev default (release has none); pull defaults to push; autoLogin follows the push target's ecr://.
+// dev default (release has none). Pull default is channel-specific: dev pulls from where it pushed
+// (one ECR host), but release push (quay) and pull (containers.pl-open.science, GA-fronted proxy) are
+// different locations by design, so release pull defaults to the built-in registry, NOT the push
+// target. autoLogin follows the push target's ecr://.
 function resolveDockerAddresses(
   channel: Channel,
   opts: BuildOptions,
@@ -149,7 +152,8 @@ function resolveDockerAddresses(
     opts.dockerPushTo ?? channelPush ?? (isDev ? defaults.DEV_DOCKER_PUSH_TARGET : undefined);
   const parsed = rawPush ? parsePushTarget(rawPush) : { registry: undefined, autoLogin: false };
 
-  const rawPull = opts.dockerRegistry ?? channelPull ?? rawPush;
+  const rawPull =
+    opts.dockerRegistry ?? channelPull ?? (isDev ? rawPush : defaults.DOCKER_REGISTRY);
   const pull = rawPull ? stripScheme(rawPull) : undefined;
 
   return { pull, push: parsed.registry, autoLogin: parsed.autoLogin };


### PR DESCRIPTION
## Problem

Block runs fail on corporate deployments: the backend tries to pull software containers from `quay.io`, which is not reachable from those environments.

## Root cause

`resolveDockerAddresses` (`run-build.ts`) defaulted the **embedded pull address** to the **push target** for every channel:

```js
const rawPull = opts.dockerRegistry ?? channelPull ?? rawPush;
```

Release CI pushes images to `quay.io/milaboratories/pl-containers` but, by design, they must be *pulled* through `containers.pl-open.science` — the Global-Accelerator-fronted proxy that gives quay a static IP (see `infrastructure-changes.md`). With no `PL_RELEASE_DOCKER_PULL_URL` set, `pull` inherited the quay push URL and got baked into the descriptor `docker.tag` (`docker.ts` `dockerTag`).

This was a regression from `a89523d` (MILAB-6497): the previous code embedded `artifact.registry` (default `containers.pl-open.science`) independent of the push target.

## Fix

Make the pull default channel-specific:

```js
const rawPull =
  opts.dockerRegistry ?? channelPull ?? (isDev ? rawPush : defaults.DOCKER_REGISTRY);
```

- **release**: pull defaults to the built-in production registry `containers.pl-open.science`, independent of the push target (quay).
- **dev**: unchanged — pull still follows push (one ECR host for both).
- `PL_RELEASE_DOCKER_PULL_URL` / `PL_DOCKER_REGISTRY` still override.

## Notes

The design docs contained a contradiction — the infra section said release push/pull are different locations, while the variable tables said "pull defaults to push". Corrected the release-channel wording in `implementor-reference.md` and `design-and-scope.md` (separate commit in `docs/text`).

## Tests

`run-build.test.ts` updated to assert release embeds `containers.pl-open.science` regardless of push target; added a case for `PL_RELEASE_DOCKER_PULL_URL` override. All 26 pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where release-channel docker descriptors embedded the quay.io push target as the pull address instead of the GA-fronted proxy `containers.pl-open.science`. The fix changes `resolveDockerAddresses` so that for release builds the pull default is `defaults.DOCKER_REGISTRY`, independent of push target, while the dev channel retains the existing behavior of pull following push.

- **`run-build.ts`**: `rawPull` default for non-dev channels changed from `rawPush` to `defaults.DOCKER_REGISTRY` (`containers.pl-open.science/milaboratories/pl-containers`), preserving the `opts.dockerRegistry` → `channelPull` → channel-default precedence.
- **`run-build.test.ts`**: Previous test that accepted `pull: "quay.io/org/repo"` is replaced with two new cases: one asserting the built-in default is embedded regardless of push target, and one asserting `PL_RELEASE_DOCKER_PULL_URL` can still override it.
- **`.changeset/docker-release-pull-registry.md`**: Patch-level changeset added for `@platforma-sdk/block-tools`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-liner fix to a default value in resolveDockerAddresses with no side effects on dev builds or explicit overrides.

The fix correctly decouples release pull from push by substituting defaults.DOCKER_REGISTRY as the release-channel pull default. The dev path is untouched. Precedence (flag > channel env var > built-in default) is preserved. Tests now assert the correct value for both the no-override and quay-push-override cases, and the PL_RELEASE_DOCKER_PULL_URL escape hatch is covered. No risky structural changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/cmd/software/run-build.ts | Core fix: release pull default changed from rawPush to defaults.DOCKER_REGISTRY; logic and comment are accurate and consistent with the CLI layer's PL_DOCKER_REGISTRY wiring. |
| tools/block-tools/src/cmd/software/run-build.test.ts | Tests correctly updated: old test expecting pull to follow push is replaced with two new cases covering the built-in default and the PL_RELEASE_DOCKER_PULL_URL override; afterEach cleanup is correct. |
| .changeset/docker-release-pull-registry.md | Appropriate patch-level changeset for @platforma-sdk/block-tools with an accurate description of the fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveDockerAddresses called] --> B{isDev?}
    B -->|yes| C[rawPush = opts.dockerPushTo ?? PL_DEV_DOCKER_PUSH_URL ?? DEV_DOCKER_PUSH_TARGET]
    B -->|no| D[rawPush = opts.dockerPushTo ?? PL_RELEASE_DOCKER_PUSH_URL ?? undefined]

    C --> E{opts.dockerRegistry set?}
    D --> F{opts.dockerRegistry set?}

    E -->|yes| G[rawPull = opts.dockerRegistry]
    E -->|no| H{PL_DEV_DOCKER_PULL_URL set?}
    H -->|yes| I[rawPull = PL_DEV_DOCKER_PULL_URL]
    H -->|no| J["rawPull = rawPush (dev: pull follows push)"]

    F -->|yes| K[rawPull = opts.dockerRegistry]
    F -->|no| L{PL_RELEASE_DOCKER_PULL_URL set?}
    L -->|yes| M[rawPull = PL_RELEASE_DOCKER_PULL_URL]
    L -->|no| N["rawPull = defaults.DOCKER_REGISTRY\n(containers.pl-open.science — FIXED)"]

    G --> O[pull = stripScheme rawPull]
    I --> O
    J --> O
    K --> O
    M --> O
    N --> O

    style N fill:#90EE90,stroke:#228B22
    style J fill:#87CEEB,stroke:#4682B4
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[resolveDockerAddresses called] --> B{isDev?}
    B -->|yes| C[rawPush = opts.dockerPushTo ?? PL_DEV_DOCKER_PUSH_URL ?? DEV_DOCKER_PUSH_TARGET]
    B -->|no| D[rawPush = opts.dockerPushTo ?? PL_RELEASE_DOCKER_PUSH_URL ?? undefined]

    C --> E{opts.dockerRegistry set?}
    D --> F{opts.dockerRegistry set?}

    E -->|yes| G[rawPull = opts.dockerRegistry]
    E -->|no| H{PL_DEV_DOCKER_PULL_URL set?}
    H -->|yes| I[rawPull = PL_DEV_DOCKER_PULL_URL]
    H -->|no| J["rawPull = rawPush (dev: pull follows push)"]

    F -->|yes| K[rawPull = opts.dockerRegistry]
    F -->|no| L{PL_RELEASE_DOCKER_PULL_URL set?}
    L -->|yes| M[rawPull = PL_RELEASE_DOCKER_PULL_URL]
    L -->|no| N["rawPull = defaults.DOCKER_REGISTRY\n(containers.pl-open.science — FIXED)"]

    G --> O[pull = stripScheme rawPull]
    I --> O
    J --> O
    K --> O
    M --> O
    N --> O

    style N fill:#90EE90,stroke:#228B22
    style J fill:#87CEEB,stroke:#4682B4
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6497: fix release docker descripto..."](https://github.com/milaboratory/platforma/commit/c9f9bd905c42dd61a52786d00d8783837fc14341) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44438127)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->