### PR TITLE
MILAB-6530: more informative postfix for linked columns headers

### DIFF
--- a/.changeset/rich-experts-kneel.md
+++ b/.changeset/rich-experts-kneel.md
@@ -1,0 +1,45 @@
+---
+"@milaboratories/columns-collection-driver": patch
+"@milaboratories/milaboratories.monetization-test": patch
+"@milaboratories/milaboratories.test-enter-numbers": patch
+"@milaboratories/milaboratories.pool-explorer": patch
+"@milaboratories/milaboratories.ui-examples": patch
+"@platforma-sdk/package-builder-lib": patch
+"@milaboratories/ts-helpers-winston": patch
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pl-middle-layer": patch
+"@milaboratories/pl-deployments": patch
+"@milaboratories/pl-healthcheck": patch
+"@milaboratories/pl-model-middle-layer": patch
+"@milaboratories/pl-mcp-server": patch
+"@milaboratories/test-helpers": patch
+"@platforma-sdk/package-builder": patch
+"@platforma-open/milaboratories.software-ptabler": patch
+"@milaboratories/computable": patch
+"@milaboratories/pl-drivers": patch
+"@milaboratories/ts-helpers": patch
+"@platforma-sdk/tengo-builder": patch
+"@milaboratories/pf-driver": patch
+"@milaboratories/pl-client": patch
+"@milaboratories/pl-config": patch
+"@milaboratories/pl-errors": patch
+"@platforma-open/milaboratories.software-ptabler.schema": patch
+"@platforma-sdk/workflow-tengo": patch
+"@platforma-sdk/bootstrap": patch
+"@milaboratories/pl-model-backend": patch
+"@platforma-sdk/block-tools": patch
+"@milaboratories/pl-model-common": patch
+"@milaboratories/pl-tree": patch
+"@milaboratories/helpers": patch
+"@milaboratories/ts-builder": patch
+"@milaboratories/ts-configs": patch
+"@milaboratories/ptabler-expression-js": patch
+"@milaboratories/uikit": patch
+"@platforma-sdk/pl-cli": patch
+"@platforma-open/milaboratories.software-ptexter": patch
+"@platforma-sdk/ui-vue": patch
+"@platforma-sdk/model": patch
+"@platforma-sdk/test": patch
+---
+
+Escape including label columns for non primary columns

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -96,9 +96,13 @@ export const platforma = BlockModelV3.create(blockDataModel)
       } as PlDataTableFilters,
 
       labelsOptions: {
-        // Custom linker label formatter to verify linker path labels in the UI.
-        // Default would produce "via L1 > L2"; this makes it "[L1 > L2]" for easy visual identification.
-        formatters: { linker: (linkerLabels) => `[${linkerLabels.join(" > ")}]` },
+        // Custom linker postfix formatter to verify linker path labels in the UI.
+        // Default would produce "via <root> L1 > L2"; this makes it "[root, L1, L2]" for easy visual
+        // identification. Each piece carries its full spec plus the computed distinguishing `text`.
+        formatters: {
+          linker: ({ root, linkers }) =>
+            `[${[root?.text, ...linkers.map((l) => l.text)].filter(Boolean).join(" > ")}]`,
+        },
       },
       displayOptions: {
         ordering: [
@@ -158,7 +162,10 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
       tableState: ctx.data.tableSplitState,
       labelsOptions: {
-        formatters: { linker: (linkerLabels) => `[${linkerLabels.join(" > ")}]` },
+        formatters: {
+          linker: ({ root, linkers }) =>
+            `[${[root?.text, ...linkers.map((l) => l.text)].filter(Boolean).join(" > ")}]`,
+        },
       },
     });
   })

--- a/lib/model/common/src/drivers/pframe/spec/spec.ts
+++ b/lib/model/common/src/drivers/pframe/spec/spec.ts
@@ -514,7 +514,7 @@ function hasCycleOfParents(axisSpec: AxisSpecNormalized) {
 
 /** Create list of normalized axisSpec (parents are in array of specs, not indexes) */
 export function getNormalizedAxesList(axes: AxisSpec[]): AxisSpecNormalized[] {
-  if (!axes.length) {
+  if (axes.length === 0) {
     return [];
   }
   const modifiedAxes: AxisSpecNormalized[] = axes.map((axis) => {

--- a/sdk/model/src/columns/column.ts
+++ b/sdk/model/src/columns/column.ts
@@ -1,9 +1,9 @@
-import type {
-  ColumnUniversalId,
-  LeafEntry,
-  PColumn,
-  PlRef,
-  PObjectId,
+import {
+  type ColumnUniversalId,
+  type LeafEntry,
+  type PColumn,
+  type PlRef,
+  type PObjectId,
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import type { TreeNodeAccessor } from "../render";

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -12,7 +12,6 @@ import {
   canonicalizeAxisId,
   dedupColumns,
   extractPObjectId,
-  isLabelColumn,
   uniqueBy,
 } from "@milaboratories/pl-model-common";
 import { collectFilterSpecColumns } from "../../../filters/traverse";
@@ -229,17 +228,6 @@ function resolveInputColumns<A, U>(
   ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
 ): undefined | ResolvedColumns {
-  const result = resolvePrimaryAndSecondaryColumns(ctx, options);
-  if (isNil(result)) return undefined;
-  const { primary, secondary } = result;
-  const filteredSecondary = excludeNotPrimaryLabelColumns(primary, secondary);
-  return { primary, secondary: filteredSecondary };
-}
-
-function resolvePrimaryAndSecondaryColumns<A, U>(
-  ctx: RenderCtxBase<A, U>,
-  options: createPlDataTableOptionsV3,
-): ResolvedColumns | undefined {
   if ("primaryColumns" in options) {
     const primary = options.primaryColumns;
     const secondary = options.columns ?? [];
@@ -263,20 +251,6 @@ function resolvePrimaryAndSecondaryColumns<A, U>(
   }
 
   return undefined;
-}
-
-function excludeNotPrimaryLabelColumns(
-  primary: ColumnRecipe[],
-  secondary: ColumnRecipe[],
-): ColumnRecipe[] {
-  const primaryAxisKeys = new Set(
-    primary.flatMap((c) => c.getSpec().axesSpec.map((a) => canonicalizeAxisId(a))),
-  );
-  return secondary.filter((c) => {
-    const spec = c.getSpec();
-    if (!isLabelColumn(spec)) return true;
-    return primaryAxisKeys.has(canonicalizeAxisId(spec.axesSpec[0]));
-  });
 }
 
 /** Split secondary recipes by query topology: leaves (no linker chain) vs joined. */
@@ -551,3 +525,111 @@ function remapFilterColumnIds(
 
   return prune(filters) as Nil | PlDataTableFilters;
 }
+
+const _ = [
+  {
+    type: "column",
+    id: '{"__isRef":true,"blockId":"6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07","name":"clusters.assign.clusterLabel"}',
+    spec: {
+      kind: "PColumn",
+      axesSpec: [
+        {
+          name: "pl7.app/vdj/clonotypeKey",
+          type: "String",
+          domain: {
+            "pl7.app/redefined-by": "aabfc81f-0fc9-4699-84e8-6e749a3e384d",
+            "pl7.app/vdj/chain": "IGHeavy",
+            "pl7.app/vdj/clonotypeKey/structure":
+              '[["pl7.app/vdj/sequence",["pl7.app/alphabet","aminoacid"],["pl7.app/vdj/feature","VDJRegion"]]]',
+            "pl7.app/vdj/clonotypingRunId": "6cfab875-649e-4c52-bb69-fe976c2b57a0",
+          },
+          annotations: {
+            "pl7.app/label": "Clonotype ID",
+            "pl7.app/segmentedBy": '["pl7.app/vdj/clonotypingRunId"]',
+            "pl7.app/table/fontFamily": "monospace",
+            "pl7.app/table/orderPriority": "110000",
+            "pl7.app/table/visibility": "default",
+          },
+        },
+      ],
+      name: "pl7.app/clusterId",
+      valueType: "String",
+      domain: {
+        "pl7.app/clustering/algorithm": "foldseek",
+        "pl7.app/clustering/blockId": "6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07",
+      },
+      annotations: {
+        "pl7.app/label": "Cluster Id",
+        "pl7.app/structure/clusteringSource": "foldseek",
+        "pl7.app/trace":
+          '[{"type":"milaboratories.samples-and-data","id":"0189e23b-5e8d-4648-8c6d-70caa5c26958","importance":10,"label":"Samples & Data"},{"type":"milaboratories.samples-and-data/dataset","id":"34U3GEP5PGJF45UG3A2WZ3JO","importance":100,"label":"MB135 + Podocytes"},{"label":"MiXCR generic amplicon","type":"milaboratories.mixcr-amplicon-alignment","id":"6cfab875-649e-4c52-bb69-fe976c2b57a0","importance":20},{"type":"milaboratories.redefine-clonotypes","importance":30,"label":"Imputed VDJRegion aa"},{"type":"milaboratories.antibody-tcr-lead-selection","importance":30,"label":"Selected Leads"},{"type":"milaboratories.3d-structure-prediction","id":"d204391a-e7dd-434d-9c24-ef77b5da81e0","importance":20,"label":"Camelid (VHH/nanobody) NBB2, CDRH3 ≤ 2.5 Å"},{"type":"milaboratories.3d-structure-clustering.clustering","id":"6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07","importance":30,"label":"Full Structure+AA, TM≥0.95, cov≥0.95"}]',
+      },
+    },
+  },
+  {
+    type: "column",
+    id: '{"__isDiscovered":true,"column":"{\\"__isRef\\":true,\\"blockId\\":\\"440a489a-8ae8-4982-9d1e-6297e7b8b8d0\\",\\"name\\":\\"pf.clusterLabel4\\"}","path":[{"column":"{\\"__isRef\\":true,\\"blockId\\":\\"440a489a-8ae8-4982-9d1e-6297e7b8b8d0\\",\\"name\\":\\"pf.link3\\"}","type":"linker"}]}',
+    spec: {
+      kind: "PColumn",
+      axesSpec: [
+        {
+          name: "pl7.app/clusterId",
+          type: "String",
+          domain: {
+            "pl7.app/clustering/algorithm": "mmseqs2",
+            "pl7.app/clustering/blockId": "440a489a-8ae8-4982-9d1e-6297e7b8b8d0",
+            "pl7.app/redefined-by": "aabfc81f-0fc9-4699-84e8-6e749a3e384d",
+            "pl7.app/vdj/chain": "IGHeavy",
+            "pl7.app/vdj/clonotypeKey/structure":
+              '[["pl7.app/vdj/sequence",["pl7.app/alphabet","aminoacid"],["pl7.app/vdj/feature","VDJRegion"]]]',
+            "pl7.app/vdj/clonotypingRunId": "6cfab875-649e-4c52-bb69-fe976c2b57a0",
+          },
+          annotations: {
+            "pl7.app/label": "Cluster Id",
+            "pl7.app/table/orderPriority": "990000",
+            "pl7.app/table/visibility": "default",
+          },
+        },
+      ],
+      name: "pl7.app/label",
+      valueType: "String",
+      annotations: {
+        "pl7.app/label": "Cluster Id",
+        "pl7.app/table/visibility": "default",
+        "pl7.app/trace":
+          '[{"importance":10,"label":"Samples & Data","type":"milaboratories.samples-and-data","id":"0189e23b-5e8d-4648-8c6d-70caa5c26958"},{"id":"34U3GEP5PGJF45UG3A2WZ3JO","importance":100,"label":"MB135 + Podocytes","type":"milaboratories.samples-and-data/dataset"},{"label":"MiXCR generic amplicon","type":"milaboratories.mixcr-amplicon-alignment","id":"6cfab875-649e-4c52-bb69-fe976c2b57a0","importance":20},{"type":"milaboratories.redefine-clonotypes","importance":30,"label":"Imputed VDJRegion aa"},{"type":"milaboratories.clonotype-clustering.clustering","importance":30,"label":"Imputed VDJRegion aa, BLOSUM62, ident:0.95, cov:0.95"}]',
+      },
+    },
+  },
+  {
+    type: "column",
+    id: '{"__isDiscovered":true,"column":"{\\"__isRef\\":true,\\"blockId\\":\\"6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07\\",\\"name\\":\\"clusters.summary.clusterLabel\\"}","path":[{"column":"{\\"__isRef\\":true,\\"blockId\\":\\"6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07\\",\\"name\\":\\"clusters.link.isCentroid\\"}","type":"linker"}]}',
+    spec: {
+      kind: "PColumn",
+      axesSpec: [
+        {
+          name: "pl7.app/clusterId",
+          type: "String",
+          domain: {
+            "pl7.app/clustering/algorithm": "foldseek",
+            "pl7.app/clustering/blockId": "6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07",
+          },
+          annotations: {
+            "pl7.app/label": "Cluster Id",
+            "pl7.app/table/orderPriority": "990000",
+            "pl7.app/table/visibility": "default",
+          },
+        },
+      ],
+      name: "pl7.app/label",
+      valueType: "String",
+      annotations: {
+        "pl7.app/label": "Cluster Id",
+        "pl7.app/table/orderPriority": "990000",
+        "pl7.app/table/visibility": "default",
+        "pl7.app/trace":
+          '[{"type":"milaboratories.samples-and-data","id":"0189e23b-5e8d-4648-8c6d-70caa5c26958","importance":10,"label":"Samples & Data"},{"type":"milaboratories.samples-and-data/dataset","id":"34U3GEP5PGJF45UG3A2WZ3JO","importance":100,"label":"MB135 + Podocytes"},{"label":"MiXCR generic amplicon","type":"milaboratories.mixcr-amplicon-alignment","id":"6cfab875-649e-4c52-bb69-fe976c2b57a0","importance":20},{"type":"milaboratories.redefine-clonotypes","importance":30,"label":"Imputed VDJRegion aa"},{"type":"milaboratories.antibody-tcr-lead-selection","importance":30,"label":"Selected Leads"},{"type":"milaboratories.3d-structure-prediction","id":"d204391a-e7dd-434d-9c24-ef77b5da81e0","importance":20,"label":"Camelid (VHH/nanobody) NBB2, CDRH3 ≤ 2.5 Å"},{"type":"milaboratories.3d-structure-clustering.clustering","id":"6b2ae9f7-526d-4fd9-8a28-c0e3756c0b07","importance":30,"label":"Full Structure+AA, TM≥0.95, cov≥0.95"}]',
+      },
+    },
+  },
+];

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -12,6 +12,7 @@ import {
   canonicalizeAxisId,
   dedupColumns,
   extractPObjectId,
+  isLabelColumn,
   uniqueBy,
 } from "@milaboratories/pl-model-common";
 import { collectFilterSpecColumns } from "../../../filters/traverse";
@@ -227,11 +228,22 @@ type ResolvedColumns = {
 function resolveInputColumns<A, U>(
   ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
+): undefined | ResolvedColumns {
+  const result = resolvePrimaryAndSecondaryColumns(ctx, options);
+  if (isNil(result)) return undefined;
+  const { primary, secondary } = result;
+  const filteredSecondary = excludeNotPrimaryLabelColumns(primary, secondary);
+  return { primary, secondary: filteredSecondary };
+}
+
+function resolvePrimaryAndSecondaryColumns<A, U>(
+  ctx: RenderCtxBase<A, U>,
+  options: createPlDataTableOptionsV3,
 ): ResolvedColumns | undefined {
   if ("primaryColumns" in options) {
     const primary = options.primaryColumns;
     const secondary = options.columns ?? [];
-    const labels = discoverLabelColumns(ctx, primary, [...primary, ...secondary]);
+    const labels = discoverLabelColumns(ctx, primary);
     // Exclude from secondary anything already present in primary: a label
     // column the block hands in as primary can be re-discovered here as a
     // label for that same axis, landing in the table twice with the same id.
@@ -251,6 +263,20 @@ function resolveInputColumns<A, U>(
   }
 
   return undefined;
+}
+
+function excludeNotPrimaryLabelColumns(
+  primary: ColumnRecipe[],
+  secondary: ColumnRecipe[],
+): ColumnRecipe[] {
+  const primaryAxisKeys = new Set(
+    primary.flatMap((c) => c.getSpec().axesSpec.map((a) => canonicalizeAxisId(a))),
+  );
+  return secondary.filter((c) => {
+    const spec = c.getSpec();
+    if (!isLabelColumn(spec)) return true;
+    return primaryAxisKeys.has(canonicalizeAxisId(spec.axesSpec[0]));
+  });
 }
 
 /** Split secondary recipes by query topology: leaves (no linker chain) vs joined. */

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -7,7 +7,7 @@ import type {
 import { PColumnName } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
 import type { ColumnRecipe, ColumnsSource } from "../../../columns";
-import { ColumnsCollection, collectLinkerIds, isLeafColumn } from "../../../columns";
+import { ColumnsCollection, isLeafColumn } from "../../../columns";
 import type { ColumnsSelectorConfig } from "./createPlDataTableV3";
 
 export type DiscoverTableColumnOptions = {
@@ -30,7 +30,7 @@ export type DiscoveredTableColumns = {
 export function discoverTableColumns(
   ctx: RenderCtxBase,
   options: DiscoverTableColumnOptions,
-): undefined | DiscoveredTableColumns {
+): DiscoveredTableColumns {
   const discoveredColumns = ColumnsCollection(options.sources, { ctx: ctx.ctx })
     .discover({ ...options.selector, anchors: options.anchors })
     .getColumns();
@@ -54,22 +54,18 @@ export function discoverTableColumns(
 export function discoverLabelColumns<A, U>(
   ctx: RenderCtxBase<A, U>,
   primary: ColumnRecipe[],
-  columns: ColumnRecipe[],
 ): ColumnRecipe[] {
-  if (columns.length === 0) return [];
+  if (primary.length === 0) return [];
 
-  const axes = columns.flatMap((col) => col.getSpec().axesSpec);
-  return (
-    ColumnsCollection(undefined, { ctx: ctx.ctx })
-      // .addSource({ columns, isFinal: true })
-      .discover({
-        include: axes.map((a) => ({
-          name: { type: "exact", value: PColumnName.Label },
-          axes: [{ name: { type: "exact", value: a.name } }],
-        })),
-        anchors: Object.fromEntries(primary.map((col, i) => [`anchor_${i}`, col.getSpec()])),
-        maxHops: columns.reduce((acc, c) => Math.max(acc, collectLinkerIds(c).length), 0),
-      })
-      .getColumns()
-  );
+  const axes = primary.flatMap((col) => col.getSpec().axesSpec);
+  return ColumnsCollection(undefined, { ctx: ctx.ctx })
+    .discover({
+      include: axes.map((a) => ({
+        name: { type: "exact", value: PColumnName.Label },
+        axes: [{ name: { type: "exact", value: a.name } }],
+      })),
+      anchors: Object.fromEntries(primary.map((col, i) => [`anchor_${i}`, col.getSpec()])),
+      maxHops: 0,
+    })
+    .getColumns();
 }

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -1,6 +1,5 @@
 import {
   Annotation,
-  type AxisId,
   type AxisQualification,
   type PColumnSpec,
   type PObjectId,
@@ -354,7 +353,9 @@ test("linkerPath with multiple steps joins with ' > '", () => {
     },
   ];
   const labels = deriveDistinctLabels(entries);
-  expect(labels).toEqual(["Col", "Col via L1 > L2"]);
+  // Minimal difference: the source-most hop L1 alone distinguishes the linked column from the bare
+  // one, so the redundant L2 is dropped.
+  expect(labels).toEqual(["Col", "Col via L1"]);
 });
 
 test("linkerPath skips steps without labels", () => {
@@ -378,7 +379,7 @@ test("linkerPath skips steps without labels", () => {
   expect(labels).toEqual(["Col", "Col via L2"]);
 });
 
-test("linkerPath with custom linkerLabelFormatter", () => {
+test("formatters.linker customizes the postfix zone", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
@@ -393,29 +394,32 @@ test("linkerPath with custom linkerLabelFormatter", () => {
     },
   ];
   const labels = deriveDistinctLabels(entries, {
-    formatters: { linker: (linkerLabels) => `[${linkerLabels.join(", ")}]` },
+    formatters: {
+      linker: ({ root, linkers }) =>
+        `[${[root?.text, ...linkers.map((l) => l.text)].filter(Boolean).join(", ")}]`,
+    },
   });
   expect(labels).toEqual(["Col", "Col [L1]"]);
 });
 
-test("linkerPath with linkerLabelFormatter returning undefined suppresses suffix", () => {
+test("formatters.linker returning undefined suppresses the postfix", () => {
   const entries: Entry[] = [
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col1" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
       linkerPath: [{ spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L1" } }) }],
     },
     {
       spec: createSpec({
-        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col2" }]) },
+        annotations: { [Annotation.Trace]: JSON.stringify([{ type: "t1", label: "Col" }]) },
       }),
+      linkerPath: [{ spec: createSpec({ annotations: { [Annotation.LinkLabel]: "L2" } }) }],
     },
   ];
-  const labels = deriveDistinctLabels(entries, {
-    formatters: { linker: () => undefined },
-  });
-  expect(labels).toEqual(["Col1", "Col2"]);
+  const labels = deriveDistinctLabels(entries, { formatters: { linker: () => undefined } });
+  // Suppressed → both keep the bare stem (collision left unresolved by the caller's choice).
+  expect(labels).toEqual(["Col", "Col"]);
 });
 
 test("linkerPath falls back to Label when LinkLabel is absent", () => {
@@ -523,39 +527,9 @@ test("formatters.anchorQualification receives anchorId", () => {
   expect(labels).toEqual(["Counts (A=X)", "Counts (A=Y)"]);
 });
 
-test("formatters.linkerStepQualification controls inline step quals", () => {
-  const s = {
-    kind: "PColumn",
-    name: "n",
-    valueType: "Int",
-    axesSpec: [],
-    annotations: { [Annotation.Label]: "Counts" },
-  } as PColumnSpec;
-  const entries: Entry[] = [
-    {
-      spec: s,
-      linkerPath: [
-        {
-          spec: createSpec({ annotations: { [Annotation.LinkLabel]: "Mapper" } }),
-          qualifications: [{ axis: { name: "sample" }, contextDomain: { batch: "X" } }],
-        },
-      ],
-    },
-    {
-      spec: s,
-      linkerPath: [
-        {
-          spec: createSpec({ annotations: { [Annotation.LinkLabel]: "Mapper" } }),
-          qualifications: [{ axis: { name: "sample" }, contextDomain: { batch: "Y" } }],
-        },
-      ],
-    },
-  ];
-  const labels = deriveDistinctLabels(entries, {
-    formatters: { linkerStepQualification: (qs) => `(${qs[0].contextDomain.batch})` },
-  });
-  expect(labels).toEqual(["Counts via Mapper (X)", "Counts via Mapper (Y)"]);
-});
+// Deferred: linker-step qualifications are not yet consumed by phase 2 — to be restored with
+// qualification support (see linked_column_postfix).
+test.todo("linker-step qualifications control inline step quals");
 
 test("addLabelAsSuffix places native label at the end", () => {
   const specs = tracesToSpecs([[{ type: "t1", label: "L1" }], [{ type: "t1", label: "L2" }]]);
@@ -738,16 +712,14 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
     expect(deriveDistinctLabels(entries)).toEqual(["Counts via Path A", "Counts via Path B"]);
   });
 
-  test("multi-step paths joined with ' > '", () => {
+  test("multi-step paths render only the differing hop (shared hub dropped)", () => {
     const s = labeledSpec("Counts");
     const entries: Entry[] = [
       { spec: s, linkerPath: [{ spec: linkerSpec("Hub") }, { spec: linkerSpec("Tail X") }] },
       { spec: s, linkerPath: [{ spec: linkerSpec("Hub") }, { spec: linkerSpec("Tail Y") }] },
     ];
-    expect(deriveDistinctLabels(entries)).toEqual([
-      "Counts via Hub > Tail X",
-      "Counts via Hub > Tail Y",
-    ]);
+    // Minimal difference: the common "Hub" hop carries no distinction and is dropped.
+    expect(deriveDistinctLabels(entries)).toEqual(["Counts via Tail X", "Counts via Tail Y"]);
   });
 
   test("hit qualifications used when nothing else differs", () => {
@@ -780,27 +752,8 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
     ]);
   });
 
-  test("linker-step qualifications used to disambiguate identical linker labels", () => {
-    const s = labeledSpec("Counts");
-    const entries: Entry[] = [
-      {
-        spec: s,
-        linkerPath: [
-          { spec: linkerSpec("Mapper"), qualifications: [qual("sample", { batch: "X" })] },
-        ],
-      },
-      {
-        spec: s,
-        linkerPath: [
-          { spec: linkerSpec("Mapper"), qualifications: [qual("sample", { batch: "Y" })] },
-        ],
-      },
-    ];
-    expect(deriveDistinctLabels(entries)).toEqual([
-      "Counts via Mapper [sample batch=X]",
-      "Counts via Mapper [sample batch=Y]",
-    ]);
-  });
+  // Deferred with qualification support in phase 2 (see linked_column_postfix).
+  test.todo("linker-step qualifications used to disambiguate identical linker labels");
 
   test("layers compose only as far as needed; no over-decoration", () => {
     const entries: Entry[] = [
@@ -899,10 +852,11 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
       },
       { spec: sB, linkerPath: [{ spec: linkerSpec("Mapper") }] },
     ];
+    // Stems already differ by trace/anchor-qual, so the shared "Mapper" linker is never needed.
     expect(deriveDistinctLabels(entries)).toEqual([
-      "Counts / RNAseq via Mapper",
-      "Counts / RNAseq via Mapper [anchor-main: sample batch=X]",
-      "Counts / ATACseq via Mapper",
+      "Counts / RNAseq",
+      "Counts / RNAseq [anchor-main: sample batch=X]",
+      "Counts / ATACseq",
     ]);
   });
 
@@ -921,127 +875,6 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
     expect(deriveDistinctLabels(entries)).toEqual([
       "Counts [anchor-main: sample]",
       "Counts [anchor-main: gene]",
-    ]);
-  });
-});
-
-describe("deriveDistinctLabels — linker step labeled by source axis", () => {
-  function labeledSpec(label: string, name = "col"): PColumnSpec {
-    return {
-      kind: "PColumn",
-      name,
-      valueType: "Int",
-      axesSpec: [],
-      annotations: { [Annotation.Label]: label },
-    } as PColumnSpec;
-  }
-
-  // A column carrying an axis with a human label. The axis is what a linker step references; its
-  // label is read from whatever column in `values` happens to carry it.
-  function specWithAxis(
-    label: string,
-    axisName: string,
-    axisLabel: string,
-    name = label,
-  ): PColumnSpec {
-    return {
-      kind: "PColumn",
-      name,
-      valueType: "Int",
-      axesSpec: [
-        { type: "String", name: axisName, annotations: { [Annotation.Label]: axisLabel } },
-      ],
-      annotations: { [Annotation.Label]: label },
-    } as PColumnSpec;
-  }
-
-  const axisRef = (name: string): AxisId => ({ type: "String", name });
-
-  test("collision resolved by the difference between source axes", () => {
-    const counts = labeledSpec("Counts");
-    const entries: Entry[] = [
-      { spec: counts, linkerPath: [{ axis: axisRef("sampleId") }] },
-      { spec: counts, linkerPath: [{ axis: axisRef("cloneId") }] },
-      // sources living elsewhere in the same value set — they carry the labeled axes
-      { spec: specWithAxis("Samples", "sampleId", "Sample") },
-      { spec: specWithAxis("Clones", "cloneId", "Clone") },
-    ];
-    expect(deriveDistinctLabels(entries)).toEqual([
-      "Counts via Sample",
-      "Counts via Clone",
-      "Samples",
-      "Clones",
-    ]);
-  });
-
-  test("source axis label is read from the hit column's own axesSpec", () => {
-    // No separate source column; the axis is present on the linked columns themselves.
-    const a = specWithAxis("Counts", "sampleId", "Sample", "counts_by_sample");
-    const b = specWithAxis("Counts", "cloneId", "Clone", "counts_by_clone");
-    const entries: Entry[] = [
-      { spec: a, linkerPath: [{ axis: axisRef("sampleId") }] },
-      { spec: b, linkerPath: [{ axis: axisRef("cloneId") }] },
-    ];
-    expect(deriveDistinctLabels(entries)).toEqual(["Counts via Sample", "Counts via Clone"]);
-  });
-
-  test("source-axis suffix appended only where needed for uniqueness", () => {
-    const entries: Entry[] = [
-      { spec: labeledSpec("Read counts") },
-      { spec: labeledSpec("Read counts"), linkerPath: [{ axis: axisRef("sampleId") }] },
-      { spec: specWithAxis("Samples", "sampleId", "Sample") },
-    ];
-    expect(deriveDistinctLabels(entries)).toEqual([
-      "Read counts",
-      "Read counts via Sample",
-      "Samples",
-    ]);
-  });
-
-  test("step is dropped when its source axis is not present in any value", () => {
-    const counts = labeledSpec("Counts");
-    const entries: Entry[] = [
-      { spec: counts, linkerPath: [{ axis: axisRef("missingA") }] },
-      { spec: counts, linkerPath: [{ axis: axisRef("missingB") }] },
-    ];
-    // Neither axis resolves → no linker zone → nothing left to disambiguate with.
-    expect(deriveDistinctLabels(entries)).toEqual(["Counts", "Counts"]);
-  });
-
-  test("step is dropped when the matched axis carries no label", () => {
-    const counts = labeledSpec("Counts");
-    const unlabeledAxisSrc: PColumnSpec = {
-      kind: "PColumn",
-      name: "src",
-      valueType: "Int",
-      axesSpec: [{ type: "String", name: "sampleId" }],
-      annotations: { [Annotation.Label]: "Src" },
-    } as PColumnSpec;
-    const entries: Entry[] = [
-      { spec: counts, linkerPath: [{ axis: axisRef("sampleId") }] },
-      { spec: unlabeledAxisSrc },
-    ];
-    expect(deriveDistinctLabels(entries)).toEqual(["Counts", "Src"]);
-  });
-
-  test("multi-step path collapses to the joined source-axis labels", () => {
-    const counts = labeledSpec("Counts");
-    const entries: Entry[] = [
-      {
-        spec: counts,
-        linkerPath: [{ axis: axisRef("hubId") }, { axis: axisRef("sampleId") }],
-      },
-      {
-        spec: counts,
-        linkerPath: [{ axis: axisRef("hubId") }, { axis: axisRef("cloneId") }],
-      },
-      { spec: specWithAxis("Hub", "hubId", "Hub") },
-      { spec: specWithAxis("Samples", "sampleId", "Sample") },
-      { spec: specWithAxis("Clones", "cloneId", "Clone") },
-    ];
-    expect(deriveDistinctLabels(entries).slice(0, 2)).toEqual([
-      "Counts via Hub > Sample",
-      "Counts via Hub > Clone",
     ]);
   });
 });

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -213,6 +213,96 @@ test.each<{ name: string; traces: Trace[]; labels: string[] }>([
   expect(deriveDistinctLabels(tracesToSpecs(traces))).toEqual(labels);
 });
 
+// Preset distilled from a real PlDataTable "all columns" dump: three columns whose native label is
+// "Cluster Id", produced by two different clustering analyses (foldseek 3D-structure clustering and
+// mmseqs2 clonotype clustering). The two foldseek columns carry a byte-identical trace, so phase 1
+// cannot tell them apart (a linker "via …" postfix does in the real pipeline); the mmseqs2 column
+// differs by its last trace step. Regression guard for "distinguish by absence": minimization used
+// to keep only ONE clustering type, leaving the other column a bare "Cluster Id" — unique only
+// because it LACKED the peer's clustering step. Each column must instead surface its OWN step.
+test("cluster-id preset: colliding columns are distinguished by a token they have, not by absence", () => {
+  const clusterId = (trace: Trace): PColumnSpec => ({
+    kind: "PColumn",
+    name: "name",
+    valueType: "String",
+    annotations: { [Annotation.Trace]: JSON.stringify(trace), [Annotation.Label]: "Cluster Id" },
+    axesSpec: [],
+  });
+
+  const provenance: Trace = [
+    { type: "milaboratories.samples-and-data", importance: 10, label: "Samples & Data" },
+    {
+      type: "milaboratories.samples-and-data/dataset",
+      importance: 100,
+      label: "MB135 + Podocytes",
+    },
+    {
+      type: "milaboratories.mixcr-amplicon-alignment",
+      importance: 20,
+      label: "MiXCR generic amplicon",
+    },
+    { type: "milaboratories.redefine-clonotypes", importance: 30, label: "Imputed VDJRegion aa" },
+  ];
+  const foldseek: Trace = [
+    ...provenance,
+    { type: "milaboratories.antibody-tcr-lead-selection", importance: 30, label: "Selected Leads" },
+    {
+      type: "milaboratories.3d-structure-prediction",
+      importance: 20,
+      label: "Camelid (VHH/nanobody) NBB2, CDRH3 ≤ 2.5 Å",
+    },
+    {
+      type: "milaboratories.3d-structure-clustering.clustering",
+      importance: 30,
+      label: "Full Structure+AA, TM≥0.95, cov≥0.95",
+    },
+  ];
+  const mmseqs2: Trace = [
+    ...provenance,
+    {
+      type: "milaboratories.clonotype-clustering.clustering",
+      importance: 30,
+      label: "Imputed VDJRegion aa, BLOSUM62, ident:0.95, cov:0.95",
+    },
+  ];
+
+  const entries: Entry[] = [clusterId(foldseek), clusterId(mmseqs2), clusterId(foldseek)];
+
+  expect(deriveDistinctLabels(entries, { includeNativeLabel: true })).toEqual([
+    "Cluster Id / Full Structure+AA, TM≥0.95, cov≥0.95",
+    "Cluster Id / Imputed VDJRegion aa, BLOSUM62, ident:0.95, cov:0.95",
+    "Cluster Id / Full Structure+AA, TM≥0.95, cov≥0.95",
+  ]);
+});
+
+// The by-presence repair must patch ONLY the bare column's own label — never the shared global type
+// set. Otherwise the token it adds for one group ("X2" needs "t") leaks onto every column that
+// carries that type, including "Y" in an unrelated group, which should stay a bare "Y".
+test("by-presence repair does not leak its token into other groups sharing that type", () => {
+  const spec = (label: string, trace: Trace): PColumnSpec => ({
+    kind: "PColumn",
+    name: "name",
+    valueType: "Int",
+    annotations: { [Annotation.Trace]: JSON.stringify(trace), [Annotation.Label]: label },
+    axesSpec: [],
+  });
+
+  const entries: Entry[] = [
+    // Group X: minimization separates the two by the higher-importance "a" (X2 ends up bare),
+    // then repair un-bares X2 with the token it actually has — "t".
+    spec("X", [{ type: "a", importance: 10, label: "A1" }]),
+    spec("X", [{ type: "t", importance: 1, label: "TX" }]),
+    // Group Y: sole "Y" column, also carries "t". Must NOT inherit X2's repair token.
+    spec("Y", [{ type: "t", importance: 1, label: "TY" }]),
+  ];
+
+  expect(deriveDistinctLabels(entries, { includeNativeLabel: true })).toEqual([
+    "X / A1",
+    "X / TX",
+    "Y",
+  ]);
+});
+
 test.each<{ name: string; traces: Trace[]; labels: string[]; forceTraceElements: string[] }>([
   {
     name: "force one element",

--- a/sdk/model/src/labels/derive_distinct_labels.test.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.test.ts
@@ -1,5 +1,6 @@
 import {
   Annotation,
+  type AxisId,
   type AxisQualification,
   type PColumnSpec,
   type PObjectId,
@@ -920,6 +921,127 @@ describe("deriveDistinctLabels v2 — linker path & qualifications", () => {
     expect(deriveDistinctLabels(entries)).toEqual([
       "Counts [anchor-main: sample]",
       "Counts [anchor-main: gene]",
+    ]);
+  });
+});
+
+describe("deriveDistinctLabels — linker step labeled by source axis", () => {
+  function labeledSpec(label: string, name = "col"): PColumnSpec {
+    return {
+      kind: "PColumn",
+      name,
+      valueType: "Int",
+      axesSpec: [],
+      annotations: { [Annotation.Label]: label },
+    } as PColumnSpec;
+  }
+
+  // A column carrying an axis with a human label. The axis is what a linker step references; its
+  // label is read from whatever column in `values` happens to carry it.
+  function specWithAxis(
+    label: string,
+    axisName: string,
+    axisLabel: string,
+    name = label,
+  ): PColumnSpec {
+    return {
+      kind: "PColumn",
+      name,
+      valueType: "Int",
+      axesSpec: [
+        { type: "String", name: axisName, annotations: { [Annotation.Label]: axisLabel } },
+      ],
+      annotations: { [Annotation.Label]: label },
+    } as PColumnSpec;
+  }
+
+  const axisRef = (name: string): AxisId => ({ type: "String", name });
+
+  test("collision resolved by the difference between source axes", () => {
+    const counts = labeledSpec("Counts");
+    const entries: Entry[] = [
+      { spec: counts, linkerPath: [{ axis: axisRef("sampleId") }] },
+      { spec: counts, linkerPath: [{ axis: axisRef("cloneId") }] },
+      // sources living elsewhere in the same value set — they carry the labeled axes
+      { spec: specWithAxis("Samples", "sampleId", "Sample") },
+      { spec: specWithAxis("Clones", "cloneId", "Clone") },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Counts via Sample",
+      "Counts via Clone",
+      "Samples",
+      "Clones",
+    ]);
+  });
+
+  test("source axis label is read from the hit column's own axesSpec", () => {
+    // No separate source column; the axis is present on the linked columns themselves.
+    const a = specWithAxis("Counts", "sampleId", "Sample", "counts_by_sample");
+    const b = specWithAxis("Counts", "cloneId", "Clone", "counts_by_clone");
+    const entries: Entry[] = [
+      { spec: a, linkerPath: [{ axis: axisRef("sampleId") }] },
+      { spec: b, linkerPath: [{ axis: axisRef("cloneId") }] },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual(["Counts via Sample", "Counts via Clone"]);
+  });
+
+  test("source-axis suffix appended only where needed for uniqueness", () => {
+    const entries: Entry[] = [
+      { spec: labeledSpec("Read counts") },
+      { spec: labeledSpec("Read counts"), linkerPath: [{ axis: axisRef("sampleId") }] },
+      { spec: specWithAxis("Samples", "sampleId", "Sample") },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual([
+      "Read counts",
+      "Read counts via Sample",
+      "Samples",
+    ]);
+  });
+
+  test("step is dropped when its source axis is not present in any value", () => {
+    const counts = labeledSpec("Counts");
+    const entries: Entry[] = [
+      { spec: counts, linkerPath: [{ axis: axisRef("missingA") }] },
+      { spec: counts, linkerPath: [{ axis: axisRef("missingB") }] },
+    ];
+    // Neither axis resolves → no linker zone → nothing left to disambiguate with.
+    expect(deriveDistinctLabels(entries)).toEqual(["Counts", "Counts"]);
+  });
+
+  test("step is dropped when the matched axis carries no label", () => {
+    const counts = labeledSpec("Counts");
+    const unlabeledAxisSrc: PColumnSpec = {
+      kind: "PColumn",
+      name: "src",
+      valueType: "Int",
+      axesSpec: [{ type: "String", name: "sampleId" }],
+      annotations: { [Annotation.Label]: "Src" },
+    } as PColumnSpec;
+    const entries: Entry[] = [
+      { spec: counts, linkerPath: [{ axis: axisRef("sampleId") }] },
+      { spec: unlabeledAxisSrc },
+    ];
+    expect(deriveDistinctLabels(entries)).toEqual(["Counts", "Src"]);
+  });
+
+  test("multi-step path collapses to the joined source-axis labels", () => {
+    const counts = labeledSpec("Counts");
+    const entries: Entry[] = [
+      {
+        spec: counts,
+        linkerPath: [{ axis: axisRef("hubId") }, { axis: axisRef("sampleId") }],
+      },
+      {
+        spec: counts,
+        linkerPath: [{ axis: axisRef("hubId") }, { axis: axisRef("cloneId") }],
+      },
+      { spec: specWithAxis("Hub", "hubId", "Hub") },
+      { spec: specWithAxis("Samples", "sampleId", "Sample") },
+      { spec: specWithAxis("Clones", "cloneId", "Clone") },
+    ];
+    expect(deriveDistinctLabels(entries).slice(0, 2)).toEqual([
+      "Counts via Hub > Sample",
+      "Counts via Hub > Clone",
     ]);
   });
 });

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -168,7 +168,16 @@ function deriveStems(values: Entry[], options: DeriveLabelsOptions): string[] {
         forcedSet,
         separator,
       );
-      return build(minimized, false) ?? throwError("Failed to derive unique labels");
+      const rendered = build(minimized, false) ?? throwError("Failed to derive unique labels");
+      return repairBareByPresence(
+        rendered,
+        minimized,
+        records,
+        stats,
+        forcedSet,
+        forceTraceElements,
+        separator,
+      );
     }
 
     additionalType++;
@@ -187,7 +196,16 @@ function deriveStems(values: Entry[], options: DeriveLabelsOptions): string[] {
     forcedSet,
     separator,
   );
-  return build(minimized, true) ?? throwError("Failed to derive unique labels");
+  const rendered = build(minimized, true) ?? throwError("Failed to derive unique labels");
+  return repairBareByPresence(
+    rendered,
+    minimized,
+    records,
+    stats,
+    forcedSet,
+    forceTraceElements,
+    separator,
+  );
 }
 
 // --- Pure helpers ---
@@ -431,4 +449,95 @@ function minimizeTypeSet(
   }
 
   return result;
+}
+
+const ABSENT_VALUE = " absent"; // sentinel value for "row has no entry of this type"
+
+/** Whether `fullType`'s rendered value differs across the group (absence counts as a value). */
+function typeDistinguishes(records: EnrichedRecord[], group: number[], fullType: string): boolean {
+  const values = new Set<string>();
+  for (const i of group) {
+    const ft = records[i].fullTrace.find((e) => e.fullType === fullType);
+    values.add(ft?.label ?? ABSENT_VALUE);
+    if (values.size > 1) return true;
+  }
+  return false;
+}
+
+/** The highest-importance trace type this row HAS (outside `typeSet`) that sets it apart from its
+ *  group peers. `undefined` when the row carries nothing distinguishing of its own. */
+function bestDistinguishingType(
+  records: EnrichedRecord[],
+  group: number[],
+  row: number,
+  typeSet: Set<string>,
+  forcedSet: Set<string>,
+  forceTraceElements: Set<string> | undefined,
+  stats: TypeStats,
+): string | undefined {
+  return records[row].fullTrace.reduce<{ type: string; imp: number } | undefined>((best, ft) => {
+    if (typeSet.has(ft.fullType) || forcedSet.has(ft.fullType) || forceTraceElements?.has(ft.type))
+      return best;
+    if (!typeDistinguishes(records, group, ft.fullType)) return best;
+    const imp = stats.importances.get(ft.fullType) ?? 0;
+    return best === undefined || imp > best.imp ? { type: ft.fullType, imp } : best;
+  }, undefined)?.type;
+}
+
+/**
+ * Un-bare columns distinguished only "by absence". After minimization a column can end up with a
+ * bare trace zone (only the forced native label) while a peer sharing that same base renders extra
+ * tokens — the column reads as unique purely because it LACKS what the peer has. For each such bare
+ * column this re-renders JUST that column's label with the highest-importance trace type it actually
+ * carries that tells it apart from its peers, so every colliding column is distinguished by a token
+ * it HAS rather than by omission.
+ *
+ * Patches individual labels rather than the shared type set on purpose: the set is global, so adding
+ * a type there would also decorate unrelated columns in other groups that happen to carry it. Only
+ * bare columns' labels grow (a superset of their previous value), so uniqueness is preserved. Groups
+ * are keyed by the base = the label rendered from the forced types alone.
+ */
+function repairBareByPresence(
+  labels: string[],
+  minimized: Set<string>,
+  records: EnrichedRecord[],
+  stats: TypeStats,
+  forcedSet: Set<string>,
+  forceTraceElements: Set<string> | undefined,
+  separator: string,
+): string[] {
+  const base = records.map((r) => renderRecordLabel(r, forcedSet, forceTraceElements, separator));
+  const isBare = records.map(
+    (r, i) => renderRecordLabel(r, minimized, forceTraceElements, separator) === base[i],
+  );
+
+  const groups = records.reduce<Map<string, number[]>>(
+    (acc, _, i) => acc.set(base[i] ?? "", [...(acc.get(base[i] ?? "") ?? []), i]),
+    new Map(),
+  );
+
+  const patched = [...labels];
+  for (const group of groups.values()) {
+    // Only asymmetric groups need repair: a bare column beside a richer peer. When every column is
+    // equally bare there is nothing to un-hide (they carry no distinguishing token of their own).
+    if (!group.some((i) => !isBare[i])) continue;
+    for (const i of group) {
+      if (!isBare[i]) continue;
+      const chosen = bestDistinguishingType(
+        records,
+        group,
+        i,
+        minimized,
+        forcedSet,
+        forceTraceElements,
+        stats,
+      );
+      if (chosen === undefined) continue;
+      const withToken = new Set([...minimized, chosen]);
+      patched[i] =
+        renderRecordLabel(records[i], withToken, forceTraceElements, separator) ?? patched[i];
+    }
+  }
+
+  return patched;
 }

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -1,8 +1,12 @@
 import {
   Annotation,
+  getAxisId,
+  matchAxisId,
   parseJson,
   readAnnotation,
+  type AxisId,
   type AxisQualification,
+  type AxisSpec,
   type MatchQualifications,
   type PObjectId,
   type PObjectSpec,
@@ -37,7 +41,14 @@ type ExtendedTraceEntry = Trace[number] & {
 };
 
 export type LinkerStep = {
-  spec: PObjectSpec;
+  /**
+   * Axis the link traverses ("the source"). When set, the step is labeled by the difference
+   * between sources: we look up this axis in the `axesSpec` of the columns in `values` and render
+   * that axis's `Annotation.Label`. If the axis can't be resolved to a label, the step is dropped.
+   */
+  axis?: AxisId;
+  /** Legacy: linker column spec. Used only when `axis` is absent; labeled by its `LinkLabel`/`Label`. */
+  spec?: PObjectSpec;
   qualifications?: AxisQualification[];
 };
 
@@ -68,7 +79,7 @@ export type DeriveLabelsFormatters = {
   linkerStepQualification?: (
     qualifications: AxisQualification[],
     stepIndex: number,
-    stepSpec: PObjectSpec,
+    stepSpec: PObjectSpec | undefined,
   ) => string | undefined;
   /** Hit-axis qualifications block. Default: `[${formatQualifications(qs)}]`. */
   hitQualification?: (
@@ -105,7 +116,8 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
       : undefined;
   const separator = options.separator ?? " / ";
 
-  const records = values.map((v, i) => enrichRecord(v, i, options));
+  const axisLabels = collectAxisLabels(values.map((v) => extractEntryParts(v).spec));
+  const records = values.map((v, i) => enrichRecord(v, i, options, axisLabels));
   const stats = collectTypeStats(records);
 
   const hasAnySynthetic = records.some((r) => r.fullTrace.some((ft) => isSyntheticType(ft.type)));
@@ -233,14 +245,53 @@ function formatQualifications(qs: AxisQualification[]): string {
   return qs.map(formatQualification).join("; ");
 }
 
+/**
+ * Index of labeled axes drawn from every spec in `values`. Used to label a linker step by its
+ * source axis: we match the step's `AxisId` against the axes carried by the columns and render the
+ * matched axis's `Annotation.Label`. The "difference between sources" then falls out of the normal
+ * minimization — only source axes that actually differ end up in the rendered label.
+ */
+type AxisLabelIndex = { id: AxisId; label: string }[];
+
+function collectAxisLabels(specs: PObjectSpec[]): AxisLabelIndex {
+  const index: AxisLabelIndex = [];
+  const seen = new Set<string>();
+  for (const spec of specs) {
+    const axesSpec = (spec as { axesSpec?: AxisSpec[] }).axesSpec;
+    if (axesSpec === undefined) continue;
+    for (const axis of axesSpec) {
+      const label = readAnnotation(axis, Annotation.Label)?.trim();
+      if (isNil(label) || label.length === 0) continue;
+      const id = getAxisId(axis);
+      const key = `${id.name} ${label}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      index.push({ id, label });
+    }
+  }
+  return index;
+}
+
+function resolveAxisLabel(axis: AxisId, axisLabels: AxisLabelIndex): string | undefined {
+  // `matchAxisId(query, target)` treats the query domain as a subset requirement, so the step's
+  // axis matches any column axis whose identity contains it.
+  const hit = axisLabels.find((entry) => matchAxisId(axis, entry.id));
+  return hit?.label;
+}
+
 function computeStepLabel(
   step: LinkerStep,
   stepIndex: number,
   formatters: DeriveLabelsFormatters | undefined,
+  axisLabels: AxisLabelIndex,
 ): string | undefined {
-  const base = (
-    readAnnotation(step.spec, Annotation.LinkLabel) ?? readAnnotation(step.spec, Annotation.Label)
-  )?.trim();
+  const base =
+    step.axis !== undefined
+      ? resolveAxisLabel(step.axis, axisLabels)
+      : (
+          readAnnotation(step.spec, Annotation.LinkLabel) ??
+          readAnnotation(step.spec, Annotation.Label)
+        )?.trim();
   if (isNil(base) || base.length === 0) return undefined;
   if (step.qualifications === undefined || step.qualifications.length === 0) return base;
   const qualText = isFunction(formatters?.linkerStepQualification)
@@ -268,7 +319,12 @@ function buildFullTrace(trace: ExtendedTraceEntry[]): FullTraceEntry[] {
   return result;
 }
 
-function enrichRecord(value: Entry, index: number, options: DeriveLabelsOptions): EnrichedRecord {
+function enrichRecord(
+  value: Entry,
+  index: number,
+  options: DeriveLabelsOptions,
+  axisLabels: AxisLabelIndex,
+): EnrichedRecord {
   const { spec, extraTrace, linkerPath, qualifications } = extractEntryParts(value);
   const formatters = options.formatters;
 
@@ -294,7 +350,7 @@ function enrichRecord(value: Entry, index: number, options: DeriveLabelsOptions)
 
   if (linkerPath !== undefined && linkerPath.length > 0) {
     const stepLabels = linkerPath
-      .map((step, i) => computeStepLabel(step, i, formatters))
+      .map((step, i) => computeStepLabel(step, i, formatters, axisLabels))
       .filter((s): s is string => !isNil(s));
     if (stepLabels.length > 0) {
       const linkerText = isFunction(formatters?.linker)

--- a/sdk/model/src/labels/derive_distinct_labels.ts
+++ b/sdk/model/src/labels/derive_distinct_labels.ts
@@ -1,13 +1,10 @@
 import {
   Annotation,
-  getAxisId,
-  matchAxisId,
   parseJson,
   readAnnotation,
-  type AxisId,
   type AxisQualification,
-  type AxisSpec,
   type MatchQualifications,
+  type PColumnSpec,
   type PObjectId,
   type PObjectSpec,
   type StringifiedJson,
@@ -15,14 +12,13 @@ import {
 } from "@milaboratories/pl-model-common";
 import { throwError } from "@milaboratories/helpers";
 import { isFunction, isNil } from "es-toolkit";
+import { derivePostfixes, type LinkerFormatter } from "./linked_column_postfix";
 
 export type { Trace, TraceEntry } from "@milaboratories/pl-model-common";
 
 const DISTANCE_PENALTY = 0.001;
 const LABEL_TYPE = "__LABEL__";
 const LABEL_TYPE_FULL = "__LABEL__@1";
-const LINKER_TYPE = "__LINKER__";
-const LINKER_TYPE_FULL = "__LINKER__@1";
 const HIT_QUAL_TYPE = "__HIT_QUAL__";
 const ANCHOR_QUAL_TYPE_PREFIX = "__ANCHOR_QUAL__:";
 
@@ -31,7 +27,7 @@ function isAnchorQualType(t: string): boolean {
 }
 
 function isSyntheticType(t: string): boolean {
-  return t === LINKER_TYPE || t === HIT_QUAL_TYPE || isAnchorQualType(t);
+  return t === HIT_QUAL_TYPE || isAnchorQualType(t);
 }
 
 /** SDK-internal trace shape — adds fields used by this algorithm only, not part of the on-disk contract. */
@@ -41,14 +37,9 @@ type ExtendedTraceEntry = Trace[number] & {
 };
 
 export type LinkerStep = {
-  /**
-   * Axis the link traverses ("the source"). When set, the step is labeled by the difference
-   * between sources: we look up this axis in the `axesSpec` of the columns in `values` and render
-   * that axis's `Annotation.Label`. If the axis can't be resolved to a label, the step is dropped.
-   */
-  axis?: AxisId;
-  /** Legacy: linker column spec. Used only when `axis` is absent; labeled by its `LinkLabel`/`Label`. */
-  spec?: PObjectSpec;
+  /** Linker column spec — its `axesSpec` yields the source axis (root); its `LinkLabel`/`Label` names it. */
+  spec: PColumnSpec;
+  /** Axis qualifications applied on this hop. Not yet consumed by the postfix (deferred). */
   qualifications?: AxisQualification[];
 };
 
@@ -58,7 +49,8 @@ export type Entry =
       spec: PObjectSpec;
       /** Extra trace entries merged with the base trace from annotations. */
       extraTrace?: ExtendedTraceEntry[];
-      /** Linker steps traversed to discover this column; rendered as "via …" only when needed for uniqueness. */
+      /** Linker steps (`[0]` source-most) traversed to reach this column; rendered as a "via …"
+       *  postfix only when needed for uniqueness — see {@link derivePostfixes}. */
       linkerPath?: LinkerStep[];
       /** Axis qualifications applied to the hit column / already-bound anchors; rendered as "[…]" suffixes. */
       qualifications?: MatchQualifications;
@@ -71,16 +63,9 @@ export type Entry =
 export type DeriveLabelsFormatters = {
   /** Native column label. Default: identity. `undefined` → label entry not added (treated as if spec had no label). */
   native?: (label: string, spec: PObjectSpec, index: number) => string | undefined;
-  /** Linker zone (whole "via …" piece). Receives step labels with step-quals already inlined.
-   *  Default: `via ${steps.join(" > ")}`. */
-  linker?: (linkerLabels: string[], spec: PObjectSpec, index: number) => string | undefined;
-  /** Per-step linker qualifications inlined into the step base label.
-   *  Default: `[${formatQualifications(qs)}]`. `undefined` → step rendered without quals. */
-  linkerStepQualification?: (
-    qualifications: AxisQualification[],
-    stepIndex: number,
-    stepSpec: PObjectSpec | undefined,
-  ) => string | undefined;
+  /** Linker/source postfix zone (phase 2). Receives the distinguishing tokens (`{ root, linkers }`)
+   *  and returns the "via …" text, or `undefined` to suppress. */
+  linker?: LinkerFormatter;
   /** Hit-axis qualifications block. Default: `[${formatQualifications(qs)}]`. */
   hitQualification?: (
     qualifications: AxisQualification[],
@@ -109,28 +94,47 @@ export type DeriveLabelsOptions = {
   formatters?: DeriveLabelsFormatters;
 };
 
+/**
+ * Distinct labels for a set of columns. Two phases:
+ *  1. {@link deriveStems} — treats each column as a single entity (native label + trace + hit/anchor
+ *     qualifications) and produces the minimal distinguishing "stem".
+ *  2. {@link derivePostfixes} — for columns still colliding on their stem, appends a "via …" postfix
+ *     describing the difference between their linker sources (root axis, then linker chain).
+ */
 export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptions = {}): string[] {
+  const stems = deriveStems(values, options);
+  return derivePostfixes(
+    values.map((v, i) => {
+      const { spec, linkerPath } = extractEntryParts(v);
+      return {
+        stem: stems[i],
+        // Hit columns are PColumns; the postfix reads their axesSpec to orient linkers.
+        hit: spec as PColumnSpec,
+        linkers: (linkerPath ?? []).map((s) => s.spec),
+      };
+    }),
+    options.formatters?.linker,
+  );
+}
+
+/** Phase 1: minimal per-column stem — native label + trace + hit/anchor qualifications, no linkers. */
+function deriveStems(values: Entry[], options: DeriveLabelsOptions): string[] {
   const forceTraceElements =
     options.forceTraceElements !== undefined && options.forceTraceElements.length > 0
       ? new Set(options.forceTraceElements)
       : undefined;
   const separator = options.separator ?? " / ";
 
-  const axisLabels = collectAxisLabels(values.map((v) => extractEntryParts(v).spec));
-  const records = values.map((v, i) => enrichRecord(v, i, options, axisLabels));
+  const records = values.map((v, i) => enrichRecord(v, i, options));
   const stats = collectTypeStats(records);
 
   const hasAnySynthetic = records.some((r) => r.fullTrace.some((ft) => isSyntheticType(ft.type)));
   const labelForced =
     (options.includeNativeLabel === true || hasAnySynthetic) &&
     stats.countByType.has(LABEL_TYPE_FULL);
-  // Tied to labeled-step presence, not path presence: entries with a non-empty linkerPath
-  // but no labeled steps contribute no LINKER_TYPE trace entry, so they do not count here.
-  const linkerForced = stats.countByType.get(LINKER_TYPE_FULL) === values.length;
 
   const forcedSet = new Set<string>();
   if (labelForced) forcedSet.add(LABEL_TYPE_FULL);
-  if (linkerForced) forcedSet.add(LINKER_TYPE_FULL);
 
   const { mainTypes, secondaryTypes } = classifyTypes(stats, values.length);
 
@@ -164,16 +168,7 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
         forcedSet,
         separator,
       );
-      const minimizedLabels =
-        build(minimized, false) ?? throwError("Failed to derive unique labels");
-      return dropRedundantLinkerSuffix(
-        records,
-        minimized,
-        forceTraceElements,
-        forcedSet,
-        separator,
-        minimizedLabels,
-      );
+      return build(minimized, false) ?? throwError("Failed to derive unique labels");
     }
 
     additionalType++;
@@ -192,15 +187,7 @@ export function deriveDistinctLabels(values: Entry[], options: DeriveLabelsOptio
     forcedSet,
     separator,
   );
-  const minimizedLabels = build(minimized, true) ?? throwError("Failed to derive unique labels");
-  return dropRedundantLinkerSuffix(
-    records,
-    minimized,
-    forceTraceElements,
-    forcedSet,
-    separator,
-    minimizedLabels,
-  );
+  return build(minimized, true) ?? throwError("Failed to derive unique labels");
 }
 
 // --- Pure helpers ---
@@ -245,61 +232,6 @@ function formatQualifications(qs: AxisQualification[]): string {
   return qs.map(formatQualification).join("; ");
 }
 
-/**
- * Index of labeled axes drawn from every spec in `values`. Used to label a linker step by its
- * source axis: we match the step's `AxisId` against the axes carried by the columns and render the
- * matched axis's `Annotation.Label`. The "difference between sources" then falls out of the normal
- * minimization — only source axes that actually differ end up in the rendered label.
- */
-type AxisLabelIndex = { id: AxisId; label: string }[];
-
-function collectAxisLabels(specs: PObjectSpec[]): AxisLabelIndex {
-  const index: AxisLabelIndex = [];
-  const seen = new Set<string>();
-  for (const spec of specs) {
-    const axesSpec = (spec as { axesSpec?: AxisSpec[] }).axesSpec;
-    if (axesSpec === undefined) continue;
-    for (const axis of axesSpec) {
-      const label = readAnnotation(axis, Annotation.Label)?.trim();
-      if (isNil(label) || label.length === 0) continue;
-      const id = getAxisId(axis);
-      const key = `${id.name} ${label}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      index.push({ id, label });
-    }
-  }
-  return index;
-}
-
-function resolveAxisLabel(axis: AxisId, axisLabels: AxisLabelIndex): string | undefined {
-  // `matchAxisId(query, target)` treats the query domain as a subset requirement, so the step's
-  // axis matches any column axis whose identity contains it.
-  const hit = axisLabels.find((entry) => matchAxisId(axis, entry.id));
-  return hit?.label;
-}
-
-function computeStepLabel(
-  step: LinkerStep,
-  stepIndex: number,
-  formatters: DeriveLabelsFormatters | undefined,
-  axisLabels: AxisLabelIndex,
-): string | undefined {
-  const base =
-    step.axis !== undefined
-      ? resolveAxisLabel(step.axis, axisLabels)
-      : (
-          readAnnotation(step.spec, Annotation.LinkLabel) ??
-          readAnnotation(step.spec, Annotation.Label)
-        )?.trim();
-  if (isNil(base) || base.length === 0) return undefined;
-  if (step.qualifications === undefined || step.qualifications.length === 0) return base;
-  const qualText = isFunction(formatters?.linkerStepQualification)
-    ? formatters.linkerStepQualification(step.qualifications, stepIndex, step.spec)
-    : `[${formatQualifications(step.qualifications)}]`;
-  return isNil(qualText) ? base : `${base} ${qualText}`;
-}
-
 function buildFullTrace(trace: ExtendedTraceEntry[]): FullTraceEntry[] {
   const result: FullTraceEntry[] = [];
   const occurrences = new Map<string, number>();
@@ -319,13 +251,8 @@ function buildFullTrace(trace: ExtendedTraceEntry[]): FullTraceEntry[] {
   return result;
 }
 
-function enrichRecord(
-  value: Entry,
-  index: number,
-  options: DeriveLabelsOptions,
-  axisLabels: AxisLabelIndex,
-): EnrichedRecord {
-  const { spec, extraTrace, linkerPath, qualifications } = extractEntryParts(value);
+function enrichRecord(value: Entry, index: number, options: DeriveLabelsOptions): EnrichedRecord {
+  const { spec, extraTrace, qualifications } = extractEntryParts(value);
   const formatters = options.formatters;
 
   const rawLabel = readAnnotation(spec, Annotation.Label);
@@ -345,20 +272,6 @@ function enrichRecord(
       const labelEntry = { label, type: LABEL_TYPE, importance: -2 };
       if (options.addLabelAsSuffix === true) trace.push(labelEntry);
       else trace.splice(0, 0, labelEntry);
-    }
-  }
-
-  if (linkerPath !== undefined && linkerPath.length > 0) {
-    const stepLabels = linkerPath
-      .map((step, i) => computeStepLabel(step, i, formatters, axisLabels))
-      .filter((s): s is string => !isNil(s));
-    if (stepLabels.length > 0) {
-      const linkerText = isFunction(formatters?.linker)
-        ? formatters.linker(stepLabels, spec, index)
-        : `via ${stepLabels.join(" > ")}`;
-      if (!isNil(linkerText)) {
-        trace.push({ type: LINKER_TYPE, label: linkerText, importance: -10 });
-      }
     }
   }
 
@@ -440,22 +353,16 @@ function renderRecordLabel(
 ): string | undefined {
   const traceParts: string[] = [];
   const anchorParts: string[] = [];
-  let linkerLabel: string | undefined;
   let hitLabel: string | undefined;
 
   for (const ft of record.fullTrace) {
     if (!(includedTypes.has(ft.fullType) || forceTraceElements?.has(ft.type))) continue;
-    if (ft.type === LINKER_TYPE) linkerLabel = ft.label;
-    else if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
+    if (ft.type === HIT_QUAL_TYPE) hitLabel = ft.label;
     else if (isAnchorQualType(ft.type)) anchorParts.push(ft.label);
     else traceParts.push(ft.label);
   }
 
-  const isEmpty =
-    traceParts.length === 0 &&
-    anchorParts.length === 0 &&
-    linkerLabel === undefined &&
-    hitLabel === undefined;
+  const isEmpty = traceParts.length === 0 && anchorParts.length === 0 && hitLabel === undefined;
 
   if (isEmpty) return undefined;
 
@@ -463,7 +370,6 @@ function renderRecordLabel(
   const append = (part: string) => {
     label = label.length === 0 ? part : `${label} ${part}`;
   };
-  if (linkerLabel !== undefined) append(linkerLabel);
   for (const a of anchorParts) append(a);
   if (hitLabel !== undefined) append(hitLabel);
 
@@ -490,48 +396,6 @@ function buildLabels(
   }
 
   return result;
-}
-
-/**
- * Drop the "via …" linker suffix from records whose label is already unique without it.
- *
- * Global minimization may include `LINKER_TYPE_FULL` solely to resolve a collision between a
- * subset of records — but `buildLabels` then renders the suffix on every record that carries a
- * linker trace entry, including ones whose stem is already unique. We strip the suffix where it
- * isn't load-bearing while keeping the symmetric rendering required by `linkerForced` /
- * `forceTraceElements`.
- *
- * Rule: a record's linker suffix is redundant iff its stem (label rendered without LINKER) does
- * not appear anywhere else in the set.
- */
-function dropRedundantLinkerSuffix(
-  records: EnrichedRecord[],
-  globalTypeSet: Set<string>,
-  forceTraceElements: Set<string> | undefined,
-  forcedSet: Set<string>,
-  separator: string,
-  labels: string[],
-): string[] {
-  if (!globalTypeSet.has(LINKER_TYPE_FULL)) return labels;
-  if (forcedSet.has(LINKER_TYPE_FULL) || forceTraceElements?.has(LINKER_TYPE)) return labels;
-
-  const setWithoutLinker = new Set(globalTypeSet);
-  setWithoutLinker.delete(LINKER_TYPE_FULL);
-
-  const stems = records.map((r) =>
-    renderRecordLabel(r, setWithoutLinker, forceTraceElements, separator),
-  );
-
-  const stemOccurrences = new Map<string, number>();
-  for (const s of stems) {
-    if (s !== undefined) stemOccurrences.set(s, (stemOccurrences.get(s) ?? 0) + 1);
-  }
-
-  return labels.map((label, i) => {
-    const stem = stems[i];
-    if (stem === undefined) return label;
-    return stemOccurrences.get(stem) === 1 ? stem : label;
-  });
 }
 
 function countUniqueLabels(result: string[] | undefined): number {

--- a/sdk/model/src/labels/linked_column_postfix.test.ts
+++ b/sdk/model/src/labels/linked_column_postfix.test.ts
@@ -1,0 +1,112 @@
+import { Annotation, type AxisSpec, type PColumnSpec } from "@milaboratories/pl-model-common";
+import { describe, expect, test } from "vitest";
+import { derivePostfixes } from "./linked_column_postfix";
+
+// Shared target axis: it's on the hit column, and every linker's hit-facing side carries it — this
+// is what lets `extractRoots` tell the source side (the "рут") from the target side.
+const TARGET: AxisSpec = { type: "String", name: "hitAxis" };
+
+const hit: PColumnSpec = {
+  kind: "PColumn",
+  name: "counts",
+  valueType: "Int",
+  axesSpec: [TARGET],
+  annotations: { [Annotation.Label]: "Counts" },
+} as PColumnSpec;
+
+/** A source-side axis, lives INSIDE a linker's axesSpec (never standalone). */
+function sourceAxis(name: string, label?: string, domain?: Record<string, string>): AxisSpec {
+  return {
+    type: "String",
+    name,
+    ...(domain ? { domain } : {}),
+    ...(label ? { annotations: { [Annotation.Label]: label } } : {}),
+  } as AxisSpec;
+}
+
+/** Linker column: bridges a source axis → the shared target axis; carries a LinkLabel. */
+function linker(linkLabel: string, src: AxisSpec, name = linkLabel): PColumnSpec {
+  return {
+    kind: "PColumn",
+    name,
+    valueType: "Int",
+    axesSpec: [src, TARGET],
+    annotations: { [Annotation.LinkLabel]: linkLabel },
+  } as PColumnSpec;
+}
+
+describe("prototype — structural postfix (difference of sources)", () => {
+  const axSample = sourceAxis("sampleId", "Sample");
+  const axClone = sourceAxis("cloneId", "Clone");
+
+  test("case 1 — same linker (label), different roots → postfix = root", () => {
+    const labels = derivePostfixes([
+      { stem: "Counts", hit, linkers: [linker("MapperA", axSample)] },
+      { stem: "Counts", hit, linkers: [linker("MapperA", axClone)] },
+    ]);
+    expect(labels).toEqual(["Counts via Sample", "Counts via Clone"]);
+  });
+
+  test("case 2 — different linkers, same root → postfix = linker", () => {
+    const labels = derivePostfixes([
+      { stem: "Counts", hit, linkers: [linker("MapperA", axSample)] },
+      { stem: "Counts", hit, linkers: [linker("MapperB", axSample)] },
+    ]);
+    expect(labels).toEqual(["Counts via MapperA", "Counts via MapperB"]);
+  });
+
+  test("case 3 — different linkers, different roots → root suffices (linker not added)", () => {
+    const labels = derivePostfixes([
+      { stem: "Counts", hit, linkers: [linker("MapperA", axSample)] },
+      { stem: "Counts", hit, linkers: [linker("MapperB", axClone)] },
+    ]);
+    expect(labels).toEqual(["Counts via Sample", "Counts via Clone"]);
+  });
+
+  test("roots share a Label but differ by domain → render only the differing domain key", () => {
+    const donorA = sourceAxis("donor", "Donor", { batch: "A" });
+    const donorB = sourceAxis("donor", "Donor", { batch: "B" });
+    const labels = derivePostfixes([
+      { stem: "Counts", hit, linkers: [linker("MapperA", donorA)] },
+      { stem: "Counts", hit, linkers: [linker("MapperA", donorB)] },
+    ]);
+    expect(labels).toEqual(["Counts via Donor[batch=A]", "Counts via Donor[batch=B]"]);
+  });
+
+  test("no collision → no postfix", () => {
+    const labels = derivePostfixes([
+      { stem: "Read counts" },
+      { stem: "Coverage", hit, linkers: [linker("MapperA", axSample)] },
+    ]);
+    expect(labels).toEqual(["Read counts", "Coverage"]);
+  });
+
+  test("collision only on a subset → bare row stays bare (direct column has no path)", () => {
+    const labels = derivePostfixes([
+      { stem: "Counts" }, // direct column, no path
+      { stem: "Counts", hit, linkers: [linker("MapperA", axSample)] },
+    ]);
+    expect(labels).toEqual(["Counts", "Counts via Sample"]);
+  });
+
+  test("mixed group — root+linker both needed globally; symmetric render, all unique", () => {
+    // A: MapperA+Sample, B: MapperA+Clone, C: MapperB+Clone
+    // root separates A from {B,C}; B vs C share root(Clone) → linker needed too.
+    const labels = derivePostfixes([
+      { stem: "Counts", hit, linkers: [linker("MapperA", axSample)] },
+      { stem: "Counts", hit, linkers: [linker("MapperA", axClone)] },
+      { stem: "Counts", hit, linkers: [linker("MapperB", axClone)] },
+    ]);
+    expect(labels).toEqual([
+      "Counts via Sample MapperA",
+      "Counts via Clone MapperA",
+      "Counts via Clone MapperB",
+    ]);
+  });
+
+  // Refinement (deferred): per-row minimal trim — row A only needs the root, so its ideal label is
+  // "Counts via Sample" without the redundant "MapperA". Requires an occurrence-count pass.
+  test.todo(
+    "per-row minimal trim: A should drop the non-load-bearing linker → 'Counts via Sample'",
+  );
+});

--- a/sdk/model/src/labels/linked_column_postfix.ts
+++ b/sdk/model/src/labels/linked_column_postfix.ts
@@ -1,0 +1,310 @@
+/**
+ * Structural postfix derivation for linked columns (phase 2 of `deriveDistinctLabels`).
+ *
+ * A linked column is
+ * reached by a CHAIN of linkers, and we distinguish two such columns by the same ideology the main
+ * algorithm uses — "find the minimal difference, escalate until unique" — over two dimensions:
+ *
+ *   - root:    the single source axis of the chain, derived from `linkers[0]` (one of its axesSpec).
+ *              This is "the source" — it's what we prefer to show ("difference of sources").
+ *   - linkers: the linker chain itself (by `LinkLabel`), a per-step fallback used only where roots
+ *              coincide.
+ *
+ * Nothing is stored redundantly: the caller passes the linker path (`linkers`) and the hit spec;
+ * root and every token are computed on the fly. The caller also supplies the `stem` (label+trace+
+ * quals from the existing single-entity machinery); this module only adds the path postfix, and
+ * only where stems collide.
+ */
+import {
+  Annotation,
+  canonicalizeJson,
+  getAxisId,
+  readAnnotation,
+  type AxisSpec,
+  type PColumnSpec,
+} from "@milaboratories/pl-model-common";
+import { isNil } from "es-toolkit";
+
+/**
+ * One entry to label: its stem plus the linker path that reached it (`linkers[0]` source-most) and
+ * the hit spec used to orient the chain. Plain columns pass neither.
+ */
+export type PostfixEntry = { stem: string; hit?: PColumnSpec; linkers?: PColumnSpec[] };
+
+/**
+ * One distinguishing piece of the postfix: the full source spec (axis or linker column — no info
+ * lost) plus `text`, the minimal text that sets it apart from the siblings (a label, or only the
+ * differing domain keys). Custom formatters may use `spec` freely; `text` is the default rendering.
+ */
+export type LinkerPart<Spec> = { spec: Spec; text: string };
+
+/** The distinguishing source of one column: its root axis (when it differs) + the linker chain. */
+export type LinkerParts = {
+  root?: LinkerPart<AxisSpec>;
+  linkers: LinkerPart<PColumnSpec>[];
+};
+
+/**
+ * Renders the postfix zone from the distinguishing sources. Default:
+ * `via ${[root, linkers.join(" > ")].filter(Boolean).join(" ")}` (using each piece's `text`).
+ * Returning `undefined` suppresses the postfix entirely (the column keeps just its stem).
+ */
+export type LinkerFormatter = (
+  parts: LinkerParts,
+  hit: PColumnSpec | undefined,
+  index: number,
+) => string | undefined;
+
+function defaultLinkerFormatter(parts: LinkerParts): string {
+  const chain = parts.linkers.map((l) => l.text).join(" > ");
+  const pieces = [parts.root?.text, chain || undefined].filter((p): p is string => !isNil(p));
+  return pieces.length === 0 ? "" : `via ${pieces.join(" ")}`;
+}
+
+// --- Node identity & minimal token (level 2: WHAT differs) -------------------
+
+type Identity = {
+  label?: string;
+  name: string;
+  domain?: Record<string, string>;
+  contextDomain?: Record<string, string>;
+};
+
+function axisIdentity(axis: AxisSpec): Identity {
+  const id = getAxisId(axis);
+  return {
+    label: readAnnotation(axis, Annotation.Label)?.trim() || undefined,
+    name: id.name,
+    domain: id.domain,
+    contextDomain: id.contextDomain,
+  };
+}
+
+/**
+ * A linker is named ONLY by its human label (`LinkLabel`/`Label`) — never by its technical column
+ * name. Returns `undefined` for an unlabeled linker, which callers treat as "not renderable": such a
+ * step is skipped, and disambiguation falls to another step or the root.
+ */
+function linkerIdentity(linker: PColumnSpec): Identity | undefined {
+  const label = (
+    readAnnotation(linker, Annotation.LinkLabel) ?? readAnnotation(linker, Annotation.Label)
+  )?.trim();
+  return label ? { label, name: label } : undefined;
+}
+
+/** Domain keys where `mine` differs from at least one competitor. */
+function differingKeys(
+  mine: Record<string, string> | undefined,
+  others: (Record<string, string> | undefined)[],
+): string[] {
+  const my = mine ?? {};
+  return [
+    ...others.reduce<Set<string>>((keys, o) => {
+      const od = o ?? {};
+      return [...new Set([...Object.keys(my), ...Object.keys(od)])].reduce(
+        (acc, k) => (my[k] !== od[k] ? acc.add(k) : acc),
+        keys,
+      );
+    }, new Set<string>()),
+  ];
+}
+
+function renderWithDomain(
+  base: string,
+  keys: string[],
+  domain: Record<string, string> | undefined,
+): string {
+  if (keys.length === 0) return base;
+  const d = domain ?? {};
+  const pairs = keys.map((k) => `${k}=${d[k] ?? "∅"}`).join(", ");
+  return `${base}[${pairs}]`;
+}
+
+/**
+ * Minimal token distinguishing `mine` from `others`: label → name → only the differing domain keys.
+ * Falls back to the bare label/name when indistinguishable at this dimension (another one covers it).
+ */
+function token(mine: Identity, others: Identity[]): string {
+  const base = mine.label ?? mine.name;
+  if (mine.label !== undefined && others.every((o) => o.label !== mine.label)) return mine.label;
+  if (others.every((o) => o.name !== mine.name)) return base;
+  const dk = differingKeys(
+    mine.domain,
+    others.map((o) => o.domain),
+  );
+  if (dk.length > 0) return renderWithDomain(base, dk, mine.domain);
+  const ck = differingKeys(
+    mine.contextDomain,
+    others.map((o) => o.contextDomain),
+  );
+  if (ck.length > 0) return renderWithDomain(base, ck, mine.contextDomain);
+  return base;
+}
+
+// --- Root extraction ---------------------------------------------------------
+
+/**
+ * The chain's single root: the source-side axis of `linkers[0]`. A linker bridges two axis groups;
+ * the side facing the next hop (`linkers[1]`, or the hit for a single-linker chain) is the target,
+ * the other side is the source → its axis is the root. `undefined` if `linkers[0]` is not a
+ * well-formed two-group linker.
+ */
+export function extractRoot(hit: PColumnSpec, linkers: PColumnSpec[]): AxisSpec | undefined {
+  const first = linkers[0];
+  if (first === undefined) return undefined;
+  const axes = first.axesSpec;
+  if (axes.length !== 2) return undefined;
+  const second = linkers[1] ?? hit;
+  return axes.find((a) => !second.axesSpec.some((b) => b.name === a.name));
+}
+
+// --- Structural diff (level 1: WHERE it differs) -----------------------------
+
+type Slot = { kind: "root" } | { kind: "linker"; i: number };
+
+const ABSENT = "__ABSENT__"; // sentinel for "this row has no value at this slot"
+
+/** A colliding group: entries + their derived roots + original indices + the postfix formatter. */
+type Group = {
+  entries: PostfixEntry[];
+  roots: (AxisSpec | undefined)[];
+  indices: number[];
+  format: LinkerFormatter;
+};
+
+function slotKey(group: Group, slot: Slot, row: number): string {
+  if (slot.kind === "root") {
+    const r = group.roots[row];
+    return r === undefined ? ABSENT : canonicalizeJson(getAxisId(r));
+  } else {
+    const l = group.entries[row].linkers?.[slot.i];
+    const id = l && linkerIdentity(l);
+    return isNil(id) ? ABSENT : canonicalizeJson(id);
+  }
+}
+
+function slotToken(group: Group, slot: Slot, row: number): string | undefined {
+  if (slot.kind === "root") {
+    const r = group.roots[row];
+    if (r === undefined) return undefined;
+    const comp = group.roots.filter((o, j) => j !== row && !isNil(o)).map((o) => axisIdentity(o!));
+    return token(axisIdentity(r), comp);
+  }
+  const l = group.entries[row].linkers?.[slot.i];
+  const id = l && linkerIdentity(l);
+  if (isNil(id)) return undefined; // unlabeled / absent linker → not renderable, skip
+  const comp = group.entries
+    .filter((_, j) => j !== row)
+    .map((e) => e.linkers?.[slot.i])
+    .map((x) => (x ? linkerIdentity(x) : undefined))
+    .filter((x): x is Identity => !isNil(x));
+  return token(id, comp);
+}
+
+function discriminates(group: Group, slot: Slot): boolean {
+  return new Set(group.entries.map((_, r) => slotKey(group, slot, r))).size > 1;
+}
+
+/** Render one row against a chosen slot set: the distinguishing root + linker pieces, formatted. */
+function renderRow(group: Group, slots: Slot[], row: number): string {
+  const rootSpec = group.roots[row];
+  const rootText = slots.some((s) => s.kind === "root")
+    ? slotToken(group, { kind: "root" }, row)
+    : undefined;
+  const root: LinkerPart<AxisSpec> | undefined =
+    rootSpec !== undefined && rootText !== undefined
+      ? { spec: rootSpec, text: rootText }
+      : undefined;
+
+  const linkers = slots
+    .filter((s): s is { kind: "linker"; i: number } => s.kind === "linker")
+    .sort((a, b) => a.i - b.i)
+    .map((s) => {
+      const spec = group.entries[row].linkers?.[s.i];
+      const text = slotToken(group, s, row);
+      return spec !== undefined && text !== undefined ? { spec, text } : undefined;
+    })
+    .filter((l): l is LinkerPart<PColumnSpec> => !isNil(l));
+
+  // No distinguishing pieces for this row → no postfix (don't invoke the formatter with empties).
+  if (root === undefined && linkers.length === 0) return "";
+  return group.format({ root, linkers }, group.entries[row].hit, group.indices[row]) ?? "";
+}
+
+function renderAll(group: Group, slots: Slot[]): string[] {
+  return group.entries.map((_, r) => renderRow(group, slots, r));
+}
+
+function allUnique(rendered: string[]): boolean {
+  return new Set(rendered).size === rendered.length;
+}
+
+/**
+ * Minimal slot set that makes the group unique. Escalate by priority (root, then linkers by step),
+ * then drop any redundant slot; render every row symmetrically against the result.
+ *
+ * KNOWN LIMITATION (review point): symmetric render can over-decorate a row in a mixed group (e.g.
+ * `via Sample MapperA` where `via Sample` alone is already unique for that row). Per-row trimming is
+ * a generalized `dropRedundantLinkerSuffix`; naive greedy trimming is unstable, so it's deferred.
+ */
+function resolveGroup(
+  entries: PostfixEntry[],
+  indices: number[],
+  format: LinkerFormatter,
+): string[] {
+  const group: Group = {
+    entries,
+    roots: entries.map((e) =>
+      e.hit && e.linkers?.length ? extractRoot(e.hit, e.linkers) : undefined,
+    ),
+    indices,
+    format,
+  };
+  const maxLen = Math.max(0, ...entries.map((e) => e.linkers?.length ?? 0));
+
+  const slots: Slot[] = [
+    { kind: "root" },
+    ...Array.from({ length: maxLen }, (_, i): Slot => ({ kind: "linker", i })),
+  ];
+
+  const escalated = slots.reduce<Slot[]>(
+    (acc, slot) =>
+      allUnique(renderAll(group, acc)) || !discriminates(group, slot) ? acc : (acc.push(slot), acc),
+    [],
+  );
+  const chosen = escalated.reduce<Slot[]>((acc, slot) => {
+    const trial = acc.filter((s) => s !== slot);
+    return allUnique(renderAll(group, trial)) ? trial : acc;
+  }, escalated);
+
+  return renderAll(group, chosen);
+}
+
+/**
+ * Full label per entry: `stem` plus, where stems collide, a minimal postfix distinguishing the
+ * linked columns by the difference between their sources.
+ */
+export function derivePostfixes(
+  entries: PostfixEntry[],
+  format: LinkerFormatter = defaultLinkerFormatter,
+): string[] {
+  const groups = entries.reduce<Map<string, number[]>>(
+    (acc, e, idx) => acc.set(e.stem, [...(acc.get(e.stem) ?? []), idx]),
+    new Map(),
+  );
+
+  const postfix = [...groups.values()].reduce<Map<number, string>>((acc, idxs) => {
+    if (idxs.length < 2) return acc; // stem already unique — no postfix
+    const resolved = resolveGroup(
+      idxs.map((i) => entries[i]),
+      idxs,
+      format,
+    );
+    return idxs.reduce((m, i, k) => m.set(i, resolved[k]), acc);
+  }, new Map());
+
+  return entries.map((e, i) => {
+    const p = postfix.get(i);
+    return p ? `${e.stem} ${p}` : e.stem;
+  });
+}

--- a/sdk/model/src/labels/linked_column_postfix.ts
+++ b/sdk/model/src/labels/linked_column_postfix.ts
@@ -47,7 +47,8 @@ export type LinkerParts = {
 /**
  * Renders the postfix zone from the distinguishing sources. Default:
  * `via ${[root, linkers.join(" > ")].filter(Boolean).join(" ")}` (using each piece's `text`).
- * Returning `undefined` suppresses the postfix entirely (the column keeps just its stem).
+ * Returning `undefined` — or the empty string `""` — suppresses the postfix entirely (the column
+ * keeps just its stem); the two are treated identically.
  */
 export type LinkerFormatter = (
   parts: LinkerParts,
@@ -61,16 +62,9 @@ function defaultLinkerFormatter(parts: LinkerParts): string {
   return pieces.length === 0 ? "" : `via ${pieces.join(" ")}`;
 }
 
-// --- Node identity & minimal token (level 2: WHAT differs) -------------------
+type AxisIdentity = { label?: string } & Pick<AxisSpec, "name" | "domain" | "contextDomain">;
 
-type Identity = {
-  label?: string;
-  name: string;
-  domain?: Record<string, string>;
-  contextDomain?: Record<string, string>;
-};
-
-function axisIdentity(axis: AxisSpec): Identity {
+function extractAxisIdentity(axis: AxisSpec): AxisIdentity {
   const id = getAxisId(axis);
   return {
     label: readAnnotation(axis, Annotation.Label)?.trim() || undefined,
@@ -85,7 +79,7 @@ function axisIdentity(axis: AxisSpec): Identity {
  * name. Returns `undefined` for an unlabeled linker, which callers treat as "not renderable": such a
  * step is skipped, and disambiguation falls to another step or the root.
  */
-function linkerIdentity(linker: PColumnSpec): Identity | undefined {
+function extractLinkerIdentity(linker: PColumnSpec): AxisIdentity | undefined {
   const label = (
     readAnnotation(linker, Annotation.LinkLabel) ?? readAnnotation(linker, Annotation.Label)
   )?.trim();
@@ -98,15 +92,21 @@ function differingKeys(
   others: (Record<string, string> | undefined)[],
 ): string[] {
   const my = mine ?? {};
-  return [
-    ...others.reduce<Set<string>>((keys, o) => {
-      const od = o ?? {};
-      return [...new Set([...Object.keys(my), ...Object.keys(od)])].reduce(
-        (acc, k) => (my[k] !== od[k] ? acc.add(k) : acc),
-        keys,
-      );
-    }, new Set<string>()),
-  ];
+  const diffKeys = new Set<string>();
+  for (const o of others) {
+    const od = o ?? {};
+    for (const k of Object.keys(my)) {
+      if (my[k] !== od[k]) {
+        diffKeys.add(k);
+      }
+    }
+    for (const k of Object.keys(od)) {
+      if (my[k] !== od[k]) {
+        diffKeys.add(k);
+      }
+    }
+  }
+  return [...diffKeys];
 }
 
 function renderWithDomain(
@@ -124,7 +124,7 @@ function renderWithDomain(
  * Minimal token distinguishing `mine` from `others`: label → name → only the differing domain keys.
  * Falls back to the bare label/name when indistinguishable at this dimension (another one covers it).
  */
-function token(mine: Identity, others: Identity[]): string {
+function deriveToken(mine: AxisIdentity, others: AxisIdentity[]): string {
   const base = mine.label ?? mine.name;
   if (mine.label !== undefined && others.every((o) => o.label !== mine.label)) return mine.label;
   if (others.every((o) => o.name !== mine.name)) return base;
@@ -141,8 +141,6 @@ function token(mine: Identity, others: Identity[]): string {
   return base;
 }
 
-// --- Root extraction ---------------------------------------------------------
-
 /**
  * The chain's single root: the source-side axis of `linkers[0]`. A linker bridges two axis groups;
  * the side facing the next hop (`linkers[1]`, or the hit for a single-linker chain) is the target,
@@ -158,8 +156,6 @@ export function extractRoot(hit: PColumnSpec, linkers: PColumnSpec[]): AxisSpec 
   return axes.find((a) => !second.axesSpec.some((b) => b.name === a.name));
 }
 
-// --- Structural diff (level 1: WHERE it differs) -----------------------------
-
 type Slot = { kind: "root" } | { kind: "linker"; i: number };
 
 const ABSENT = "__ABSENT__"; // sentinel for "this row has no value at this slot"
@@ -172,44 +168,46 @@ type Group = {
   format: LinkerFormatter;
 };
 
-function slotKey(group: Group, slot: Slot, row: number): string {
+function deriveSlotKey(group: Group, slot: Slot, row: number): string {
   if (slot.kind === "root") {
     const r = group.roots[row];
     return r === undefined ? ABSENT : canonicalizeJson(getAxisId(r));
   } else {
     const l = group.entries[row].linkers?.[slot.i];
-    const id = l && linkerIdentity(l);
+    const id = l && extractLinkerIdentity(l);
     return isNil(id) ? ABSENT : canonicalizeJson(id);
   }
 }
 
-function slotToken(group: Group, slot: Slot, row: number): string | undefined {
+function deriveSlotToken(group: Group, slot: Slot, row: number): string | undefined {
   if (slot.kind === "root") {
     const r = group.roots[row];
     if (r === undefined) return undefined;
-    const comp = group.roots.filter((o, j) => j !== row && !isNil(o)).map((o) => axisIdentity(o!));
-    return token(axisIdentity(r), comp);
+    const comp = group.roots
+      .filter((o, j) => j !== row && !isNil(o))
+      .map((o) => extractAxisIdentity(o!));
+    return deriveToken(extractAxisIdentity(r), comp);
   }
   const l = group.entries[row].linkers?.[slot.i];
-  const id = l && linkerIdentity(l);
+  const id = l && extractLinkerIdentity(l);
   if (isNil(id)) return undefined; // unlabeled / absent linker → not renderable, skip
   const comp = group.entries
     .filter((_, j) => j !== row)
     .map((e) => e.linkers?.[slot.i])
-    .map((x) => (x ? linkerIdentity(x) : undefined))
-    .filter((x): x is Identity => !isNil(x));
-  return token(id, comp);
+    .map((x) => (x ? extractLinkerIdentity(x) : undefined))
+    .filter((x): x is AxisIdentity => !isNil(x));
+  return deriveToken(id, comp);
 }
 
-function discriminates(group: Group, slot: Slot): boolean {
-  return new Set(group.entries.map((_, r) => slotKey(group, slot, r))).size > 1;
+function getDiscriminates(group: Group, slot: Slot): boolean {
+  return new Set(group.entries.map((_, r) => deriveSlotKey(group, slot, r))).size > 1;
 }
 
 /** Render one row against a chosen slot set: the distinguishing root + linker pieces, formatted. */
 function renderRow(group: Group, slots: Slot[], row: number): string {
   const rootSpec = group.roots[row];
   const rootText = slots.some((s) => s.kind === "root")
-    ? slotToken(group, { kind: "root" }, row)
+    ? deriveSlotToken(group, { kind: "root" }, row)
     : undefined;
   const root: LinkerPart<AxisSpec> | undefined =
     rootSpec !== undefined && rootText !== undefined
@@ -221,14 +219,16 @@ function renderRow(group: Group, slots: Slot[], row: number): string {
     .sort((a, b) => a.i - b.i)
     .map((s) => {
       const spec = group.entries[row].linkers?.[s.i];
-      const text = slotToken(group, s, row);
+      const text = deriveSlotToken(group, s, row);
       return spec !== undefined && text !== undefined ? { spec, text } : undefined;
     })
     .filter((l): l is LinkerPart<PColumnSpec> => !isNil(l));
 
   // No distinguishing pieces for this row → no postfix (don't invoke the formatter with empties).
   if (root === undefined && linkers.length === 0) return "";
-  return group.format({ root, linkers }, group.entries[row].hit, group.indices[row]) ?? "";
+  // A formatter may suppress the postfix by returning `undefined` or `""`; `|| ""` collapses both
+  // to the same empty value so neither counts as a distinguishing token during slot escalation.
+  return group.format({ root, linkers }, group.entries[row].hit, group.indices[row]) || "";
 }
 
 function renderAll(group: Group, slots: Slot[]): string[] {
@@ -269,7 +269,9 @@ function resolveGroup(
 
   const escalated = slots.reduce<Slot[]>(
     (acc, slot) =>
-      allUnique(renderAll(group, acc)) || !discriminates(group, slot) ? acc : (acc.push(slot), acc),
+      allUnique(renderAll(group, acc)) || !getDiscriminates(group, slot)
+        ? acc
+        : (acc.push(slot), acc),
     [],
   );
   const chosen = escalated.reduce<Slot[]>((acc, slot) => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the old single-pass linker-suffix approach in `deriveDistinctLabels` with a two-phase architecture: phase 1 (`deriveStems`) produces a minimal "stem" per column from its label, trace, and hit/anchor qualifications (no linker info), and phase 2 (`derivePostfixes`, new `linked_column_postfix.ts`) appends a "via …" postfix only where stems collide, choosing the minimal difference of source axes and linker chains. It also adds `repairBareByPresence` to fix columns that were previously distinguished only by absence of a peer's token, and narrows `discoverLabelColumns` to primary columns with `maxHops: 0`.

- **New `linked_column_postfix.ts`**: Implements phase 2 — groups entries by stem, escalates over root axis → linker chain slots until unique, exposes a richer `LinkerFormatter` API (`{ root, linkers }` instead of `string[]`).
- **`derive_distinct_labels.ts` refactored**: `LINKER_TYPE` synthetic trace entry and `dropRedundantLinkerSuffix` removed; new `repairBareByPresence` added; `LinkerStep.spec` narrowed from `PObjectSpec` to `PColumnSpec`.
- **`discoverLabelColumns` narrowed**: Only primary columns are used as anchors, `maxHops` hardcoded to `0` — prevents linked/secondary columns from being re-discovered as label columns.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after removing the dead debug data blob from createPlDataTableV3.ts — everything else is well-tested and logically sound.

The two-phase label derivation logic and the new postfix module are thoroughly tested and the algorithm is well-reasoned. One file, createPlDataTableV3.ts, contains a 107-line constant assigned to `_` that holds real-looking block IDs and serialized column specs — dead code that would ship in the built package as-is.

sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts — the const _ = [...] block at the bottom must be deleted before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/labels/linked_column_postfix.ts | New phase-2 postfix module: derives minimal "via …" suffixes for colliding linked columns by comparing root axes and linker chains; well-documented with a complete test suite covering all edge cases. |
| sdk/model/src/labels/derive_distinct_labels.ts | Refactored into two phases: deriveStems (phase 1, label+trace minimization, formerly the whole function) and derivePostfixes (phase 2, delegated to linked_column_postfix); removed LINKER_TYPE synthetic trace entry; added repairBareByPresence to un-bare columns distinguished only by absence. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | discoverLabelColumns call narrowed to primary-only columns; contains a 107-line dead debug data blob (const _ = [...]) that must be removed before merging. |
| sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts | discoverLabelColumns simplified: now uses only primary columns as anchors with maxHops=0 (direct-only), removing the secondary-column pass and computed maxHops; return type of discoverTableColumns widened to always-defined. |
| sdk/model/src/labels/derive_distinct_labels.test.ts | Tests updated for the two-phase architecture: new regression tests for "cluster-id preset" and "by-presence repair", updated expectations for minimal linker rendering, two qualification tests deferred to .todo. |
| sdk/model/src/labels/linked_column_postfix.test.ts | New test file covering derivePostfixes: root-only, linker-only, mixed-group, domain-qualified, no-collision, and collision-subset cases; one .todo deferred for per-row trimming. |
| etc/blocks/table-test/model/src/index.ts | Custom linker formatter updated from (string[]) to ({root, linkers}) shape to match the new LinkerFormatter API. |
| sdk/model/src/columns/column.ts | Cosmetic: import style changed from import type { ... } to import { type ... } per-identifier; no functional change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant DDL as deriveDistinctLabels
    participant DS as deriveStems (phase 1)
    participant DP as derivePostfixes (phase 2)
    participant RG as resolveGroup
    participant RPB as repairBareByPresence

    Caller->>DDL: entries[], options
    DDL->>DS: entries[], options
    DS->>DS: enrichRecord() — build trace (label + qual types, no linker)
    DS->>DS: minimizeTypeSet() — minimal discriminating type set
    DS->>DS: build() — render labels from minimized set
    DS->>RPB: rendered[], minimized, records, stats
    RPB->>RPB: find bare columns (distinguished only by absence)
    RPB->>RPB: bestDistinguishingType() per bare column
    RPB-->>DS: patched stems[]
    DS-->>DDL: stems[]
    DDL->>DP: "PostfixEntry[] {stem, hit, linkers[]}"
    DP->>DP: group entries by stem
    loop per colliding stem-group
        DP->>RG: group entries + indices
        RG->>RG: extractRoot() — source axis of linkers[0]
        RG->>RG: escalate slots (root → linker[0] → linker[1]…) until allUnique
        RG->>RG: drop redundant slots (greedy)
        RG->>RG: "renderAll() — format({ root, linkers }, hit, idx)"
        RG-->>DP: postfix strings[]
    end
    DP-->>DDL: final labels[] (stem + postfix or bare stem)
    DDL-->>Caller: string[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant DDL as deriveDistinctLabels
    participant DS as deriveStems (phase 1)
    participant DP as derivePostfixes (phase 2)
    participant RG as resolveGroup
    participant RPB as repairBareByPresence

    Caller->>DDL: entries[], options
    DDL->>DS: entries[], options
    DS->>DS: enrichRecord() — build trace (label + qual types, no linker)
    DS->>DS: minimizeTypeSet() — minimal discriminating type set
    DS->>DS: build() — render labels from minimized set
    DS->>RPB: rendered[], minimized, records, stats
    RPB->>RPB: find bare columns (distinguished only by absence)
    RPB->>RPB: bestDistinguishingType() per bare column
    RPB-->>DS: patched stems[]
    DS-->>DDL: stems[]
    DDL->>DP: "PostfixEntry[] {stem, hit, linkers[]}"
    DP->>DP: group entries by stem
    loop per colliding stem-group
        DP->>RG: group entries + indices
        RG->>RG: extractRoot() — source axis of linkers[0]
        RG->>RG: escalate slots (root → linker[0] → linker[1]…) until allUnique
        RG->>RG: drop redundant slots (greedy)
        RG->>RG: "renderAll() — format({ root, linkers }, hit, idx)"
        RG-->>DP: postfix strings[]
    end
    DP-->>DDL: final labels[] (stem + postfix or bare stem)
    DDL-->>Caller: string[]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Refactor label derivation logic to enhan..."](https://github.com/milaboratory/platforma/commit/f25c08f31503d981bc1d75b86b7cf24c74ae198b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45109812)</sub>

<!-- /greptile_comment -->