### PR TITLE
PFrames bump

### DIFF
--- a/.changeset/few-pans-lead.md
+++ b/.changeset/few-pans-lead.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+"@platforma-sdk/workflow-tengo": patch
+---
+
+PFrames bump

--- a/lib/ptabler/software/src/requirements.txt
+++ b/lib/ptabler/software/src/requirements.txt
@@ -1,7 +1,7 @@
 polars-lts-cpu==1.33.1
 polars-hash-lts-cpu==0.5.5
 polars-ds-lts-cpu==0.10.2
-polars-pf==1.1.55
+polars-pf==1.1.56
 duckdb==1.5.2
 pyarrow==24.0.0
 msgspec==0.19.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,14 +28,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.55
-      version: 1.1.55
+      specifier: 1.1.56
+      version: 1.1.56
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.55
-      version: 1.1.55
+      specifier: 1.1.56
+      version: 1.1.56
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.55
-      version: 1.1.55
+      specifier: 1.1.56
+      version: 1.1.56
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^2.0.1
       version: 2.0.1
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.11.2
-      version: 1.11.2
+      specifier: 1.11.4
+      version: 1.11.4
     '@platforma-open/milaboratories.software-conda-empty':
       specifier: ^1.0.1
       version: 1.0.1
@@ -2379,7 +2379,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2530,7 +2530,7 @@ importers:
         version: link:../../../tools/ts-configs
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.11.2
+        version: 1.11.4
       '@types/archiver':
         specifier: 'catalog:'
         version: 6.0.3
@@ -2557,10 +2557,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.55(encoding@0.1.13)
+        version: 1.1.56(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -3046,10 +3046,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.55(encoding@0.1.13)
+        version: 1.1.56(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3334,7 +3334,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.11.2
+        version: 1.11.4
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../../tools/block-tools
@@ -3343,7 +3343,7 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.11.2
+        version: 1.11.4
       '@platforma-sdk/block-tools':
         specifier: workspace:*
         version: link:../../tools/block-tools
@@ -3707,7 +3707,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.55
+        version: 1.1.56
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5430,18 +5430,18 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.55':
-    resolution: {integrity: sha512-TbudDPMixADLyVr5UsiXhf+zq7YCJA3osFrzDn7Lr5aeyorCjiXDkVOGKpID7GkkssuVsNpPXtoGdA71Y2tLjQ==}
+  '@milaboratories/pframes-rs-node@1.1.56':
+    resolution: {integrity: sha512-H6qltcR+HHb2kAy0U0zP90rqmv/MZGGkdXIyf89FUZTpoHOlXG4Ahxq7wXp9vviUczci4cLl2L0Q+dL2XGcsUA==}
 
-  '@milaboratories/pframes-rs-serv@1.1.55':
-    resolution: {integrity: sha512-cGByUULBA/JiwyFEBZrVNOEbnbrMPWWHCWLprRKlVWlmDMaRmsVft/tFpnle46BhDZWpoWbaKEZ8NGOtGqDCXw==}
+  '@milaboratories/pframes-rs-serv@1.1.56':
+    resolution: {integrity: sha512-Pi0CRuvkfL+PqdgQ8im0MW5tqVjUvJ8hJbOG7v5pS45adg8tuq4TyrAoWN7un9ZWQ6KRLypUD+7eXCwhjOwADg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.55':
-    resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
+  '@milaboratories/pframes-rs-wasip2@1.1.56':
+    resolution: {integrity: sha512-54bhC6XCAVO09J/sqVwEKA4hhTa27BDDNdH8BE+6+LvjBVkg/qq2/f0MzdrVijrmagbr97F1zgj5wIgUqwCSoA==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.55':
-    resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
+  '@milaboratories/pframes-rs-wasm@1.1.56':
+    resolution: {integrity: sha512-k/RQqiF+SwoOtFnYQ+i34Lzna8prOoFbLHaPY5oEUOrB/czehosFMzRQJAeFDKOxI/SbrH4D5jmWzTgUuhavLQ==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.2
@@ -5927,11 +5927,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0':
     resolution: {integrity: sha512-PRGkgsVY08tQvoucU8fJmeCF+x9XjiHHjNTbxWqddqx2EZpiUvmylkxtU8i8xJW13cesAI+xHv3NsVUXQaRDqA==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.22':
-    resolution: {integrity: sha512-8cFlOrT4lTSb/uz/T8CUYoJWhqFAheOVycne7HmMIsXPdeyF23iV0q9rV4w9bKSg+ER8qzkmSrxT/G8bF68oyA==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.24':
+    resolution: {integrity: sha512-5ne8Fmlhu1YKB5RYgq4c/AvYzb+sUY4hzv/bKIj0E3aDgJdMYO6M6lMicDzQTMagrGRu9FIhDewIgo++TX3+Yw==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.11.2':
-    resolution: {integrity: sha512-0mwC1U40h8tXp9qoA0eaVMgg2QWyQtJySRv58z/Hj8ILflLjsqBzfaTV9NvtA5Nt5Y61vfjizzTKsZdsVFcOHw==}
+  '@platforma-open/milaboratories.runenv-python-3@1.11.4':
+    resolution: {integrity: sha512-bxMOj9sN6/jn+iaR62R5vShdLgcJDZoCH/qKOoKaBHNp4LYZfgBKwGf6rGU5aXAoAAF/DcNsYrWguUT1HIvA7A==}
 
   '@platforma-open/milaboratories.software-conda-empty@1.0.1':
     resolution: {integrity: sha512-nftT6/lXdHvDu7Wedc3HCXiLrzHrIl7B4/8jRGgP5EAJy4agIrAk95Ht7/DGBzGIqXUkRdgN2XB46LxMWt1l3g==}
@@ -11042,18 +11042,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.55(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.56(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.55
+      '@milaboratories/pframes-rs-serv': 1.1.56
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.55':
+  '@milaboratories/pframes-rs-serv@1.1.56':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -11062,12 +11062,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.55': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.56': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.55
+      '@milaboratories/pframes-rs-wasip2': 1.1.56
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 
@@ -11465,11 +11465,11 @@ snapshots:
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.22': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.24': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.11.2':
+  '@platforma-open/milaboratories.runenv-python-3@1.11.4':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.22
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.24
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
       '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
       '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -258,9 +258,9 @@ catalog:
   # in case the changes are not backward-compatible. When adding new functionality - bump pframes-rs
   # and then `REQUIRES_PFRAMES_VERSION` after a week or two, to give the users time to update desktop
   # before SDK starts requiring a newer version of desktop.
-  "@milaboratories/pframes-rs-node": 1.1.55
-  "@milaboratories/pframes-rs-wasip2": 1.1.55
-  "@milaboratories/pframes-rs-wasm": 1.1.55
+  "@milaboratories/pframes-rs-node": 1.1.56
+  "@milaboratories/pframes-rs-wasip2": 1.1.56
+  "@milaboratories/pframes-rs-wasm": 1.1.56
 
   "quickjs-emscripten": 0.31.0
 
@@ -303,7 +303,7 @@ catalog:
   "@platforma-open/milaboratories.software-small-binaries": ^2.1.1
   "@platforma-open/milaboratories.software-test-utils": ^1.1.6
   "@platforma-open/milaboratories.software-conda-empty": ^1.0.1
-  "@platforma-open/milaboratories.runenv-python-3": 1.11.2
+  "@platforma-open/milaboratories.runenv-python-3": 1.11.4
 
   "shx": ^0.4.0
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a patch-level bump of the PFrames library suite (`@milaboratories/pframes-rs-*`) from `1.1.55` to `1.1.56` across all three runtime targets (node, wasm, wasip2), their Python counterpart `polars-pf` (`1.1.55` → `1.1.56`), and the Python runtime environment (`@platforma-open/milaboratories.runenv-python-3` `1.11.2` → `1.11.4`). Changeset entries are created for the four internal packages (`software-ptabler`, `pf-spec-driver`, `pf-driver`, `workflow-tengo`) that consume these dependencies.

- **pframes-rs bump (node / wasm / wasip2)**: All three runtime variants of the Rust-backed PFrames engine advance from `1.1.55` to `1.1.56`; the transitive `pframes-rs-serv` binary is updated in tandem.
- **Python environment bump**: `runenv-python-3` moves from `1.11.2` to `1.11.4` (skipping `1.11.3`), pulling in `runenv-python-3.12.10` from `1.3.22` to `1.3.24`; `polars-pf` in `requirements.txt` mirrors the pframes-rs patch version.
- **`REQUIRES_PFRAMES_VERSION` not changed**: The compatibility floor in `block_flags.ts` remains at `1_001_031` (`1.1.31`), consistent with the workspace comment that it only needs updating for backward-incompatible changes.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Straightforward patch-level version bumps with no structural changes; the lockfile and requirements.txt are kept in sync across all targets.

All changes are mechanical version increments across four pframes-rs targets, their Python mirror, and the Python runtime environment. The four internal consumer packages get patch changeset entries. The REQUIRES_PFRAMES_VERSION floor is intentionally left at 1.1.31 per the workspace comment (only moves on backward-incompatible changes). The one minor observation is the skipped intermediate versions in runenv-python-3 (1.11.3) and runenv-python-3.12.10 (1.3.23), which is cosmetic and likely reflects yanked releases upstream.

No files require special attention; pnpm-workspace.yaml and requirements.txt are the only editable sources and both look correct.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Catalog versions bumped for pframes-rs-{node,wasip2,wasm} (1.1.55→1.1.56) and runenv-python-3 (1.11.2→1.11.4); no structural changes. |
| pnpm-lock.yaml | Lock file regenerated to reflect all catalog version bumps; all four pframes-rs variants and runenv-python-3 snapshots updated consistently. |
| lib/ptabler/software/src/requirements.txt | polars-pf bumped from 1.1.55 to 1.1.56, keeping the Python package in sync with the Rust pframes-rs packages. |
| .changeset/few-pans-lead.md | Patch changeset correctly lists the four internal packages affected by the PFrames bump. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Catalog ["pnpm-workspace.yaml catalog"]
        A["@milaboratories/pframes-rs-node\n1.1.55 → 1.1.56"]
        B["@milaboratories/pframes-rs-wasm\n1.1.55 → 1.1.56"]
        C["@milaboratories/pframes-rs-wasip2\n1.1.55 → 1.1.56"]
        D["@platforma-open/milaboratories.runenv-python-3\n1.11.2 → 1.11.4"]
    end
    subgraph Transitive ["Transitive Dependencies"]
        E["@milaboratories/pframes-rs-serv\n1.1.55 → 1.1.56"]
        F["runenv-python-3.12.10\n1.3.22 → 1.3.24"]
    end
    subgraph Python ["Python (requirements.txt)"]
        G["polars-pf\n1.1.55 → 1.1.56"]
    end
    subgraph Consumers ["Internal packages (changeset)"]
        H["@milaboratories/pf-driver\npatch"]
        I["@milaboratories/pf-spec-driver\npatch"]
        J["@platforma-open/milaboratories.software-ptabler\npatch"]
        K["@platforma-sdk/workflow-tengo\npatch"]
    end
    A --> E
    D --> F
    A --> H
    A --> I
    B --> H
    B --> I
    C --> H
    C --> I
    G --> J
    A --> K
    B --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Catalog ["pnpm-workspace.yaml catalog"]
        A["@milaboratories/pframes-rs-node\n1.1.55 → 1.1.56"]
        B["@milaboratories/pframes-rs-wasm\n1.1.55 → 1.1.56"]
        C["@milaboratories/pframes-rs-wasip2\n1.1.55 → 1.1.56"]
        D["@platforma-open/milaboratories.runenv-python-3\n1.11.2 → 1.11.4"]
    end
    subgraph Transitive ["Transitive Dependencies"]
        E["@milaboratories/pframes-rs-serv\n1.1.55 → 1.1.56"]
        F["runenv-python-3.12.10\n1.3.22 → 1.3.24"]
    end
    subgraph Python ["Python (requirements.txt)"]
        G["polars-pf\n1.1.55 → 1.1.56"]
    end
    subgraph Consumers ["Internal packages (changeset)"]
        H["@milaboratories/pf-driver\npatch"]
        I["@milaboratories/pf-spec-driver\npatch"]
        J["@platforma-open/milaboratories.software-ptabler\npatch"]
        K["@platforma-sdk/workflow-tengo\npatch"]
    end
    A --> E
    D --> F
    A --> H
    A --> I
    B --> H
    B --> I
    C --> H
    C --> I
    G --> J
    A --> K
    B --> K
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apnpm-lock.yaml%3A5927-5938%0A**Skipped%20patch%20versions%20in%20runenv-python-3**%0A%0A%60runenv-python-3%60%20jumps%20from%20%601.11.2%60%20to%20%601.11.4%60%20%28skipping%20%601.11.3%60%29%20and%20%60runenv-python-3.12.10%60%20from%20%601.3.22%60%20to%20%601.3.24%60%20%28skipping%20%601.3.23%60%29.%20Were%20%601.11.3%60%20%2F%20%601.3.23%60%20yanked%20or%20broken%20releases%3F%20If%20so%2C%20a%20brief%20comment%20in%20the%20workspace%20catalog%20noting%20the%20skip%20would%20help%20future%20maintainers%20understand%20why%20the%20version%20gap%20exists.%0A%0A&repo=milaboratory%2Fplatforma&pr=1759&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-lock.yaml:5927-5938
**Skipped patch versions in runenv-python-3**

`runenv-python-3` jumps from `1.11.2` to `1.11.4` (skipping `1.11.3`) and `runenv-python-3.12.10` from `1.3.22` to `1.3.24` (skipping `1.3.23`). Were `1.11.3` / `1.3.23` yanked or broken releases? If so, a brief comment in the workspace catalog noting the skip would help future maintainers understand why the version gap exists.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["PFrames bump"](https://github.com/milaboratory/platforma/commit/db6bbfa9e0152e4b0e18bba67e901cfbd22943e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45659592)</sub>

<!-- /greptile_comment -->