### PR TITLE
Add Limit node to pframe QuerySpec/QueryData

### DIFF
--- a/.changeset/ecr-login-lock.md
+++ b/.changeset/ecr-login-lock.md
@@ -1,0 +1,6 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Fix concurrent `docker login` race during parallel software builds: serialize the ECR login
+across processes with a cross-process file lock, avoiding the macOS keychain -25299 error.

--- a/.changeset/three-pants-mix.md
+++ b/.changeset/three-pants-mix.md
@@ -2,6 +2,8 @@
 "@milaboratories/pl-model-common": patch
 "@milaboratories/pf-spec-driver": patch
 "@milaboratories/pf-driver": patch
+"@platforma-sdk/model": patch
 ---
 
-PFrames update
+PFrames update: add Limit query node. createPlDataTableV3 caps results at 50k
+rows when the runtime supports the pFrameQueryLimitSupport feature flag.

--- a/.changeset/three-pants-mix.md
+++ b/.changeset/three-pants-mix.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-model-common": patch
+"@milaboratories/pf-spec-driver": patch
+"@milaboratories/pf-driver": patch
+---
+
+PFrames update

--- a/lib/model/common/src/drivers/pframe/query/query_common.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_common.ts
@@ -919,6 +919,29 @@ export interface QueryFilter<Q, E> {
 }
 
 /**
+ * Limit query operation.
+ *
+ * Keeps only the first `fetch` records.
+ *
+ * **Behavior**:
+ * - All axes and columns pass through unchanged; only record count changes
+ * - Order is determined by the pending sort of the input (or axis order by default)
+ *
+ * @template Q - Input query type
+ *
+ * @example
+ * // Keep the first 100 records
+ * { type: 'limit', input: dataQuery, fetch: 100 }
+ */
+export interface QueryLimit<Q> {
+  type: "limit";
+  /** Input query to limit */
+  input: Q;
+  /** Maximum number of records to keep */
+  fetch: number;
+}
+
+/**
  * Column reference query (leaf node).
  *
  * References an existing column by its unique identifier.

--- a/lib/model/common/src/drivers/pframe/query/query_data.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_data.ts
@@ -23,6 +23,7 @@ import type {
   QueryFilter,
   QueryInlineColumn,
   QueryJoinEntry,
+  QueryLimit,
   QueryLinkerJoin,
   QueryOuterJoin,
   QuerySliceAxes,
@@ -101,6 +102,8 @@ export type DataQuerySliceAxes = QuerySliceAxes<DataQuery, number>;
 export type DataQuerySort = QuerySort<DataQuery, DataQueryExpression>;
 /** @see QueryFilter */
 export type DataQueryFilter = QueryFilter<DataQuery, DataQueryBooleanExpression>;
+/** @see QueryLimit */
+export type DataQueryLimit = QueryLimit<DataQuery>;
 /** @see QueryTransformColumns */
 export type DataQueryTransformColumns = QueryTransformColumns<
   DataQuery,
@@ -129,6 +132,7 @@ export type DataQuery =
   | DataQuerySliceAxes
   | DataQuerySort
   | DataQueryFilter
+  | DataQueryLimit
   | DataQueryTransformColumns;
 
 /** @see ExprAxisRef */

--- a/lib/model/common/src/drivers/pframe/query/query_spec.ts
+++ b/lib/model/common/src/drivers/pframe/query/query_spec.ts
@@ -24,6 +24,7 @@ import type {
   QueryFilter,
   QueryInlineColumn,
   QueryJoinEntry,
+  QueryLimit,
   QueryLinkerJoin,
   QueryOuterJoin,
   QuerySliceAxes,
@@ -88,6 +89,8 @@ export type SpecQueryFilter<C = ColumnUniversalId> = QueryFilter<
   SpecQuery<C>,
   SpecQueryBooleanExpression
 >;
+/** @see QueryLimit */
+export type SpecQueryLimit<C = ColumnUniversalId> = QueryLimit<SpecQuery<C>>;
 /** @see QueryTransformColumns */
 export type SpecQueryTransformColumns<C = ColumnUniversalId> = QueryTransformColumns<
   SpecQuery<C>,
@@ -131,6 +134,7 @@ export type SpecQuery<C = ColumnUniversalId> =
   | SpecQuerySliceAxes<C>
   | SpecQuerySort<C>
   | SpecQueryFilter<C>
+  | SpecQueryLimit<C>
   | SpecQueryTransformColumns<C>
   | SpecQuerySpecOverride<C>;
 

--- a/lib/model/common/src/drivers/pframe/query/utils.ts
+++ b/lib/model/common/src/drivers/pframe/query/utils.ts
@@ -95,6 +95,7 @@ export function traverseQuerySpec<C1, C2>(
     }
     case "filter":
     case "sort":
+    case "limit":
     case "sliceAxes":
     case "transformColumns":
     case "specOverride":
@@ -259,6 +260,12 @@ function cmpQuerySpec(lhs: SpecQuery, rhs: SpecQuery): number {
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
     case "filter":
       return cmpQuerySpec(lhs.input, (rhs as typeof lhs).input);
+    case "limit": {
+      const rhsLimit = rhs as typeof lhs;
+      const cmp = cmpQuerySpec(lhs.input, rhsLimit.input);
+      if (cmp !== 0) return cmp;
+      return lhs.fetch - rhsLimit.fetch;
+    }
     case "specOverride": {
       const rhsSo = rhs as typeof lhs;
       const cmp = cmpQuerySpec(lhs.input, rhsSo.input);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ catalogs:
     fast-json-patch:
       specifier: ^3.1.1
       version: 3.1.1
+    fd-lock:
+      specifier: ^2.2.0
+      version: 2.2.0
     fs-extra:
       specifier: ^11.2.0
       version: 11.3.0
@@ -4172,6 +4175,9 @@ importers:
       commander:
         specifier: 'catalog:'
         version: 15.0.0
+      fd-lock:
+        specifier: 'catalog:'
+        version: 2.2.0(bare-url@2.4.6)
       lru-cache:
         specifier: 'catalog:'
         version: 11.2.2
@@ -7075,15 +7081,56 @@ packages:
   b4a@1.6.6:
     resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-addon-resolve@1.10.1:
+    resolution: {integrity: sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
 
   bare-events@2.4.2:
     resolution: {integrity: sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
   bare-fs@4.0.1:
     resolution: {integrity: sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==}
     engines: {bare: '>=1.7.0'}
+
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-module-resolve@1.12.4:
+    resolution: {integrity: sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
 
   bare-os@3.4.0:
     resolution: {integrity: sha512-9Ous7UlnKbe3fMi7Y+qh0DwAup6A1JkYgPnjvMDNOlmnxNRQvQ/7Nst+OnUQKzk0iAT0m9BisbDVp9gCv8+ETA==}
@@ -7092,8 +7139,28 @@ packages:
   bare-path@3.0.0:
     resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
 
+  bare-semver@1.1.0:
+    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
   bare-stream@2.3.0:
     resolution: {integrity: sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==}
+
+  bare-url@2.4.6:
+    resolution: {integrity: sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -7650,6 +7717,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -7720,6 +7790,9 @@ packages:
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
+
+  fd-lock@2.2.0:
+    resolution: {integrity: sha512-Il4jWBhjjgvUg+z8d0bC7ncXqB42caqKTUpnZ9jpcqiPmw8bkIixt7Kic1czbZPMxAQD/9kEqfZ5Dq77nSll0w==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -7808,6 +7881,9 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fs-native-extensions@1.5.0:
+    resolution: {integrity: sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -8812,6 +8888,9 @@ packages:
     resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
     engines: {node: '>= 0.8.0'}
 
+  ready-resource@1.2.0:
+    resolution: {integrity: sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==}
+
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
@@ -8827,6 +8906,10 @@ packages:
 
   request-light@0.7.0:
     resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
+
+  require-addon@1.2.0:
+    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
+    engines: {bare: '>=1.10.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -8849,6 +8932,9 @@ packages:
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
+
+  resource-on-exit@1.0.0:
+    resolution: {integrity: sha512-ViJwJAknCkLRJRPR+9SISQQ7R5eRgtdIHLJsM2hHx1MweAJbJxJ5XnMjjq0Lc7ZGv44ufzAqds1nKxiVkdy4ag==}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -9101,6 +9187,9 @@ packages:
   streamx@2.20.1:
     resolution: {integrity: sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -9197,6 +9286,9 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -9624,6 +9716,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-runtime@1.4.0:
+    resolution: {integrity: sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -12710,10 +12805,20 @@ snapshots:
 
   b4a@1.6.6: {}
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
-  bare-events@2.4.2:
-    optional: true
+  bare-addon-resolve@1.10.1(bare-url@2.4.6):
+    dependencies:
+      bare-module-resolve: 1.12.4(bare-url@2.4.6)
+      bare-semver: 1.1.0
+    optionalDependencies:
+      bare-url: 2.4.6
+
+  bare-events@2.4.2: {}
+
+  bare-events@2.9.1: {}
 
   bare-fs@4.0.1:
     dependencies:
@@ -12722,19 +12827,50 @@ snapshots:
       bare-stream: 2.3.0
     optional: true
 
-  bare-os@3.4.0:
-    optional: true
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.0.0
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.6
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-module-resolve@1.12.4(bare-url@2.4.6):
+    dependencies:
+      bare-semver: 1.1.0
+    optionalDependencies:
+      bare-url: 2.4.6
+
+  bare-os@3.4.0: {}
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.4.0
-    optional: true
+
+  bare-semver@1.1.0: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   bare-stream@2.3.0:
     dependencies:
       b4a: 1.6.6
       streamx: 2.20.1
     optional: true
+
+  bare-url@2.4.6:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -13317,6 +13453,12 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
@@ -13416,6 +13558,18 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fd-lock@2.2.0(bare-url@2.4.6):
+    dependencies:
+      bare-fs: 4.7.4
+      fs-native-extensions: 1.5.0(bare-url@2.4.6)
+      ready-resource: 1.2.0
+      resource-on-exit: 1.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bare-url
+      - react-native-b4a
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -13500,6 +13654,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fs-native-extensions@1.5.0(bare-url@2.4.6):
+    dependencies:
+      require-addon: 1.2.0(bare-url@2.4.6)
+      which-runtime: 1.4.0
+    transitivePeerDependencies:
+      - bare-url
 
   fs.realpath@1.0.0: {}
 
@@ -14472,6 +14633,10 @@ snapshots:
 
   readline-sync@1.4.10: {}
 
+  ready-resource@1.2.0:
+    dependencies:
+      bare-events: 2.4.2
+
   rechoir@0.6.2:
     dependencies:
       resolve: 1.22.8
@@ -14483,6 +14648,12 @@ snapshots:
   regenerator-runtime@0.14.1: {}
 
   request-light@0.7.0: {}
+
+  require-addon@1.2.0(bare-url@2.4.6):
+    dependencies:
+      bare-addon-resolve: 1.10.1(bare-url@2.4.6)
+    transitivePeerDependencies:
+      - bare-url
 
   require-directory@2.1.1: {}
 
@@ -14499,6 +14670,8 @@ snapshots:
       is-core-module: 2.15.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  resource-on-exit@1.0.0: {}
 
   retry@0.12.0: {}
 
@@ -14825,6 +14998,14 @@ snapshots:
     optionalDependencies:
       bare-events: 2.4.2
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -14943,6 +15124,12 @@ snapshots:
       minizlib: 3.0.1
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
 
   term-size@2.2.1: {}
 
@@ -15321,6 +15508,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-runtime@1.4.0: {}
 
   which@1.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,14 +28,14 @@ catalogs:
       specifier: ^7.0.1
       version: 7.0.1
     '@milaboratories/pframes-rs-node':
-      specifier: 1.1.56
-      version: 1.1.56
+      specifier: 1.1.57
+      version: 1.1.57
     '@milaboratories/pframes-rs-wasip2':
-      specifier: 1.1.56
-      version: 1.1.56
+      specifier: 1.1.57
+      version: 1.1.57
     '@milaboratories/pframes-rs-wasm':
-      specifier: 1.1.56
-      version: 1.1.56
+      specifier: 1.1.57
+      version: 1.1.57
     '@milaboratories/software-pframes-conv':
       specifier: 2.2.9
       version: 2.2.9
@@ -2379,7 +2379,7 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.57(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../common
@@ -2557,10 +2557,10 @@ importers:
         version: link:../../util/helpers
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.56(encoding@0.1.13)
+        version: 1.1.57(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.57(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-model-common':
         specifier: workspace:*
         version: link:../../model/common
@@ -3046,10 +3046,10 @@ importers:
         version: link:../../model/pf-spec-driver
       '@milaboratories/pframes-rs-node':
         specifier: 'catalog:'
-        version: 1.1.56(encoding@0.1.13)
+        version: 1.1.57(encoding@0.1.13)
       '@milaboratories/pframes-rs-wasm':
         specifier: 'catalog:'
-        version: 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
+        version: 1.1.57(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)
       '@milaboratories/pl-client':
         specifier: workspace:*
         version: link:../pl-client
@@ -3707,7 +3707,7 @@ importers:
     dependencies:
       '@milaboratories/pframes-rs-wasip2':
         specifier: 'catalog:'
-        version: 1.1.56
+        version: 1.1.57
       '@milaboratories/software-pframes-conv':
         specifier: 'catalog:'
         version: 2.2.9
@@ -5430,18 +5430,18 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pframes-rs-node@1.1.56':
-    resolution: {integrity: sha512-H6qltcR+HHb2kAy0U0zP90rqmv/MZGGkdXIyf89FUZTpoHOlXG4Ahxq7wXp9vviUczci4cLl2L0Q+dL2XGcsUA==}
+  '@milaboratories/pframes-rs-node@1.1.57':
+    resolution: {integrity: sha512-k7WX8L58WcdLd5MneK9RScab1JUyYDb1DKo71q9vPoyC4c2xMJZTE+yvr0MFnym8AJFyf5rmC/PhioPDY1PVdg==}
 
-  '@milaboratories/pframes-rs-serv@1.1.56':
-    resolution: {integrity: sha512-Pi0CRuvkfL+PqdgQ8im0MW5tqVjUvJ8hJbOG7v5pS45adg8tuq4TyrAoWN7un9ZWQ6KRLypUD+7eXCwhjOwADg==}
+  '@milaboratories/pframes-rs-serv@1.1.57':
+    resolution: {integrity: sha512-fgdWnAGByTPeSFh6lw/FKj32nBeYuETVYjrYAkCNgF6iRtl3UZyMKtIP2rsrmoPpxOMP546gzxlb2nHkIp0ThA==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.56':
-    resolution: {integrity: sha512-54bhC6XCAVO09J/sqVwEKA4hhTa27BDDNdH8BE+6+LvjBVkg/qq2/f0MzdrVijrmagbr97F1zgj5wIgUqwCSoA==}
+  '@milaboratories/pframes-rs-wasip2@1.1.57':
+    resolution: {integrity: sha512-jqbcU1aZL0DoJF+yOHxr0pjNecN6mdyNVen96DER2tMEVZj1XvkyreiRM7qijhBIudKRlYAiBo3gMVg1oVECow==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.56':
-    resolution: {integrity: sha512-k/RQqiF+SwoOtFnYQ+i34Lzna8prOoFbLHaPY5oEUOrB/czehosFMzRQJAeFDKOxI/SbrH4D5jmWzTgUuhavLQ==}
+  '@milaboratories/pframes-rs-wasm@1.1.57':
+    resolution: {integrity: sha512-8KaPREf5s+0pWbN3qQi6u2kpK5Ck4L9As138nF/FGICGZJnqIDKXX/0vbwIPFavRpJQ8qrgR02h1Ol4vEbHCsg==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.2
@@ -11042,18 +11042,18 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pframes-rs-node@1.1.56(encoding@0.1.13)':
+  '@milaboratories/pframes-rs-node@1.1.57(encoding@0.1.13)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.56
+      '@milaboratories/pframes-rs-serv': 1.1.57
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.56':
+  '@milaboratories/pframes-rs-serv@1.1.57':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -11062,12 +11062,12 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.56': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.57': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
+  '@milaboratories/pframes-rs-wasm@1.1.57(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@lib+model+common)(@milaboratories/pl-model-middle-layer@lib+model+middle-layer)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.56
+      '@milaboratories/pframes-rs-wasip2': 1.1.57
       '@milaboratories/pl-model-common': link:lib/model/common
       '@milaboratories/pl-model-middle-layer': link:lib/model/middle-layer
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -258,9 +258,9 @@ catalog:
   # in case the changes are not backward-compatible. When adding new functionality - bump pframes-rs
   # and then `REQUIRES_PFRAMES_VERSION` after a week or two, to give the users time to update desktop
   # before SDK starts requiring a newer version of desktop.
-  "@milaboratories/pframes-rs-node": 1.1.56
-  "@milaboratories/pframes-rs-wasip2": 1.1.56
-  "@milaboratories/pframes-rs-wasm": 1.1.56
+  "@milaboratories/pframes-rs-node": 1.1.57
+  "@milaboratories/pframes-rs-wasip2": 1.1.57
+  "@milaboratories/pframes-rs-wasm": 1.1.57
 
   "quickjs-emscripten": 0.31.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -193,6 +193,8 @@ catalog:
 
   "commander": ^15.0.0
 
+  "fd-lock": ^2.2.0
+
   "turbo": 2.5.3
 
   "husky": ^9.1.7

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV3.ts
@@ -32,6 +32,7 @@ export function createPTableDefV3(params: {
   secondary: ColumnRecipe[];
   filters?: Nil | PlDataTableFilters;
   sorting?: Nil | PTableSorting[];
+  limit?: Nil | number;
 }): PTableDefV2<ColumnUniversalId> {
   let query: SpecQuery = {
     type: params.primaryJoinType === "inner" ? "innerJoin" : "fullJoin",
@@ -80,6 +81,10 @@ export function createPTableDefV3(params: {
         nullsFirst: s.naAndAbsentAreLeastValues,
       })),
     };
+  }
+
+  if (!isNil(params.limit)) {
+    query = { type: "limit", input: query, fetch: params.limit };
   }
 
   return { query };

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -97,12 +97,19 @@ export type ColumnVisibilityRule = {
   visibility: "default" | "optional" | "hidden";
 };
 
+/** Row cap applied to data-table queries when the runtime supports the limit node. */
+const PL_DATA_TABLE_ROW_LIMIT = 50_000;
+
 export function createPlDataTableV3<A, U>(
   ctx: RenderCtxBase<A, U>,
   options: createPlDataTableOptionsV3,
 ): PlDataTableModel | undefined {
   const state = upgradePlDataTableStateV2(options.tableState);
   const primaryJoinType = options.primaryJoinType ?? "full";
+
+  // Cap rows only when the desktop's pframe engine understands the `limit` query
+  // node; older runtimes silently ignore an unknown flag, so fall back to no limit.
+  const limit = ctx.featureFlags?.pFrameQueryLimitSupport && PL_DATA_TABLE_ROW_LIMIT;
 
   const resolved = resolveInputColumns(ctx, options);
   if (resolved === undefined) return undefined;
@@ -157,6 +164,7 @@ export function createPlDataTableV3<A, U>(
     secondary: [...direct, ...linked],
     filters,
     sorting,
+    limit,
   });
 
   const fullHandle = ctx.createPTableV2(fullDef);
@@ -193,6 +201,7 @@ export function createPlDataTableV3<A, U>(
     secondary: [...visible.direct, ...visible.linked],
     filters,
     sorting,
+    limit,
   });
   const visibleHandle = ctx.createPTableV2(visibleDef);
 

--- a/sdk/model/src/render/api.ts
+++ b/sdk/model/src/render/api.ts
@@ -603,10 +603,9 @@ export abstract class RenderCtxBase<Args = unknown, Data = unknown> {
     return getService(name);
   }
 
-  // /** Can be used to determine features provided by the desktop instance. */
-  // public get featureFlags() {
-  //   return this.ctx.featureFlags;
-  // }
+  public get featureFlags() {
+    return this.ctx.featureFlags;
+  }
 
   private getNamedAccessor(name: string): TreeNodeAccessor | undefined {
     return ifDef(

--- a/sdk/model/src/render/internal.ts
+++ b/sdk/model/src/render/internal.ts
@@ -214,6 +214,7 @@ export const GlobalCfgRenderCtxFeatureFlags = {
   pTablePartitionFiltersSupport: true as const,
   pFrameInSetFilterSupport: true as const,
   lazyColumnStatusSupport: true as const,
+  pFrameQueryLimitSupport: true as const,
 };
 
 export interface GlobalCfgRenderCtx extends GlobalCfgRenderCtxMethods, ServiceDispatch {

--- a/tools/block-tools/package.json
+++ b/tools/block-tools/package.json
@@ -46,6 +46,7 @@
     "@platforma-sdk/package-builder-lib": "workspace:*",
     "canonicalize": "catalog:",
     "commander": "catalog:",
+    "fd-lock": "catalog:",
     "lru-cache": "catalog:",
     "mime-types": "catalog:",
     "tar": "catalog:",

--- a/tools/block-tools/src/cmd/software/ecr-login.ts
+++ b/tools/block-tools/src/cmd/software/ecr-login.ts
@@ -1,9 +1,12 @@
 import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
 import * as os from "node:os";
+import * as path from "node:path";
 import {
   ECRPUBLICClient as EcrPublicClient,
   GetAuthorizationTokenCommand,
 } from "@aws-sdk/client-ecr-public";
+import FDLock from "fd-lock";
 import { util, defaults, type Logger } from "@platforma-sdk/package-builder-lib";
 
 const PUBLIC_ECR_HOST = "public.ecr.aws";
@@ -27,6 +30,19 @@ function registryHost(registry: string): string {
 function ssoLoginHint(): string {
   const profile = process.env.AWS_PROFILE ?? process.env.PL_AWS_PROFILE ?? defaults.AWS_DEV_PROFILE;
   return `  aws sso login --profile ${profile}`;
+}
+
+// Serialize `docker login` across processes: turbo logs every package in at once, and concurrent
+// writes to the shared per-host credential store race (macOS keychain fails with -25299).
+async function withHostLoginLock<T>(host: string, fn: () => T): Promise<T> {
+  const fd = fs.openSync(path.join(os.tmpdir(), `pl-ecr-login-${host}.lock`), "w");
+  const lock = new FDLock(fd, { wait: true });
+  await lock.ready();
+  try {
+    return fn();
+  } finally {
+    await lock.close(); // releases the flock and closes the fd
+  }
 }
 
 // docker login to public ECR with an SDK-fetched token. No cached-auth check — re-authenticates
@@ -64,11 +80,13 @@ export async function ensureEcrLogin(registry: string, logger?: Logger): Promise
     );
   }
 
-  const login = spawnSync("docker", ["login", "--username", user, "--password-stdin", host], {
-    input: password,
-    stdio: ["pipe", "inherit", "inherit"],
-    env: { ...process.env, HOME: process.env.HOME || os.homedir() },
-  });
+  const login = await withHostLoginLock(host, () =>
+    spawnSync("docker", ["login", "--username", user, "--password-stdin", host], {
+      input: password,
+      stdio: ["pipe", "inherit", "inherit"],
+      env: { ...process.env, HOME: process.env.HOME || os.homedir() },
+    }),
+  );
   if (login.error || login.status !== 0) {
     throw util.CLIError(`'docker login ${host}' failed`);
   }

--- a/tools/block-tools/src/cmd/software/fd-lock.d.ts
+++ b/tools/block-tools/src/cmd/software/fd-lock.d.ts
@@ -1,0 +1,11 @@
+// fd-lock ships no types. Minimal surface we use: a cross-process advisory lock (flock) over an fd.
+declare module "fd-lock" {
+  export default class FDLock {
+    constructor(fd: number, opts?: { wait?: boolean });
+    readonly locked: boolean;
+    /** Acquire the lock; blocks until available when constructed with { wait: true }. */
+    ready(): Promise<void>;
+    /** Release the lock and close the underlying fd. */
+    close(): Promise<void>;
+  }
+}


### PR DESCRIPTION
Mirrors the `QueryLimit` node added in pframes-rs 1.1.57.

## Changes
- `QueryLimit<Q>` interface in `query_common.ts` (`type: "limit"`, `input`, `fetch`)
- `SpecQueryLimit` / `DataQueryLimit` aliases + union members
- `limit` handled in `traverseQuerySpec` (input passthrough) and `cmpQuerySpec` (compares input, then `fetch`)
- Bump pframes-rs catalog to 1.1.57

`spec_override_collapse.ts` needs no change — its `default` branch already rejects `limit` as unsupported, matching sort/filter.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR mirrors the `QueryLimit` node introduced in `pframes-rs 1.1.57` by adding the corresponding TypeScript types and plumbing across the query layer. The implementation is clean and consistent with how existing wrapper nodes (`filter`, `sort`, `sliceAxes`) are handled.

- **New types** — `QueryLimit<Q>` generic interface in `query_common.ts`, with `DataQueryLimit` and `SpecQueryLimit<C>` aliases added to the respective union types.
- **`traverseQuerySpec`** — `"limit"` falls into the existing input-passthrough group; `cmpQuerySpec` gains a proper `limit` case that compares `input` first and then `fetch`.
- **Catalog bump** — `pframes-rs-node`, `pframes-rs-wasip2`, and `pframes-rs-wasm` updated from `1.1.56` to `1.1.57`; `REQUIRES_PFRAMES_VERSION` is intentionally left unchanged per the workspace convention (updated later to give desktop time to catch up).

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a straightforward type-layer addition with correct traversal and comparison logic.

The new limit node is wired up correctly in both traverseQuerySpec (input passthrough, identical to filter/sort) and cmpQuerySpec (compares input then fetch). The only gap is that utils.test.ts has no test exercising the limit path in traverseQuerySpec, so a future accidental breakage in that branch would go undetected.

utils.ts and utils.test.ts — the new limit case in traverseQuerySpec lacks a matching test.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/common/src/drivers/pframe/query/query_common.ts | Adds QueryLimit<Q> generic interface (type: 'limit', input, fetch) — well-documented, mirrors pframes-rs structure. |
| lib/model/common/src/drivers/pframe/query/query_data.ts | Adds DataQueryLimit alias and adds it to the DataQuery union — straightforward, consistent with other node aliases. |
| lib/model/common/src/drivers/pframe/query/query_spec.ts | Adds SpecQueryLimit<C> alias and adds it to the SpecQuery<C> union — correct and consistent. |
| lib/model/common/src/drivers/pframe/query/utils.ts | Adds 'limit' to traverseQuerySpec input-passthrough group and adds a cmpQuerySpec case comparing input then fetch; no new tests added for the limit case. |
| pnpm-workspace.yaml | Bumps pframes-rs-node, pframes-rs-wasip2, and pframes-rs-wasm from 1.1.56 to 1.1.57 in the catalog. |
| .changeset/three-pants-mix.md | Patch changeset for pl-model-common, pf-spec-driver, and pf-driver with 'PFrames update' description. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SpecQuery / DataQuery Union"] -->|new member| B["SpecQueryLimit / DataQueryLimit"]
    B --> C["QueryLimit (query_common.ts)"]
    C --> D["type: 'limit'"]
    C --> E["input: Q"]
    C --> F["fetch: number"]

    G["traverseQuerySpec"] -->|fall-through group| H["'filter' | 'sort' | 'limit' | 'sliceAxes' | .."]
    H --> I["result = { ...query, input: traverseQuerySpec(query.input, visitor) }"]

    J["cmpQuerySpec"] -->|case 'limit'| K["cmpQuerySpec(lhs.input, rhs.input)"]
    K -->|cmp !== 0| L["return cmp"]
    K -->|cmp === 0| M["return lhs.fetch - rhs.fetch"]

    N["pframes-rs catalog"] -->|bump 1.1.56 to 1.1.57| O["node / wasip2 / wasm"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Limit node to pframe QuerySpec/Query..."](https://github.com/milaboratory/platforma/commit/bc15113a91d36e1c9f5c70eefdd1b54e287febac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46216575)</sub>

<!-- /greptile_comment -->