### PR TITLE
MILAB-6132: fixes for default table filters

### DIFF
--- a/.changeset/pldatatable-default-filters-clearable.md
+++ b/.changeset/pldatatable-default-filters-clearable.md
@@ -1,0 +1,9 @@
+---
+"@platforma-sdk/ui-vue": patch
+"@platforma-sdk/model": patch
+---
+
+PlDataTable: allow the default filter group to be fully cleared, and harden filter merging.
+
+- `PlAdvancedFilter`: when the last leaf of a non-removable group (e.g. the pinned default-filters group) is deleted, keep it as an empty group instead of splicing the whole group out. This lets the default-filters group be emptied (previously the last default filter could not be removed); the group's reset still restores the defaults.
+- `createPlDataTableV3.concatFilters`: AND-combine operands that are not `and` groups (a bare leaf, a `not`, or an `or` group) by treating them as single members, instead of assuming every operand has a `.filters` array. Fixes a `TypeError` crash when the persisted filter state is a lone leaf (e.g. a single sheet selection) and a case where an `or` root was incorrectly OR-merged with the defaults.

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { concatFilters } from "./createPlDataTableV3";
+import type { PlDataTableFilters, PlDataTableFilterSpecLeaf } from "../typesV8";
+
+// concatFilters only inspects each operand's `.type` (and spreads `.filters` of
+// an "and" node), so the leaf payload is irrelevant — minimal shapes suffice.
+type Node = PlDataTableFilters | PlDataTableFilterSpecLeaf;
+
+const leaf = (id: string): PlDataTableFilterSpecLeaf =>
+  ({ type: "isNA", column: { type: "column", id } }) as unknown as PlDataTableFilterSpecLeaf;
+const and = (...filters: Node[]): PlDataTableFilters =>
+  ({ type: "and", filters }) as unknown as PlDataTableFilters;
+const or = (...filters: Node[]): PlDataTableFilters =>
+  ({ type: "or", filters }) as unknown as PlDataTableFilters;
+const not = (filter: Node): PlDataTableFilters =>
+  ({ type: "not", filter }) as unknown as PlDataTableFilters;
+
+describe("concatFilters", () => {
+  test("a nil operand returns the other side unchanged", () => {
+    const a = and(leaf("x"));
+    expect(concatFilters(null, a)).toBe(a);
+    expect(concatFilters(a, null)).toBe(a);
+    expect(concatFilters(null, null)).toBeNull();
+  });
+
+  test("two AND groups merge their children", () => {
+    expect(concatFilters(and(leaf("u1"), leaf("u2")), and(leaf("d1")))).toEqual(
+      and(leaf("u1"), leaf("u2"), leaf("d1")),
+    );
+  });
+
+  test("a bare leaf is combined as a single AND operand (no crash)", () => {
+    // Regression: a lone sheet-selection leaf used to throw on `[...a.filters]`.
+    expect(concatFilters(leaf("sheet"), and(leaf("d1"), leaf("d2")))).toEqual(
+      and(leaf("sheet"), leaf("d1"), leaf("d2")),
+    );
+    // ...and on either side.
+    expect(concatFilters(and(leaf("u1")), leaf("d"))).toEqual(and(leaf("u1"), leaf("d")));
+  });
+
+  test("an OR group is preserved as one operand, not flattened into AND", () => {
+    // Regression: old code kept type "or" (or spread the OR's children into the
+    // AND), turning "d1 OR d2" into "d1 AND d2".
+    expect(concatFilters(or(leaf("u1"), leaf("u2")), and(leaf("d1")))).toEqual(
+      and(or(leaf("u1"), leaf("u2")), leaf("d1")),
+    );
+    expect(concatFilters(and(leaf("u1")), or(leaf("d1"), leaf("d2")))).toEqual(
+      and(leaf("u1"), or(leaf("d1"), leaf("d2"))),
+    );
+  });
+
+  test("an empty AND group contributes nothing", () => {
+    expect(concatFilters(and(), and(leaf("d1")))).toEqual(and(leaf("d1")));
+    expect(concatFilters(and(leaf("u1")), and())).toEqual(and(leaf("u1")));
+  });
+
+  test("a NOT node is combined as a single operand (no crash)", () => {
+    const n = not(leaf("x"));
+    expect(concatFilters(n, and(leaf("d1")))).toEqual(and(n, leaf("d1")));
+  });
+});

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -393,7 +393,13 @@ function concatFilters(
 ): Nil | PlDataTableFilters {
   if (isNil(a)) return b;
   if (isNil(b)) return a;
-  return { ...a, filters: [...a.filters, ...b.filters] };
+  // AND-combine: spread the children of an "and" root, and treat anything else
+  // (a bare leaf, a "not", or an "or" root) as a single operand. The persisted
+  // `filters` state can be a bare leaf (e.g. a lone sheet selection) even though
+  // the type says it is a root group, so we must not assume `.filters` exists.
+  const operands = (f: PlDataTableFilters): PlDataTableFilterNode[] =>
+    f.type === "and" ? f.filters : [f as PlDataTableFilterNode];
+  return { type: "and", filters: [...operands(a), ...operands(b)] };
 }
 
 /** Pick user sorting from state if set, otherwise fall back to options default.

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -386,8 +386,9 @@ function filterFilters(
   return prune(filters) as Nil | PlDataTableFilters;
 }
 
-/** Merge two filter trees into one AND-combined tree. Returns the non-nil one if the other is nil. */
-function concatFilters(
+/** Merge two filter trees into one AND-combined tree. Returns the non-nil one if the other is nil.
+ *  Exported for unit testing. */
+export function concatFilters(
   a: Nil | PlDataTableFilters,
   b: Nil | PlDataTableFilters,
 ): Nil | PlDataTableFilters {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -394,10 +394,6 @@ export function concatFilters(
 ): Nil | PlDataTableFilters {
   if (isNil(a)) return b;
   if (isNil(b)) return a;
-  // AND-combine: spread the children of an "and" root, and treat anything else
-  // (a bare leaf, a "not", or an "or" root) as a single operand. The persisted
-  // `filters` state can be a bare leaf (e.g. a lone sheet selection) even though
-  // the type says it is a root group, so we must not assume `.filters` exists.
   const operands = (f: PlDataTableFilters): PlDataTableFilterNode[] =>
     f.type === "and" ? f.filters : [f as PlDataTableFilterNode];
   return { type: "and", filters: [...operands(a), ...operands(b)] };

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
@@ -126,11 +126,7 @@ function removeFilterFromGroup(groupIdx: number, filterIdx: number) {
   produceFiltersUpdate((draft: RootFilter) => {
     const group = getDraftGroupContent(draft, groupIdx);
     const removingLastLeaf = group.filters.length === 1 && filterIdx === 0;
-    // Auto-remove the whole group when its last leaf is deleted — but only if the
-    // group is removable. A non-removable group (e.g. a pinned default-filters
-    // group) must persist as an empty group instead of being spliced out, so the
-    // consumer keeps a stable group it can distinguish as "emptied" (and reset),
-    // rather than "deleted".
+
     if (removingLastLeaf && props.isRemovable(draft.filters[groupIdx], groupIdx)) {
       draft.filters.splice(groupIdx, 1);
     } else {

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
@@ -125,7 +125,13 @@ function addColumnToGroup(groupIdx: number, selectedSourceId: PlAdvancedFilterCo
 function removeFilterFromGroup(groupIdx: number, filterIdx: number) {
   produceFiltersUpdate((draft: RootFilter) => {
     const group = getDraftGroupContent(draft, groupIdx);
-    if (group.filters.length === 1 && filterIdx === 0) {
+    const removingLastLeaf = group.filters.length === 1 && filterIdx === 0;
+    // Auto-remove the whole group when its last leaf is deleted — but only if the
+    // group is removable. A non-removable group (e.g. a pinned default-filters
+    // group) must persist as an empty group instead of being spliced out, so the
+    // consumer keeps a stable group it can distinguish as "emptied" (and reset),
+    // rather than "deleted".
+    if (removingLastLeaf && props.isRemovable(draft.filters[groupIdx], groupIdx)) {
       draft.filters.splice(groupIdx, 1);
     } else {
       group.filters.splice(filterIdx, 1);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes clearing and composition of default table filters.
- `PlAdvancedFilter` — the Vue filter-tree editor; deleting the final leaf now preserves non-removable groups as empty groups so pinned defaults remain resettable.
- `PlDataTableFilters` — the model type representing a table filter tree; leaf, `not`, and `or` roots are now preserved as individual operands when combined with defaults.
- `concatFilters` — the helper that combines persisted and default filters; it now produces an AND-combined tree while flattening only existing `and` roots.
- `PlDataTableFilterSpecLeaf` — a terminal filter condition associated with a column; lone leaves are now accepted during filter merging instead of causing access to a missing `.filters` array.
- Regression tests cover nil operands, leaves, `and`, `or`, `not`, and empty `and` groups.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed filter composition and empty-group paths behaving consistently with their downstream consumers.

Non-AND roots are preserved as operands under a new AND root, empty merged groups are pruned safely, and preserved non-removable UI groups remain editable and resettable without affecting query semantics.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Correctly normalizes heterogeneous filter roots into an AND tree and avoids assuming every operand exposes a filters array. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.test.ts | Adds focused regression coverage for all relevant root shapes and empty-group behavior. |
| sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue | Preserves a non-removable group after its final leaf is deleted while retaining existing behavior for removable groups. |
| .changeset/pldatatable-default-filters-clearable.md | Accurately documents the model and UI package fixes and their user-visible motivation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  U[Persisted user filters] --> C[concatFilters]
  D[Default filters] --> C
  C --> A[AND-combined filter tree]
  A --> R[Resolve and prune column references]
  R --> T[Table query]
  E[Delete final default-filter leaf] --> P[Preserve empty non-removable group]
  P --> S[Resettable default-filter state]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(PlDataTable): unit-test concatFilte..."](https://github.com/milaboratory/platforma/commit/5d2c31cf2db80511c1abd54af5322862962b667f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47556467)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Block model](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-model.md)
- Knowledge Base — [UI Vue SDK and Component Library](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/ui-vue-sdk.md)
</details>

<!-- /greptile_comment -->