### PR TITLE
MILAB-6651: pin cellLinker side assignment in the TS linker engine

### DIFF
--- a/.changeset/milab-6651-linker-side-assignment-tests.md
+++ b/.changeset/milab-6651-linker-side-assignment-tests.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only change. Adds characterisation tests for `LinkerMap` linker side
+assignment (MILAB-6651). No API, behaviour, or type changes, so no release is
+needed.

--- a/lib/model/common/src/drivers/pframe/linker_columns.test.ts
+++ b/lib/model/common/src/drivers/pframe/linker_columns.test.ts
@@ -347,16 +347,25 @@ describe("MILAB-6651 cellLinker side assignment", () => {
     to: [axisSampleId, axisCellId],
   });
 
+  /**
+   * Group membership as a sorted set. `getAxesGroups` documents "There are no order
+   * inside every group" (`linker_columns.ts:271`), so asserting a particular order
+   * *within* a group would pin an implementation detail the source explicitly
+   * disclaims. Which group comes *first* is what side assignment reads, and that is
+   * asserted positionally.
+   */
+  const names = (axes: AxisSpecNormalized[]) => axes.map((a) => a.name).sort();
+
   test("grouping order puts the sample/cell component first, so it becomes the one-side", () => {
     const groups = LinkerMap.getAxesGroups(
       getNormalizedAxesList([axisSampleId, axisCellId, axisClonotype]),
     );
 
     expect(groups.length).toBe(2);
-    // groups[0] is destructured as `left` — the one-side. This is inverted:
+    // groups[0] is destructured as `left` — the one-side. That is inverted:
     // {sampleId, cellId} is the many-side in reality.
-    expect(groups[0].map((a) => a.name)).toEqual(["sampleId", "cellId"]);
-    expect(groups[1].map((a) => a.name)).toEqual(["scClonotypeKey"]);
+    expect(names(groups[0])).toEqual(["cellId", "sampleId"]);
+    expect(names(groups[1])).toEqual(["scClonotypeKey"]);
   });
 
   test("a clonotype-keyed source reaches cell-level axes today (the leakage)", () => {
@@ -389,25 +398,40 @@ describe("MILAB-6651 cellLinker side assignment", () => {
   });
 
   /**
-   * H3 (partial) — cross-engine parity.
+   * Exhaustive companion to the ordering test above, and the TS mirror of
+   * `split_component_order_follows_authoring_order_for_every_permutation` in
+   * pframes-rs `axes_spec.rs`.
    *
-   * The Rust `LinkerIndex` and this TS `LinkerMap` are independent implementations
-   * of the same convention. Rust gets its component ordering from
-   * `disjoint::DisjointSet::sets()`; TS derives it from its own index scan
-   * (`getAxesGroups`, `linker_columns.ts:304,330`). Nothing links the two, and they
-   * have already drifted twice (malformed-linker handling, `excludeColumns`).
+   * Group *membership* must not depend on authoring order; which group comes *first*
+   * must. That distinction is the whole of MILAB-6651 — the cellLinker's axes group
+   * correctly however they are written down, and it is purely their position that
+   * decides which component gets treated as the one-side. So no structural rule can
+   * recover the intended direction; it has to be declared or read from data.
    *
-   * This asserts the TS half of the shared expectation. The Rust half is
-   * `cell_linker_sides_are_inverted_today` in `linker_index.rs`. Keeping them in
-   * sync is manual — a genuine shared fixture would need a generated contract.
+   * Note the two engines reach this ordering independently: Rust via
+   * `disjoint::DisjointSet::sets()`, TS via its own index scan (`linker_columns.ts:304,330`).
+   * Nothing couples them, and they have already drifted twice (malformed-linker
+   * handling, `excludeColumns` support), so both sides assert it separately. A real
+   * shared fixture would need a generated cross-repo contract.
    */
-  test("parity: TS groups the real cellLinker the same way Rust splits it", () => {
-    const groups = LinkerMap.getAxesGroups(
-      getNormalizedAxesList([axisSampleId, axisCellId, axisClonotype]),
-    );
+  test("grouping is authoring-order independent, but group position is not", () => {
+    const normalized = getNormalizedAxesList([axisSampleId, axisCellId, axisClonotype]);
 
-    // Mirrors Rust: one_side_axes_ids().len() == 2, many_side_axes() == [scClonotypeKey].
-    expect(groups[0].length).toBe(2);
-    expect(groups[1].map((a) => a.name)).toEqual(["scClonotypeKey"]);
+    for (const order of allPermutations(normalized)) {
+      const groups = LinkerMap.getAxesGroups(order);
+      expect(groups.length).toBe(2);
+
+      // Membership is invariant across all 6 orderings.
+      expect(groups.map(names).sort((a, b) => a[0].localeCompare(b[0]))).toEqual([
+        ["cellId", "sampleId"],
+        ["scClonotypeKey"],
+      ]);
+
+      // Position tracks the earliest-written member of each group — which is exactly
+      // why a mis-authored linker inverts its own sides.
+      const earliest = (group: AxisSpecNormalized[]) =>
+        Math.min(...group.map((a) => order.findIndex((o) => o.name === a.name)));
+      expect(earliest(groups[0])).toBeLessThan(earliest(groups[1]));
+    }
   });
 });

--- a/lib/model/common/src/drivers/pframe/linker_columns.test.ts
+++ b/lib/model/common/src/drivers/pframe/linker_columns.test.ts
@@ -314,3 +314,100 @@ describe("Linker columns", () => {
     expect(linkerMap.getReachableByLinkersAxesFromAxes([axisA])).toEqual([]);
   });
 });
+
+/**
+ * MILAB-6651 — side assignment for the real `pl7.app/sc/cellLinker`.
+ *
+ * In the data, many cells map to ONE clonotype, so the clonotype is the linker's
+ * one-side and the sample/cell pair is its many-side. `mixcr-clonotyping` authors
+ * the axes as `[sampleId, cellId <- sampleId, scClonotypeKey]`, and side assignment
+ * is purely positional — `getAxesGroups` returns groups ordered by their smallest
+ * contained index and `fromColumns` destructures `const [left, right] = groups`
+ * (`linker_columns.ts:53`). So the engine reads the sides backwards.
+ *
+ * These are characterization tests: they assert the WRONG behaviour that exists
+ * today. When explicit sides land, they must flip — and that flip is the proof.
+ */
+describe("MILAB-6651 cellLinker side assignment", () => {
+  const axisSampleId = makeTestAxis({ name: "sampleId" });
+  const axisCellId = makeTestAxis({ name: "cellId", parents: [axisSampleId] });
+  const axisClonotype = makeTestAxis({ name: "scClonotypeKey" });
+
+  /** `[sampleId, cellId <- sampleId, scClonotypeKey]` — the layout as authored. */
+  const asAuthored = makeLinkerColumn({
+    name: "cellLinker",
+    from: [axisSampleId, axisCellId],
+    to: [axisClonotype],
+  });
+
+  /** The same linker with the clonotype component authored first. */
+  const corrected = makeLinkerColumn({
+    name: "cellLinker",
+    from: [axisClonotype],
+    to: [axisSampleId, axisCellId],
+  });
+
+  test("grouping order puts the sample/cell component first, so it becomes the one-side", () => {
+    const groups = LinkerMap.getAxesGroups(
+      getNormalizedAxesList([axisSampleId, axisCellId, axisClonotype]),
+    );
+
+    expect(groups.length).toBe(2);
+    // groups[0] is destructured as `left` — the one-side. This is inverted:
+    // {sampleId, cellId} is the many-side in reality.
+    expect(groups[0].map((a) => a.name)).toEqual(["sampleId", "cellId"]);
+    expect(groups[1].map((a) => a.name)).toEqual(["scClonotypeKey"]);
+  });
+
+  test("a clonotype-keyed source reaches cell-level axes today (the leakage)", () => {
+    const linkerMap = LinkerMap.fromColumns([asAuthored]);
+
+    // Edges are stored many-side -> one-side (`linker_columns.ts:91`), so with the
+    // sides inverted a clonotype-keyed table can traverse down to per-cell axes.
+    // This is what puts cell-level columns into a clonotype-keyed p-frame.
+    expect(
+      new Set(linkerMap.getReachableByLinkersAxesFromAxes([axisClonotype]).map((a) => a.name)),
+    ).toEqual(new Set(["cellId", "sampleId"]));
+  });
+
+  test("a cell-keyed source cannot reach the clonotype today (the lost capability)", () => {
+    // The trunk must carry the whole parent tree. Linker map keys are built from
+    // `getArrayFromAxisTree`, so the cell trunk's key is [cellId, sampleId]; passing
+    // cellId alone yields the key [cellId] and misses for an unrelated reason.
+    const cellTrunk = [axisSampleId, axisCellId];
+
+    const asAuthoredMap = LinkerMap.fromColumns([asAuthored]);
+    expect(asAuthoredMap.getReachableByLinkersAxesFromAxes(cellTrunk)).toEqual([]);
+
+    // Authoring the same linker with correct sides makes the intended cell ->
+    // clonotype enrichment appear, and removes the reverse traversal.
+    const correctedMap = LinkerMap.fromColumns([corrected]);
+    expect(correctedMap.getReachableByLinkersAxesFromAxes(cellTrunk).map((a) => a.name)).toEqual([
+      "scClonotypeKey",
+    ]);
+    expect(correctedMap.getReachableByLinkersAxesFromAxes([axisClonotype])).toEqual([]);
+  });
+
+  /**
+   * H3 (partial) — cross-engine parity.
+   *
+   * The Rust `LinkerIndex` and this TS `LinkerMap` are independent implementations
+   * of the same convention. Rust gets its component ordering from
+   * `disjoint::DisjointSet::sets()`; TS derives it from its own index scan
+   * (`getAxesGroups`, `linker_columns.ts:304,330`). Nothing links the two, and they
+   * have already drifted twice (malformed-linker handling, `excludeColumns`).
+   *
+   * This asserts the TS half of the shared expectation. The Rust half is
+   * `cell_linker_sides_are_inverted_today` in `linker_index.rs`. Keeping them in
+   * sync is manual — a genuine shared fixture would need a generated contract.
+   */
+  test("parity: TS groups the real cellLinker the same way Rust splits it", () => {
+    const groups = LinkerMap.getAxesGroups(
+      getNormalizedAxesList([axisSampleId, axisCellId, axisClonotype]),
+    );
+
+    // Mirrors Rust: one_side_axes_ids().len() == 2, many_side_axes() == [scClonotypeKey].
+    expect(groups[0].length).toBe(2);
+    expect(groups[1].map((a) => a.name)).toEqual(["scClonotypeKey"]);
+  });
+});


### PR DESCRIPTION
## What this does

Adds characterisation tests for `LinkerMap`, mirroring tests added to pframes-rs. Test-only change.

They assert the behaviour that exists **today**, which is wrong. They must flip when linker sides become explicit, and that flip is the proof the fix worked.

## Why LinkerMap needs its own tests

Two engines implement the same linker convention. Rust `LinkerIndex` plans queries inside pframes-rs. This TS `LinkerMap` collects columns at model time — `sdk/model/src/render/util/column_collection.ts:520` and `sdk/model/src/pframe_utils/axes.ts:77` — where only specs are available and `pl-model-common` deliberately carries no pframes-rs dependency.

Both derive component ordering independently: Rust from `disjoint::DisjointSet::sets()`, TS from its own index scan in `getAxesGroups`. Nothing couples them, and they have already drifted twice — Rust hard-errors on more than two components while TS silently skips, and only Rust honours `excludeColumns`. So each side asserts the expectation separately. A genuine shared fixture would need a generated cross-repo contract.

## What the tests establish

`pl7.app/sc/cellLinker` is authored `[sampleId, cellId <- sampleId, scClonotypeKey]`. `getAxesGroups` returns groups ordered by smallest contained index, and `fromColumns` destructures `const [left, right] = groups` (`linker_columns.ts:53`), so the sample/cell component becomes the one-side. That is backwards: many cells map to one clonotype.

Two consequences follow, both asserted:

- **A clonotype-keyed source reaches cell-level axes.** Edges are stored many-side → one-side (`linker_columns.ts:91`), so inverted sides let a clonotype-keyed table traverse down to per-cell axes. This is how cell-level columns reach a clonotype-keyed p-frame.
- **A cell-keyed source cannot reach the clonotype.** Authoring the clonotype component first reverses both directions, which makes the intended cell → clonotype enrichment appear.

A fourth test walks all six authoring orders and separates the two things this issue turns on: **group membership is authoring-order independent; group position is not.** The axes group correctly however they are written down, and position alone decides which component is treated as the one-side. No structural rule can recover the intended direction from the spec — it must be declared or read from data.

## Verification

`vitest run` in `lib/model/common` — 112 pass across 9 files. `ts-builder` formatter, linter, and type-check all clean.

## Two notes for a reviewer

**The trunk in these tests carries its whole parent tree.** Linker map keys come from `getArrayFromAxisTree`, so a cell trunk's key is `[cellId, sampleId]`. Passing `cellId` alone yields the key `[cellId]` and misses on key shape rather than on reachability. An early draft of these tests passed for exactly that wrong reason.

**Group contents are compared as sorted sets, deliberately.** `getAxesGroups` documents *"There are no order inside every group"* (`linker_columns.ts:271`), so asserting a specific order within a group would pin something the source disclaims. Only order between groups is pinned.

Separately: this package's `test` script passes `--coverage` but instruments nothing — it reports 0% with 112 tests passing. Pre-existing, and not addressed here.
