### PR TITLE
MILAB-6701: name column predicates after capability, not recipe class

### DIFF
--- a/.changeset/column-data-access-api.md
+++ b/.changeset/column-data-access-api.md
@@ -10,19 +10,23 @@ that suggested a third one, so picking the right guard meant reading the
 implementation. Three call sites out of four in the first consumer block picked
 the wrong one.
 
-- `hasDirectData(recipe)` — new. Narrows to `DataColumn`, the interface that
+- `hasReachableData(recipe)` — new. Narrows to `DataColumn`, the interface that
   exposes `getData()`. True for a bare leaf and for a spec-override over one:
   the only shapes whose data still matches their spec.
 - `isSelfContained(recipe)` — new. Whether the column resolves without pulling
   in other columns. Replaces `isLeafColumn`, same semantics.
 - `ColumnLazy` → `DataColumn`, `ColumnLazyImpl` → `DataColumnImpl`,
-  `ColumnLazyId` / `ColumnLazyData` → `DataColumnId` / `DataColumnData`.
+  `ColumnLazyId` / `ColumnLazyData` → `DataColumnId` / `ColumnData`.
   Deprecated aliases keep existing imports compiling.
-- `ColumnOverriddenRecipe` now implements `getData()`, delegating to its inner
-  leaf — spec overrides never reshape data.
+- A spec override over a leaf is now readable too: `ColumnOverriddenRecipe.wrap`
+  picks a data-bearing variant when the wrapped recipe carries data, so
+  `getData()` exists exactly where it can be called and there is no throwing
+  path behind the guard. The choice is structural — it follows from the id — so
+  the same id always yields the same class whether it came from `withSpecs` or
+  from parsing a string.
 - `isColumnLazy` is deprecated. Its one remaining use is a legacy slot typed
   `PObjectId` (`PColumn.id`, `PColumnIdAndSpec.columnId`).
 - `getLeafColumnData` is deprecated **and behaves differently**: it used to walk
   past an axis-filtered layer and return the underlying leaf's *unsliced* data,
   which does not match the recipe's spec. It now returns `undefined` for
-  anything `hasDirectData` rejects.
+  anything `hasReachableData` rejects.

--- a/.changeset/column-data-access-api.md
+++ b/.changeset/column-data-access-api.md
@@ -1,0 +1,28 @@
+---
+"@platforma-sdk/model": minor
+---
+
+Name the column predicates after what a caller can do, not after the recipe classes
+
+`isLeafColumn` and `isColumnLazy` answered two different questions ("does this
+column need other columns to resolve?" and "can I read its data?") under names
+that suggested a third one, so picking the right guard meant reading the
+implementation. Three call sites out of four in the first consumer block picked
+the wrong one.
+
+- `hasDirectData(recipe)` — new. Narrows to `DataColumn`, the interface that
+  exposes `getData()`. True for a bare leaf and for a spec-override over one:
+  the only shapes whose data still matches their spec.
+- `isSelfContained(recipe)` — new. Whether the column resolves without pulling
+  in other columns. Replaces `isLeafColumn`, same semantics.
+- `ColumnLazy` → `DataColumn`, `ColumnLazyImpl` → `DataColumnImpl`,
+  `ColumnLazyId` / `ColumnLazyData` → `DataColumnId` / `DataColumnData`.
+  Deprecated aliases keep existing imports compiling.
+- `ColumnOverriddenRecipe` now implements `getData()`, delegating to its inner
+  leaf — spec overrides never reshape data.
+- `isColumnLazy` is deprecated. Its one remaining use is a legacy slot typed
+  `PObjectId` (`PColumn.id`, `PColumnIdAndSpec.columnId`).
+- `getLeafColumnData` is deprecated **and behaves differently**: it used to walk
+  past an axis-filtered layer and return the underlying leaf's *unsliced* data,
+  which does not match the recipe's spec. It now returns `undefined` for
+  anything `hasDirectData` rejects.

--- a/.changeset/column-data-access-api.md
+++ b/.changeset/column-data-access-api.md
@@ -10,23 +10,35 @@ that suggested a third one, so picking the right guard meant reading the
 implementation. Three call sites out of four in the first consumer block picked
 the wrong one.
 
-- `hasReachableData(recipe)` — new. Narrows to `DataColumn`, the interface that
-  exposes `getData()`. True for a bare leaf and for a spec-override over one:
+New predicates:
+
+- `hasReachableData(recipe)` — narrows to `DataColumnRecipe`, the interface that
+  exposes `getData()`. True for a bare leaf and for a spec override over one:
   the only shapes whose data still matches their spec.
-- `isSelfContained(recipe)` — new. Whether the column resolves without pulling
-  in other columns. Replaces `isLeafColumn`, same semantics.
-- `ColumnLazy` → `DataColumn`, `ColumnLazyImpl` → `DataColumnImpl`,
-  `ColumnLazyId` / `ColumnLazyData` → `DataColumnId` / `ColumnData`.
-  Deprecated aliases keep existing imports compiling.
-- A spec override over a leaf is now readable too: `ColumnOverriddenRecipe.wrap`
-  picks a data-bearing variant when the wrapped recipe carries data, so
-  `getData()` exists exactly where it can be called and there is no throwing
-  path behind the guard. The choice is structural — it follows from the id — so
-  the same id always yields the same class whether it came from `withSpecs` or
-  from parsing a string.
-- `isColumnLazy` is deprecated. Its one remaining use is a legacy slot typed
-  `PObjectId` (`PColumn.id`, `PColumnIdAndSpec.columnId`).
-- `getLeafColumnData` is deprecated **and behaves differently**: it used to walk
-  past an axis-filtered layer and return the underlying leaf's *unsliced* data,
-  which does not match the recipe's spec. It now returns `undefined` for
-  anything `hasReachableData` rejects.
+- `hasSingleDataColumn(recipe)` — whether the column resolves without pulling in
+  other columns, i.e. depends on exactly one storage column. Replaces
+  `isLeafColumn`.
+- `isDataColumn(value)` — whether the value is a bare leaf, whose `id` is a
+  `PObjectId` naming a real storage column. Use it only where a type forces that
+  id shape (`PColumn.id`, `PColumnIdAndSpec.columnId`).
+
+A spec override over a leaf is now readable: `ColumnOverriddenRecipe.wrap` picks
+a data-bearing variant when the wrapped recipe carries data, so `getData()`
+exists exactly where it can be called and there is no throwing path behind the
+guard. The choice is structural — it follows from the id — so the same id always
+yields the same class whether it came from `withSpecs` or from parsing a string.
+
+**Breaking renames.** `ColumnLazy` → `DataColumn` (the factory) plus
+`DataColumnRecipe` (the interface), `ColumnLazyImpl` → `DataColumnImpl`,
+`ColumnLazyId` → `DataColumnId`, `ColumnLazyData` → `ColumnData`.
+
+**Removed.**
+
+- `isColumnLazy` → `isDataColumn` (same check, contract-shaped name).
+- `getLeafColumnData` — it walked past an axis-filtered layer and returned the
+  underlying leaf's *unsliced* data, inconsistent with the recipe's spec;
+  replace with `hasReachableData(c) ? c.getData() : undefined`.
+- `isColumnRecipe` → `isColumn`.
+- The `ColumnLazy*` names above are gone rather than aliased.
+
+`isLeafColumn` remains as a deprecated alias of `hasSingleDataColumn`.

--- a/docs/column-access-api.md
+++ b/docs/column-access-api.md
@@ -23,7 +23,7 @@ physical/logical id split and the recipe-authoring contract.
    The sandbox only ever holds ids and opaque handles.
 4. `getSpec()` is a host round-trip per column. Columns you never inspect cost
    nothing.
-5. Data is mostly *not* readable in the sandbox. Hand `recipe.id` to the host
+5. Data is mostly _not_ readable in the sandbox. Hand `recipe.id` to the host
    (`createPFrame` / `createPTableV2` / `createPlDataTableV3`) and let it
    materialise.
 6. Nothing is mutable. To get a different spec, encode it into a new id with
@@ -38,32 +38,32 @@ Every public export of the module, by role. Details follow in the sections below
 
 ### Discovery
 
-| Export | Kind | One-liner |
-| --- | --- | --- |
-| `ColumnsCollection(sources?, deps?)` | function + type | Host-driven column set. Entry point for all discovery. |
-| `isColumnsCollection(value)` | guard | Narrows to `ColumnsCollection`. |
-| `ColumnsSourceShorthand` | type | `"result_pool" \| "current_block"`. |
-| `ColumnsSource` | type | Provider / accessor / `{ columns, isFinal }`. |
-| `ColumnsCollectionDeps` | type | `{ ctx?, driver? }` — ctx override and test seam. |
-| `ColumnsCollectionImpl` | class | Instance type behind `ColumnsCollection`; never constructed directly. |
+| Export                               | Kind            | One-liner                                                             |
+| ------------------------------------ | --------------- | --------------------------------------------------------------------- |
+| `ColumnsCollection(sources?, deps?)` | function + type | Host-driven column set. Entry point for all discovery.                |
+| `isColumnsCollection(value)`         | guard           | Narrows to `ColumnsCollection`.                                       |
+| `ColumnsSourceShorthand`             | type            | `"result_pool" \| "current_block"`.                                   |
+| `ColumnsSource`                      | type            | Provider / accessor / `{ columns, isFinal }`.                         |
+| `ColumnsCollectionDeps`              | type            | `{ ctx?, driver? }` — ctx override and test seam.                     |
+| `ColumnsCollectionImpl`              | class           | Instance type behind `ColumnsCollection`; never constructed directly. |
 
 ### Columns
 
-| Export | Kind | One-liner |
-| --- | --- | --- |
-| `Column(source, opts?)` | function + type | Unified factory: string id or object source → `ColumnRecipe`. |
-| `ColumnRecipe` | interface + function | The recipe contract; also the id-shape-dispatching factory. |
-| `ColumnRecipe.getStatus(id, opts?)` | function | Resolution status of an id without building the recipe. |
-| `DataColumn(source, opts?)` | function | Leaf factory, plus `.fromId` / `.fromPlRef` / `.fromAccessor` / `.fromColumn` and the `getStatus*` statics. |
-| `DataColumnRecipe` | interface | `ColumnRecipe` + `getData()`. |
-| `ColumnSource` | type | Input union of `Column(...)`. |
-| `DataColumnSource` | type | Input union of `DataColumn(...)`. |
-| `DataColumnId` | type | Alias of `PObjectId` — a leaf's id. |
-| `ColumnData` | type | `undefined \| PColumnDataUniversal` — what `getData()` returns. |
-| `ColumnDiscoveredRecipe` | class | Discovery hit reached through a linker chain. |
-| `ColumnFilteredRecipe` | class | Axis-sliced projection. |
-| `ColumnOverriddenRecipe` | class | Spec-patched projection. |
-| `DataColumnImpl` | class | Leaf implementation. Internal — hold `DataColumnRecipe`. |
+| Export                              | Kind                 | One-liner                                                                                                   |
+| ----------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `Column(source, opts?)`             | function + type      | Unified factory: string id or object source → `ColumnRecipe`.                                               |
+| `ColumnRecipe`                      | interface + function | The recipe contract; also the id-shape-dispatching factory.                                                 |
+| `ColumnRecipe.getStatus(id, opts?)` | function             | Resolution status of an id without building the recipe.                                                     |
+| `DataColumn(source, opts?)`         | function             | Leaf factory, plus `.fromId` / `.fromPlRef` / `.fromAccessor` / `.fromColumn` and the `getStatus*` statics. |
+| `DataColumnRecipe`                  | interface            | `ColumnRecipe` + `getData()`.                                                                               |
+| `ColumnSource`                      | type                 | Input union of `Column(...)`.                                                                               |
+| `DataColumnSource`                  | type                 | Input union of `DataColumn(...)`.                                                                           |
+| `DataColumnId`                      | type                 | Alias of `PObjectId` — a leaf's id.                                                                         |
+| `ColumnData`                        | type                 | `undefined \| PColumnDataUniversal` — what `getData()` returns.                                             |
+| `ColumnDiscoveredRecipe`            | class                | Discovery hit reached through a linker chain.                                                               |
+| `ColumnFilteredRecipe`              | class                | Axis-sliced projection.                                                                                     |
+| `ColumnOverriddenRecipe`            | class                | Spec-patched projection.                                                                                    |
+| `DataColumnImpl`                    | class                | Leaf implementation. Internal — hold `DataColumnRecipe`.                                                    |
 
 You do not name the recipe classes in ordinary block code. They are listed
 because they appear in stack traces and in `instanceof` checks inside the SDK;
@@ -78,31 +78,31 @@ you cannot import them.
 
 ### Predicates
 
-| Export | Kind | Answers |
-| --- | --- | --- |
-| `isColumn(value)` | guard | Is this any recipe? |
-| `hasReachableData(recipe)` | guard → `DataColumnRecipe` | Can I read the data here, consistent with the spec? |
-| `hasSingleDataColumn(recipe)` | boolean | Does it read exactly one storage column? |
-| `isDataColumn(value)` | guard → `DataColumnRecipe<PObjectId>` | Is this a bare leaf, i.e. is its `id` a `PObjectId`? |
-| `hasColumnData(recipe, opts?)` | boolean | Do the underlying data resources actually carry bytes? |
-| `isLeafColumn` | deprecated alias | Same as `hasSingleDataColumn`. |
+| Export                         | Kind                                  | Answers                                                |
+| ------------------------------ | ------------------------------------- | ------------------------------------------------------ |
+| `isColumn(value)`              | guard                                 | Is this any recipe?                                    |
+| `hasReachableData(recipe)`     | guard → `DataColumnRecipe`            | Can I read the data here, consistent with the spec?    |
+| `hasSingleDataColumn(recipe)`  | boolean                               | Does it read exactly one storage column?               |
+| `isDataColumn(value)`          | guard → `DataColumnRecipe<PObjectId>` | Is this a bare leaf, i.e. is its `id` a `PObjectId`?   |
+| `hasColumnData(recipe, opts?)` | boolean                               | Do the underlying data resources actually carry bytes? |
+| `isLeafColumn`                 | deprecated alias                      | Same as `hasSingleDataColumn`.                         |
 
 ### Status and Errors
 
-| Export | Kind | One-liner |
-| --- | --- | --- |
-| `ColumnFieldStatus` | type | `"present" \| "resolving" \| "absent"` — data-field status, worst across referenced ids. |
-| `ColumnResolutionStatus` | type | Same value space; folds spec + registry readiness. |
-| `ColumnAbsentError` | class | Thrown by factories when a column provably will not appear. |
+| Export                   | Kind  | One-liner                                                                                |
+| ------------------------ | ----- | ---------------------------------------------------------------------------------------- |
+| `ColumnFieldStatus`      | type  | `"present" \| "resolving" \| "absent"` — data-field status, worst across referenced ids. |
+| `ColumnResolutionStatus` | type  | Same value space; folds spec + registry readiness.                                       |
+| `ColumnAbsentError`      | class | Thrown by factories when a column provably will not appear.                              |
 
 ### Utilities
 
-| Export | Kind | One-liner |
-| --- | --- | --- |
+| Export                                       | Kind     | One-liner                                                               |
+| -------------------------------------------- | -------- | ----------------------------------------------------------------------- |
 | `deriveColumnOptions(source, labelOptions?)` | function | `ColumnOption[]` — `{ id, label }` drop-down options over a collection. |
-| `ColumnOption` | type | `{ id: ColumnUniversalId; label: string }`. |
-| `expandByPartition(inputs, splitAxes, opts?)` | function | Fan a column out into one recipe per partition value. |
-| `SplitAxis`, `ExpandByPartitionOpts` | types | `{ idx }` and `{ axisValuesLabels? }`. |
+| `ColumnOption`                               | type     | `{ id: ColumnUniversalId; label: string }`.                             |
+| `splitByAxes(inputs, splitAxes, opts?)`      | function | Fan a column out into one recipe per distinct value of the given axes.  |
+| `SplitAxis`, `SplitByAxesOpts`               | types    | `{ idx }` and `{ axisValuesLabels? }`.                                  |
 
 ### Exported but Not Part of the Surface
 
@@ -112,13 +112,13 @@ for one is usually re-implementing something `ColumnsCollection` or
 `createPlDataTableV3` already does. Listed so you know what they are when you
 meet them in SDK code, not so you call them.
 
-| Export | What it is |
-| --- | --- |
-| `deriveAxisValuesLabels(source?, opts?)` | Builds an `(axisId) => Record<value, label>` callback from `pl7.app/label` columns — the shape `expandByPartition`'s `axisValuesLabels` option takes. |
-| `collectLinkerIds(recipe)` | Non-hit `PObjectId`s referenced by the recipe's query. |
-| `collectLinkerColumns(recipe, opts?)` | The same set, resolved to leaves. Throws if any is unresolvable. |
-| `hitQualifications(recipe)` | Hit-side axis qualifications, or `[]`. |
-| `queriesQualifications(recipe)` | Per-primary-column axis qualifications, or `{}`. |
+| Export                                   | What it is                                                                                                                                      |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deriveAxisValuesLabels(source?, opts?)` | Builds an `(axisId) => Record<value, label>` callback from `pl7.app/label` columns — the shape `splitByAxes`'s `axisValuesLabels` option takes. |
+| `collectLinkerIds(recipe)`               | Non-hit `PObjectId`s referenced by the recipe's query.                                                                                          |
+| `collectLinkerColumns(recipe, opts?)`    | The same set, resolved to leaves. Throws if any is unresolvable.                                                                                |
+| `hitQualifications(recipe)`              | Hit-side axis qualifications, or `[]`.                                                                                                          |
+| `queriesQualifications(recipe)`          | Per-primary-column axis qualifications, or `{}`.                                                                                                |
 
 If you do end up needing one of the last four, use them rather than descending
 the wrapper classes by hand: they encapsulate the layering invariants
@@ -130,13 +130,13 @@ wrappers are added.
 Rarely needed in block code: `ColumnsCollection` sources cover the same ground
 with less ceremony. Reach for these only when you need a provider object itself.
 
-| Export | Kind | One-liner |
-| --- | --- | --- |
-| `ColumnsProvider` | interface + factory | `{ getColumns(), isFinal() }`; the factory dispatches on accessor vs upstream-block list. |
-| `ArrayColumnsProvider` | class | Wraps a `PColumn[]` / leaf array. Prefer the `{ columns, isFinal }` source shape. |
-| `AccessorColumnsProvider`, `ResultPoolColumnsProvider` | factory + type | Memoised providers over an accessor root / the result pool. |
-| `AccessorColumnsProviderImpl`, `ResultPoolColumnsProviderImpl` | classes | Their implementations. |
-| `isColumnProvider`, `toColumnProvider`, `getCtxProviders` | functions | Shape guard, coercion, ambient-ctx provider triplet. |
+| Export                                                         | Kind                | One-liner                                                                                 |
+| -------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------- |
+| `ColumnsProvider`                                              | interface + factory | `{ getColumns(), isFinal() }`; the factory dispatches on accessor vs upstream-block list. |
+| `ArrayColumnsProvider`                                         | class               | Wraps a `PColumn[]` / leaf array. Prefer the `{ columns, isFinal }` source shape.         |
+| `AccessorColumnsProvider`, `ResultPoolColumnsProvider`         | factory + type      | Memoised providers over an accessor root / the result pool.                               |
+| `AccessorColumnsProviderImpl`, `ResultPoolColumnsProviderImpl` | classes             | Their implementations.                                                                    |
+| `isColumnProvider`, `toColumnProvider`, `getCtxProviders`      | functions           | Shape guard, coercion, ambient-ctx provider triplet.                                      |
 
 ## `ColumnsCollection`
 
@@ -155,13 +155,13 @@ is no `dispose()`: the host pins each handle to the active render ctx.
 pool. Narrow it aggressively — every entry widens the host-side spec frame the
 collection queries against.
 
-| Source entry | Expands to |
-| --- | --- |
-| `"current_block"` | `outputs` + `prerun` accessors of this block, whichever exist |
-| `"result_pool"` | the upstream-block result pool |
-| `TreeNodeAccessor` | that subtree |
-| `ColumnsCollection` | that collection, by handle (chaining) |
-| `ColumnsProvider` | its `getColumns()` ids + `isFinal()` |
+| Source entry           | Expands to                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------ |
+| `"current_block"`      | `outputs` + `prerun` accessors of this block, whichever exist                              |
+| `"result_pool"`        | the upstream-block result pool                                                             |
+| `TreeNodeAccessor`     | that subtree                                                                               |
+| `ColumnsCollection`    | that collection, by handle (chaining)                                                      |
+| `ColumnsProvider`      | its `getColumns()` ids + `isFinal()`                                                       |
 | `{ columns, isFinal }` | the entries' `.id`s; `columns` accepts `PColumn` / `DataColumnRecipe` / any `ColumnRecipe` |
 
 `isFinal` says whether the visible column set can still grow. While upstream
@@ -171,16 +171,16 @@ compute it; you supply it only with the `{ columns, isFinal }` shape.
 **Instance surface.** Every method that returns a collection mints a fresh
 handle on the host; the receiver is unchanged.
 
-| Member | Returns | Cost |
-| --- | --- | --- |
-| `.handle` | `CollectionHandle` | free — pass into another `ColumnsCollection(...)` |
-| `.isEmpty()` | `boolean` | host call, no ids transferred |
-| `.isFinal()` | `boolean` | host call |
-| `.getColumnIds()` | `ColumnUniversalId[]` | host call; the cheapest exit |
-| `.getColumns()` | `ColumnRecipe[]` | ids + one recipe construction each |
-| `.addSource(source)` | `ColumnsCollection` | host call |
-| `.discover(options)` | `ColumnsCollection` | host-side discovery query |
-| `.filter(options)` | `ColumnsCollection` | host-side selector match |
+| Member               | Returns               | Cost                                              |
+| -------------------- | --------------------- | ------------------------------------------------- |
+| `.handle`            | `CollectionHandle`    | free — pass into another `ColumnsCollection(...)` |
+| `.isEmpty()`         | `boolean`             | host call, no ids transferred                     |
+| `.isFinal()`         | `boolean`             | host call                                         |
+| `.getColumnIds()`    | `ColumnUniversalId[]` | host call; the cheapest exit                      |
+| `.getColumns()`      | `ColumnRecipe[]`      | ids + one recipe construction each                |
+| `.addSource(source)` | `ColumnsCollection`   | host call                                         |
+| `.discover(options)` | `ColumnsCollection`   | host-side discovery query                         |
+| `.filter(options)`   | `ColumnsCollection`   | host-side selector match                          |
 
 `getColumnIds()` is the fast path when the ids are all you need — and they
 usually are, because the id-accepting consumers take them directly.
@@ -208,11 +208,11 @@ ColumnsCollection([alreadyNarrowed, "result_pool"]);
 
 ```ts
 interface DiscoverColumnsOptions {
-  include?: ColumnSelector;   // omitted = include all
-  exclude?: ColumnSelector;   // applied after include
-  mode?: MatchingMode;        // default "enrichment"; ignored without anchors
+  include?: ColumnSelector; // omitted = include all
+  exclude?: ColumnSelector; // applied after include
+  mode?: MatchingMode; // default "enrichment"; ignored without anchors
   anchors?: Record<string, AnchorEntry>;
-  maxHops?: number;           // default 4 with anchors, 0 without
+  maxHops?: number; // default 4 with anchors, 0 without
 }
 
 type ColumnsDiscoverOptions = DiscoverColumnsOptions;
@@ -227,11 +227,11 @@ it is called on. It matches selectors against what is already in the set.
 `AnchorEntry` is `PlRef | PObjectId | PColumnSpec | RelaxedColumnSelector`. All
 four are plain JSON, so the option object crosses the bridge unchanged.
 
-| `MatchingMode` | Axis behaviour |
-| --- | --- |
+| `MatchingMode`           | Axis behaviour                                                      |
+| ------------------------ | ------------------------------------------------------------------- |
 | `"enrichment"` (default) | anchor axes may float over un-mapped hit axes — "extend this query" |
-| `"related"` | both source and hit axes may float; widest match |
-| `"exact"` | no floating, no qualifications; strict equality |
+| `"related"`              | both source and hit axes may float; widest match                    |
+| `"exact"`                | no floating, no qualifications; strict equality                     |
 
 ### Selectors
 
@@ -245,8 +245,8 @@ interface RelaxedColumnSelector {
   domain?: Record<string, RelaxedStringMatchers>;
   contextDomain?: Record<string, RelaxedStringMatchers>;
   annotations?: Record<string, RelaxedStringMatchers>;
-  axes?: RelaxedAxisSelector[];      // { name?, type?, domain?, contextDomain?, annotations? }
-  partialAxesMatch?: boolean;        // omit to require an exact axis-set length
+  axes?: RelaxedAxisSelector[]; // { name?, type?, domain?, contextDomain?, annotations? }
+  partialAxesMatch?: boolean; // omit to require an exact axis-set length
 }
 
 type ColumnSelector = RelaxedColumnSelector | RelaxedColumnSelector[];
@@ -261,7 +261,7 @@ Semantics:
 - **Prefer `{ type: "exact", value }` over `^…$`** when you mean one literal
   name. Column namespaces are full of `.` and `/`; the exact matcher takes the
   value literally and needs no escaping.
-- Annotation and domain keys must be *present* in the spec to match. A negation
+- Annotation and domain keys must be _present_ in the spec to match. A negation
   regex will not match columns that lack the key at all — use `exclude` for
   "not this", not a regex.
 - There are no `(spec) => boolean` selectors. The point of a selector is that it
@@ -296,14 +296,14 @@ interface ColumnRecipe<ID extends ColumnRecipeId = ColumnRecipeId> {
 
 (`sdk/model/src/columns/column_recipes/types.ts`)
 
-| Member | Cost | Notes |
-| --- | --- | --- |
-| `id` | free | field, not a method. Canonical, addressable, transportable. |
-| `getReferencedIds()` | free | every storage column the recipe reaches. |
-| `getSpec()` | **host round-trip**, memoised per instance | always returns a value — a constructed recipe is spec-complete by contract. |
-| `getQuery()` | free | the `SpecQuery` IR the host executes. |
-| `getDataStatus()` | host call, memoised | worst status across `getReferencedIds()`. |
-| `withSpecs(patch)` | free | new recipe, new id; receiver unchanged. |
+| Member               | Cost                                       | Notes                                                                       |
+| -------------------- | ------------------------------------------ | --------------------------------------------------------------------------- |
+| `id`                 | free                                       | field, not a method. Canonical, addressable, transportable.                 |
+| `getReferencedIds()` | free                                       | every storage column the recipe reaches.                                    |
+| `getSpec()`          | **host round-trip**, memoised per instance | always returns a value — a constructed recipe is spec-complete by contract. |
+| `getQuery()`         | free                                       | the `SpecQuery` IR the host executes.                                       |
+| `getDataStatus()`    | host call, memoised                        | worst status across `getReferencedIds()`.                                   |
+| `withSpecs(patch)`   | free                                       | new recipe, new id; receiver unchanged.                                     |
 
 Two recipes are equal as value-objects exactly when their ids match. There is no
 `getData()` on this interface, no spec field, and no `getSpecOverrides` /
@@ -316,7 +316,7 @@ specs. Most pipelines never call it: they pass `.id` on.
 
 ```ts
 type SpecOverrides = Pick<PColumnSpec, "domain" | "contextDomain" | "annotations"> & {
-  axesSpec?: AxisPatches;   // Record<axisIndex, Partial<AxisSpec>> — positional, not AxisSpec[]
+  axesSpec?: AxisPatches; // Record<axisIndex, Partial<AxisSpec>> — positional, not AxisSpec[]
 };
 ```
 
@@ -342,7 +342,7 @@ If you find yourself calling `getSpec()` only to feed the result back into
 
 ```ts
 interface DataColumnRecipe<ID = ColumnRecipeId> extends ColumnRecipe<ID> {
-  getData(): ColumnData;   // undefined | PColumnDataUniversal — host round-trip
+  getData(): ColumnData; // undefined | PColumnDataUniversal — host round-trip
 }
 ```
 
@@ -355,12 +355,12 @@ throwing path behind the guard.
 
 The id decides the class. You never choose it.
 
-| Id shape on the wire | Recipe class | What it is |
-| --- | --- | --- |
-| bare `PObjectId` | `DataColumnImpl` (as `DataColumnRecipe`) | a plain stored column; spec and data both reachable |
-| `ColumnOverriddenId` | `ColumnOverriddenRecipe` | "that recipe, with domain / contextDomain / annotations / axes patched" |
-| `ColumnFilteredId` | `ColumnFilteredRecipe` | "that recipe, with some axes pinned to values" |
-| `ColumnDiscoveredId` | `ColumnDiscoveredRecipe` | a discovery hit, carrying the linker path back to its anchor |
+| Id shape on the wire | Recipe class                             | What it is                                                              |
+| -------------------- | ---------------------------------------- | ----------------------------------------------------------------------- |
+| bare `PObjectId`     | `DataColumnImpl` (as `DataColumnRecipe`) | a plain stored column; spec and data both reachable                     |
+| `ColumnOverriddenId` | `ColumnOverriddenRecipe`                 | "that recipe, with domain / contextDomain / annotations / axes patched" |
+| `ColumnFilteredId`   | `ColumnFilteredRecipe`                   | "that recipe, with some axes pinned to values"                          |
+| `ColumnDiscoveredId` | `ColumnDiscoveredRecipe`                 | a discovery hit, carrying the linker path back to its anchor            |
 
 Layering rules, enforced by the wrappers themselves:
 
@@ -393,8 +393,8 @@ The one entry point. Routing:
 Call the dispatchers directly when the call site is unambiguous:
 
 ```ts
-ColumnRecipe(id);              // string id, routed by shape
-DataColumn(source);            // id | PlRef | PColumn | LeafEntry | DataColumnRecipe
+ColumnRecipe(id); // string id, routed by shape
+DataColumn(source); // id | PlRef | PColumn | LeafEntry | DataColumnRecipe
 DataColumn.fromId(pObjectId);
 DataColumn.fromPlRef(ref);
 DataColumn.fromColumn(pColumn);
@@ -423,10 +423,10 @@ DataColumn.getStatusByAccessor(entry);
 Inside a loop over known ids, one `getStatus` up front beats a try/catch around
 the factory.
 
-| Type | Means |
-| --- | --- |
-| `ColumnFieldStatus` | data-field status, worst across every referenced id. What `recipe.getDataStatus()` returns; the usual thing to check while iterating recipes. |
-| `ColumnResolutionStatus` | same values, but folds spec readiness and leaf-registry readiness: "can this recipe be *constructed* at all in this ctx". |
+| Type                     | Means                                                                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ColumnFieldStatus`      | data-field status, worst across every referenced id. What `recipe.getDataStatus()` returns; the usual thing to check while iterating recipes. |
+| `ColumnResolutionStatus` | same values, but folds spec readiness and leaf-registry readiness: "can this recipe be _constructed_ at all in this ctx".                     |
 
 Both are `"present" | "resolving" | "absent"`, worst-wins (`absent` ▸
 `resolving` ▸ `present`).
@@ -444,10 +444,10 @@ classes exist is an implementation detail behind `recipe.id` — never
 `instanceof`-narrow to one.
 
 ```ts
-isColumn(value);              // value is Column                     — any recipe
-hasReachableData(recipe);     // recipe is DataColumnRecipe           — data readable here
-hasSingleDataColumn(recipe);  // boolean                             — reads one column, not several
-isDataColumn(value);          // value is DataColumnRecipe<PObjectId> — bare leaf
+isColumn(value); // value is Column                     — any recipe
+hasReachableData(recipe); // recipe is DataColumnRecipe           — data readable here
+hasSingleDataColumn(recipe); // boolean                             — reads one column, not several
+isDataColumn(value); // value is DataColumnRecipe<PObjectId> — bare leaf
 ```
 
 **`hasReachableData` — "can I read the data?"** True for a bare leaf and for a
@@ -470,18 +470,18 @@ The SDK's own `discoverTableColumns` splits on exactly this predicate.
 
 **`isDataColumn` — "is this a storage column?"** True only for a bare leaf,
 whose `id` is a `PObjectId` naming a real column in storage. Reach for it when a
-*type* forces that id shape — `PColumn.id`, `PColumnIdAndSpec.columnId` — not
+_type_ forces that id shape — `PColumn.id`, `PColumnIdAndSpec.columnId` — not
 when you merely want to read data.
 
 The predicates are independent. An axis-filtered leaf reads a single column and
 has no reachable data. Pick by what you do next, not by which sounds stricter:
 
-| You want to… | Guard |
-| --- | --- |
-| call `getData()` in the sandbox | `hasReachableData` |
+| You want to…                              | Guard                 |
+| ----------------------------------------- | --------------------- |
+| call `getData()` in the sandbox           | `hasReachableData`    |
 | use it as a `createPlDataTableV3` primary | `hasSingleDataColumn` |
-| put its id in a `PObjectId`-typed slot | `isDataColumn` |
-| know whether bytes actually landed | `hasColumnData` |
+| put its id in a `PObjectId`-typed slot    | `isDataColumn`        |
+| know whether bytes actually landed        | `hasColumnData`       |
 
 ## Utilities
 
@@ -511,10 +511,10 @@ const options = deriveColumnOptions(
 );
 ```
 
-### `expandByPartition`
+### `splitByAxes`
 
 ```ts
-expandByPartition(
+splitByAxes(
   inputs: Column[],
   splitAxes: { idx: number }[],
   opts?: { axisValuesLabels?: (axisId: AxisId) => undefined | Record<string | number, string> },
@@ -530,9 +530,11 @@ node), `Overridden` adds `domain[axisName]` plus a `split:<axisId>` entry on
 Inputs must be readable here — partition keys are inspected via `getData()`.
 Guard with `hasReachableData`, not `hasSingleDataColumn`.
 
-`axisValuesLabels` is optional; without it a split is labelled by its raw axis
-value. Supply your own resolver, or `deriveAxisValuesLabels()` to build one from
-the `pl7.app/label` columns in scope.
+`axisValuesLabels` defaults to `deriveAxisValuesLabels()` over the ambient
+render ctx, so splits are labelled from the `pl7.app/label` columns in scope
+without any wiring. The label columns are discovered lazily, on the first axis
+lookup. Supply your own resolver to narrow the label source, or
+`() => undefined` to keep raw axis values.
 
 Returns `undefined` when an input's data is neither a live `TreeNodeAccessor`
 nor parsed `DataInfoEntries`, or when partition keys can't be read — i.e. "not
@@ -548,21 +550,21 @@ and the cast silences the type-checker, not the runtime invariant.
 
 ### Accepts Ids
 
-| Consumer | Accepts |
-| --- | --- |
-| `ctx.createPFrame(def)` | `PFrameDef<PObjectId \| SUniversalPColumnId \| PColumn<…>>` — ids and `PColumn`s, mixed |
-| `ctx.createPTableV2(def)` | `PTableDefV2<ColumnUniversalId \| PColumn<…>>` |
-| `createPlDataTableV3(ctx, options)` | `ColumnRecipe[]` directly, or a declarative discovery config |
+| Consumer                            | Accepts                                                                                 |
+| ----------------------------------- | --------------------------------------------------------------------------------------- |
+| `ctx.createPFrame(def)`             | `PFrameDef<PObjectId \| SUniversalPColumnId \| PColumn<…>>` — ids and `PColumn`s, mixed |
+| `ctx.createPTableV2(def)`           | `PTableDefV2<ColumnUniversalId \| PColumn<…>>`                                          |
+| `createPlDataTableV3(ctx, options)` | `ColumnRecipe[]` directly, or a declarative discovery config                            |
 
 `SUniversalPColumnId` is a legacy alias of `ColumnUniversalId` — same type, no
 migration needed where a signature still names it.
 
 ```ts
-ctx.createPFrame(collection.getColumnIds());   // cheapest form
-ctx.createPFrame(recipes.map((c) => c.id));    // works for any recipe, leaf or wrapped
+ctx.createPFrame(collection.getColumnIds()); // cheapest form
+ctx.createPFrame(recipes.map((c) => c.id)); // works for any recipe, leaf or wrapped
 ```
 
-Passing ids is also the *only* way to feed wrapped recipes into a PFrame. Most
+Passing ids is also the _only_ way to feed wrapped recipes into a PFrame. Most
 of them cannot be read in the sandbox at all, but `recipe.id` is a
 `ColumnUniversalId` the host resolves server-side. Don't try to narrow a recipe
 list before building a PFrame — pass `.id`.
@@ -573,12 +575,12 @@ Prefer the id form whenever the column came from the host in the first place.
 
 ### Does Not Accept Ids
 
-| Slot | Needs | Why |
-| --- | --- | --- |
-| `ctx.createPTable(def)` (v1) | `PColumn<PColumnDataUniversal>[]` | pre-id API; use `createPTableV2` |
-| `createPFrameForGraphs(ctx, cols)` | `PColumn<PColumnDataUniversal>[]` | no id form yet |
-| `PColumn.id` | `PObjectId` | physical id slot |
-| `PColumnIdAndSpec.columnId` | `PObjectId` | physical id slot |
+| Slot                               | Needs                             | Why                              |
+| ---------------------------------- | --------------------------------- | -------------------------------- |
+| `ctx.createPTable(def)` (v1)       | `PColumn<PColumnDataUniversal>[]` | pre-id API; use `createPTableV2` |
+| `createPFrameForGraphs(ctx, cols)` | `PColumn<PColumnDataUniversal>[]` | no id form yet                   |
+| `PColumn.id`                       | `PObjectId`                       | physical id slot                 |
+| `PColumnIdAndSpec.columnId`        | `PObjectId`                       | physical id slot                 |
 
 The bridge, valid **only** for bare leaves:
 
@@ -652,16 +654,16 @@ drops valid projections.
 
 What crosses the sandbox bridge, and when.
 
-| Operation | Bridge traffic |
-| --- | --- |
-| `ColumnsCollection(...)`, `.discover`, `.filter`, `.addSource` | one host call, returns a handle |
-| `.isEmpty()`, `.isFinal()` | one host call, no payload |
-| `.getColumnIds()` | one host call, N id strings |
-| `.getColumns()` | ids + per-id registry resolution (no spec bytes) |
-| `recipe.id`, `.getQuery()`, `.getReferencedIds()`, `.withSpecs()` | none |
-| `recipe.getSpec()` | one round-trip per recipe, memoised per instance |
-| `recipe.getData()` | one round-trip, memoised per instance |
-| `createPFrame(ids)` / `createPTableV2(ids)` | ids only; host resolves spec and data |
+| Operation                                                         | Bridge traffic                                   |
+| ----------------------------------------------------------------- | ------------------------------------------------ |
+| `ColumnsCollection(...)`, `.discover`, `.filter`, `.addSource`    | one host call, returns a handle                  |
+| `.isEmpty()`, `.isFinal()`                                        | one host call, no payload                        |
+| `.getColumnIds()`                                                 | one host call, N id strings                      |
+| `.getColumns()`                                                   | ids + per-id registry resolution (no spec bytes) |
+| `recipe.id`, `.getQuery()`, `.getReferencedIds()`, `.withSpecs()` | none                                             |
+| `recipe.getSpec()`                                                | one round-trip per recipe, memoised per instance |
+| `recipe.getData()`                                                | one round-trip, memoised per instance            |
+| `createPFrame(ids)` / `createPTableV2(ids)`                       | ids only; host resolves spec and data            |
 
 Rules that follow:
 
@@ -674,7 +676,7 @@ Rules that follow:
 
 `etc/blocks/table-test/model/src/index.ts` exercises the surface end to end:
 anchored discovery, `hasSingleDataColumn` for the primary split,
-`hasReachableData` before `expandByPartition`, `deriveAxisValuesLabels`, recipe
+`hasReachableData` before `splitByAxes`, recipe
 ids used as filter and sort targets, and both `createPlDataTableV3` forms.
 
 ```ts
@@ -691,9 +693,7 @@ const countLeaves = ColumnsCollection()
   .getColumns()
   .filter(hasReachableData);
 
-const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
-  axisValuesLabels: deriveAxisValuesLabels(),
-});
+const splitRecipes = splitByAxes(countLeaves, [{ idx: 0 }]);
 if (splitRecipes === undefined) return undefined;
 
 const primaryIds = new Set(primary.map((c) => c.id));
@@ -713,13 +713,13 @@ return createPlDataTableV3(ctx, {
 
 Still exported, do not write new code against it:
 
-| Name | Instead |
-| --- | --- |
-| `isLeafColumn` | `hasSingleDataColumn` |
-| `ResultPool` and every column entry point on it (`ctx.resultPool.*`) | `ColumnsCollection` / `Column(ref)` |
-| `TreeNodeAccessor.getPColumns()` | `ColumnsCollection([accessor])` |
-| `ctx.getBlockLabel(blockId)` | nothing — slated to return dummy values |
-| `SUniversalPColumnId` | `ColumnUniversalId` (same type) |
+| Name                                                                 | Instead                                 |
+| -------------------------------------------------------------------- | --------------------------------------- |
+| `isLeafColumn`                                                       | `hasSingleDataColumn`                   |
+| `ResultPool` and every column entry point on it (`ctx.resultPool.*`) | `ColumnsCollection` / `Column(ref)`     |
+| `TreeNodeAccessor.getPColumns()`                                     | `ColumnsCollection([accessor])`         |
+| `ctx.getBlockLabel(blockId)`                                         | nothing — slated to return dummy values |
+| `SUniversalPColumnId`                                                | `ColumnUniversalId` (same type)         |
 
 `TreeNodeAccessor.getIsFinal()` is not deprecated, but once you have wrapped the
 accessor in a collection, read `collection.isFinal()` instead — same answer for
@@ -733,23 +733,3 @@ label }` wire shape with `refsWithEnrichments`. Its `@deprecated` note points at
 since that changes the stored value from a `PlRef` to a `ColumnUniversalId`.
 
 Removed names and their one-to-one replacements are in the migration doc.
-
-## Where the Code Lives
-
-| Area | Path |
-| --- | --- |
-| Collection proxy | `sdk/model/src/columns/columns_collection.ts` |
-| Leaf recipe, factories, `ColumnAbsentError` | `sdk/model/src/columns/data_column.ts` |
-| Recipe contract and dispatcher | `sdk/model/src/columns/column_recipes/{types,index}.ts` |
-| Wrapper recipes | `sdk/model/src/columns/column_recipes/column_{overrided,filtered,discovered}_recipe.ts` |
-| Unified `Column`, `isColumn` | `sdk/model/src/columns/column.ts` |
-| Predicates and recipe-walk helpers | `sdk/model/src/columns/utils.ts` |
-| Partition split | `sdk/model/src/columns/expand_by_partition.ts` |
-| Axis-value labels | `sdk/model/src/columns/derive_axis_values_labels.ts` |
-| Providers | `sdk/model/src/columns/column_providers/` |
-| Id types and helpers | `lib/model/common/src/drivers/pframe/spec/{ids,overridden,filtered_column,discovered_column}.ts` |
-| Selector types and normalisation | `lib/model/common/src/columns/column_selector.ts` |
-| Discover options | `lib/model/common/src/drivers/columns/discover_columns_options.ts` |
-| Collection driver contract | `lib/model/common/src/drivers/columns/columns_collection_driver.ts` |
-| Host-side physical resolver | `lib/node/pl-middle-layer/src/js_render/column_registry.ts` |
-| Table assembly | `sdk/model/src/components/PlDataTable/createPlDataTable/` |

--- a/docs/column-access-api.md
+++ b/docs/column-access-api.md
@@ -103,11 +103,27 @@ you cannot import them.
 | `ColumnOption` | type | `{ id: ColumnUniversalId; label: string }`. |
 | `expandByPartition(inputs, splitAxes, opts?)` | function | Fan a column out into one recipe per partition value. |
 | `SplitAxis`, `ExpandByPartitionOpts` | types | `{ idx }` and `{ axisValuesLabels? }`. |
-| `deriveAxisValuesLabels(source?, opts?)` | function | `(axisId) => Record<value, label>` from `pl7.app/label` columns. |
-| `collectLinkerIds(recipe)` | function | Non-hit `PObjectId`s referenced by the recipe's query. |
-| `collectLinkerColumns(recipe, opts?)` | function | Same set, resolved to leaves. Throws if any is unresolvable. |
-| `hitQualifications(recipe)` | function | Hit-side axis qualifications, or `[]`. |
-| `queriesQualifications(recipe)` | function | Per-primary-column axis qualifications, or `{}`. |
+
+### Exported but Not Part of the Surface
+
+The module also exports the names below. They exist for the SDK's own consumers
+and are not the utility surface a block writes against — a block that reaches
+for one is usually re-implementing something `ColumnsCollection` or
+`createPlDataTableV3` already does. Listed so you know what they are when you
+meet them in SDK code, not so you call them.
+
+| Export | What it is |
+| --- | --- |
+| `deriveAxisValuesLabels(source?, opts?)` | Builds an `(axisId) => Record<value, label>` callback from `pl7.app/label` columns — the shape `expandByPartition`'s `axisValuesLabels` option takes. |
+| `collectLinkerIds(recipe)` | Non-hit `PObjectId`s referenced by the recipe's query. |
+| `collectLinkerColumns(recipe, opts?)` | The same set, resolved to leaves. Throws if any is unresolvable. |
+| `hitQualifications(recipe)` | Hit-side axis qualifications, or `[]`. |
+| `queriesQualifications(recipe)` | Per-primary-column axis qualifications, or `{}`. |
+
+If you do end up needing one of the last four, use them rather than descending
+the wrapper classes by hand: they encapsulate the layering invariants
+(`Overridden` / `Filtered` over at most one `Discovered`) and keep working as
+wrappers are added.
 
 ### Providers — Plumbing
 
@@ -514,6 +530,10 @@ node), `Overridden` adds `domain[axisName]` plus a `split:<axisId>` entry on
 Inputs must be readable here — partition keys are inspected via `getData()`.
 Guard with `hasReachableData`, not `hasSingleDataColumn`.
 
+`axisValuesLabels` is optional; without it a split is labelled by its raw axis
+value. Supply your own resolver, or `deriveAxisValuesLabels()` to build one from
+the `pl7.app/label` columns in scope.
+
 Returns `undefined` when an input's data is neither a live `TreeNodeAccessor`
 nor parsed `DataInfoEntries`, or when partition keys can't be read — i.e. "not
 ready yet, try next render pass". Throws when a requested `idx` exceeds the
@@ -523,35 +543,6 @@ This is the sanctioned way to split a column. Do not fabricate ids by string
 concatenation (`` `${col.id}#${value}` ``) or by nesting a canonical id inside a
 `LocalPObjectId` path: both produce ids that fail `extractPObjectId` downstream,
 and the cast silences the type-checker, not the runtime invariant.
-
-### `deriveAxisValuesLabels`
-
-```ts
-deriveAxisValuesLabels(
-  source?: ColumnsCollection | (ColumnsCollection | ColumnsSource)[],
-  opts?: { ctx?: GlobalCfgRenderCtx },
-): (axisId: AxisId) => Record<string | number, string> | undefined;
-```
-
-Discovers `pl7.app/label` columns in `source` (default: ambient ctx),
-materialises their value→label maps eagerly, keys them by canonical axis id.
-Pair with `expandByPartition` for human-readable split labels.
-
-Skips recipes whose data is not directly readable, label columns with more than
-one axis, and data resource types other than `PColumnData/Json` /
-`PColumnData/JsonPartitioned`.
-
-### Recipe Walking
-
-Use these rather than descending the wrapper classes by hand — they encapsulate
-the layering invariants and keep working as wrappers are added.
-
-| Helper | Returns |
-| --- | --- |
-| `collectLinkerIds(recipe)` | every non-hit `PObjectId` in `recipe.getQuery()`, deduped in traversal order. Pure query walk, no registry access. |
-| `collectLinkerColumns(recipe, opts?)` | the same set resolved to leaf `DataColumnRecipe`s. Throws if any fails to resolve. |
-| `hitQualifications(recipe)` | hit-side `AxisQualification[]` from the inner `ColumnDiscoveredRecipe`, or `[]` for leaves and overrides-over-leaves. |
-| `queriesQualifications(recipe)` | `Record<PObjectId, AxisQualification[]>` — per-primary-column qualifications to apply at the consumer's outer join. |
 
 ## Handing Columns to Consumers
 

--- a/docs/column-access-api.md
+++ b/docs/column-access-api.md
@@ -1,0 +1,764 @@
+# Column Access API — Surface Reference
+
+Everything a block model uses to find, describe and hand off PColumns:
+`ColumnsCollection`, `Column` / `ColumnRecipe` / `DataColumn`, the predicates,
+the selector shapes, and the consumers that accept column ids.
+
+All names below are exported from `@platforma-sdk/model`. Source lives in
+`sdk/model/src/columns/` unless stated otherwise.
+
+**Related docs.** [`migrations/2026-05-20-new-column-access-mechanism.md`](../migrations/2026-05-20-new-column-access-mechanism.md)
+maps the old API onto this one and is the place for "what replaced X" —
+this document is the surface itself, for code that has no old shape to
+migrate from. [`column-identity.md`](./column-identity.md) covers the
+physical/logical id split and the recipe-authoring contract.
+
+## The Model in Six Lines
+
+1. A column **is** its id — a `ColumnUniversalId` string. Everything else is
+   derived from it.
+2. A `ColumnRecipe` is a typed, immutable accessor over one id. It is a
+   description of how to obtain a column, not the column's contents.
+3. Discovery and filtering run **on the host**, against the host's spec frame.
+   The sandbox only ever holds ids and opaque handles.
+4. `getSpec()` is a host round-trip per column. Columns you never inspect cost
+   nothing.
+5. Data is mostly *not* readable in the sandbox. Hand `recipe.id` to the host
+   (`createPFrame` / `createPTableV2` / `createPlDataTableV3`) and let it
+   materialise.
+6. Nothing is mutable. To get a different spec, encode it into a new id with
+   `withSpecs(patch)`.
+
+The 8 MB sandbox input limit is why all six hold. Pulling specs you don't need
+is the failure mode this API exists to prevent.
+
+## Export Map
+
+Every public export of the module, by role. Details follow in the sections below.
+
+### Discovery
+
+| Export | Kind | One-liner |
+| --- | --- | --- |
+| `ColumnsCollection(sources?, deps?)` | function + type | Host-driven column set. Entry point for all discovery. |
+| `isColumnsCollection(value)` | guard | Narrows to `ColumnsCollection`. |
+| `ColumnsSourceShorthand` | type | `"result_pool" \| "current_block"`. |
+| `ColumnsSource` | type | Provider / accessor / `{ columns, isFinal }`. |
+| `ColumnsCollectionDeps` | type | `{ ctx?, driver? }` — ctx override and test seam. |
+| `ColumnsCollectionImpl` | class | Instance type behind `ColumnsCollection`; never constructed directly. |
+
+### Columns
+
+| Export | Kind | One-liner |
+| --- | --- | --- |
+| `Column(source, opts?)` | function + type | Unified factory: string id or object source → `ColumnRecipe`. |
+| `ColumnRecipe` | interface + function | The recipe contract; also the id-shape-dispatching factory. |
+| `ColumnRecipe.getStatus(id, opts?)` | function | Resolution status of an id without building the recipe. |
+| `DataColumn(source, opts?)` | function | Leaf factory, plus `.fromId` / `.fromPlRef` / `.fromAccessor` / `.fromColumn` and the `getStatus*` statics. |
+| `DataColumnRecipe` | interface | `ColumnRecipe` + `getData()`. |
+| `ColumnSource` | type | Input union of `Column(...)`. |
+| `DataColumnSource` | type | Input union of `DataColumn(...)`. |
+| `DataColumnId` | type | Alias of `PObjectId` — a leaf's id. |
+| `ColumnData` | type | `undefined \| PColumnDataUniversal` — what `getData()` returns. |
+| `ColumnDiscoveredRecipe` | class | Discovery hit reached through a linker chain. |
+| `ColumnFilteredRecipe` | class | Axis-sliced projection. |
+| `ColumnOverriddenRecipe` | class | Spec-patched projection. |
+| `DataColumnImpl` | class | Leaf implementation. Internal — hold `DataColumnRecipe`. |
+
+You do not name the recipe classes in ordinary block code. They are listed
+because they appear in stack traces and in `instanceof` checks inside the SDK;
+narrow with the predicates instead.
+
+Two more classes exist in that file set and are deliberately **not** exported
+from `@platforma-sdk/model`: `DataColumnOverriddenRecipe` (the data-bearing
+variant of an override, which is what `hasReachableData` tests for) and
+`rebrandLeafId` (the wrapper-query helper described in
+[`column-identity.md`](./column-identity.md)). You will see them in SDK code;
+you cannot import them.
+
+### Predicates
+
+| Export | Kind | Answers |
+| --- | --- | --- |
+| `isColumn(value)` | guard | Is this any recipe? |
+| `hasReachableData(recipe)` | guard → `DataColumnRecipe` | Can I read the data here, consistent with the spec? |
+| `hasSingleDataColumn(recipe)` | boolean | Does it read exactly one storage column? |
+| `isDataColumn(value)` | guard → `DataColumnRecipe<PObjectId>` | Is this a bare leaf, i.e. is its `id` a `PObjectId`? |
+| `hasColumnData(recipe, opts?)` | boolean | Do the underlying data resources actually carry bytes? |
+| `isLeafColumn` | deprecated alias | Same as `hasSingleDataColumn`. |
+
+### Status and Errors
+
+| Export | Kind | One-liner |
+| --- | --- | --- |
+| `ColumnFieldStatus` | type | `"present" \| "resolving" \| "absent"` — data-field status, worst across referenced ids. |
+| `ColumnResolutionStatus` | type | Same value space; folds spec + registry readiness. |
+| `ColumnAbsentError` | class | Thrown by factories when a column provably will not appear. |
+
+### Utilities
+
+| Export | Kind | One-liner |
+| --- | --- | --- |
+| `deriveColumnOptions(source, labelOptions?)` | function | `ColumnOption[]` — `{ id, label }` drop-down options over a collection. |
+| `ColumnOption` | type | `{ id: ColumnUniversalId; label: string }`. |
+| `expandByPartition(inputs, splitAxes, opts?)` | function | Fan a column out into one recipe per partition value. |
+| `SplitAxis`, `ExpandByPartitionOpts` | types | `{ idx }` and `{ axisValuesLabels? }`. |
+| `deriveAxisValuesLabels(source?, opts?)` | function | `(axisId) => Record<value, label>` from `pl7.app/label` columns. |
+| `collectLinkerIds(recipe)` | function | Non-hit `PObjectId`s referenced by the recipe's query. |
+| `collectLinkerColumns(recipe, opts?)` | function | Same set, resolved to leaves. Throws if any is unresolvable. |
+| `hitQualifications(recipe)` | function | Hit-side axis qualifications, or `[]`. |
+| `queriesQualifications(recipe)` | function | Per-primary-column axis qualifications, or `{}`. |
+
+### Providers — Plumbing
+
+Rarely needed in block code: `ColumnsCollection` sources cover the same ground
+with less ceremony. Reach for these only when you need a provider object itself.
+
+| Export | Kind | One-liner |
+| --- | --- | --- |
+| `ColumnsProvider` | interface + factory | `{ getColumns(), isFinal() }`; the factory dispatches on accessor vs upstream-block list. |
+| `ArrayColumnsProvider` | class | Wraps a `PColumn[]` / leaf array. Prefer the `{ columns, isFinal }` source shape. |
+| `AccessorColumnsProvider`, `ResultPoolColumnsProvider` | factory + type | Memoised providers over an accessor root / the result pool. |
+| `AccessorColumnsProviderImpl`, `ResultPoolColumnsProviderImpl` | classes | Their implementations. |
+| `isColumnProvider`, `toColumnProvider`, `getCtxProviders` | functions | Shape guard, coercion, ambient-ctx provider triplet. |
+
+## `ColumnsCollection`
+
+```ts
+ColumnsCollection(
+  sources?: (ColumnsCollection | ColumnsSource | ColumnsSourceShorthand)[],
+  deps?: { ctx?: GlobalCfgRenderCtx; driver?: ColumnsCollectionDriverModel },
+): ColumnsCollection;
+```
+
+A sandbox proxy over a host-owned column set (`columns_collection.ts`). It holds
+an opaque `CollectionHandle` and a driver reference — no specs, no data. There
+is no `dispose()`: the host pins each handle to the active render ctx.
+
+**Sources.** Omitting `sources` means current block outputs + prerun + result
+pool. Narrow it aggressively — every entry widens the host-side spec frame the
+collection queries against.
+
+| Source entry | Expands to |
+| --- | --- |
+| `"current_block"` | `outputs` + `prerun` accessors of this block, whichever exist |
+| `"result_pool"` | the upstream-block result pool |
+| `TreeNodeAccessor` | that subtree |
+| `ColumnsCollection` | that collection, by handle (chaining) |
+| `ColumnsProvider` | its `getColumns()` ids + `isFinal()` |
+| `{ columns, isFinal }` | the entries' `.id`s; `columns` accepts `PColumn` / `DataColumnRecipe` / any `ColumnRecipe` |
+
+`isFinal` says whether the visible column set can still grow. While upstream
+blocks are running it keeps growing across render passes. Built-in sources
+compute it; you supply it only with the `{ columns, isFinal }` shape.
+
+**Instance surface.** Every method that returns a collection mints a fresh
+handle on the host; the receiver is unchanged.
+
+| Member | Returns | Cost |
+| --- | --- | --- |
+| `.handle` | `CollectionHandle` | free — pass into another `ColumnsCollection(...)` |
+| `.isEmpty()` | `boolean` | host call, no ids transferred |
+| `.isFinal()` | `boolean` | host call |
+| `.getColumnIds()` | `ColumnUniversalId[]` | host call; the cheapest exit |
+| `.getColumns()` | `ColumnRecipe[]` | ids + one recipe construction each |
+| `.addSource(source)` | `ColumnsCollection` | host call |
+| `.discover(options)` | `ColumnsCollection` | host-side discovery query |
+| `.filter(options)` | `ColumnsCollection` | host-side selector match |
+
+`getColumnIds()` is the fast path when the ids are all you need — and they
+usually are, because the id-accepting consumers take them directly.
+
+`getColumns()` builds a recipe per id. Two consequences worth knowing:
+
+- Ids that are still resolving are **dropped**, so the result can be shorter
+  than `getColumnIds()`.
+- An id whose column is provably absent makes recipe construction throw
+  `ColumnAbsentError`. Catch it at the boundary if partial absence should be
+  surfaced rather than silently yielding an empty table.
+
+```ts
+// only the current block's own outputs/prerun
+ColumnsCollection(["current_block"]);
+// upstream blocks only
+ColumnsCollection(["result_pool"]);
+// current block plus one extra subtree
+ColumnsCollection(["current_block", someAccessor]);
+// chain onto an existing collection
+ColumnsCollection([alreadyNarrowed, "result_pool"]);
+```
+
+### `discover` and `filter` Options
+
+```ts
+interface DiscoverColumnsOptions {
+  include?: ColumnSelector;   // omitted = include all
+  exclude?: ColumnSelector;   // applied after include
+  mode?: MatchingMode;        // default "enrichment"; ignored without anchors
+  anchors?: Record<string, AnchorEntry>;
+  maxHops?: number;           // default 4 with anchors, 0 without
+}
+
+type ColumnsDiscoverOptions = DiscoverColumnsOptions;
+type ColumnsFilterOptions = Omit<DiscoverColumnsOptions, "mode" | "maxHops">;
+```
+
+(`lib/model/common/src/drivers/columns/discover_columns_options.ts`)
+
+`filter` has no `mode` / `maxHops` — traversal scope is fixed by the collection
+it is called on. It matches selectors against what is already in the set.
+
+`AnchorEntry` is `PlRef | PObjectId | PColumnSpec | RelaxedColumnSelector`. All
+four are plain JSON, so the option object crosses the bridge unchanged.
+
+| `MatchingMode` | Axis behaviour |
+| --- | --- |
+| `"enrichment"` (default) | anchor axes may float over un-mapped hit axes — "extend this query" |
+| `"related"` | both source and hit axes may float; widest match |
+| `"exact"` | no floating, no qualifications; strict equality |
+
+### Selectors
+
+```ts
+type RelaxedStringMatchers = string | StringMatcher | (string | StringMatcher)[];
+type StringMatcher = { type: "exact"; value: string } | { type: "regex"; value: string };
+
+interface RelaxedColumnSelector {
+  name?: RelaxedStringMatchers;
+  type?: ColumnValueType | ColumnValueType[];
+  domain?: Record<string, RelaxedStringMatchers>;
+  contextDomain?: Record<string, RelaxedStringMatchers>;
+  annotations?: Record<string, RelaxedStringMatchers>;
+  axes?: RelaxedAxisSelector[];      // { name?, type?, domain?, contextDomain?, annotations? }
+  partialAxesMatch?: boolean;        // omit to require an exact axis-set length
+}
+
+type ColumnSelector = RelaxedColumnSelector | RelaxedColumnSelector[];
+```
+
+(`lib/model/common/src/columns/column_selector.ts`)
+
+Semantics:
+
+- Keys **within** one selector are ANDed. An array of selectors is ORed.
+- A bare string is normalised to `{ type: "regex", value }`.
+- **Prefer `{ type: "exact", value }` over `^…$`** when you mean one literal
+  name. Column namespaces are full of `.` and `/`; the exact matcher takes the
+  value literally and needs no escaping.
+- Annotation and domain keys must be *present* in the spec to match. A negation
+  regex will not match columns that lack the key at all — use `exclude` for
+  "not this", not a regex.
+- There are no `(spec) => boolean` selectors. The point of a selector is that it
+  runs host-side, where no spec has to cross the bridge.
+
+When a predicate genuinely cannot be expressed — cross-column logic, parsing a
+JSON annotation payload, a runtime-built `Set` — narrow with selectors first and
+post-filter the survivors in JS, knowing each survivor pays one `getSpec()`:
+
+```ts
+const cols = ColumnsCollection(["result_pool"])
+  .discover({ anchors: { main: anchorSpec }, mode: "enrichment", maxHops: 2 })
+  .filter({ exclude: [{ type: "File" }, { annotations: { "pl7.app/isLinkerColumn": "true" } }] })
+  .getColumns()
+  .filter((c) => parseTrace(c.getSpec()).type !== "lead-selection");
+```
+
+## Recipes
+
+### `ColumnRecipe`
+
+```ts
+interface ColumnRecipe<ID extends ColumnRecipeId = ColumnRecipeId> {
+  readonly id: ID;
+  getReferencedIds(): PObjectId[];
+  getSpec(): PColumnSpec;
+  getQuery(): SpecQuery;
+  getDataStatus(): ColumnFieldStatus;
+  withSpecs(overrides: SpecOverrides): ColumnRecipe;
+}
+```
+
+(`sdk/model/src/columns/column_recipes/types.ts`)
+
+| Member | Cost | Notes |
+| --- | --- | --- |
+| `id` | free | field, not a method. Canonical, addressable, transportable. |
+| `getReferencedIds()` | free | every storage column the recipe reaches. |
+| `getSpec()` | **host round-trip**, memoised per instance | always returns a value — a constructed recipe is spec-complete by contract. |
+| `getQuery()` | free | the `SpecQuery` IR the host executes. |
+| `getDataStatus()` | host call, memoised | worst status across `getReferencedIds()`. |
+| `withSpecs(patch)` | free | new recipe, new id; receiver unchanged. |
+
+Two recipes are equal as value-objects exactly when their ids match. There is no
+`getData()` on this interface, no spec field, and no `getSpecOverrides` /
+`getDiscovery` / `getAxisFilters` — those are details of the id.
+
+Iterating a 5k-column collection and calling `getSpec()` on each fetches 5k
+specs. Most pipelines never call it: they pass `.id` on.
+
+### `withSpecs`
+
+```ts
+type SpecOverrides = Pick<PColumnSpec, "domain" | "contextDomain" | "annotations"> & {
+  axesSpec?: AxisPatches;   // Record<axisIndex, Partial<AxisSpec>> — positional, not AxisSpec[]
+};
+```
+
+The patch is encoded **into the id**, so the result is a real addressable column
+that travels as a string:
+
+```ts
+const tagged = col.withSpecs({ annotations: { "myblock/highlight": "true" } });
+tagged.id !== col.id; // true — original col untouched
+```
+
+Repeated calls flatten: `col.withSpecs(a).withSpecs(b)` is equal-by-id to
+`col.withSpecs(merge(a, b))`. There is never an `Overridden<Overridden<…>>`.
+
+`axesSpec` patches are keyed by positional index, deliberately — linker specs
+carry several axes with the same `name` distinguished only by domain. A patch at
+an index past the end appends an axis.
+
+If you find yourself calling `getSpec()` only to feed the result back into
+`withSpecs`, express the change as a patch and skip the round-trip.
+
+### `DataColumnRecipe`
+
+```ts
+interface DataColumnRecipe<ID = ColumnRecipeId> extends ColumnRecipe<ID> {
+  getData(): ColumnData;   // undefined | PColumnDataUniversal — host round-trip
+}
+```
+
+A **capability**, not a class. Only two shapes carry it: a bare leaf, and a spec
+override over a bare leaf — the only shapes whose data still matches their spec.
+Narrow with `hasReachableData`; the method is absent otherwise, so there is no
+throwing path behind the guard.
+
+### Id Shapes and Recipe Classes
+
+The id decides the class. You never choose it.
+
+| Id shape on the wire | Recipe class | What it is |
+| --- | --- | --- |
+| bare `PObjectId` | `DataColumnImpl` (as `DataColumnRecipe`) | a plain stored column; spec and data both reachable |
+| `ColumnOverriddenId` | `ColumnOverriddenRecipe` | "that recipe, with domain / contextDomain / annotations / axes patched" |
+| `ColumnFilteredId` | `ColumnFilteredRecipe` | "that recipe, with some axes pinned to values" |
+| `ColumnDiscoveredId` | `ColumnDiscoveredRecipe` | a discovery hit, carrying the linker path back to its anchor |
+
+Layering rules, enforced by the wrappers themselves:
+
+- `ColumnOverriddenRecipe` is always **outermost**. `filtered.withSpecs(p)`
+  yields `Overridden<Filtered<inner>>`; the reverse is unreachable through the
+  public API.
+- At most one `Overridden` layer, at most one `Filtered` layer, at most one
+  `Discovered` layer in any chain.
+- A bare leaf is the only recipe built from a `TreeNodeAccessor` / `PColumn` /
+  `PlRef`. Every other shape is produced by `discover` / `filter` / `withSpecs`
+  and is passed around by `.id`.
+
+Spec derivation per layer: `Discovered` passes the hit's spec through (the
+linker chain enables co-indexing, it does not remap axes); `Filtered` drops the
+pinned axes from `axesSpec`; `Overridden` applies the patch.
+
+## Factories
+
+```ts
+Column(source: ColumnSource, opts?): undefined | ColumnRecipe;
+```
+
+The one entry point. Routing:
+
+- **string id** (`PObjectId` or `ColumnUniversalId`) → `ColumnRecipe(id)`, which
+  dispatches on the parsed id shape.
+- **object** (`PlRef` / `LeafEntry` / `PColumn` / `DataColumnRecipe`) →
+  `DataColumn(source)`. These shapes only ever map to a bare leaf.
+
+Call the dispatchers directly when the call site is unambiguous:
+
+```ts
+ColumnRecipe(id);              // string id, routed by shape
+DataColumn(source);            // id | PlRef | PColumn | LeafEntry | DataColumnRecipe
+DataColumn.fromId(pObjectId);
+DataColumn.fromPlRef(ref);
+DataColumn.fromColumn(pColumn);
+DataColumn.fromAccessor(leafEntry);
+```
+
+**Return contract.** Every factory returns `undefined` while the column is still
+`resolving` — retry on the next render pass, more accessor inputs may arrive.
+Every factory throws `ColumnAbsentError` when the column is `absent` — every
+relevant accessor reports `inputsLocked` and the column did not appear, so it
+never will in this ctx. Always check for `undefined` before chaining.
+
+`ColumnRecipe(id)` additionally throws for an id variant it cannot build (e.g. a
+legacy `AnchoredPColumnId`, which needs an anchor map to resolve).
+
+### Status Without Construction
+
+```ts
+ColumnRecipe.getStatus(id, opts?);        // any id shape, dispatches by parsed key
+DataColumn.getStatus(source, opts?);      // any DataColumnSource
+DataColumn.getStatusById(id, opts?);
+DataColumn.getStatusByPlRef(ref, opts?);
+DataColumn.getStatusByAccessor(entry);
+```
+
+Inside a loop over known ids, one `getStatus` up front beats a try/catch around
+the factory.
+
+| Type | Means |
+| --- | --- |
+| `ColumnFieldStatus` | data-field status, worst across every referenced id. What `recipe.getDataStatus()` returns; the usual thing to check while iterating recipes. |
+| `ColumnResolutionStatus` | same values, but folds spec readiness and leaf-registry readiness: "can this recipe be *constructed* at all in this ctx". |
+
+Both are `"present" | "resolving" | "absent"`, worst-wins (`absent` ▸
+`resolving` ▸ `present`).
+
+`getDataStatus() === "present"` means the `.data` field is wired onto the
+accessor. It does **not** mean bytes have arrived. When you need that stronger
+claim, use `hasColumnData(recipe)`, which walks every referenced leaf and checks
+`hasData()` across all of them (inline `PColumnValues` count as present, an
+unresolvable leaf counts as not-ready rather than throwing).
+
+## Predicates
+
+Named after what you can do with the column, not after which class it is. Which
+classes exist is an implementation detail behind `recipe.id` — never
+`instanceof`-narrow to one.
+
+```ts
+isColumn(value);              // value is Column                     — any recipe
+hasReachableData(recipe);     // recipe is DataColumnRecipe           — data readable here
+hasSingleDataColumn(recipe);  // boolean                             — reads one column, not several
+isDataColumn(value);          // value is DataColumnRecipe<PObjectId> — bare leaf
+```
+
+**`hasReachableData` — "can I read the data?"** True for a bare leaf and for a
+spec override over one. False for an axis-filtered recipe: its spec has dropped
+axes the underlying data still carries, so the two no longer line up and the
+slice only exists engine-side. False for anything reached through other columns.
+In both false cases, pass `recipe.id` to the host instead.
+
+**`hasSingleDataColumn` — "one column or several?"** True for a bare leaf and
+for projections over one (spec overrides, axis slicing) — layers, but no new
+columns. False when the recipe reaches its data through further columns, which
+is what a linker-chain discovery hit does.
+
+Why it matters: a recipe over a single data column is co-indexed by its own
+axes, so its spec is the whole truth about them. One that reads several only
+lines up after the join, and drags axes into that join its own spec never
+mentions. That is the **primary vs linker-joined** split at the
+`createPlDataTableV3` boundary — only single-column recipes are valid primaries.
+The SDK's own `discoverTableColumns` splits on exactly this predicate.
+
+**`isDataColumn` — "is this a storage column?"** True only for a bare leaf,
+whose `id` is a `PObjectId` naming a real column in storage. Reach for it when a
+*type* forces that id shape — `PColumn.id`, `PColumnIdAndSpec.columnId` — not
+when you merely want to read data.
+
+The predicates are independent. An axis-filtered leaf reads a single column and
+has no reachable data. Pick by what you do next, not by which sounds stricter:
+
+| You want to… | Guard |
+| --- | --- |
+| call `getData()` in the sandbox | `hasReachableData` |
+| use it as a `createPlDataTableV3` primary | `hasSingleDataColumn` |
+| put its id in a `PObjectId`-typed slot | `isDataColumn` |
+| know whether bytes actually landed | `hasColumnData` |
+
+## Utilities
+
+### `deriveColumnOptions`
+
+```ts
+deriveColumnOptions(
+  source: ColumnsCollection | ColumnsSource[],
+  labelOptions?: DeriveLabelsOptions,
+): ColumnOption[];   // { id: ColumnUniversalId; label: string }[]
+```
+
+Labels every column already in `source` via `deriveDistinctLabels`. Filtering is
+the caller's job — pass a collection you already narrowed. Note it calls
+`getSpec()` on every entry, so narrow first.
+
+The `id`-valued option shape is what the id-accepting consumers want. A block
+arg holding one of these is typed `ColumnUniversalId`, not `PlRef` — see the
+migration doc's persisted-data section before changing a stored field's type.
+
+```ts
+const options = deriveColumnOptions(
+  ColumnsCollection(["result_pool"]).discover({
+    include: { axes: [{ name: [{ type: "exact", value: "pl7.app/sampleId" }] }] },
+    mode: "enrichment",
+  }),
+);
+```
+
+### `expandByPartition`
+
+```ts
+expandByPartition(
+  inputs: Column[],
+  splitAxes: { idx: number }[],
+  opts?: { axisValuesLabels?: (axisId: AxisId) => undefined | Record<string | number, string> },
+): ColumnRecipe[] | undefined;
+```
+
+One recipe per Cartesian combination of unique partition values on the requested
+axes. Each split is `Overridden(Filtered(inner))`: `Filtered` pins the axes and
+drops them from `axesSpec` (the engine does the slicing via a `sliceAxes` query
+node), `Overridden` adds `domain[axisName]` plus a `split:<axisId>` entry on
+`pl7.app/trace` so `deriveDistinctLabels` can tell the splits apart.
+
+Inputs must be readable here — partition keys are inspected via `getData()`.
+Guard with `hasReachableData`, not `hasSingleDataColumn`.
+
+Returns `undefined` when an input's data is neither a live `TreeNodeAccessor`
+nor parsed `DataInfoEntries`, or when partition keys can't be read — i.e. "not
+ready yet, try next render pass". Throws when a requested `idx` exceeds the
+column's partition-key depth.
+
+This is the sanctioned way to split a column. Do not fabricate ids by string
+concatenation (`` `${col.id}#${value}` ``) or by nesting a canonical id inside a
+`LocalPObjectId` path: both produce ids that fail `extractPObjectId` downstream,
+and the cast silences the type-checker, not the runtime invariant.
+
+### `deriveAxisValuesLabels`
+
+```ts
+deriveAxisValuesLabels(
+  source?: ColumnsCollection | (ColumnsCollection | ColumnsSource)[],
+  opts?: { ctx?: GlobalCfgRenderCtx },
+): (axisId: AxisId) => Record<string | number, string> | undefined;
+```
+
+Discovers `pl7.app/label` columns in `source` (default: ambient ctx),
+materialises their value→label maps eagerly, keys them by canonical axis id.
+Pair with `expandByPartition` for human-readable split labels.
+
+Skips recipes whose data is not directly readable, label columns with more than
+one axis, and data resource types other than `PColumnData/Json` /
+`PColumnData/JsonPartitioned`.
+
+### Recipe Walking
+
+Use these rather than descending the wrapper classes by hand — they encapsulate
+the layering invariants and keep working as wrappers are added.
+
+| Helper | Returns |
+| --- | --- |
+| `collectLinkerIds(recipe)` | every non-hit `PObjectId` in `recipe.getQuery()`, deduped in traversal order. Pure query walk, no registry access. |
+| `collectLinkerColumns(recipe, opts?)` | the same set resolved to leaf `DataColumnRecipe`s. Throws if any fails to resolve. |
+| `hitQualifications(recipe)` | hit-side `AxisQualification[]` from the inner `ColumnDiscoveredRecipe`, or `[]` for leaves and overrides-over-leaves. |
+| `queriesQualifications(recipe)` | `Record<PObjectId, AxisQualification[]>` — per-primary-column qualifications to apply at the consumer's outer join. |
+
+## Handing Columns to Consumers
+
+### Accepts Ids
+
+| Consumer | Accepts |
+| --- | --- |
+| `ctx.createPFrame(def)` | `PFrameDef<PObjectId \| SUniversalPColumnId \| PColumn<…>>` — ids and `PColumn`s, mixed |
+| `ctx.createPTableV2(def)` | `PTableDefV2<ColumnUniversalId \| PColumn<…>>` |
+| `createPlDataTableV3(ctx, options)` | `ColumnRecipe[]` directly, or a declarative discovery config |
+
+`SUniversalPColumnId` is a legacy alias of `ColumnUniversalId` — same type, no
+migration needed where a signature still names it.
+
+```ts
+ctx.createPFrame(collection.getColumnIds());   // cheapest form
+ctx.createPFrame(recipes.map((c) => c.id));    // works for any recipe, leaf or wrapped
+```
+
+Passing ids is also the *only* way to feed wrapped recipes into a PFrame. Most
+of them cannot be read in the sandbox at all, but `recipe.id` is a
+`ColumnUniversalId` the host resolves server-side. Don't try to narrow a recipe
+list before building a PFrame — pass `.id`.
+
+`PColumn` objects with live `TreeNodeAccessor` / `DataInfo` data still work when
+the column was assembled in the sandbox; `finalizePColumnData` is the converter.
+Prefer the id form whenever the column came from the host in the first place.
+
+### Does Not Accept Ids
+
+| Slot | Needs | Why |
+| --- | --- | --- |
+| `ctx.createPTable(def)` (v1) | `PColumn<PColumnDataUniversal>[]` | pre-id API; use `createPTableV2` |
+| `createPFrameForGraphs(ctx, cols)` | `PColumn<PColumnDataUniversal>[]` | no id form yet |
+| `PColumn.id` | `PObjectId` | physical id slot |
+| `PColumnIdAndSpec.columnId` | `PObjectId` | physical id slot |
+
+The bridge, valid **only** for bare leaves:
+
+```ts
+const leaves = recipes.filter(isDataColumn);
+const pCols: PColumn<PColumnDataUniversal>[] = leaves.map((c) => ({
+  id: c.id,
+  spec: c.getSpec(),
+  data: c.getData()!,
+}));
+```
+
+`isDataColumn` — not `hasReachableData` — is the right guard: `PColumn.id` is
+typed `PObjectId`, which only a bare leaf carries. An override over a leaf is
+readable but exposes a `ColumnUniversalId` that the slot rejects. There is no
+materialisation path for `Filtered` or `Discovered` recipes at all; if your
+discovery emits those and you need a `PColumn`-only helper, the helper has to
+grow id support.
+
+### `createPlDataTableV3`
+
+Two forms (`sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts`):
+
+```ts
+// Form A — declarative. The helper discovers and splits primary/secondary itself.
+createPlDataTableV3(ctx, {
+  columns: {
+    sources: [...],                          // ColumnsSource[] — no string shorthand here
+    anchors: { main: anchorSpec },
+    selector: { mode: "enrichment", maxHops: 4, include: [...], exclude: [...] },
+  },
+  tableState, filters, sorting, primaryJoinType, labelsOptions, displayOptions,
+});
+
+// Form B — you discover, you split.
+createPlDataTableV3(ctx, {
+  primaryColumns: primary,     // ColumnRecipe[] — must pass hasSingleDataColumn
+  columns: secondary,          // ColumnRecipe[]
+  ...
+});
+```
+
+Form A specifics:
+
+- `sources` is `ColumnsSource[]`. The `"result_pool"` / `"current_block"`
+  shorthands are accepted only by `ColumnsCollection` itself — pass accessors or
+  a collection instance here.
+- `selector` is `ColumnsSelectorConfig`, whose `include` / `exclude` are typed
+  as the **strict** `MultiColumnSelector` (`name?: StringMatcher[]`,
+  `domain?: Record<string, StringMatcher[]>`), unlike the relaxed form
+  `ColumnsCollection.discover` accepts. The runtime normalises either; the types
+  here do not.
+- `displayOptions.ordering[].match` and `visibility[].match` are `ColumnSelector`,
+  not lambdas. Anything not selector-expressible has no place in display options.
+  First matching rule wins, so `{ match: {} }` is the catch-all — put the
+  exception rules above it.
+
+Pick Form B when display rules depend on predicates a selector can't express: do
+the discovery yourself, post-filter in JS, and hand over the exact recipe lists.
+
+**`primaryColumns` must pass `hasSingleDataColumn`.** `discover` with anchors
+returns a mix of direct hits, projections over a leaf (still fine as primaries)
+and multi-hop `Discovered` hits (not fine). Form A does the split for you; Form
+B trusts you. A multi-axis `Discovered` in `primaryColumns` makes
+`discoverLabelColumns` pull in label columns on its extra axes, which then enter
+the engine join as disjoint-axes tables and fail with `axes sets are disjoint`.
+Filter with `hasSingleDataColumn` — not `isDataColumn`, which is stricter and
+drops valid projections.
+
+## Cost Model
+
+What crosses the sandbox bridge, and when.
+
+| Operation | Bridge traffic |
+| --- | --- |
+| `ColumnsCollection(...)`, `.discover`, `.filter`, `.addSource` | one host call, returns a handle |
+| `.isEmpty()`, `.isFinal()` | one host call, no payload |
+| `.getColumnIds()` | one host call, N id strings |
+| `.getColumns()` | ids + per-id registry resolution (no spec bytes) |
+| `recipe.id`, `.getQuery()`, `.getReferencedIds()`, `.withSpecs()` | none |
+| `recipe.getSpec()` | one round-trip per recipe, memoised per instance |
+| `recipe.getData()` | one round-trip, memoised per instance |
+| `createPFrame(ids)` / `createPTableV2(ids)` | ids only; host resolves spec and data |
+
+Rules that follow:
+
+1. Push filtering into selectors. A column that never matches never costs a spec.
+2. Prefer ids to recipes when passing things around.
+3. Call `getSpec()` on survivors only, never across a whole pool.
+4. Don't read a spec just to patch it — use `withSpecs`.
+
+## Working Example
+
+`etc/blocks/table-test/model/src/index.ts` exercises the surface end to end:
+anchored discovery, `hasSingleDataColumn` for the primary split,
+`hasReachableData` before `expandByPartition`, `deriveAxisValuesLabels`, recipe
+ids used as filter and sort targets, and both `createPlDataTableV3` forms.
+
+```ts
+const valueAnchor = { name: "value", axes: [{ name: "name" }] };
+
+const primary = ColumnsCollection()
+  .discover({ anchors: { main: valueAnchor }, mode: "exact" })
+  .getColumns()
+  .filter(hasSingleDataColumn);
+if (primary.length === 0) return undefined;
+
+const countLeaves = ColumnsCollection()
+  .filter({ include: { name: [{ type: "exact", value: "count" }] } })
+  .getColumns()
+  .filter(hasReachableData);
+
+const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
+  axisValuesLabels: deriveAxisValuesLabels(),
+});
+if (splitRecipes === undefined) return undefined;
+
+const primaryIds = new Set(primary.map((c) => c.id));
+const secondary = ColumnsCollection()
+  .discover({ anchors: { main: valueAnchor }, mode: "enrichment", maxHops: 4 })
+  .getColumns()
+  .filter((c) => !primaryIds.has(c.id));
+
+return createPlDataTableV3(ctx, {
+  primaryColumns: primary,
+  columns: [...secondary, ...splitRecipes],
+  tableState: ctx.data.tableSplitState,
+});
+```
+
+## Deprecated Surface
+
+Still exported, do not write new code against it:
+
+| Name | Instead |
+| --- | --- |
+| `isLeafColumn` | `hasSingleDataColumn` |
+| `ResultPool` and every column entry point on it (`ctx.resultPool.*`) | `ColumnsCollection` / `Column(ref)` |
+| `TreeNodeAccessor.getPColumns()` | `ColumnsCollection([accessor])` |
+| `ctx.getBlockLabel(blockId)` | nothing — slated to return dummy values |
+| `SUniversalPColumnId` | `ColumnUniversalId` (same type) |
+
+`TreeNodeAccessor.getIsFinal()` is not deprecated, but once you have wrapped the
+accessor in a collection, read `collection.isFinal()` instead — same answer for
+a single-accessor source, and it stays correct as you add sources.
+
+One exception worth naming: `ctx.resultPool.getOptions(selectors, opts)` is
+still the supported entry point when you need the `Option[]` = `{ ref: PlRef,
+label }` wire shape with `refsWithEnrichments`. Its `@deprecated` note points at
+`ctx.getOptions`, which has not been promoted to `RenderCtxBase` yet. Move to
+`deriveColumnOptions` when you can also update the workflow and UI consumers,
+since that changes the stored value from a `PlRef` to a `ColumnUniversalId`.
+
+Removed names and their one-to-one replacements are in the migration doc.
+
+## Where the Code Lives
+
+| Area | Path |
+| --- | --- |
+| Collection proxy | `sdk/model/src/columns/columns_collection.ts` |
+| Leaf recipe, factories, `ColumnAbsentError` | `sdk/model/src/columns/data_column.ts` |
+| Recipe contract and dispatcher | `sdk/model/src/columns/column_recipes/{types,index}.ts` |
+| Wrapper recipes | `sdk/model/src/columns/column_recipes/column_{overrided,filtered,discovered}_recipe.ts` |
+| Unified `Column`, `isColumn` | `sdk/model/src/columns/column.ts` |
+| Predicates and recipe-walk helpers | `sdk/model/src/columns/utils.ts` |
+| Partition split | `sdk/model/src/columns/expand_by_partition.ts` |
+| Axis-value labels | `sdk/model/src/columns/derive_axis_values_labels.ts` |
+| Providers | `sdk/model/src/columns/column_providers/` |
+| Id types and helpers | `lib/model/common/src/drivers/pframe/spec/{ids,overridden,filtered_column,discovered_column}.ts` |
+| Selector types and normalisation | `lib/model/common/src/columns/column_selector.ts` |
+| Discover options | `lib/model/common/src/drivers/columns/discover_columns_options.ts` |
+| Collection driver contract | `lib/model/common/src/drivers/columns/columns_collection_driver.ts` |
+| Host-side physical resolver | `lib/node/pl-middle-layer/src/js_render/column_registry.ts` |
+| Table assembly | `sdk/model/src/components/PlDataTable/createPlDataTable/` |

--- a/docs/column-identity.md
+++ b/docs/column-identity.md
@@ -70,7 +70,7 @@ Every concrete `ColumnRecipe` must satisfy:
 2. `recipe.getQuery()` returns a `SpecQuery` whose terminal column leaf
    carries `recipe.id` — not the inner recipe's id, not the bare id.
 
-For leaf recipes (`ColumnLazyImpl`) this is trivial: `id` is the bare
+For leaf recipes (`DataColumnImpl`) this is trivial: `id` is the bare
 `PObjectId` and the query is `{type: "column", column: id}`.
 
 For wrapper recipes (Overridden / Filtered / Discovered) the inner recipe

--- a/docs/column-identity.md
+++ b/docs/column-identity.md
@@ -5,6 +5,10 @@ and the host (`pl-middle-layer`). Two distinct identities are involved in a
 table-rendering pipeline; mixing them up causes engine-level "column not
 found" errors and silent variant deduplication.
 
+For the consumer-facing surface built on these ids — `ColumnsCollection`,
+the recipe factories, the predicates — see
+[`column-access-api.md`](./column-access-api.md).
+
 ## The two identities
 
 ### Physical identity — `PObjectId`
@@ -127,7 +131,7 @@ the leaves is what makes that lookup succeed.
   `lib/model/common/src/drivers/pframe/query/query_spec.ts`,
   `lib/model/common/src/drivers/pframe/table_common.ts`.
 - Recipe implementations:
-  `sdk/model/src/columns/column_lazy.ts`,
+  `sdk/model/src/columns/data_column.ts`,
   `sdk/model/src/columns/column_recipes/column_overrided_recipe.ts`,
   `sdk/model/src/columns/column_recipes/column_filtered_recipe.ts`,
   `sdk/model/src/columns/column_recipes/column_discovered_recipe.ts`,

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -6,8 +6,7 @@ import {
   PlDataTableFilters,
   createPlDataTableStateV2,
   createPlDataTableV3,
-  deriveAxisValuesLabels,
-  expandByPartition,
+  splitByAxes,
   hasSingleDataColumn,
   hasReachableData,
   type InferHrefType,
@@ -146,9 +145,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
       .getColumns()
       .filter(hasReachableData);
 
-    const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
-      axisValuesLabels: deriveAxisValuesLabels(),
-    });
+    const splitRecipes = splitByAxes(countLeaves, [{ idx: 0 }]);
     if (splitRecipes === undefined) return undefined;
 
     const primaryIds = new Set<ColumnUniversalId>(primary.map((c) => c.id));

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -8,7 +8,7 @@ import {
   createPlDataTableV3,
   deriveAxisValuesLabels,
   expandByPartition,
-  isSelfContained,
+  hasSingleDataColumn,
   hasReachableData,
   type InferHrefType,
   type InferOutputsType,
@@ -138,7 +138,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const primary = ColumnsCollection()
       .discover({ anchors: { main: valueAnchor }, mode: "exact" })
       .getColumns()
-      .filter(isSelfContained);
+      .filter(hasSingleDataColumn);
     if (primary.length === 0) return undefined;
 
     const countLeaves = ColumnsCollection()

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -9,7 +9,7 @@ import {
   deriveAxisValuesLabels,
   expandByPartition,
   isSelfContained,
-  hasDirectData,
+  hasReachableData,
   type InferHrefType,
   type InferOutputsType,
   type PlDataTableStateV2,
@@ -144,7 +144,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const countLeaves = ColumnsCollection()
       .filter({ include: { name: [{ type: "exact", value: "count" }] } })
       .getColumns()
-      .filter(hasDirectData);
+      .filter(hasReachableData);
 
     const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
       axisValuesLabels: deriveAxisValuesLabels(),

--- a/etc/blocks/table-test/model/src/index.ts
+++ b/etc/blocks/table-test/model/src/index.ts
@@ -8,7 +8,8 @@ import {
   createPlDataTableV3,
   deriveAxisValuesLabels,
   expandByPartition,
-  isColumnLazy,
+  isSelfContained,
+  hasDirectData,
   type InferHrefType,
   type InferOutputsType,
   type PlDataTableStateV2,
@@ -129,7 +130,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
   .outputWithStatus("tableSplitV3", (ctx) => {
     const valueAnchor = { name: "value", axes: [{ name: "name" }] };
 
-    // Use only leaf (ColumnLazy) hits as primary. `discover` with anchors can
+    // Use only self-contained hits as primary. `discover` with anchors can
     // also surface multi-axis Discovered variants (e.g. count [group, name]
     // reached via linker_name_group_alt); those belong in secondary, not in
     // the join's primary side — mirrors what `discoverTableColumns` does
@@ -137,13 +138,13 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const primary = ColumnsCollection()
       .discover({ anchors: { main: valueAnchor }, mode: "exact" })
       .getColumns()
-      .filter(isColumnLazy);
+      .filter(isSelfContained);
     if (primary.length === 0) return undefined;
 
     const countLeaves = ColumnsCollection()
       .filter({ include: { name: [{ type: "exact", value: "count" }] } })
       .getColumns()
-      .filter(isColumnLazy);
+      .filter(hasDirectData);
 
     const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
       axisValuesLabels: deriveAxisValuesLabels(),

--- a/etc/blocks/table-test/test/src/wf.test.ts
+++ b/etc/blocks/table-test/test/src/wf.test.ts
@@ -102,7 +102,7 @@ blockTest(
     const fullIndices = Array.from({ length: fullShape.columns }, (_, i) => i);
     const fullData = await pFrameDriver.getData(fullHandle, fullIndices);
 
-    // `count` (group, name) is partitioned by `group`. expandByPartition fans
+    // `count` (group, name) is partitioned by `group`. splitByAxes fans
     // it out into one column per group value — G1 and G2. Each split column
     // has `group` axis sliced away and its `domain.group = "<value>"` patched
     // via specOverride. The values come from count.tsv:

--- a/lib/model/common/src/columns/dedup.ts
+++ b/lib/model/common/src/columns/dedup.ts
@@ -20,7 +20,7 @@ import { isPObjectId } from "../pool";
  *
  * Shared by sandbox-side `extractColumns` (column_providers) and host-side
  * `ColumnsCollectionDriverImpl.getColumns` — both layers need identical
- * dedup semantics, but operate on different concrete item types (DataColumn
+ * dedup semantics, but operate on different concrete item types (DataColumnRecipe
  * vs. raw ColumnUniversalId).
  */
 export function dedupColumns<T>(

--- a/lib/model/common/src/columns/dedup.ts
+++ b/lib/model/common/src/columns/dedup.ts
@@ -20,7 +20,7 @@ import { isPObjectId } from "../pool";
  *
  * Shared by sandbox-side `extractColumns` (column_providers) and host-side
  * `ColumnsCollectionDriverImpl.getColumns` — both layers need identical
- * dedup semantics, but operate on different concrete item types (ColumnLazy
+ * dedup semantics, but operate on different concrete item types (DataColumn
  * vs. raw ColumnUniversalId).
  */
 export function dedupColumns<T>(

--- a/lib/model/common/src/columns/providers.ts
+++ b/lib/model/common/src/columns/providers.ts
@@ -8,7 +8,7 @@ import type { AccessorLike, ColumnEntriesProvider, LeafEntry, UpstreamBlockCtx }
  * exposes `isFinal()` via the root's `getInputsLocked()`.
  *
  * Used directly on the host side; sandbox extends it with `getColumns()`
- * returning {@link DataColumn}s — see `AccessorColumnsProvider` in
+ * returning {@link DataColumnRecipe}s — see `AccessorColumnsProvider` in
  * `@platforma-sdk/model`.
  */
 export class AccessorEntriesProvider<

--- a/lib/model/common/src/columns/providers.ts
+++ b/lib/model/common/src/columns/providers.ts
@@ -8,7 +8,7 @@ import type { AccessorLike, ColumnEntriesProvider, LeafEntry, UpstreamBlockCtx }
  * exposes `isFinal()` via the root's `getInputsLocked()`.
  *
  * Used directly on the host side; sandbox extends it with `getColumns()`
- * returning {@link ColumnLazy}s — see `AccessorColumnsProvider` in
+ * returning {@link DataColumn}s — see `AccessorColumnsProvider` in
  * `@platforma-sdk/model`.
  */
 export class AccessorEntriesProvider<

--- a/migrations/2026-05-20-new-column-access-mechanism.md
+++ b/migrations/2026-05-20-new-column-access-mechanism.md
@@ -18,6 +18,10 @@ What this means for you, the consumer:
 
 The rest of this document is the mechanical migration. Each change is an instance of one of the rules above.
 
+For code with no old shape to migrate from, the API surface itself is documented in
+[`docs/column-access-api.md`](../docs/column-access-api.md) — every export, its cost, and
+which consumers accept ids.
+
 ---
 
 ## Column access — `ColumnCollectionBuilder` → `ColumnsCollection`

--- a/migrations/2026-05-20-new-column-access-mechanism.md
+++ b/migrations/2026-05-20-new-column-access-mechanism.md
@@ -270,7 +270,7 @@ ctx.createPFrame(recipes.map((c) => c.id)); // works for any recipe — leaf or 
 
 (Code that still needs a `PColumn<...>[]`, e.g. `createPFrameForGraphs`, does not have this id-form yet — see the "DataColumn → PColumn adapter" section below for the materialisation pattern that only works for leaves.)
 
-You can still pass `PColumn` objects with live `TreeNodeAccessor` / `DataInfo` data when the column was assembled in the sandbox (e.g. via `expandByPartition`); the helper that converts those (`transformPColumnData`) was renamed and exported as `finalizePColumnData`. Prefer the id form whenever the column came from the host in the first place.
+You can still pass `PColumn` objects with live `TreeNodeAccessor` / `DataInfo` data when the column was assembled in the sandbox (e.g. via `splitByAxes`); the helper that converts those (`transformPColumnData`) was renamed and exported as `finalizePColumnData`. Prefer the id form whenever the column came from the host in the first place.
 
 ---
 
@@ -710,7 +710,7 @@ Notes:
 - `PColumnIdAndSpec.columnId: PObjectId` — same constraint by the same logic. Only `DataColumn.id` (bare `PObjectId`) goes there; never a `ColumnUniversalId` from a wrapper recipe.
 - The `{ anchor: 'main', idx: 1 }` axis-binding from legacy `getAnchoredPColumns` has no `RelaxedAxisSelector` form. Workaround: read the anchor's `axesSpec[i].name` and pass it as `axes: [{ name }]` in the new selector — the axis-name match is enough for the common case.
 
-### Splitting columns by partition — use `expandByPartition`
+### Splitting a column into one column per axis value — use `splitByAxes`
 
 The legacy "snapshot to N synthetic PColumns" pattern (read `data` accessor, fan out, wrap each item with a fresh id, re-wrap via `DataColumnImpl.fromColumn`) does not fit the new recipe model. Two traps:
 
@@ -718,16 +718,15 @@ The legacy "snapshot to N synthetic PColumns" pattern (read `data` accessor, fan
 
 2. **You cannot embed a foreign canonical id inside `LocalPObjectId.resolvePath` either.** `createLocalPObjectId([col.id, ...], value)` parses and passes `extractPObjectId`, but it abuses the semantics of `LocalPObjectKey` (a path inside a _block's own_ local tree) by stuffing a `GlobalPObjectId` JSON in as a path element. Nested canonical ids are not how this layer composes.
 
-**Use the SDK helper `expandByPartition`** instead. Internally it pairs `ColumnFilteredRecipe.wrap` (pins specific axes to specific values, generates a `sliceAxes` query node) with `ColumnOverriddenRecipe.wrap` (overlays domain + trace annotations). The result per split is a canonical `ColumnOverriddenId(source: ColumnFilteredId, specOverrides)` — distinct, parseable, linked to the source for linker discovery — and the PFrame engine does the data slicing, so you never materialise filtered `data` in the sandbox.
+**Use the SDK helper `splitByAxes`** instead. Internally it pairs `ColumnFilteredRecipe.wrap` (pins specific axes to specific values, generates a `sliceAxes` query node) with `ColumnOverriddenRecipe.wrap` (overlays domain + trace annotations). The result per split is a canonical `ColumnOverriddenId(source: ColumnFilteredId, specOverrides)` — distinct, parseable, linked to the source for linker discovery — and the PFrame engine does the data slicing, so you never materialise filtered `data` in the sandbox.
 
-For human-readable axis-value labels in the trace annotation, pair it with `deriveAxisValuesLabels()` — the modern replacement for the legacy `ctx.resultPool.findLabels(axisId)`. It reads all label columns in scope and returns a `(axisId) => Record<value, label>` resolver.
+Human-readable axis-value labels in the trace annotation come for free: the `axisValuesLabels` option defaults to `deriveAxisValuesLabels()` — the modern replacement for the legacy `ctx.resultPool.findLabels(axisId)`. It reads all label columns in scope and returns a `(axisId) => Record<value, label>` resolver, discovered lazily on the first lookup. Pass the option explicitly to narrow the label source, or `() => undefined` to keep raw axis values.
 
 ```ts
 import {
   ColumnsCollection,
   createPlDataTableV3,
-  deriveAxisValuesLabels,
-  expandByPartition,
+  splitByAxes,
   hasReachableData,
   hasSingleDataColumn,
 } from "@platforma-sdk/model";
@@ -748,7 +747,7 @@ import {
     .filter(hasSingleDataColumn);
   if (primary.length === 0) return undefined;
 
-  // Inputs for the split must be readable here — `expandByPartition` calls
+  // Inputs for the split must be readable here — `splitByAxes` calls
   // `getData()` on each to inspect partitions. `hasSingleDataColumn` is the wrong
   // guard: an axis-filtered column passes it but has no readable data.
   const countLeaves = ColumnsCollection()
@@ -756,9 +755,7 @@ import {
     .getColumns()
     .filter(hasReachableData);
 
-  const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
-    axisValuesLabels: deriveAxisValuesLabels(),
-  });
+  const splitRecipes = splitByAxes(countLeaves, [{ idx: 0 }]);
   if (splitRecipes === undefined) return undefined;
 
   const primaryIds = new Set(primary.map((c) => c.id));

--- a/migrations/2026-05-20-new-column-access-mechanism.md
+++ b/migrations/2026-05-20-new-column-access-mechanism.md
@@ -124,7 +124,7 @@ The bare leaf is the only recipe you ever construct from a `TreeNodeAccessor` / 
 
 `getData()` is available on a leaf and on an override over one — those are the shapes whose data still matches their spec, and together they form the `DataColumn` interface. An axis-filtered recipe deliberately has no `getData()`: its spec has dropped the pinned axes while the underlying data still carries them, so the slice only exists engine-side.
 
-For most code this is all you need to know: **you hold recipes, you pass ids, you call `getSpec()` only on survivors.** You never need to know which recipe class you're holding — narrow with `hasReachableData` / `isSelfContained` and use the helpers in `@platforma-sdk/model` (`collectLinkerColumns`, `hitQualifications`, …) rather than walking the recipe tree by hand.
+For most code this is all you need to know: **you hold recipes, you pass ids, you call `getSpec()` only on survivors.** You never need to know which recipe class you're holding — narrow with `hasReachableData` / `hasSingleDataColumn` and use the helpers in `@platforma-sdk/model` (`collectLinkerColumns`, `hitQualifications`, …) rather than walking the recipe tree by hand.
 
 ### Reading and constructing columns
 
@@ -144,26 +144,35 @@ if (hasReachableData(col)) {
 
 Iterating a 5k-column collection to call `getSpec()` on every entry will fetch 5k specs. If you only need ids, pass `col.id` straight through to whatever needs it — `createPFrame` / `createPTable` accept ids directly, so most pipelines never call `getSpec()` at all.
 
-### Predicates — `isColumn` / `isColumnRecipe` / `hasReachableData` / `isSelfContained`
+### Predicates — `isColumn` / `isDataColumn` / `hasReachableData` / `hasSingleDataColumn`
 
 They are named after what you can do with the column, not after which recipe class it is. Which classes exist is an implementation detail behind `recipe.id`; never `instanceof`-narrow to one.
 
 ```ts
-isColumn(value); // value is Column        (alias of isColumnRecipe)
-isColumnRecipe(value); // value is ColumnRecipe  (any recipe)
-hasReachableData(recipe); // recipe is DataColumn   (data readable here, matching getSpec())
-isSelfContained(recipe); // boolean               (resolves without other columns)
+isColumn(value); // value is Column               (any recipe)
+isDataColumn(value); // value is DataColumnRecipe     (bare leaf — id is a storage PObjectId)
+hasReachableData(recipe); // recipe is DataColumnRecipe    (data readable here, matching getSpec())
+hasSingleDataColumn(recipe); // boolean                      (reads one data column, not several)
 ```
 
 **`hasReachableData` — "can I read the data?"** True for a bare leaf and for a spec-override over one; those are the only shapes whose data still lines up with their spec. False for an axis-filtered recipe — its spec has dropped axes the underlying data still carries, and the slice happens engine-side — and false for anything reached through other columns. In both of those cases pass `recipe.id` to `createPFrame` / `createPTable` and let the host materialise it.
 
-**`isSelfContained` — "does it need other columns?"** True when the recipe is described entirely by its own source column plus projections over it. A column that is *not* self-contained reaches its data through other columns, so it brings axes into a join that its own spec never mentions. Use it for the **primary vs linker-joined** split at the `createPlDataTableV3` boundary: only self-contained columns are valid primaries, projections over a plain leaf included. The SDK's own `createPlDataTableV3` uses `isSelfContained` for this — mirror it in your block code.
+**`hasSingleDataColumn` — "does it read one column or several?"** True for a bare leaf and for projections over one (spec overrides, axis slicing) — those add layers but no new columns. False when the recipe gets at its data through further columns, which is what happens when discovery reached it via a linker chain.
 
-The two are independent: an axis-filtered leaf is self-contained but has no direct data. Pick by what you do next with the result, not by which one sounds stricter.
+Such a column is co-indexed by its own axes, so its spec is the whole truth about them. A column that reads several only lines up after they are joined in, and therefore drags axes into the join its own spec never mentions. That is the **primary vs linker-joined** split at the `createPlDataTableV3` boundary: only single-column recipes are valid primaries, projections over a plain leaf included. The SDK's own `createPlDataTableV3` uses `hasSingleDataColumn` for this — mirror it in your block code.
 
-Deprecated predecessors, still exported: `isLeafColumn` (renamed to `isSelfContained`, same semantics) and `isColumnLazy` (bare leaf only). The one case that still needs `isColumnLazy` is a legacy slot typed `PObjectId` — `PColumn.id`, `PColumnIdAndSpec.columnId` — which only bare leaves carry; wrappers expose `ColumnUniversalId`.
+The two predicates are independent: an axis-filtered leaf reads a single column but has no reachable data. Pick by what you do next with the result, not by which one sounds stricter.
 
-`getLeafColumnData(recipe)` is deprecated and its behaviour changed: it used to walk past an axis-filtered layer and hand back the underlying leaf's **unsliced** data, which does not match the recipe's spec. It now returns `undefined` for anything `hasReachableData` rejects. Use `hasReachableData(c) ? c.getData() : …` instead.
+**`isDataColumn` — "is this a storage column?"** True only for a bare leaf, whose `id` is a `PObjectId` naming a real column in storage. Reach for it when a type forces you to that id shape — `PColumn.id`, `PColumnIdAndSpec.columnId` — not when you merely want to read data; `hasReachableData` is the guard for that and also admits a spec-override over a leaf.
+
+`isLeafColumn` is still exported as a deprecated alias of `hasSingleDataColumn` (same semantics).
+
+**Removed:**
+
+- `isColumnLazy` → `isDataColumn`. Same check, named for the contract rather than for how the leaf is implemented.
+- `getLeafColumnData` — it walked past an axis-filtered layer and returned the underlying leaf's unsliced data, which does not match the recipe's spec. Replace with `hasReachableData(c) ? c.getData() : undefined`.
+- `isColumnRecipe` → `isColumn`.
+- `ColumnLazy` / `ColumnLazyImpl` / `ColumnLazyId` / `ColumnLazyData` → `DataColumn` / `DataColumnImpl` / `DataColumnId` / `ColumnData`.
 
 There is a single top-level entry point, `Column(source)`. It picks the right factory by source shape and returns a `ColumnRecipe`:
 
@@ -680,7 +689,7 @@ When the same accessor is reused as a discovery **source** (e.g. `sampledRows` i
 A handful of SDK helpers (most notably `createPFrameForGraphs`, and any consumer typed against `PColumn<PColumnDataUniversal>[]`) still take materialised `PColumn[]` only — they do not yet accept `ColumnRecipe[]` / ids. The bridge is straightforward when every recipe in the set is a **bare leaf** (`DataColumn`):
 
 ```ts
-const leaves = recipes.filter(isColumnLazy);
+const leaves = recipes.filter(isDataColumn);
 const pCols: PColumn<PColumnDataUniversal>[] = leaves.map((c) => ({
   id: c.id,
   spec: c.getSpec(),
@@ -689,7 +698,7 @@ const pCols: PColumn<PColumnDataUniversal>[] = leaves.map((c) => ({
 return createPFrameForGraphs(ctx, pCols);
 ```
 
-This is the one place `isColumnLazy` is still the right guard, despite being deprecated: the `PColumn.id` slot is typed `PObjectId`, which only a bare leaf carries — every wrapper, including an override over a leaf, exposes `ColumnUniversalId`. `hasReachableData` is the wrong narrow here precisely because it also admits those overrides. Same reasoning applies to `PColumnIdAndSpec.columnId`.
+`isDataColumn` — not `hasReachableData` — is the right guard here: the `PColumn.id` slot is typed `PObjectId`, which only a bare leaf carries, while every wrapper (including an override over a leaf) exposes `ColumnUniversalId`. `hasReachableData` is the wrong narrow precisely because it also admits those overrides. Same reasoning applies to `PColumnIdAndSpec.columnId`.
 
 Notes:
 
@@ -716,7 +725,7 @@ import {
   deriveAxisValuesLabels,
   expandByPartition,
   hasReachableData,
-  isSelfContained,
+  hasSingleDataColumn,
 } from "@platforma-sdk/model";
 
 .outputWithStatus("tableSplit", (ctx) => {
@@ -726,17 +735,17 @@ import {
   // can also surface multi-axis Discovered variants (e.g. `count [group, name]`
   // reached via a linker); those belong in secondary, not in the join's primary
   // side. Mirrors what `discoverTableColumns` does internally for the
-  // selector-form path. `isSelfContained` accepts bare `DataColumn` plus
+  // selector-form path. `hasSingleDataColumn` accepts bare `DataColumn` plus
   // `Overridden` / `Filtered` over a leaf — anything whose chain reaches a
   // `Discovered` is rejected.
   const primary = ColumnsCollection()
     .discover({ anchors: { main: valueAnchor }, mode: "exact" })
     .getColumns()
-    .filter(isSelfContained);
+    .filter(hasSingleDataColumn);
   if (primary.length === 0) return undefined;
 
   // Inputs for the split must be readable here — `expandByPartition` calls
-  // `getData()` on each to inspect partitions. `isSelfContained` is the wrong
+  // `getData()` on each to inspect partitions. `hasSingleDataColumn` is the wrong
   // guard: an axis-filtered column passes it but has no readable data.
   const countLeaves = ColumnsCollection()
     .filter({ include: { name: [{ type: "exact", value: "count" }] } })
@@ -773,4 +782,4 @@ Two architectural invariants worth remembering when reading or extending this pa
 
 - **`ColumnOverriddenRecipe` is always the outermost wrap.** `ColumnFilteredRecipe.withSpecs(overrides)` yields `Overridden<Filtered<inner>>` automatically. Do not try to construct `Filtered<Overridden<...>>` — the SDK has no public path to that layering and the invariant is enforced inside `unwrapOverrides`.
 
-- **`primaryColumns` must be leaf-form only.** `discover` with anchors returns a mix of bare `DataColumn` (direct anchor hits), `Overridden` / `Filtered` over a leaf (projections — still leaf-form), and `ColumnDiscoveredRecipe` (multi-hop hits via linker chains). The selector-form of `createPlDataTableV3` (via `discoverTableColumns`) splits these into `primary` / `secondary` for you using `isSelfContained`; the `primaryColumns` form trusts you to do the same. If a multi-axis Discovered slips into `primaryColumns`, `discoverLabelColumns` flat-maps its extra axes into the include set and pulls in label columns on those axes — which then appear in the engine join as disjoint-axes tables and crash with `axes sets are disjoint`. The fix is `.filter(isSelfContained)` on the discover result — **not** `isColumnLazy`, which is stricter and drops valid `Filtered` / `Overridden`-over-leaf primaries.
+- **`primaryColumns` must be leaf-form only.** `discover` with anchors returns a mix of bare `DataColumn` (direct anchor hits), `Overridden` / `Filtered` over a leaf (projections — still leaf-form), and `ColumnDiscoveredRecipe` (multi-hop hits via linker chains). The selector-form of `createPlDataTableV3` (via `discoverTableColumns`) splits these into `primary` / `secondary` for you using `hasSingleDataColumn`; the `primaryColumns` form trusts you to do the same. If a multi-axis Discovered slips into `primaryColumns`, `discoverLabelColumns` flat-maps its extra axes into the include set and pulls in label columns on those axes — which then appear in the engine join as disjoint-axes tables and crash with `axes sets are disjoint`. The fix is `.filter(hasSingleDataColumn)` on the discover result — **not** `isDataColumn`, which is stricter and drops valid `Filtered` / `Overridden`-over-leaf primaries.

--- a/migrations/2026-05-20-new-column-access-mechanism.md
+++ b/migrations/2026-05-20-new-column-access-mechanism.md
@@ -47,7 +47,7 @@ The collection itself is **host-driven** — it never ships specs into the sandb
 
 - `"current_block"` — shorthand for `outputs` + `prerun` accessors of the current block;
 - `"result_pool"` — shorthand for the upstream-block result pool;
-- a `TreeNodeAccessor`, a `ColumnsProvider`, another `ColumnsCollection`, or a column-like shape `{ columns, isFinal }`. The `columns` array accepts `PColumn` / `ColumnLazy` / any `ColumnRecipe` — the source only needs `.id` from each entry.
+- a `TreeNodeAccessor`, a `ColumnsProvider`, another `ColumnsCollection`, or a column-like shape `{ columns, isFinal }`. The `columns` array accepts `PColumn` / `DataColumn` / any `ColumnRecipe` — the source only needs `.id` from each entry.
 
 `isFinal` says whether everything upstream has finished computing. While blocks are still running the set of visible columns keeps growing across render passes; `isFinal: true` means it won't grow anymore. The built-in sources figure this out themselves — you only set it explicitly when you pass `{ columns, isFinal }`.
 
@@ -94,7 +94,7 @@ const cols = ColumnsCollection()
   .filter((c) => myCustomPredicate(c.getSpec())); // sandbox-side, one round-trip per survivor
 ```
 
-### `ColumnRecipe` vs `ColumnLazy` — what you're actually holding
+### `ColumnRecipe` vs `DataColumn` — what you're actually holding
 
 Every column you get back from the new API is a **`ColumnRecipe`**: an immutable, identity-bearing _description_ of how to obtain a column — not the column data itself. The recipe interface is intentionally narrow:
 
@@ -107,22 +107,24 @@ recipe.getDataStatus(); // "present" | "absent" | "resolving" (worst across refe
 recipe.withSpecs(patch); // returns a new recipe with the patch baked into the id
 ```
 
-Note what's **not** there: there is no `getData()` on a recipe. Data is only meaningful at a leaf — `Overridden` / `Filtered` / `Discovered` recipes are descriptions whose data is fetched on the **host** when you hand the id to `createPFrame` / `createPTable`. Pulling data into the sandbox for a non-leaf recipe would defeat the whole point of the refactor.
+Note what's **not** there: there is no `getData()` on a recipe. For most recipes the data is fetched on the **host** when you hand the id to `createPFrame` / `createPTable`; pulling it into the sandbox would defeat the whole point of the refactor. The recipes that _can_ be read here implement `DataColumn`, and you reach that capability through `hasDirectData(recipe)` — see below.
 
 The id is the source of truth; the recipe is just a typed accessor over it. The id string encodes _how_ the column was produced, and each form has its own recipe class:
 
 | Id shape on the wire  | Recipe class             | What it represents                                                                                                      |
 | --------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| bare `PObjectId`      | `ColumnLazy`             | a plain upstream column — spec comes from the host accessor, data is reachable as `TreeNodeAccessor`                    |
+| bare `PObjectId`      | `DataColumn`             | a plain upstream column — spec comes from the host accessor, data is reachable as `TreeNodeAccessor`                    |
 | `ColumnOverriddenKey` | `ColumnOverriddenRecipe` | "this other recipe, but with annotations/domain/axes patched" — `withSpecs()` builds these                              |
 | `ColumnFilteredKey`   | `ColumnFilteredRecipe`   | "this recipe restricted to a subset of axes" — produced by `ColumnsCollection.filter`                                   |
 | `ColumnDiscoveredKey` | `ColumnDiscoveredRecipe` | the result of a `ColumnsCollection.discover` hit, carrying the join graph back to its anchor so the spec can be rebuilt |
 
 The `*Key` rows are the parsed JSON object shapes; the stringified-on-the-wire form for each is `Column*Id` (e.g. `ColumnOverriddenId`).
 
-**`ColumnLazy` is the only recipe class with `getData()`.** It is the _leaf_ — `implements ColumnRecipe<PObjectId>` — and is also the only recipe you ever construct from a `TreeNodeAccessor` / `PColumn` / `PlRef`. Everything else is a wrapper around a leaf id; you produce the wrappers by calling `discover` / `filter` / `withSpecs`, and you pass them around by `.id`.
+The bare leaf is the only recipe you ever construct from a `TreeNodeAccessor` / `PColumn` / `PlRef`. Everything else is a wrapper around a leaf id; you produce the wrappers by calling `discover` / `filter` / `withSpecs`, and you pass them around by `.id`.
 
-For most code this is all you need to know: **you hold recipes, you pass ids, you call `getSpec()` only on survivors.** The recipe-kind taxonomy only becomes visible when you `instanceof`-narrow to a leaf to call `getData()`, and even then most call sites are better off using the helpers in `@platforma-sdk/model` (`collectLinkerColumns`, `hitQualifications`, …) than walking the recipe tree by hand.
+`getData()` is available on a leaf and on an override over one — those are the shapes whose data still matches their spec, and together they form the `DataColumn` interface. An axis-filtered recipe deliberately has no `getData()`: its spec has dropped the pinned axes while the underlying data still carries them, so the slice only exists engine-side.
+
+For most code this is all you need to know: **you hold recipes, you pass ids, you call `getSpec()` only on survivors.** You never need to know which recipe class you're holding — narrow with `hasDirectData` / `isSelfContained` and use the helpers in `@platforma-sdk/model` (`collectLinkerColumns`, `hitQualifications`, …) rather than walking the recipe tree by hand.
 
 ### Reading and constructing columns
 
@@ -134,48 +136,45 @@ col.getReferencedIds(); // leaf-set this recipe depends on
 col.getSpec(); // PColumnSpec — bridge round-trip on first call
 col.getDataStatus(); // ColumnFieldStatus: "present" | "absent" | "resolving"
 
-// Only on ColumnLazy (the leaf) — narrow first.
-// `ColumnLazy` (the value) is the dispatcher function with statics attached,
-// so `instanceof ColumnLazy` does not narrow. Always use the `isColumnLazy`
-// guard — do **not** import the internal `ColumnLazyImpl` symbol to
-// `instanceof`-narrow either; that's an implementation detail.
-if (isColumnLazy(col)) {
+// Data is not on the recipe interface — narrow first.
+if (hasDirectData(col)) {
   col.getData(); // PColumnDataUniversal | undefined — bridge round-trip
 }
 ```
 
 Iterating a 5k-column collection to call `getSpec()` on every entry will fetch 5k specs. If you only need ids, pass `col.id` straight through to whatever needs it — `createPFrame` / `createPTable` accept ids directly, so most pipelines never call `getSpec()` at all.
 
-### Type guards — `isColumn` / `isColumnRecipe` / `isColumnLazy` / `isLeafColumn`
+### Predicates — `isColumn` / `isColumnRecipe` / `hasDirectData` / `isSelfContained`
 
-Four guards are exported alongside the factories so consumers don't need to import the internal `*Impl` symbols just to narrow:
+They are named after what you can do with the column, not after which recipe class it is. Which classes exist is an implementation detail behind `recipe.id`; never `instanceof`-narrow to one.
 
 ```ts
-isColumn(value); // value is Column          (alias of isColumnRecipe)
-isColumnRecipe(value); // value is ColumnRecipe    (any recipe — leaf or wrapper)
-isColumnLazy(value); // value is ColumnLazy      (bare leaf only — the one with getData())
-isLeafColumn(recipe); // boolean              (leaf-form: chain contains no Discovered)
+isColumn(value); // value is Column        (alias of isColumnRecipe)
+isColumnRecipe(value); // value is ColumnRecipe  (any recipe)
+hasDirectData(recipe); // recipe is DataColumn   (data readable here, matching getSpec())
+isSelfContained(recipe); // boolean               (resolves without other columns)
 ```
 
-Use `isColumnLazy` instead of `instanceof ColumnLazy`: `ColumnLazy` (the value) is the dispatcher function with statics, not the class, so `instanceof` does not narrow there.
+**`hasDirectData` — "can I read the data?"** True for a bare leaf and for a spec-override over one; those are the only shapes whose data still lines up with their spec. False for an axis-filtered recipe — its spec has dropped axes the underlying data still carries, and the slice happens engine-side — and false for anything reached through other columns. In both of those cases pass `recipe.id` to `createPFrame` / `createPTable` and let the host materialise it.
 
-**`isColumnLazy` vs `isLeafColumn` — pick by what you do with the result.**
+**`isSelfContained` — "does it need other columns?"** True when the recipe is described entirely by its own source column plus projections over it. A column that is *not* self-contained reaches its data through other columns, so it brings axes into a join that its own spec never mentions. Use it for the **primary vs linker-joined** split at the `createPlDataTableV3` boundary: only self-contained columns are valid primaries, projections over a plain leaf included. The SDK's own `createPlDataTableV3` uses `isSelfContained` for this — mirror it in your block code.
 
-- `isColumnLazy(c)` — strict, type-narrowing predicate. Returns `true` only for the **bare leaf** (`ColumnLazy`). Use it when you need access to `getData()` directly, or when the type forces you to a bare leaf — e.g. `PColumnIdAndSpec.columnId` and `PColumn.id` are `PObjectId`, which only bare leaves carry; wrappers expose `ColumnUniversalId`.
-- `isLeafColumn(recipe)` — broader, boolean (not a type guard). Returns `true` for any recipe whose wrapper chain contains no `ColumnDiscoveredRecipe` — so `Overridden` / `Filtered` over a bare leaf still count. Use it for the **primary vs linker-joined** classification at the `createPlDataTableV3` boundary: anything that has no `Discovered` in its chain is a valid primary, projections over a plain leaf included. The SDK's own `createPlDataTableV3` uses `isLeafColumn` for this split — mirror it in your block code.
+The two are independent: an axis-filtered leaf is self-contained but has no direct data. Pick by what you do next with the result, not by which one sounds stricter.
 
-Counterpart for reading data without a strict `isColumnLazy` narrow: `getLeafColumnData(recipe)` walks the wrapper chain down to the bottom leaf and returns its data (throws when the chain reaches a `Discovered`).
+Deprecated predecessors, still exported: `isLeafColumn` (renamed to `isSelfContained`, same semantics) and `isColumnLazy` (bare leaf only). The one case that still needs `isColumnLazy` is a legacy slot typed `PObjectId` — `PColumn.id`, `PColumnIdAndSpec.columnId` — which only bare leaves carry; wrappers expose `ColumnUniversalId`.
+
+`getLeafColumnData(recipe)` is deprecated and its behaviour changed: it used to walk past an axis-filtered layer and hand back the underlying leaf's **unsliced** data, which does not match the recipe's spec. It now returns `undefined` for anything `hasDirectData` rejects. Use `hasDirectData(c) ? c.getData() : …` instead.
 
 There is a single top-level entry point, `Column(source)`. It picks the right factory by source shape and returns a `ColumnRecipe`:
 
 ```ts
-Column(source); // id string | PlRef | PColumn | LeafEntry | ColumnLazy
+Column(source); // id string | PlRef | PColumn | LeafEntry | DataColumn
 ```
 
 Routing rules:
 
 - **String id** (`PObjectId` or `ColumnUniversalId`) → `ColumnRecipe(id)`. The id shape decides which recipe class comes back (see the table above) — you don't pick, the id does.
-- **Object source** (`PlRef` / `LeafEntry` / `PColumn` / `ColumnLazy`) → `ColumnLazy(source)`. These shapes only ever map to the bare `ColumnLazy` case.
+- **Object source** (`PlRef` / `LeafEntry` / `PColumn` / `DataColumn`) → `DataColumn(source)`. These shapes only ever map to the bare `DataColumn` case.
 
 `Column(source)` returns `undefined` when the source can't be resolved (e.g. an id whose accessor isn't reachable from the current ctx, or a `PlRef` with no matching entry). Always check before chaining.
 
@@ -183,16 +182,16 @@ When the intent at the call site is unambiguous you can call the dispatchers dir
 
 ```ts
 ColumnRecipe(id); // string id → routed by id shape
-ColumnLazy(source); // id | PlRef | PColumn | LeafEntry | ColumnLazy
+DataColumn(source); // id | PlRef | PColumn | LeafEntry | DataColumn
 ```
 
 Or the explicit factories when the source shape would otherwise be ambiguous:
 
 ```ts
-ColumnLazy.fromId(id); // PObjectId
-ColumnLazy.fromPlRef(ref); // PlRef
-ColumnLazy.fromColumn(pColumn); // already-materialised PColumn
-ColumnLazy.fromAccessor(leafEntry); // direct accessor binding
+DataColumn.fromId(id); // PObjectId
+DataColumn.fromPlRef(ref); // PlRef
+DataColumn.fromColumn(pColumn); // already-materialised PColumn
+DataColumn.fromAccessor(leafEntry); // direct accessor binding
 ```
 
 ### Two flavours of "not yet" — `resolving` vs `absent`
@@ -206,10 +205,10 @@ Use the static `getStatus` helpers when you need the answer without paying for t
 
 ```ts
 ColumnRecipe.getStatus(id); // any id shape — dispatches by parsed key
-ColumnLazy.getStatus(source); // PObjectId / PlRef / LeafEntry / PColumn / ColumnLazy
-ColumnLazy.getStatusById(id);
-ColumnLazy.getStatusByPlRef(ref);
-ColumnLazy.getStatusByAccessor(entry);
+DataColumn.getStatus(source); // PObjectId / PlRef / LeafEntry / PColumn / DataColumn
+DataColumn.getStatusById(id);
+DataColumn.getStatusByPlRef(ref);
+DataColumn.getStatusByAccessor(entry);
 ```
 
 A recipe factory returns `undefined` for `resolving` (try again on the next render pass — more accessor inputs may still arrive), and throws **`ColumnAbsentError`** for `absent` (every relevant accessor is `inputsLocked`; the column will not appear in this ctx). Catch `ColumnAbsentError` at boundaries — resolver / filter-and-sort wiring / data-table assembly — when partial absence should be surfaced rather than silently producing an empty result. Inside a tight loop over already-known ids, prefer `getStatus(...)` once up-front over a try/catch around the factory.
@@ -250,13 +249,13 @@ When you already have a `ColumnsCollection`, skip the intermediate recipes entir
 ctx.createPFrame(collection.getColumnIds());
 ```
 
-This is also the canonical way to feed **wrapped recipes** (`ColumnDiscoveredRecipe` / `ColumnFilteredRecipe` / `ColumnOverriddenRecipe`) into a PFrame. They have no `getData()` — but `recipe.id` is a `ColumnUniversalId` that `createPFrame` accepts directly, and the host materialises it server-side. So instead of trying to narrow a recipe list to leaves before building a PFrame, pass `.id`:
+This is also the canonical way to feed **wrapped recipes** (`ColumnDiscoveredRecipe` / `ColumnFilteredRecipe` / `ColumnOverriddenRecipe`) into a PFrame. Most of them cannot be read in the sandbox at all — but `recipe.id` is a `ColumnUniversalId` that `createPFrame` accepts directly, and the host materialises it server-side. So instead of trying to narrow a recipe list before building a PFrame, pass `.id`:
 
 ```ts
 ctx.createPFrame(recipes.map((c) => c.id)); // works for any recipe — leaf or wrapped
 ```
 
-(Code that still needs a `PColumn<...>[]`, e.g. `createPFrameForGraphs`, does not have this id-form yet — see the "ColumnLazy → PColumn adapter" section below for the materialisation pattern that only works for leaves.)
+(Code that still needs a `PColumn<...>[]`, e.g. `createPFrameForGraphs`, does not have this id-form yet — see the "DataColumn → PColumn adapter" section below for the materialisation pattern that only works for leaves.)
 
 You can still pass `PColumn` objects with live `TreeNodeAccessor` / `DataInfo` data when the column was assembled in the sandbox (e.g. via `expandByPartition`); the helper that converts those (`transformPColumnData`) was renamed and exported as `finalizePColumnData`. Prefer the id form whenever the column came from the host in the first place.
 
@@ -264,23 +263,23 @@ You can still pass `PColumn` objects with live `TreeNodeAccessor` / `DataInfo` d
 
 ## `ResultPool` / `RenderCtxBase` — all column access goes through `ColumnsCollection`
 
-The whole `ResultPool` class is `@deprecated`. Every column-discovery / column-fetch entry point on it (and the convenience wrappers on `RenderCtxBase`) pulled specs eagerly — exactly the pattern this refactor exists to kill. Use `ColumnsCollection` + `ColumnLazy` for **everything**.
+The whole `ResultPool` class is `@deprecated`. Every column-discovery / column-fetch entry point on it (and the convenience wrappers on `RenderCtxBase`) pulled specs eagerly — exactly the pattern this refactor exists to kill. Use `ColumnsCollection` + `DataColumn` for **everything**.
 
 | Old                                                                                                | New                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ctx.resultPool.getData()` / `getDataFromResultPool()`                                             | `ColumnsCollection(["result_pool"]).getColumns()` — iterate the resulting `ColumnRecipe[]` and pass `.id`s into `createPFrame` / `createPTable`; never iterate `getData()` over the whole pool                                                                                                                                                                                                                                                                                                                                                   |
 | `ctx.resultPool.getDataWithErrors()` / `getDataWithErrorsFromResultPool()`                         | same; per-column status comes from `recipe.getDataStatus()` ("present" / "absent" / "resolving"). Errors live on the host — surface them at the consumer (PFrame/PTable) instead of the result-pool boundary                                                                                                                                                                                                                                                                                                                                     |
 | `ctx.resultPool.getSpecs()` / `getSpecsFromResultPool()`                                           | `ColumnsCollection(["result_pool"]).getColumns()` and `getSpec()` only on the survivors of a discover/filter — never iterate `getSpec()` over the whole pool                                                                                                                                                                                                                                                                                                                                                                                     |
-| `ctx.resultPool.getDataByRef(ref)`                                                                 | `ColumnLazy.fromPlRef(ref)?.getData()` — `getData()` lives on the leaf `ColumnLazy`, not on the generic `ColumnRecipe`                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `ctx.resultPool.getPColumnByRef(ref)`                                                              | `ColumnLazy.fromPlRef(ref)` (or the unified `Column(ref)`, which for `PlRef` likewise yields a `ColumnLazy`)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `ctx.resultPool.getSpecByRef(ref)` / `getPColumnSpecByRef(ref)`                                    | `Column(ref)?.getSpec()` (or `ColumnLazy.fromPlRef(ref)?.getSpec()`) — `getSpec()` is on every recipe, so either form types out                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `ctx.resultPool.getDataByRef(ref)`                                                                 | `DataColumn.fromPlRef(ref)?.getData()` — `getData()` lives on the leaf `DataColumn`, not on the generic `ColumnRecipe`                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `ctx.resultPool.getPColumnByRef(ref)`                                                              | `DataColumn.fromPlRef(ref)` (or the unified `Column(ref)`, which for `PlRef` likewise yields a `DataColumn`)                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `ctx.resultPool.getSpecByRef(ref)` / `getPColumnSpecByRef(ref)`                                    | `Column(ref)?.getSpec()` (or `DataColumn.fromPlRef(ref)?.getSpec()`) — `getSpec()` is on every recipe, so either form types out                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `ctx.resultPool.selectColumns(predicate)`                                                          | `ColumnsCollection(["result_pool"]).discover({ include }).getColumns()` — push the predicate into `include` so filtering runs host-side; fall back to a JS post-`.filter((c) => …(c.getSpec()))` only if you must                                                                                                                                                                                                                                                                                                                                |
 | `ctx.resultPool.findDataWithCompatibleSpec(spec)`                                                  | `ColumnsCollection(["result_pool"]).discover({ anchors: { main: spec }, mode: "default" }).getColumns()`                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `ctx.resultPool.getOptions(predicate, labelOps)`                                                   | **Stay on `ctx.resultPool.getOptions(...)`** — it preserves the `Option[]` = `{ ref: PlRef, label }` wire shape and `refsWithEnrichments`. (The `@deprecated` JSDoc on `ResultPool` lists `ctx.getOptions` as the migration target, but the method has **not** been promoted to `RenderCtxBase` yet — `ctx.getOptions` is not callable.) Switch to `ColumnsCollection(["result_pool"]).discover({ include }).getColumns()` + `deriveLabels` **only when** the consumer wants column **ids** (e.g. for `createPFrame`/`createPTable`), not PlRefs |
 | `ctx.resultPool.getAnchoredPColumns(anchors, selectors, opts)`                                     | `ColumnsCollection(["result_pool"]).discover({ anchors, include: selectors, … }).getColumnIds()` — each id is already a `ColumnUniversalId`, pass directly into `createPFrame` / `createPTable`                                                                                                                                                                                                                                                                                                                                                  |
 | `ctx.resultPool.getCanonicalOptions(anchors, selectors, opts)`                                     | same discover call; map `(col) => ({ value: col.id, label: deriveLabel(col) })`                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `ctx.resultPool.resolveAnchorCtx({ key: PlRef })`                                                  | per-entry: `isPlRef(v) ? Column(v)?.getSpec() : v`. `ColumnsCollection.discover` accepts the resulting `{ key: PColumnSpec }` directly                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `ctx.resultPool.findLabels(axis)` / `findLabelsForColumnAxis(spec, axisIdx)` / `ctx.findLabels(…)` | discover label columns via `ColumnsCollection` (`{ name: "^pl7.app/label$", axes: [{ name: axis.name }] }`) and read JSON data off the resulting `ColumnLazy`                                                                                                                                                                                                                                                                                                                                                                                    |
+| `ctx.resultPool.findLabels(axis)` / `findLabelsForColumnAxis(spec, axisIdx)` / `ctx.findLabels(…)` | discover label columns via `ColumnsCollection` (`{ name: "^pl7.app/label$", axes: [{ name: axis.name }] }`) and read JSON data off the resulting `DataColumn`                                                                                                                                                                                                                                                                                                                                                                                    |
 | `ctx.getBlockLabel(blockId)`                                                                       | `@deprecated` on `RenderCtxBase` — still callable but slated to return dummy values; do not write new code against it                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 Deprecated aliases that just forward to the non-`*FromResultPool` versions (`getDataFromResultPool`, `getDataWithErrorsFromResultPool`, `getSpecsFromResultPool`) follow the same row as their canonical name. `ctx.resultPool` itself is `@deprecated` — the `*ByRef` reads have already moved to `ctx.*ByRef` on `RenderCtxBase` (see the migration map in the JSDoc above `class ResultPool` in `sdk/model/src/render/api.ts`), but the recommended migration is straight to `Column(ref)` / `ColumnsCollection`, which doesn't touch `ctx.resultPool` at all.
@@ -294,7 +293,7 @@ Always pass `["result_pool"]` (or the narrowest source set that works) — the d
 A few helpers in `sdk/model/src/columns/utils.ts` cover the recipe-walk cases you'd otherwise hand-roll:
 
 - **`collectLinkerIds(recipe): PObjectId[]`** — every non-hit `PObjectId` referenced by `recipe.getQuery()`, deduped in traversal order. Pure query walk, no registry access.
-- **`collectLinkerColumns(recipe, opts?): ColumnLazy[]`** — same set, resolved against the ambient ctx as leaf `ColumnLazy` instances. Throws if any linker fails to resolve — direct replacement for the legacy `resolveLinkers`.
+- **`collectLinkerColumns(recipe, opts?): DataColumn[]`** — same set, resolved against the ambient ctx as leaf `DataColumn` instances. Throws if any linker fails to resolve — direct replacement for the legacy `resolveLinkers`.
 - **`hitQualifications(recipe): readonly AxisQualification[]`** — hit-side axis qualifications, pulled out of the inner `ColumnDiscoveredRecipe` (if any). Returns `[]` for plain leaves / overrided-over-leaf chains.
 - **`queriesQualifications(recipe): Readonly<Record<PObjectId, AxisQualification[]>>`** — per-primary-column qualifications, applied to outer primary anchors at the consumer boundary.
 
@@ -332,7 +331,7 @@ The biggest mechanical hazard. `ColumnMatch` had a nested `.column` field carryi
 | `m.column.spec.name`        | `c.getSpec().name`          | host round-trip                                                                       |
 | `m.column.spec.axesSpec`    | `c.getSpec().axesSpec`      | host round-trip                                                                       |
 | `m.column.spec.annotations` | `c.getSpec().annotations`   | host round-trip                                                                       |
-| `m.column.data`             | _only on `ColumnLazy`_      | narrow first: `if (isColumnLazy(c)) c.getData()`                                      |
+| `m.column.data`             | _only on `DataColumn`_      | narrow first: `if (hasDirectData(c)) c.getData()`                                     |
 | `m.column.data.get()`       | `c.getData()` (no `.get()`) | the `.get()` indirection is gone — `getData()` is the read.                           |
 
 The rule is the same as for any other recipe: **filter host-side via `include` / `exclude` whenever possible, call `getSpec()` only on survivors**. Whenever you see a long `.filter(m => …m.column.spec…)` chain in legacy code, the first migration step is "what of this is expressible as a selector?".
@@ -455,7 +454,7 @@ const cols = ColumnsCollection(['result_pool'])
   // Non-selector-expressible: axis-count, runtime-Set membership, etc.
   .filter((c) => !(isLinkerColumn(c) && c.getSpec().axesSpec.length > 2));
 
-const [primary, secondary] = partitionByLeaf(cols);  // bare ColumnLazy vs wrapped recipes
+const [primary, secondary] = partitionByLeaf(cols);  // bare DataColumn vs wrapped recipes
 
 return createPlDataTableV3(ctx, {
   primaryColumns: primary,
@@ -650,7 +649,7 @@ Switch to `ColumnsCollection(["result_pool"]).discover({...}).getColumns()` only
 
 ## `accessor.getPColumns()` / `getIsFinal()` → `ColumnsCollection([accessor])`
 
-`TreeNodeAccessor.getPColumns()` is `@deprecated` and now returns `ColumnLazy[]` (the transitive break: every `.spec` / `.data` read on its result needs `.getSpec()` / `.getData()`). The replacement is **wrap the accessor as a source of a `ColumnsCollection`** — once that's done, every read goes through the collection's host-side surface:
+`TreeNodeAccessor.getPColumns()` is `@deprecated` and now returns `DataColumn[]` (the transitive break: every `.spec` / `.data` read on its result needs `.getSpec()` / `.getData()`). The replacement is **wrap the accessor as a source of a `ColumnsCollection`** — once that's done, every read goes through the collection's host-side surface:
 
 ```diff
 - const sampledRowsAccessor = ctx.outputs?.resolve({ field: 'sampledRows', ... });
@@ -676,9 +675,9 @@ When the same accessor is reused as a discovery **source** (e.g. `sampledRows` i
 
 ---
 
-## Helpers that still need `PColumn[]` — `ColumnLazy` → `PColumn` adapter
+## Helpers that still need `PColumn[]` — `DataColumn` → `PColumn` adapter
 
-A handful of SDK helpers (most notably `createPFrameForGraphs`, and any consumer typed against `PColumn<PColumnDataUniversal>[]`) still take materialised `PColumn[]` only — they do not yet accept `ColumnRecipe[]` / ids. The bridge is straightforward when every recipe in the set is a **bare leaf** (`ColumnLazy`):
+A handful of SDK helpers (most notably `createPFrameForGraphs`, and any consumer typed against `PColumn<PColumnDataUniversal>[]`) still take materialised `PColumn[]` only — they do not yet accept `ColumnRecipe[]` / ids. The bridge is straightforward when every recipe in the set is a **bare leaf** (`DataColumn`):
 
 ```ts
 const leaves = recipes.filter(isColumnLazy);
@@ -690,17 +689,17 @@ const pCols: PColumn<PColumnDataUniversal>[] = leaves.map((c) => ({
 return createPFrameForGraphs(ctx, pCols);
 ```
 
-Use strict `isColumnLazy` here, **not** the broader `isLeafColumn`. The `PColumn.id` slot is typed `PObjectId`, which only bare `ColumnLazy` carries — wrappers (`Overridden` / `Filtered`-over-leaf) expose `ColumnUniversalId`. Same reasoning applies to `PColumnIdAndSpec.columnId`. `isColumnLazy` is both a type guard and the canonical narrow — pass it straight to `Array.prototype.filter` (no manual predicate, no `ColumnLazyImpl` import).
+This is the one place `isColumnLazy` is still the right guard, despite being deprecated: the `PColumn.id` slot is typed `PObjectId`, which only a bare leaf carries — every wrapper, including an override over a leaf, exposes `ColumnUniversalId`. `hasDirectData` is the wrong narrow here precisely because it also admits those overrides. Same reasoning applies to `PColumnIdAndSpec.columnId`.
 
 Notes:
 
-- This **only works for `ColumnLazy`**. `ColumnOverriddenRecipe` / `ColumnDiscoveredRecipe` / `ColumnFilteredRecipe` have no `getData()` — there is no "materialise this recipe to a PColumn" path in the sandbox. If your discovery emits any wrapped recipes and you need to feed them into a PColumn-only helper, the helper needs to grow id-form support (or you avoid it for that source).
-- `PColumnIdAndSpec.columnId: PObjectId` — same constraint by the same logic. Only `ColumnLazy.id` (bare `PObjectId`) goes there; never a `ColumnUniversalId` from a wrapper recipe.
+- This **only works for a bare leaf**. `ColumnDiscoveredRecipe` / `ColumnFilteredRecipe` cannot be read in the sandbox at all, and `ColumnOverriddenRecipe` — though readable via `hasDirectData` — carries a `ColumnUniversalId` that the `PColumn.id` slot rejects. There is no "materialise this recipe to a PColumn" path for any of them. If your discovery emits wrapped recipes and you need to feed them into a PColumn-only helper, the helper needs to grow id-form support (or you avoid it for that source).
+- `PColumnIdAndSpec.columnId: PObjectId` — same constraint by the same logic. Only `DataColumn.id` (bare `PObjectId`) goes there; never a `ColumnUniversalId` from a wrapper recipe.
 - The `{ anchor: 'main', idx: 1 }` axis-binding from legacy `getAnchoredPColumns` has no `RelaxedAxisSelector` form. Workaround: read the anchor's `axesSpec[i].name` and pass it as `axes: [{ name }]` in the new selector — the axis-name match is enough for the common case.
 
 ### Splitting columns by partition — use `expandByPartition`
 
-The legacy "snapshot to N synthetic PColumns" pattern (read `data` accessor, fan out, wrap each item with a fresh id, re-wrap via `ColumnLazyImpl.fromColumn`) does not fit the new recipe model. Two traps:
+The legacy "snapshot to N synthetic PColumns" pattern (read `data` accessor, fan out, wrap each item with a fresh id, re-wrap via `DataColumnImpl.fromColumn`) does not fit the new recipe model. Two traps:
 
 1. **You cannot fabricate ids by string concatenation.** `${col.id}#${value} as PObjectId` looks fine, but the result is not canonical JSON — `JSON.parse` rejects the trailing suffix and any consumer walking the id graph (`discoverLabelColumns` → `collectLinkerIds` → `extractPObjectId` inside `createPlDataTableV3`) throws with `id "..." is not a valid canonical column id`. The cast silences the type-checker, not the runtime invariant.
 
@@ -716,8 +715,8 @@ import {
   createPlDataTableV3,
   deriveAxisValuesLabels,
   expandByPartition,
-  isColumnLazy,
-  isLeafColumn,
+  hasDirectData,
+  isSelfContained,
 } from "@platforma-sdk/model";
 
 .outputWithStatus("tableSplit", (ctx) => {
@@ -727,22 +726,22 @@ import {
   // can also surface multi-axis Discovered variants (e.g. `count [group, name]`
   // reached via a linker); those belong in secondary, not in the join's primary
   // side. Mirrors what `discoverTableColumns` does internally for the
-  // selector-form path. `isLeafColumn` accepts bare `ColumnLazy` plus
+  // selector-form path. `isSelfContained` accepts bare `DataColumn` plus
   // `Overridden` / `Filtered` over a leaf — anything whose chain reaches a
   // `Discovered` is rejected.
   const primary = ColumnsCollection()
     .discover({ anchors: { main: valueAnchor }, mode: "exact" })
     .getColumns()
-    .filter(isLeafColumn);
+    .filter(isSelfContained);
   if (primary.length === 0) return undefined;
 
-  // Inputs for the split must be unwrapped bare leaves — `expandByPartition`
-  // reads `getData()` on each, which only `ColumnLazy` exposes directly. Use
-  // strict `isColumnLazy` here, not `isLeafColumn`.
+  // Inputs for the split must be readable here — `expandByPartition` calls
+  // `getData()` on each to inspect partitions. `isSelfContained` is the wrong
+  // guard: an axis-filtered column passes it but has no readable data.
   const countLeaves = ColumnsCollection()
     .filter({ include: { name: [{ type: "exact", value: "count" }] } })
     .getColumns()
-    .filter(isColumnLazy);
+    .filter(hasDirectData);
 
   const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
     axisValuesLabels: deriveAxisValuesLabels(),
@@ -774,4 +773,4 @@ Two architectural invariants worth remembering when reading or extending this pa
 
 - **`ColumnOverriddenRecipe` is always the outermost wrap.** `ColumnFilteredRecipe.withSpecs(overrides)` yields `Overridden<Filtered<inner>>` automatically. Do not try to construct `Filtered<Overridden<...>>` — the SDK has no public path to that layering and the invariant is enforced inside `unwrapOverrides`.
 
-- **`primaryColumns` must be leaf-form only.** `discover` with anchors returns a mix of bare `ColumnLazy` (direct anchor hits), `Overridden` / `Filtered` over a leaf (projections — still leaf-form), and `ColumnDiscoveredRecipe` (multi-hop hits via linker chains). The selector-form of `createPlDataTableV3` (via `discoverTableColumns`) splits these into `primary` / `secondary` for you using `isLeafColumn`; the `primaryColumns` form trusts you to do the same. If a multi-axis Discovered slips into `primaryColumns`, `discoverLabelColumns` flat-maps its extra axes into the include set and pulls in label columns on those axes — which then appear in the engine join as disjoint-axes tables and crash with `axes sets are disjoint`. The fix is `.filter(isLeafColumn)` on the discover result — **not** `isColumnLazy`, which is stricter and drops valid `Filtered` / `Overridden`-over-leaf primaries.
+- **`primaryColumns` must be leaf-form only.** `discover` with anchors returns a mix of bare `DataColumn` (direct anchor hits), `Overridden` / `Filtered` over a leaf (projections — still leaf-form), and `ColumnDiscoveredRecipe` (multi-hop hits via linker chains). The selector-form of `createPlDataTableV3` (via `discoverTableColumns`) splits these into `primary` / `secondary` for you using `isSelfContained`; the `primaryColumns` form trusts you to do the same. If a multi-axis Discovered slips into `primaryColumns`, `discoverLabelColumns` flat-maps its extra axes into the include set and pulls in label columns on those axes — which then appear in the engine join as disjoint-axes tables and crash with `axes sets are disjoint`. The fix is `.filter(isSelfContained)` on the discover result — **not** `isColumnLazy`, which is stricter and drops valid `Filtered` / `Overridden`-over-leaf primaries.

--- a/migrations/2026-05-20-new-column-access-mechanism.md
+++ b/migrations/2026-05-20-new-column-access-mechanism.md
@@ -107,7 +107,7 @@ recipe.getDataStatus(); // "present" | "absent" | "resolving" (worst across refe
 recipe.withSpecs(patch); // returns a new recipe with the patch baked into the id
 ```
 
-Note what's **not** there: there is no `getData()` on a recipe. For most recipes the data is fetched on the **host** when you hand the id to `createPFrame` / `createPTable`; pulling it into the sandbox would defeat the whole point of the refactor. The recipes that _can_ be read here implement `DataColumn`, and you reach that capability through `hasDirectData(recipe)` — see below.
+Note what's **not** there: there is no `getData()` on a recipe. For most recipes the data is fetched on the **host** when you hand the id to `createPFrame` / `createPTable`; pulling it into the sandbox would defeat the whole point of the refactor. The recipes that _can_ be read here implement `DataColumn`, and you reach that capability through `hasReachableData(recipe)` — see below.
 
 The id is the source of truth; the recipe is just a typed accessor over it. The id string encodes _how_ the column was produced, and each form has its own recipe class:
 
@@ -124,7 +124,7 @@ The bare leaf is the only recipe you ever construct from a `TreeNodeAccessor` / 
 
 `getData()` is available on a leaf and on an override over one — those are the shapes whose data still matches their spec, and together they form the `DataColumn` interface. An axis-filtered recipe deliberately has no `getData()`: its spec has dropped the pinned axes while the underlying data still carries them, so the slice only exists engine-side.
 
-For most code this is all you need to know: **you hold recipes, you pass ids, you call `getSpec()` only on survivors.** You never need to know which recipe class you're holding — narrow with `hasDirectData` / `isSelfContained` and use the helpers in `@platforma-sdk/model` (`collectLinkerColumns`, `hitQualifications`, …) rather than walking the recipe tree by hand.
+For most code this is all you need to know: **you hold recipes, you pass ids, you call `getSpec()` only on survivors.** You never need to know which recipe class you're holding — narrow with `hasReachableData` / `isSelfContained` and use the helpers in `@platforma-sdk/model` (`collectLinkerColumns`, `hitQualifications`, …) rather than walking the recipe tree by hand.
 
 ### Reading and constructing columns
 
@@ -137,25 +137,25 @@ col.getSpec(); // PColumnSpec — bridge round-trip on first call
 col.getDataStatus(); // ColumnFieldStatus: "present" | "absent" | "resolving"
 
 // Data is not on the recipe interface — narrow first.
-if (hasDirectData(col)) {
+if (hasReachableData(col)) {
   col.getData(); // PColumnDataUniversal | undefined — bridge round-trip
 }
 ```
 
 Iterating a 5k-column collection to call `getSpec()` on every entry will fetch 5k specs. If you only need ids, pass `col.id` straight through to whatever needs it — `createPFrame` / `createPTable` accept ids directly, so most pipelines never call `getSpec()` at all.
 
-### Predicates — `isColumn` / `isColumnRecipe` / `hasDirectData` / `isSelfContained`
+### Predicates — `isColumn` / `isColumnRecipe` / `hasReachableData` / `isSelfContained`
 
 They are named after what you can do with the column, not after which recipe class it is. Which classes exist is an implementation detail behind `recipe.id`; never `instanceof`-narrow to one.
 
 ```ts
 isColumn(value); // value is Column        (alias of isColumnRecipe)
 isColumnRecipe(value); // value is ColumnRecipe  (any recipe)
-hasDirectData(recipe); // recipe is DataColumn   (data readable here, matching getSpec())
+hasReachableData(recipe); // recipe is DataColumn   (data readable here, matching getSpec())
 isSelfContained(recipe); // boolean               (resolves without other columns)
 ```
 
-**`hasDirectData` — "can I read the data?"** True for a bare leaf and for a spec-override over one; those are the only shapes whose data still lines up with their spec. False for an axis-filtered recipe — its spec has dropped axes the underlying data still carries, and the slice happens engine-side — and false for anything reached through other columns. In both of those cases pass `recipe.id` to `createPFrame` / `createPTable` and let the host materialise it.
+**`hasReachableData` — "can I read the data?"** True for a bare leaf and for a spec-override over one; those are the only shapes whose data still lines up with their spec. False for an axis-filtered recipe — its spec has dropped axes the underlying data still carries, and the slice happens engine-side — and false for anything reached through other columns. In both of those cases pass `recipe.id` to `createPFrame` / `createPTable` and let the host materialise it.
 
 **`isSelfContained` — "does it need other columns?"** True when the recipe is described entirely by its own source column plus projections over it. A column that is *not* self-contained reaches its data through other columns, so it brings axes into a join that its own spec never mentions. Use it for the **primary vs linker-joined** split at the `createPlDataTableV3` boundary: only self-contained columns are valid primaries, projections over a plain leaf included. The SDK's own `createPlDataTableV3` uses `isSelfContained` for this — mirror it in your block code.
 
@@ -163,7 +163,7 @@ The two are independent: an axis-filtered leaf is self-contained but has no dire
 
 Deprecated predecessors, still exported: `isLeafColumn` (renamed to `isSelfContained`, same semantics) and `isColumnLazy` (bare leaf only). The one case that still needs `isColumnLazy` is a legacy slot typed `PObjectId` — `PColumn.id`, `PColumnIdAndSpec.columnId` — which only bare leaves carry; wrappers expose `ColumnUniversalId`.
 
-`getLeafColumnData(recipe)` is deprecated and its behaviour changed: it used to walk past an axis-filtered layer and hand back the underlying leaf's **unsliced** data, which does not match the recipe's spec. It now returns `undefined` for anything `hasDirectData` rejects. Use `hasDirectData(c) ? c.getData() : …` instead.
+`getLeafColumnData(recipe)` is deprecated and its behaviour changed: it used to walk past an axis-filtered layer and hand back the underlying leaf's **unsliced** data, which does not match the recipe's spec. It now returns `undefined` for anything `hasReachableData` rejects. Use `hasReachableData(c) ? c.getData() : …` instead.
 
 There is a single top-level entry point, `Column(source)`. It picks the right factory by source shape and returns a `ColumnRecipe`:
 
@@ -331,7 +331,7 @@ The biggest mechanical hazard. `ColumnMatch` had a nested `.column` field carryi
 | `m.column.spec.name`        | `c.getSpec().name`          | host round-trip                                                                       |
 | `m.column.spec.axesSpec`    | `c.getSpec().axesSpec`      | host round-trip                                                                       |
 | `m.column.spec.annotations` | `c.getSpec().annotations`   | host round-trip                                                                       |
-| `m.column.data`             | _only on `DataColumn`_      | narrow first: `if (hasDirectData(c)) c.getData()`                                     |
+| `m.column.data`             | _only on `DataColumn`_      | narrow first: `if (hasReachableData(c)) c.getData()`                                     |
 | `m.column.data.get()`       | `c.getData()` (no `.get()`) | the `.get()` indirection is gone — `getData()` is the read.                           |
 
 The rule is the same as for any other recipe: **filter host-side via `include` / `exclude` whenever possible, call `getSpec()` only on survivors**. Whenever you see a long `.filter(m => …m.column.spec…)` chain in legacy code, the first migration step is "what of this is expressible as a selector?".
@@ -689,11 +689,11 @@ const pCols: PColumn<PColumnDataUniversal>[] = leaves.map((c) => ({
 return createPFrameForGraphs(ctx, pCols);
 ```
 
-This is the one place `isColumnLazy` is still the right guard, despite being deprecated: the `PColumn.id` slot is typed `PObjectId`, which only a bare leaf carries — every wrapper, including an override over a leaf, exposes `ColumnUniversalId`. `hasDirectData` is the wrong narrow here precisely because it also admits those overrides. Same reasoning applies to `PColumnIdAndSpec.columnId`.
+This is the one place `isColumnLazy` is still the right guard, despite being deprecated: the `PColumn.id` slot is typed `PObjectId`, which only a bare leaf carries — every wrapper, including an override over a leaf, exposes `ColumnUniversalId`. `hasReachableData` is the wrong narrow here precisely because it also admits those overrides. Same reasoning applies to `PColumnIdAndSpec.columnId`.
 
 Notes:
 
-- This **only works for a bare leaf**. `ColumnDiscoveredRecipe` / `ColumnFilteredRecipe` cannot be read in the sandbox at all, and `ColumnOverriddenRecipe` — though readable via `hasDirectData` — carries a `ColumnUniversalId` that the `PColumn.id` slot rejects. There is no "materialise this recipe to a PColumn" path for any of them. If your discovery emits wrapped recipes and you need to feed them into a PColumn-only helper, the helper needs to grow id-form support (or you avoid it for that source).
+- This **only works for a bare leaf**. `ColumnDiscoveredRecipe` / `ColumnFilteredRecipe` cannot be read in the sandbox at all, and `ColumnOverriddenRecipe` — though readable via `hasReachableData` — carries a `ColumnUniversalId` that the `PColumn.id` slot rejects. There is no "materialise this recipe to a PColumn" path for any of them. If your discovery emits wrapped recipes and you need to feed them into a PColumn-only helper, the helper needs to grow id-form support (or you avoid it for that source).
 - `PColumnIdAndSpec.columnId: PObjectId` — same constraint by the same logic. Only `DataColumn.id` (bare `PObjectId`) goes there; never a `ColumnUniversalId` from a wrapper recipe.
 - The `{ anchor: 'main', idx: 1 }` axis-binding from legacy `getAnchoredPColumns` has no `RelaxedAxisSelector` form. Workaround: read the anchor's `axesSpec[i].name` and pass it as `axes: [{ name }]` in the new selector — the axis-name match is enough for the common case.
 
@@ -715,7 +715,7 @@ import {
   createPlDataTableV3,
   deriveAxisValuesLabels,
   expandByPartition,
-  hasDirectData,
+  hasReachableData,
   isSelfContained,
 } from "@platforma-sdk/model";
 
@@ -741,7 +741,7 @@ import {
   const countLeaves = ColumnsCollection()
     .filter({ include: { name: [{ type: "exact", value: "count" }] } })
     .getColumns()
-    .filter(hasDirectData);
+    .filter(hasReachableData);
 
   const splitRecipes = expandByPartition(countLeaves, [{ idx: 0 }], {
     axisValuesLabels: deriveAxisValuesLabels(),

--- a/sdk/model/src/columns/__test_helpers__/collection_driver.ts
+++ b/sdk/model/src/columns/__test_helpers__/collection_driver.ts
@@ -10,7 +10,7 @@
  * Calling {@link TestCollectionDriverHandle.installAmbientCtx} additionally
  * installs a minimal `globalThis.cfgRenderCtx` AND plants a stub
  * `ColumnEntriesProvider` into the ctx-providers cache so registered specs
- * are reachable via `DataColumn.fromId` (and therefore via
+ * are reachable via `DataColumnRecipe.fromId` (and therefore via
  * `ColumnsCollection.getColumns()`).
  */
 import type {
@@ -29,7 +29,7 @@ import type { GlobalCfgRenderCtx } from "../../render/internal";
 import { TreeNodeAccessor } from "../../render/accessor";
 import { _ctxProvidersCache } from "../column_providers";
 import type { ColumnsProvider } from "../column_providers";
-import { DataColumn, DataColumnImpl } from "../data_column";
+import { DataColumn, type DataColumnRecipe } from "../data_column";
 
 export interface TestCollectionDriverHandle {
   readonly driver: ColumnsCollectionDriverModel;
@@ -38,7 +38,7 @@ export interface TestCollectionDriverHandle {
   /**
    * Install a minimal `globalThis.cfgRenderCtx` so `getService("columnsCollection")`
    * resolves to this driver and registered columns are reachable via
-   * `DataColumn.fromId`. Call inside `beforeEach` if the code under test uses
+   * `DataColumnRecipe.fromId`. Call inside `beforeEach` if the code under test uses
    * the ambient ctx instead of an explicit `driver` option.
    */
   installAmbientCtx(): void;
@@ -163,9 +163,9 @@ function buildStubProvider(
   for (const [id, spec] of specMap) {
     entries.set(id, { accessor: stubAccessorFor(id, spec), name: id, id });
   }
-  const columns: DataColumn<PObjectId>[] = [];
+  const columns: DataColumnRecipe<PObjectId>[] = [];
   for (const [id, spec] of specMap) {
-    columns.push(DataColumnImpl.fromColumn({ id, spec, data: undefined as never }));
+    columns.push(DataColumn.fromColumn({ id, spec, data: undefined as never }));
   }
   return {
     getPObjectEntries: () => entries,

--- a/sdk/model/src/columns/__test_helpers__/collection_driver.ts
+++ b/sdk/model/src/columns/__test_helpers__/collection_driver.ts
@@ -10,7 +10,7 @@
  * Calling {@link TestCollectionDriverHandle.installAmbientCtx} additionally
  * installs a minimal `globalThis.cfgRenderCtx` AND plants a stub
  * `ColumnEntriesProvider` into the ctx-providers cache so registered specs
- * are reachable via `ColumnLazy.fromId` (and therefore via
+ * are reachable via `DataColumn.fromId` (and therefore via
  * `ColumnsCollection.getColumns()`).
  */
 import type {
@@ -29,7 +29,7 @@ import type { GlobalCfgRenderCtx } from "../../render/internal";
 import { TreeNodeAccessor } from "../../render/accessor";
 import { _ctxProvidersCache } from "../column_providers";
 import type { ColumnsProvider } from "../column_providers";
-import { ColumnLazy, ColumnLazyImpl } from "../column_lazy";
+import { DataColumn, DataColumnImpl } from "../data_column";
 
 export interface TestCollectionDriverHandle {
   readonly driver: ColumnsCollectionDriverModel;
@@ -38,7 +38,7 @@ export interface TestCollectionDriverHandle {
   /**
    * Install a minimal `globalThis.cfgRenderCtx` so `getService("columnsCollection")`
    * resolves to this driver and registered columns are reachable via
-   * `ColumnLazy.fromId`. Call inside `beforeEach` if the code under test uses
+   * `DataColumn.fromId`. Call inside `beforeEach` if the code under test uses
    * the ambient ctx instead of an explicit `driver` option.
    */
   installAmbientCtx(): void;
@@ -148,7 +148,7 @@ export function createTestCollectionDriver(): TestCollectionDriverHandle {
  * Construct a {@link ColumnEntriesProvider} + {@link ColumnsProvider} backed
  * by an `(id → spec)` map. Each entry carries a fake {@link TreeNodeAccessor}
  * whose only contract is the surface `readSpec` / `readData` /
- * `readDataStatus` (in `p_column_lazy.ts`) actually call:
+ * `readDataStatus` (in `data_column.ts`) actually call:
  *   - `traverse({field: `${name}.spec`, ignoreError: true})` →
  *     stub-accessor whose `getDataAsJson()` returns the spec.
  *   - `traverse({field: `${name}.data`})` → `undefined` (data is not
@@ -163,9 +163,9 @@ function buildStubProvider(
   for (const [id, spec] of specMap) {
     entries.set(id, { accessor: stubAccessorFor(id, spec), name: id, id });
   }
-  const columns: ColumnLazy[] = [];
+  const columns: DataColumn<PObjectId>[] = [];
   for (const [id, spec] of specMap) {
-    columns.push(ColumnLazyImpl.fromColumn({ id, spec, data: undefined as never }));
+    columns.push(DataColumnImpl.fromColumn({ id, spec, data: undefined as never }));
   }
   return {
     getPObjectEntries: () => entries,

--- a/sdk/model/src/columns/__test_helpers__/stub_registry.ts
+++ b/sdk/model/src/columns/__test_helpers__/stub_registry.ts
@@ -3,7 +3,7 @@
  * `ColumnRegistry.resolve(id)` returns a `LeafEntry` whose spec accessor
  * reports `hasData() === true` and `getDataAsJson()` returns the supplied
  * spec. Sufficient for code that goes through
- * `getCtxProviders` / `readLeafSpecAccessor` (e.g. `ColumnLazy.fromId`,
+ * `getCtxProviders` / `readLeafSpecAccessor` (e.g. `DataColumn.fromId`,
  * `ColumnDiscoveredRecipe.fromKey`).
  *
  * Two leaf shapes:
@@ -28,7 +28,7 @@ import type { GlobalCfgRenderCtx } from "../../render/internal";
 import type { TreeNodeAccessor } from "../../render/accessor";
 import { _ctxProvidersCache } from "../column_providers";
 import type { ColumnsProvider } from "../column_providers";
-import { ColumnLazy, ColumnLazyImpl } from "../column_lazy";
+import { DataColumn, DataColumnImpl } from "../data_column";
 
 /** Fine-grained per-leaf stub config. Defaults match the shorthand form. */
 export type StubLeafConfig = {
@@ -65,14 +65,14 @@ function buildStubProvider(
       acc.entries.set(id, { accessor: stubAccessorFor(id, cfg), name: id, id });
       if (cfg.spec !== undefined && cfg.specHasData) {
         acc.columns.push(
-          ColumnLazyImpl.fromColumn({ id, spec: cfg.spec, data: undefined as never }),
+          DataColumnImpl.fromColumn({ id, spec: cfg.spec, data: undefined as never }),
         );
       }
       return acc;
     },
     {
       entries: new Map<PObjectId, LeafEntry<TreeNodeAccessor>>(),
-      columns: [] as ColumnLazy[],
+      columns: [] as DataColumn<PObjectId>[],
     },
   );
   return {

--- a/sdk/model/src/columns/__test_helpers__/stub_registry.ts
+++ b/sdk/model/src/columns/__test_helpers__/stub_registry.ts
@@ -3,7 +3,7 @@
  * `ColumnRegistry.resolve(id)` returns a `LeafEntry` whose spec accessor
  * reports `hasData() === true` and `getDataAsJson()` returns the supplied
  * spec. Sufficient for code that goes through
- * `getCtxProviders` / `readLeafSpecAccessor` (e.g. `DataColumn.fromId`,
+ * `getCtxProviders` / `readLeafSpecAccessor` (e.g. `DataColumnRecipe.fromId`,
  * `ColumnDiscoveredRecipe.fromKey`).
  *
  * Two leaf shapes:
@@ -28,7 +28,7 @@ import type { GlobalCfgRenderCtx } from "../../render/internal";
 import type { TreeNodeAccessor } from "../../render/accessor";
 import { _ctxProvidersCache } from "../column_providers";
 import type { ColumnsProvider } from "../column_providers";
-import { DataColumn, DataColumnImpl } from "../data_column";
+import { DataColumn, type DataColumnRecipe } from "../data_column";
 
 /** Fine-grained per-leaf stub config. Defaults match the shorthand form. */
 export type StubLeafConfig = {
@@ -64,15 +64,13 @@ function buildStubProvider(
       const cfg = normalizeLeafInput(raw);
       acc.entries.set(id, { accessor: stubAccessorFor(id, cfg), name: id, id });
       if (cfg.spec !== undefined && cfg.specHasData) {
-        acc.columns.push(
-          DataColumnImpl.fromColumn({ id, spec: cfg.spec, data: undefined as never }),
-        );
+        acc.columns.push(DataColumn.fromColumn({ id, spec: cfg.spec, data: undefined as never }));
       }
       return acc;
     },
     {
       entries: new Map<PObjectId, LeafEntry<TreeNodeAccessor>>(),
-      columns: [] as DataColumn<PObjectId>[],
+      columns: [] as DataColumnRecipe<PObjectId>[],
     },
   );
   return {

--- a/sdk/model/src/columns/column.ts
+++ b/sdk/model/src/columns/column.ts
@@ -7,8 +7,14 @@ import {
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import type { TreeNodeAccessor } from "../render";
-import { DataColumn, type ColumnData } from "./data_column";
-import { ColumnRecipe, ColumnRecipeId, isColumnRecipe } from "./column_recipes";
+import { DataColumn, DataColumnRecipe, DataColumnImpl, type ColumnData } from "./data_column";
+import {
+  ColumnDiscoveredRecipe,
+  ColumnFilteredRecipe,
+  ColumnOverriddenRecipe,
+  ColumnRecipe,
+  ColumnRecipeId,
+} from "./column_recipes";
 
 export type ColumnSource =
   | PObjectId
@@ -16,14 +22,14 @@ export type ColumnSource =
   | PlRef
   | LeafEntry<TreeNodeAccessor>
   | PColumn<ColumnData>
-  | DataColumn<PObjectId>;
+  | DataColumnRecipe<PObjectId>;
 
 /**
  * Unified entry point — routes between the two top-level dispatchers:
  *   - string id (`PObjectId` / `ColumnUniversalId`) → {@link ColumnRecipe}
- *   - object source (`PlRef` / `LeafEntry` / `PColumn` / `DataColumn`) → {@link DataColumn}
+ *   - object source (`PlRef` / `LeafEntry` / `PColumn` / `DataColumnRecipe`) → {@link DataColumnRecipe}
  *
- * `DataColumn` is itself a `ColumnRecipe<PObjectId>`, so the return type is
+ * `DataColumnRecipe` is itself a `ColumnRecipe<PObjectId>`, so the return type is
  * the common `ColumnRecipe`.
  */
 export function Column(
@@ -39,8 +45,13 @@ export type Column<ID extends ColumnRecipeId = ColumnRecipeId> = ColumnRecipe<ID
 /**
  * Type-guard for the `Column` type — currently aliased to `ColumnRecipe`, so
  * this is equivalent to {@link isColumnRecipe}. Kept as a separate export to
- * mirror the `Column` / `ColumnRecipe` / `DataColumn` factory triple.
+ * mirror the `Column` / `ColumnRecipe` / `DataColumnRecipe` factory triple.
  */
 export function isColumn(value: unknown): value is Column {
-  return isColumnRecipe(value);
+  return (
+    value instanceof DataColumnImpl ||
+    value instanceof ColumnFilteredRecipe ||
+    value instanceof ColumnDiscoveredRecipe ||
+    value instanceof ColumnOverriddenRecipe
+  );
 }

--- a/sdk/model/src/columns/column.ts
+++ b/sdk/model/src/columns/column.ts
@@ -7,7 +7,7 @@ import {
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import type { TreeNodeAccessor } from "../render";
-import { ColumnLazy, ColumnLazyImpl, type ColumnLazyData } from "./column_lazy";
+import { DataColumn, type DataColumnData } from "./data_column";
 import { ColumnRecipe, ColumnRecipeId, isColumnRecipe } from "./column_recipes";
 
 export type ColumnSource =
@@ -15,15 +15,15 @@ export type ColumnSource =
   | ColumnUniversalId
   | PlRef
   | LeafEntry<TreeNodeAccessor>
-  | PColumn<ColumnLazyData>
-  | ColumnLazyImpl;
+  | PColumn<DataColumnData>
+  | DataColumn<PObjectId>;
 
 /**
  * Unified entry point — routes between the two top-level dispatchers:
  *   - string id (`PObjectId` / `ColumnUniversalId`) → {@link ColumnRecipe}
- *   - object source (`PlRef` / `LeafEntry` / `PColumn` / `ColumnLazy`) → {@link ColumnLazy}
+ *   - object source (`PlRef` / `LeafEntry` / `PColumn` / `DataColumn`) → {@link DataColumn}
  *
- * `ColumnLazy` is itself a `ColumnRecipe<PObjectId>`, so the return type is
+ * `DataColumn` is itself a `ColumnRecipe<PObjectId>`, so the return type is
  * the common `ColumnRecipe`.
  */
 export function Column(
@@ -31,7 +31,7 @@ export function Column(
   opts?: { ctx?: GlobalCfgRenderCtx },
 ): undefined | ColumnRecipe {
   if (typeof source === "string") return ColumnRecipe(source, opts);
-  return ColumnLazy(source, opts);
+  return DataColumn(source, opts);
 }
 
 export type Column<ID extends ColumnRecipeId = ColumnRecipeId> = ColumnRecipe<ID>;
@@ -39,7 +39,7 @@ export type Column<ID extends ColumnRecipeId = ColumnRecipeId> = ColumnRecipe<ID
 /**
  * Type-guard for the `Column` type — currently aliased to `ColumnRecipe`, so
  * this is equivalent to {@link isColumnRecipe}. Kept as a separate export to
- * mirror the `Column` / `ColumnRecipe` / `ColumnLazy` factory triple.
+ * mirror the `Column` / `ColumnRecipe` / `DataColumn` factory triple.
  */
 export function isColumn(value: unknown): value is Column {
   return isColumnRecipe(value);

--- a/sdk/model/src/columns/column.ts
+++ b/sdk/model/src/columns/column.ts
@@ -7,7 +7,7 @@ import {
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import type { TreeNodeAccessor } from "../render";
-import { DataColumn, type DataColumnData } from "./data_column";
+import { DataColumn, type ColumnData } from "./data_column";
 import { ColumnRecipe, ColumnRecipeId, isColumnRecipe } from "./column_recipes";
 
 export type ColumnSource =
@@ -15,7 +15,7 @@ export type ColumnSource =
   | ColumnUniversalId
   | PlRef
   | LeafEntry<TreeNodeAccessor>
-  | PColumn<DataColumnData>
+  | PColumn<ColumnData>
   | DataColumn<PObjectId>;
 
 /**

--- a/sdk/model/src/columns/column_providers/index.ts
+++ b/sdk/model/src/columns/column_providers/index.ts
@@ -1,9 +1,13 @@
-import { PColumn, type ColumnEntriesProvider } from "@milaboratories/pl-model-common";
+import {
+  PColumn,
+  type ColumnEntriesProvider,
+  type PObjectId,
+} from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx, PColumnDataUniversal } from "../../render/internal";
 import { getCfgRenderCtx } from "../../internal";
 import { MainAccessorName, StagingAccessorName } from "../../render/internal";
 import { TreeNodeAccessor } from "../../render/accessor";
-import { ColumnLazy } from "../column_lazy";
+import { DataColumn } from "../data_column";
 import type { ColumnsSource } from "./types";
 import { ArrayColumnsProvider, ColumnsProvider } from "./providers";
 
@@ -69,7 +73,9 @@ export function toColumnProvider(source: ColumnsSource): ColumnsProvider {
 }
 
 function isColumnArray(source: unknown): source is {
-  readonly columns: ReadonlyArray<PColumn<undefined | PColumnDataUniversal> | ColumnLazy>;
+  readonly columns: ReadonlyArray<
+    PColumn<undefined | PColumnDataUniversal> | DataColumn<PObjectId>
+  >;
   readonly isFinal: boolean;
 } {
   if (typeof source !== "object" || source === null) return false;

--- a/sdk/model/src/columns/column_providers/index.ts
+++ b/sdk/model/src/columns/column_providers/index.ts
@@ -7,7 +7,7 @@ import type { GlobalCfgRenderCtx, PColumnDataUniversal } from "../../render/inte
 import { getCfgRenderCtx } from "../../internal";
 import { MainAccessorName, StagingAccessorName } from "../../render/internal";
 import { TreeNodeAccessor } from "../../render/accessor";
-import { DataColumn } from "../data_column";
+import { DataColumnRecipe } from "../data_column";
 import type { ColumnsSource } from "./types";
 import { ArrayColumnsProvider, ColumnsProvider } from "./providers";
 
@@ -74,7 +74,7 @@ export function toColumnProvider(source: ColumnsSource): ColumnsProvider {
 
 function isColumnArray(source: unknown): source is {
   readonly columns: ReadonlyArray<
-    PColumn<undefined | PColumnDataUniversal> | DataColumn<PObjectId>
+    PColumn<undefined | PColumnDataUniversal> | DataColumnRecipe<PObjectId>
   >;
   readonly isFinal: boolean;
 } {

--- a/sdk/model/src/columns/column_providers/providers.ts
+++ b/sdk/model/src/columns/column_providers/providers.ts
@@ -2,10 +2,11 @@ import {
   AccessorEntriesProvider,
   ResultPoolEntriesProvider,
   type PColumn,
+  type PObjectId,
   type UpstreamBlockCtx,
 } from "@milaboratories/pl-model-common";
 import { AccessorHandle, PColumnDataUniversal, TreeNodeAccessor } from "../../render";
-import { ColumnLazy, ColumnLazyImpl } from "../column_lazy";
+import { DataColumnImpl, type DataColumn } from "../data_column";
 import { getCfgRenderCtx } from "../../internal";
 import { isNil } from "es-toolkit";
 import { LRUCache } from "lru-cache";
@@ -20,7 +21,7 @@ import { LRUCache } from "lru-cache";
  */
 export interface ColumnsProvider {
   /** Returns all currently known PColumn columns as lazy views. */
-  getColumns(): ColumnLazy[];
+  getColumns(): DataColumn<PObjectId>[];
   /** Whether the provider has finished enumerating all its columns. */
   isFinal(): boolean;
 }
@@ -92,16 +93,16 @@ export function ResultPoolColumnsProvider(
  * id-index source — `ColumnRegistry` does not consume it.
  */
 export class ArrayColumnsProvider implements ColumnsProvider {
-  private readonly columns: ColumnLazy[];
+  private readonly columns: DataColumn<PObjectId>[];
 
   constructor(
-    columns: ReadonlyArray<PColumn<undefined | PColumnDataUniversal> | ColumnLazy>,
+    columns: ReadonlyArray<PColumn<undefined | PColumnDataUniversal> | DataColumn<PObjectId>>,
     private readonly _isFinal: boolean,
   ) {
-    this.columns = columns.map((c) => ColumnLazyImpl.fromColumn(c));
+    this.columns = columns.map((c) => DataColumnImpl.fromColumn(c));
   }
 
-  getColumns(): ColumnLazy[] {
+  getColumns(): DataColumn<PObjectId>[] {
     return this.columns;
   }
 
@@ -113,24 +114,24 @@ export class ArrayColumnsProvider implements ColumnsProvider {
 /**
  * Sandbox-specific provider over a {@link TreeNodeAccessor} root. Uses the
  * accessor's own `resolvePath` as the canonical root path for id construction,
- * and adds `getColumns()` returning {@link ColumnLazy}s on top of the generic
+ * and adds `getColumns()` returning {@link DataColumn<PObjectId>}s on top of the generic
  * entries index.
  */
 export class AccessorColumnsProviderImpl
   extends AccessorEntriesProvider<TreeNodeAccessor>
   implements ColumnsProvider
 {
-  private cachedColumns?: ColumnLazy[];
+  private cachedColumns?: DataColumn<PObjectId>[];
 
   constructor(root: TreeNodeAccessor) {
     super(root, root.resolvePath);
   }
 
-  getColumns(): ColumnLazy[] {
+  getColumns(): DataColumn<PObjectId>[] {
     if (this.cachedColumns !== undefined) return this.cachedColumns;
     return (this.cachedColumns = Array.from(this.entries.values())
-      .map((e) => ColumnLazyImpl.fromAccessor(e))
-      .filter((v): v is ColumnLazy => !isNil(v)));
+      .map((e) => DataColumnImpl.fromAccessor(e))
+      .filter((v): v is DataColumn<PObjectId> => !isNil(v)));
   }
 }
 
@@ -146,7 +147,7 @@ export class ResultPoolColumnsProviderImpl
   extends ResultPoolEntriesProvider<TreeNodeAccessor>
   implements ColumnsProvider
 {
-  private cachedColumns?: ColumnLazy[];
+  private cachedColumns?: DataColumn<PObjectId>[];
 
   constructor(
     rawPool: ReadonlyArray<
@@ -170,11 +171,11 @@ export class ResultPoolColumnsProviderImpl
     super(blocks);
   }
 
-  getColumns(): ColumnLazy[] {
+  getColumns(): DataColumn<PObjectId>[] {
     if (this.cachedColumns !== undefined) return this.cachedColumns;
     return (this.cachedColumns = Array.from(this.getPObjectEntries().values())
-      .map((e) => ColumnLazyImpl.fromAccessor(e))
-      .filter((v): v is ColumnLazy => !isNil(v)));
+      .map((e) => DataColumnImpl.fromAccessor(e))
+      .filter((v): v is DataColumn<PObjectId> => !isNil(v)));
   }
 }
 

--- a/sdk/model/src/columns/column_providers/providers.ts
+++ b/sdk/model/src/columns/column_providers/providers.ts
@@ -6,7 +6,7 @@ import {
   type UpstreamBlockCtx,
 } from "@milaboratories/pl-model-common";
 import { AccessorHandle, PColumnDataUniversal, TreeNodeAccessor } from "../../render";
-import { DataColumnImpl, type DataColumn } from "../data_column";
+import { DataColumn, DataColumnRecipe } from "../data_column";
 import { getCfgRenderCtx } from "../../internal";
 import { isNil } from "es-toolkit";
 import { LRUCache } from "lru-cache";
@@ -21,7 +21,7 @@ import { LRUCache } from "lru-cache";
  */
 export interface ColumnsProvider {
   /** Returns all currently known PColumn columns as lazy views. */
-  getColumns(): DataColumn<PObjectId>[];
+  getColumns(): DataColumnRecipe<PObjectId>[];
   /** Whether the provider has finished enumerating all its columns. */
   isFinal(): boolean;
 }
@@ -93,16 +93,16 @@ export function ResultPoolColumnsProvider(
  * id-index source — `ColumnRegistry` does not consume it.
  */
 export class ArrayColumnsProvider implements ColumnsProvider {
-  private readonly columns: DataColumn<PObjectId>[];
+  private readonly columns: DataColumnRecipe<PObjectId>[];
 
   constructor(
-    columns: ReadonlyArray<PColumn<undefined | PColumnDataUniversal> | DataColumn<PObjectId>>,
+    columns: ReadonlyArray<PColumn<undefined | PColumnDataUniversal> | DataColumnRecipe<PObjectId>>,
     private readonly _isFinal: boolean,
   ) {
-    this.columns = columns.map((c) => DataColumnImpl.fromColumn(c));
+    this.columns = columns.map((c) => DataColumn.fromColumn(c));
   }
 
-  getColumns(): DataColumn<PObjectId>[] {
+  getColumns(): DataColumnRecipe<PObjectId>[] {
     return this.columns;
   }
 
@@ -114,24 +114,24 @@ export class ArrayColumnsProvider implements ColumnsProvider {
 /**
  * Sandbox-specific provider over a {@link TreeNodeAccessor} root. Uses the
  * accessor's own `resolvePath` as the canonical root path for id construction,
- * and adds `getColumns()` returning {@link DataColumn<PObjectId>}s on top of the generic
+ * and adds `getColumns()` returning {@link DataColumnRecipe<PObjectId>}s on top of the generic
  * entries index.
  */
 export class AccessorColumnsProviderImpl
   extends AccessorEntriesProvider<TreeNodeAccessor>
   implements ColumnsProvider
 {
-  private cachedColumns?: DataColumn<PObjectId>[];
+  private cachedColumns?: DataColumnRecipe<PObjectId>[];
 
   constructor(root: TreeNodeAccessor) {
     super(root, root.resolvePath);
   }
 
-  getColumns(): DataColumn<PObjectId>[] {
+  getColumns(): DataColumnRecipe<PObjectId>[] {
     if (this.cachedColumns !== undefined) return this.cachedColumns;
     return (this.cachedColumns = Array.from(this.entries.values())
-      .map((e) => DataColumnImpl.fromAccessor(e))
-      .filter((v): v is DataColumn<PObjectId> => !isNil(v)));
+      .map((e) => DataColumn.fromAccessor(e))
+      .filter((v): v is DataColumnRecipe<PObjectId> => !isNil(v)));
   }
 }
 
@@ -147,7 +147,7 @@ export class ResultPoolColumnsProviderImpl
   extends ResultPoolEntriesProvider<TreeNodeAccessor>
   implements ColumnsProvider
 {
-  private cachedColumns?: DataColumn<PObjectId>[];
+  private cachedColumns?: DataColumnRecipe<PObjectId>[];
 
   constructor(
     rawPool: ReadonlyArray<
@@ -171,11 +171,11 @@ export class ResultPoolColumnsProviderImpl
     super(blocks);
   }
 
-  getColumns(): DataColumn<PObjectId>[] {
+  getColumns(): DataColumnRecipe<PObjectId>[] {
     if (this.cachedColumns !== undefined) return this.cachedColumns;
     return (this.cachedColumns = Array.from(this.getPObjectEntries().values())
-      .map((e) => DataColumnImpl.fromAccessor(e))
-      .filter((v): v is DataColumn<PObjectId> => !isNil(v)));
+      .map((e) => DataColumn.fromAccessor(e))
+      .filter((v): v is DataColumnRecipe<PObjectId> => !isNil(v)));
   }
 }
 

--- a/sdk/model/src/columns/column_providers/types.ts
+++ b/sdk/model/src/columns/column_providers/types.ts
@@ -1,7 +1,7 @@
 import type { PColumn } from "@milaboratories/pl-model-common";
 import { TreeNodeAccessor } from "../../render";
 import type { PColumnDataUniversal } from "../../render/internal";
-import type { ColumnLazy } from "../column_lazy";
+import type { DataColumn } from "../data_column";
 import type { ColumnRecipe } from "../column_recipes";
 import type { ColumnsProvider } from "./providers";
 
@@ -10,7 +10,7 @@ import type { ColumnsProvider } from "./providers";
  * Includes TreeNodeAccessor, ColumnsProvider, and arrays of columns.
  *
  * The array form accepts plain {@link PColumn}s (materialized snapshots),
- * {@link ColumnLazy} leaves, or any {@link ColumnRecipe} — builders only
+ * {@link DataColumn} leaves, or any {@link ColumnRecipe} — builders only
  * need each entry's `id` for serialization.
  */
 export type ColumnsSource =
@@ -18,7 +18,7 @@ export type ColumnsSource =
   | TreeNodeAccessor
   | {
       readonly columns: ReadonlyArray<
-        PColumn<undefined | PColumnDataUniversal> | ColumnLazy | ColumnRecipe
+        PColumn<undefined | PColumnDataUniversal> | DataColumn | ColumnRecipe
       >;
       readonly isFinal: boolean;
     };

--- a/sdk/model/src/columns/column_providers/types.ts
+++ b/sdk/model/src/columns/column_providers/types.ts
@@ -1,7 +1,7 @@
 import type { PColumn } from "@milaboratories/pl-model-common";
 import { TreeNodeAccessor } from "../../render";
 import type { PColumnDataUniversal } from "../../render/internal";
-import type { DataColumn } from "../data_column";
+import type { DataColumnRecipe } from "../data_column";
 import type { ColumnRecipe } from "../column_recipes";
 import type { ColumnsProvider } from "./providers";
 
@@ -10,7 +10,7 @@ import type { ColumnsProvider } from "./providers";
  * Includes TreeNodeAccessor, ColumnsProvider, and arrays of columns.
  *
  * The array form accepts plain {@link PColumn}s (materialized snapshots),
- * {@link DataColumn} leaves, or any {@link ColumnRecipe} — builders only
+ * {@link DataColumnRecipe} leaves, or any {@link ColumnRecipe} — builders only
  * need each entry's `id` for serialization.
  */
 export type ColumnsSource =
@@ -18,7 +18,7 @@ export type ColumnsSource =
   | TreeNodeAccessor
   | {
       readonly columns: ReadonlyArray<
-        PColumn<undefined | PColumnDataUniversal> | DataColumn | ColumnRecipe
+        PColumn<undefined | PColumnDataUniversal> | DataColumnRecipe | ColumnRecipe
       >;
       readonly isFinal: boolean;
     };

--- a/sdk/model/src/columns/column_recipes/column_discovered_recipe.ts
+++ b/sdk/model/src/columns/column_recipes/column_discovered_recipe.ts
@@ -37,7 +37,7 @@ import { throwError } from "@milaboratories/helpers";
 export class ColumnDiscoveredRecipe implements ColumnRecipe<ColumnDiscoveredId> {
   /**
    * Validate the key + resolve every referenced column via
-   * {@link ColumnLazy.fromId} (which itself checks the leaf accessor reports
+   * {@link DataColumn.fromId} (which itself checks the leaf accessor reports
    * `hasData()`). Returns `undefined` if the key is malformed or any
    * referenced column is not yet spec-resolvable.
    *

--- a/sdk/model/src/columns/column_recipes/column_discovered_recipe.ts
+++ b/sdk/model/src/columns/column_recipes/column_discovered_recipe.ts
@@ -37,7 +37,7 @@ import { throwError } from "@milaboratories/helpers";
 export class ColumnDiscoveredRecipe implements ColumnRecipe<ColumnDiscoveredId> {
   /**
    * Validate the key + resolve every referenced column via
-   * {@link DataColumn.fromId} (which itself checks the leaf accessor reports
+   * {@link DataColumnRecipe.fromId} (which itself checks the leaf accessor reports
    * `hasData()`). Returns `undefined` if the key is malformed or any
    * referenced column is not yet spec-resolvable.
    *

--- a/sdk/model/src/columns/column_recipes/column_overrided_recipe.ts
+++ b/sdk/model/src/columns/column_recipes/column_overrided_recipe.ts
@@ -11,7 +11,7 @@ import {
   type SpecQuery,
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../../render/internal";
-import type { DataColumn, DataColumnData } from "../data_column";
+import type { DataColumn, ColumnData } from "../data_column";
 import type { ColumnFieldStatus, ColumnResolutionStatus } from "./types";
 import { ColumnRecipe } from "./index";
 import { Column } from "../column";
@@ -43,12 +43,41 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
    */
   static wrap(col: Column, overrides: SpecOverrides): ColumnOverriddenRecipe {
     if (col instanceof ColumnOverriddenRecipe) {
-      return new ColumnOverriddenRecipe(col.inner, mergeSpecOverrides(col.overrides, overrides));
+      return ColumnOverriddenRecipe.build(col.inner, mergeSpecOverrides(col.overrides, overrides));
     }
     // `inner` is not an Overridden wrap (the `instanceof` branch above handles
     // that). Narrow the id union here so the constructor parameter stays
     // honest with `ColumnOverriddenKey.source`.
-    return new ColumnOverriddenRecipe(col as NonOverriddenColumn, overrides);
+    return ColumnOverriddenRecipe.build(col as NonOverriddenColumn, overrides);
+  }
+
+  /**
+   * Pick the variant from the inner recipe: data-bearing inner →
+   * {@link DataColumnOverriddenRecipe}, otherwise the plain wrapper.
+   *
+   * The choice is **structural**, not a readiness check — it follows from
+   * which kind of recipe `inner` is, which in turn follows from the id alone
+   * (a bare `PObjectId` source is a leaf, anything else is not). So the same
+   * id always yields the same class, whether it was built via `withSpecs` or
+   * parsed from a string, and recipes stay value-objects that are equal iff
+   * their ids match.
+   *
+   * Re-deriving from `inner` on every build is also what keeps the merge path
+   * honest: `overridden.withSpecs(a).withSpecs(b)` cannot silently drop the
+   * data-bearing variant.
+   *
+   * Discriminated by method presence rather than `instanceof DataColumnImpl`
+   * to keep this module free of a runtime import cycle with `../data_column`.
+   * By the flat-merge invariant `inner` is never an Overridden, so the only
+   * recipe kind reaching here that carries `getData` is the leaf.
+   */
+  private static build(
+    inner: NonOverriddenColumn,
+    overrides: SpecOverrides,
+  ): ColumnOverriddenRecipe {
+    return typeof (inner as Partial<DataColumn>).getData === "function"
+      ? new DataColumnOverriddenRecipe(inner, overrides)
+      : new ColumnOverriddenRecipe(inner, overrides);
   }
 
   /**
@@ -68,7 +97,7 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
   private queryCache?: { readonly value: SpecQuery };
   private dataStatusCache?: { readonly value: ColumnFieldStatus };
 
-  private constructor(
+  protected constructor(
     private readonly inner: NonOverriddenColumn,
     private readonly overrides: SpecOverrides,
   ) {
@@ -96,26 +125,6 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
       this.dataStatusCache = { value: this.inner.getDataStatus() };
     }
     return this.dataStatusCache.value;
-  }
-
-  /**
-   * Overrides are a pure spec patch — they never reshape the data — so the
-   * inner column's data stays consistent with this recipe's spec and can be
-   * passed straight through.
-   *
-   * Only valid when `inner` itself carries data. By the flat-merge invariant
-   * `inner` is never another Overridden, so it is a leaf, a Filtered or a
-   * Discovered — and only the leaf exposes `getData`. Gate with
-   * `hasDirectData(recipe)` instead of calling this blind.
-   */
-  getData(): DataColumnData {
-    const inner = this.inner as Partial<DataColumn>;
-    if (typeof inner.getData !== "function") {
-      throw new Error(
-        `ColumnOverriddenRecipe.getData: inner recipe of ${this.id} carries no directly readable data`,
-      );
-    }
-    return inner.getData();
   }
 
   /**
@@ -163,5 +172,29 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
    */
   withSpecs(overrides: SpecOverrides): Column {
     return ColumnOverriddenRecipe.wrap(this, overrides);
+  }
+}
+
+/**
+ * The variant produced when the wrapped recipe is itself data-bearing.
+ *
+ * Overrides are a pure spec patch — they never reshape the data — so the inner
+ * column's data stays consistent with this recipe's spec and is passed
+ * straight through. Which variant you get is decided once, at construction:
+ * see {@link build}.
+ *
+ * Not something callers name. Narrow with `hasReachableData(recipe)`, which
+ * yields the {@link DataColumn} interface.
+ */
+export class DataColumnOverriddenRecipe
+  extends ColumnOverriddenRecipe
+  implements DataColumn<ColumnOverriddenId>
+{
+  /**
+   * Safe by construction: {@link build} only picks this class when the inner
+   * recipe exposes `getData`.
+   */
+  getData(): ColumnData {
+    return (this.getInner() as DataColumn).getData();
   }
 }

--- a/sdk/model/src/columns/column_recipes/column_overrided_recipe.ts
+++ b/sdk/model/src/columns/column_recipes/column_overrided_recipe.ts
@@ -11,6 +11,7 @@ import {
   type SpecQuery,
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../../render/internal";
+import type { DataColumn, DataColumnData } from "../data_column";
 import type { ColumnFieldStatus, ColumnResolutionStatus } from "./types";
 import { ColumnRecipe } from "./index";
 import { Column } from "../column";
@@ -95,6 +96,26 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
       this.dataStatusCache = { value: this.inner.getDataStatus() };
     }
     return this.dataStatusCache.value;
+  }
+
+  /**
+   * Overrides are a pure spec patch — they never reshape the data — so the
+   * inner column's data stays consistent with this recipe's spec and can be
+   * passed straight through.
+   *
+   * Only valid when `inner` itself carries data. By the flat-merge invariant
+   * `inner` is never another Overridden, so it is a leaf, a Filtered or a
+   * Discovered — and only the leaf exposes `getData`. Gate with
+   * `hasDirectData(recipe)` instead of calling this blind.
+   */
+  getData(): DataColumnData {
+    const inner = this.inner as Partial<DataColumn>;
+    if (typeof inner.getData !== "function") {
+      throw new Error(
+        `ColumnOverriddenRecipe.getData: inner recipe of ${this.id} carries no directly readable data`,
+      );
+    }
+    return inner.getData();
   }
 
   /**

--- a/sdk/model/src/columns/column_recipes/column_overrided_recipe.ts
+++ b/sdk/model/src/columns/column_recipes/column_overrided_recipe.ts
@@ -11,7 +11,7 @@ import {
   type SpecQuery,
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../../render/internal";
-import type { DataColumn, ColumnData } from "../data_column";
+import { type DataColumnRecipe, type ColumnData, isDataColumn } from "../data_column";
 import type { ColumnFieldStatus, ColumnResolutionStatus } from "./types";
 import { ColumnRecipe } from "./index";
 import { Column } from "../column";
@@ -34,7 +34,7 @@ type NonOverriddenColumn = Column<Exclude<ColumnUniversalId, ColumnOverriddenId>
  * This invariant matches the one enforced inside `unwrapOverrides` from
  * pl-model-common: it explicitly throws on a nested override-wrap.
  */
-export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
+export class ColumnOverriddenRecipe implements ColumnRecipe<ColumnOverriddenId> {
   /**
    * Wrap any recipe with overrides. If `inner` is already a
    * {@link ColumnOverriddenRecipe}, merges `overrides` into the existing ones
@@ -75,7 +75,7 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
     inner: NonOverriddenColumn,
     overrides: SpecOverrides,
   ): ColumnOverriddenRecipe {
-    return typeof (inner as Partial<DataColumn>).getData === "function"
+    return isDataColumn(inner)
       ? new DataColumnOverriddenRecipe(inner, overrides)
       : new ColumnOverriddenRecipe(inner, overrides);
   }
@@ -184,17 +184,17 @@ export class ColumnOverriddenRecipe implements Column<ColumnOverriddenId> {
  * see {@link build}.
  *
  * Not something callers name. Narrow with `hasReachableData(recipe)`, which
- * yields the {@link DataColumn} interface.
+ * yields the {@link DataColumnRecipe} interface.
  */
 export class DataColumnOverriddenRecipe
   extends ColumnOverriddenRecipe
-  implements DataColumn<ColumnOverriddenId>
+  implements DataColumnRecipe<ColumnOverriddenId>
 {
   /**
    * Safe by construction: {@link build} only picks this class when the inner
    * recipe exposes `getData`.
    */
   getData(): ColumnData {
-    return (this.getInner() as DataColumn).getData();
+    return (this.getInner() as DataColumnRecipe).getData();
   }
 }

--- a/sdk/model/src/columns/column_recipes/column_recipes.test.ts
+++ b/sdk/model/src/columns/column_recipes/column_recipes.test.ts
@@ -24,7 +24,7 @@ import { ColumnDiscoveredRecipe } from "./column_discovered_recipe";
 import { ColumnOverriddenRecipe } from "./column_overrided_recipe";
 import { ColumnFilteredRecipe } from "./column_filtered_recipe";
 import { ColumnRecipe } from "./index";
-import { ColumnAbsentError } from "../column_lazy";
+import { ColumnAbsentError } from "../data_column";
 import type { ColumnFieldStatus } from "./types";
 import { installStubRegistry } from "../__test_helpers__/stub_registry";
 import { throwError } from "@milaboratories/helpers";
@@ -581,7 +581,7 @@ describe("Wrapper getStatusByKey delegates to source", () => {
 });
 
 describe("ColumnRecipe.getStatus (top-level dispatcher)", () => {
-  test("routes bare PObjectId to ColumnLazyImpl.getStatusById", () => {
+  test("routes bare PObjectId to DataColumnImpl.getStatusById", () => {
     setupCtx({ [baseLeaf]: stubSpec() });
     expect(ColumnRecipe.getStatus(baseLeaf)).toBe("present");
   });

--- a/sdk/model/src/columns/column_recipes/index.ts
+++ b/sdk/model/src/columns/column_recipes/index.ts
@@ -8,7 +8,7 @@ import {
   isColumnFilteredKey,
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../../render/internal";
-import { ColumnLazyImpl } from "../column_lazy";
+import { DataColumnImpl } from "../data_column";
 import { ColumnDiscoveredRecipe } from "./column_discovered_recipe";
 import { ColumnFilteredRecipe } from "./column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_overrided_recipe";
@@ -19,7 +19,7 @@ import type {
 } from "./types";
 
 export type { ColumnFieldStatus, ColumnRecipeId, ColumnResolutionStatus, SpecQuery } from "./types";
-export { ColumnAbsentError } from "../column_lazy";
+export { ColumnAbsentError } from "../data_column";
 export { ColumnDiscoveredRecipe } from "./column_discovered_recipe";
 export { ColumnFilteredRecipe } from "./column_filtered_recipe";
 export { ColumnOverriddenRecipe } from "./column_overrided_recipe";
@@ -38,7 +38,7 @@ export interface ColumnRecipe<
  * concrete recipe variant based on the id's encoding and recurses on
  * wrappers' inner `source`:
  *
- *   - bare {@link PObjectId} (non-JSON)               → `ColumnLazy.fromId`
+ *   - bare {@link PObjectId} (non-JSON)               → `DataColumn.fromId`
  *   - `ColumnDiscoveredKey`                          → {@link ColumnDiscoveredRecipe}
  *   - `ColumnOverriddenKey { source, specOverrides }` → recurse on `source`,
  *                                                       then {@link ColumnOverriddenRecipe.wrap}
@@ -56,7 +56,7 @@ function ColumnRecipeBuild(
   const parsed = parseColumnIdSafely(id);
 
   if (isPObjectKey(parsed)) {
-    return ColumnLazyImpl.fromId(id as PObjectId, opts);
+    return DataColumnImpl.fromId(id as PObjectId, opts);
   }
 
   if (isColumnDiscoveredKey(parsed)) {
@@ -98,7 +98,7 @@ function ColumnRecipeGetStatus(
   opts: { ctx?: GlobalCfgRenderCtx } = {},
 ): ColumnResolutionStatus {
   const parsed = parseColumnIdSafely(id);
-  if (isPObjectKey(parsed)) return ColumnLazyImpl.getStatusById(id as PObjectId, opts);
+  if (isPObjectKey(parsed)) return DataColumnImpl.getStatusById(id as PObjectId, opts);
   if (isColumnDiscoveredKey(parsed)) return ColumnDiscoveredRecipe.getStatusByKey(parsed, opts);
   if (isColumnOverriddenKey(parsed)) return ColumnOverriddenRecipe.getStatusByKey(parsed, opts);
   if (isColumnFilteredKey(parsed)) return ColumnFilteredRecipe.getStatusByKey(parsed, opts);
@@ -112,14 +112,14 @@ export const ColumnRecipe: typeof ColumnRecipeBuild & {
 });
 
 /**
- * Type-guard for any recipe class — leaf {@link ColumnLazyImpl} or any of the
+ * Type-guard for any recipe class — leaf {@link DataColumnImpl} or any of the
  * wrapper recipes ({@link ColumnDiscoveredRecipe}, {@link ColumnFilteredRecipe},
  * {@link ColumnOverriddenRecipe}). Use when a value may be a raw id, a `PColumn`,
  * or a recipe and you want to branch on the recipe case.
  */
 export function isColumnRecipe(value: unknown): value is ColumnRecipe {
   return (
-    value instanceof ColumnLazyImpl ||
+    value instanceof DataColumnImpl ||
     value instanceof ColumnDiscoveredRecipe ||
     value instanceof ColumnFilteredRecipe ||
     value instanceof ColumnOverriddenRecipe

--- a/sdk/model/src/columns/column_recipes/index.ts
+++ b/sdk/model/src/columns/column_recipes/index.ts
@@ -8,7 +8,7 @@ import {
   isColumnFilteredKey,
 } from "@milaboratories/pl-model-common";
 import type { GlobalCfgRenderCtx } from "../../render/internal";
-import { DataColumnImpl } from "../data_column";
+import { DataColumn } from "../data_column";
 import { ColumnDiscoveredRecipe } from "./column_discovered_recipe";
 import { ColumnFilteredRecipe } from "./column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_overrided_recipe";
@@ -38,7 +38,7 @@ export interface ColumnRecipe<
  * concrete recipe variant based on the id's encoding and recurses on
  * wrappers' inner `source`:
  *
- *   - bare {@link PObjectId} (non-JSON)               → `DataColumn.fromId`
+ *   - bare {@link PObjectId} (non-JSON)               → `DataColumnRecipe.fromId`
  *   - `ColumnDiscoveredKey`                          → {@link ColumnDiscoveredRecipe}
  *   - `ColumnOverriddenKey { source, specOverrides }` → recurse on `source`,
  *                                                       then {@link ColumnOverriddenRecipe.wrap}
@@ -56,7 +56,7 @@ function ColumnRecipeBuild(
   const parsed = parseColumnIdSafely(id);
 
   if (isPObjectKey(parsed)) {
-    return DataColumnImpl.fromId(id as PObjectId, opts);
+    return DataColumn.fromId(id as PObjectId, opts);
   }
 
   if (isColumnDiscoveredKey(parsed)) {
@@ -98,7 +98,7 @@ function ColumnRecipeGetStatus(
   opts: { ctx?: GlobalCfgRenderCtx } = {},
 ): ColumnResolutionStatus {
   const parsed = parseColumnIdSafely(id);
-  if (isPObjectKey(parsed)) return DataColumnImpl.getStatusById(id as PObjectId, opts);
+  if (isPObjectKey(parsed)) return DataColumn.getStatusById(id as PObjectId, opts);
   if (isColumnDiscoveredKey(parsed)) return ColumnDiscoveredRecipe.getStatusByKey(parsed, opts);
   if (isColumnOverriddenKey(parsed)) return ColumnOverriddenRecipe.getStatusByKey(parsed, opts);
   if (isColumnFilteredKey(parsed)) return ColumnFilteredRecipe.getStatusByKey(parsed, opts);
@@ -110,18 +110,3 @@ export const ColumnRecipe: typeof ColumnRecipeBuild & {
 } = Object.assign(ColumnRecipeBuild, {
   getStatus: ColumnRecipeGetStatus,
 });
-
-/**
- * Type-guard for any recipe class — leaf {@link DataColumnImpl} or any of the
- * wrapper recipes ({@link ColumnDiscoveredRecipe}, {@link ColumnFilteredRecipe},
- * {@link ColumnOverriddenRecipe}). Use when a value may be a raw id, a `PColumn`,
- * or a recipe and you want to branch on the recipe case.
- */
-export function isColumnRecipe(value: unknown): value is ColumnRecipe {
-  return (
-    value instanceof DataColumnImpl ||
-    value instanceof ColumnDiscoveredRecipe ||
-    value instanceof ColumnFilteredRecipe ||
-    value instanceof ColumnOverriddenRecipe
-  );
-}

--- a/sdk/model/src/columns/data_column.test.ts
+++ b/sdk/model/src/columns/data_column.test.ts
@@ -6,12 +6,12 @@ import {
   type PColumnSpec,
   type PObjectId,
 } from "@milaboratories/pl-model-common";
-import { ColumnAbsentError, ColumnLazy, ColumnLazyImpl } from "./column_lazy";
+import { ColumnAbsentError, DataColumn, DataColumnImpl } from "./data_column";
 import { _ctxProvidersCache } from "./column_providers";
 import { installStubRegistry } from "./__test_helpers__/stub_registry";
 
 // --- Ambient ctx mock ------------------------------------------------------
-// ColumnLazy constructor pulls `getCfgRenderCtx()` from globalThis. A minimal
+// DataColumn constructor pulls `getCfgRenderCtx()` from globalThis. A minimal
 // mock with empty index is enough — these tests don't exercise resolve paths.
 
 const mockCtx = {
@@ -34,12 +34,12 @@ const baseLeaf = createLocalPObjectId(["main", "out"], "col-1");
 const stubSpec = { kind: "PColumn", name: "stub" } as unknown as PColumnSpec;
 
 function lazyOf(id: PObjectId, spec: PColumnSpec = stubSpec) {
-  return ColumnLazyImpl.fromColumn({ id, spec, data: undefined });
+  return DataColumnImpl.fromColumn({ id, spec, data: undefined });
 }
 
 // --- clone flattening -------------------------------------------------------
 
-describe("ColumnLazy.clone", () => {
+describe("DataColumn.clone", () => {
   test("two successive clones produce flat wrap (no nesting)", () => {
     const c0 = lazyOf(baseLeaf);
     const c1 = c0.withSpecs({
@@ -77,7 +77,7 @@ describe("ColumnLazy.clone", () => {
 
 // --- spec() override application -------------------------------------------
 
-describe("ColumnLazy.spec — applySpecOverrides", () => {
+describe("DataColumn.spec — applySpecOverrides", () => {
   test("base spec with no overrides returns readers.spec verbatim", () => {
     const c = lazyOf(baseLeaf);
     expect(c.getSpec()).toBe(stubSpec);
@@ -86,7 +86,7 @@ describe("ColumnLazy.spec — applySpecOverrides", () => {
   test("fromId throws ColumnAbsentError when ctx has no handles", () => {
     // Empty registry — `isFinal()` returns true vacuously, so the leaf is
     // provably absent (no provider will ever supply it).
-    expect(() => ColumnLazyImpl.fromId(baseLeaf)).toThrow(ColumnAbsentError);
+    expect(() => DataColumnImpl.fromId(baseLeaf)).toThrow(ColumnAbsentError);
   });
 
   test("appends axes at indices past base.axesSpec.length", () => {
@@ -129,67 +129,67 @@ describe("ColumnLazy.spec — applySpecOverrides", () => {
 
 // --- resolution status / absent throw --------------------------------------
 
-describe("ColumnLazy resolution: fromId / fromAccessor / getStatus", () => {
+describe("DataColumn resolution: fromId / fromAccessor / getStatus", () => {
   test("fromId returns undefined when registry is unfinalized and id not found", () => {
     // `isFinal: false` → resolver can't tell yet → resolving → undefined.
     installStubRegistry(mockCtx, {}, { isFinal: false });
-    expect(ColumnLazyImpl.fromId(baseLeaf)).toBeUndefined();
+    expect(DataColumnImpl.fromId(baseLeaf)).toBeUndefined();
   });
 
   test("fromId throws ColumnAbsentError when leaf has no spec field on locked accessor", () => {
     // Leaf entry present, no spec field, accessor locked → absent forever.
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: true } });
-    expect(() => ColumnLazyImpl.fromId(baseLeaf)).toThrow(ColumnAbsentError);
+    expect(() => DataColumnImpl.fromId(baseLeaf)).toThrow(ColumnAbsentError);
   });
 
   test("fromId returns undefined when leaf has no spec field on unlocked accessor", () => {
     // Leaf entry present, no spec field, accessor unlocked → spec may still arrive.
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: false } });
-    expect(ColumnLazyImpl.fromId(baseLeaf)).toBeUndefined();
+    expect(DataColumnImpl.fromId(baseLeaf)).toBeUndefined();
   });
 
   test("fromId returns undefined when spec accessor exists but hasData is false", () => {
     // Spec resource present, bytes not yet written — transient resolving.
     installStubRegistry(mockCtx, { [baseLeaf]: { spec: stubSpec, specHasData: false } });
-    expect(ColumnLazyImpl.fromId(baseLeaf)).toBeUndefined();
+    expect(DataColumnImpl.fromId(baseLeaf)).toBeUndefined();
   });
 
   test("fromAccessor throws ColumnAbsentError when accessor is locked without spec", () => {
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: true } });
     const entry = pluckLeafEntry(baseLeaf);
-    expect(() => ColumnLazyImpl.fromAccessor(entry)).toThrow(ColumnAbsentError);
+    expect(() => DataColumnImpl.fromAccessor(entry)).toThrow(ColumnAbsentError);
   });
 
   test("fromAccessor returns undefined when accessor is unlocked without spec", () => {
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: false } });
     const entry = pluckLeafEntry(baseLeaf);
-    expect(ColumnLazyImpl.fromAccessor(entry)).toBeUndefined();
+    expect(DataColumnImpl.fromAccessor(entry)).toBeUndefined();
   });
 
   test("getStatusById returns 'absent' / 'resolving' / 'present' across configurations", () => {
     // present — spec with data on a locked, populated leaf.
     installStubRegistry(mockCtx, { [baseLeaf]: stubSpec });
-    expect(ColumnLazy.getStatusById(baseLeaf)).toBe("present");
+    expect(DataColumn.getStatusById(baseLeaf)).toBe("present");
 
     // resolving — same leaf id, spec bytes not yet written.
     installStubRegistry(mockCtx, { [baseLeaf]: { spec: stubSpec, specHasData: false } });
-    expect(ColumnLazy.getStatusById(baseLeaf)).toBe("resolving");
+    expect(DataColumn.getStatusById(baseLeaf)).toBe("resolving");
 
     // resolving — leaf entry exists but spec field missing on an unlocked accessor.
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: false } });
-    expect(ColumnLazy.getStatusById(baseLeaf)).toBe("resolving");
+    expect(DataColumn.getStatusById(baseLeaf)).toBe("resolving");
 
     // absent — leaf entry exists with no spec field on a locked accessor.
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: true } });
-    expect(ColumnLazy.getStatusById(baseLeaf)).toBe("absent");
+    expect(DataColumn.getStatusById(baseLeaf)).toBe("absent");
 
     // absent — id not in any provider and registry is final.
     installStubRegistry(mockCtx, {}, { isFinal: true });
-    expect(ColumnLazy.getStatusById(baseLeaf)).toBe("absent");
+    expect(DataColumn.getStatusById(baseLeaf)).toBe("absent");
 
     // resolving — id not in any provider but registry still enumerating.
     installStubRegistry(mockCtx, {}, { isFinal: false });
-    expect(ColumnLazy.getStatusById(baseLeaf)).toBe("resolving");
+    expect(DataColumn.getStatusById(baseLeaf)).toBe("resolving");
   });
 });
 

--- a/sdk/model/src/columns/data_column.test.ts
+++ b/sdk/model/src/columns/data_column.test.ts
@@ -6,12 +6,12 @@ import {
   type PColumnSpec,
   type PObjectId,
 } from "@milaboratories/pl-model-common";
-import { ColumnAbsentError, DataColumn, DataColumnImpl } from "./data_column";
+import { ColumnAbsentError, DataColumnImpl } from "./data_column";
 import { _ctxProvidersCache } from "./column_providers";
 import { installStubRegistry } from "./__test_helpers__/stub_registry";
 
 // --- Ambient ctx mock ------------------------------------------------------
-// DataColumn constructor pulls `getCfgRenderCtx()` from globalThis. A minimal
+// DataColumnImpl constructor pulls `getCfgRenderCtx()` from globalThis. A minimal
 // mock with empty index is enough — these tests don't exercise resolve paths.
 
 const mockCtx = {
@@ -39,7 +39,7 @@ function lazyOf(id: PObjectId, spec: PColumnSpec = stubSpec) {
 
 // --- clone flattening -------------------------------------------------------
 
-describe("DataColumn.clone", () => {
+describe("DataColumnImpl.clone", () => {
   test("two successive clones produce flat wrap (no nesting)", () => {
     const c0 = lazyOf(baseLeaf);
     const c1 = c0.withSpecs({
@@ -77,7 +77,7 @@ describe("DataColumn.clone", () => {
 
 // --- spec() override application -------------------------------------------
 
-describe("DataColumn.spec — applySpecOverrides", () => {
+describe("DataColumnImpl.spec — applySpecOverrides", () => {
   test("base spec with no overrides returns readers.spec verbatim", () => {
     const c = lazyOf(baseLeaf);
     expect(c.getSpec()).toBe(stubSpec);
@@ -129,7 +129,7 @@ describe("DataColumn.spec — applySpecOverrides", () => {
 
 // --- resolution status / absent throw --------------------------------------
 
-describe("DataColumn resolution: fromId / fromAccessor / getStatus", () => {
+describe("DataColumnImpl resolution: fromId / fromAccessor / getStatus", () => {
   test("fromId returns undefined when registry is unfinalized and id not found", () => {
     // `isFinal: false` → resolver can't tell yet → resolving → undefined.
     installStubRegistry(mockCtx, {}, { isFinal: false });
@@ -169,27 +169,27 @@ describe("DataColumn resolution: fromId / fromAccessor / getStatus", () => {
   test("getStatusById returns 'absent' / 'resolving' / 'present' across configurations", () => {
     // present — spec with data on a locked, populated leaf.
     installStubRegistry(mockCtx, { [baseLeaf]: stubSpec });
-    expect(DataColumn.getStatusById(baseLeaf)).toBe("present");
+    expect(DataColumnImpl.getStatusById(baseLeaf)).toBe("present");
 
     // resolving — same leaf id, spec bytes not yet written.
     installStubRegistry(mockCtx, { [baseLeaf]: { spec: stubSpec, specHasData: false } });
-    expect(DataColumn.getStatusById(baseLeaf)).toBe("resolving");
+    expect(DataColumnImpl.getStatusById(baseLeaf)).toBe("resolving");
 
     // resolving — leaf entry exists but spec field missing on an unlocked accessor.
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: false } });
-    expect(DataColumn.getStatusById(baseLeaf)).toBe("resolving");
+    expect(DataColumnImpl.getStatusById(baseLeaf)).toBe("resolving");
 
     // absent — leaf entry exists with no spec field on a locked accessor.
     installStubRegistry(mockCtx, { [baseLeaf]: { accessorLocked: true } });
-    expect(DataColumn.getStatusById(baseLeaf)).toBe("absent");
+    expect(DataColumnImpl.getStatusById(baseLeaf)).toBe("absent");
 
     // absent — id not in any provider and registry is final.
     installStubRegistry(mockCtx, {}, { isFinal: true });
-    expect(DataColumn.getStatusById(baseLeaf)).toBe("absent");
+    expect(DataColumnImpl.getStatusById(baseLeaf)).toBe("absent");
 
     // resolving — id not in any provider but registry still enumerating.
     installStubRegistry(mockCtx, {}, { isFinal: false });
-    expect(DataColumn.getStatusById(baseLeaf)).toBe("resolving");
+    expect(DataColumnImpl.getStatusById(baseLeaf)).toBe("resolving");
   });
 });
 

--- a/sdk/model/src/columns/data_column.ts
+++ b/sdk/model/src/columns/data_column.ts
@@ -20,13 +20,34 @@ import { TreeNodeAccessor } from "../render";
 import type {
   ColumnFieldStatus,
   ColumnRecipe,
+  ColumnRecipeId,
   ColumnResolutionStatus,
 } from "./column_recipes/types";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
 
-export type ColumnLazyId = PObjectId;
-export type ColumnLazyData = undefined | PColumnDataUniversal;
+export type DataColumnId = PObjectId;
+export type DataColumnData = undefined | PColumnDataUniversal;
 export type { ColumnFieldStatus, ColumnResolutionStatus } from "./column_recipes/types";
+
+/**
+ * A {@link ColumnRecipe} that can be read directly in the sandbox: its
+ * {@link getData} is guaranteed to be consistent with {@link getSpec}.
+ *
+ * This is a *capability*, not a class. Only two recipe shapes carry it — a
+ * bare leaf and a spec-override over a bare leaf — because those are the only
+ * ones whose data still matches their spec. An axis-filtered recipe drops axes
+ * from its spec while the underlying data keeps them, and a discovered recipe
+ * only materialises after a join; neither can be read here, so neither
+ * implements this interface.
+ *
+ * Narrow to it with `hasDirectData(recipe)` rather than testing for a concrete
+ * class — which recipe classes exist is an implementation detail behind
+ * `recipe.id`.
+ */
+export interface DataColumn<ID extends ColumnRecipeId = ColumnRecipeId> extends ColumnRecipe<ID> {
+  /** Column data, consistent with {@link ColumnRecipe.getSpec}. */
+  getData(): DataColumnData;
+}
 
 /**
  * Thrown by leaf-recipe factories when the requested column is provably
@@ -47,22 +68,24 @@ export class ColumnAbsentError extends Error {
 }
 
 /**
- * ColumnLazy is the leaf-recipe building block: a {@link ColumnRecipe} whose
- * `id` is a bare {@link PObjectId} and whose readers are bound to a single
- * tree-accessor leaf. Layered encodings (Overridden / Discovered / Filtered)
- * are reified through their dedicated recipe classes and reference leaf
- * columns by id.
+ * The leaf-recipe building block: a {@link DataColumn} whose `id` is a bare
+ * {@link PObjectId} and whose readers are bound to a single tree-accessor
+ * leaf. Layered encodings (Overridden / Discovered / Filtered) are reified
+ * through their dedicated recipe classes and reference leaf columns by id.
+ *
+ * Internal — consumers hold the {@link DataColumn} interface and construct
+ * through the {@link DataColumn} dispatcher.
  */
-export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
+export class DataColumnImpl implements DataColumn<PObjectId> {
   private specCache?: { readonly value: PColumnSpec };
-  private dataCache?: { readonly value: ColumnLazyData };
+  private dataCache?: { readonly value: DataColumnData };
   private dataStatusCache?: { readonly value: ColumnFieldStatus };
 
   private constructor(
     public readonly id: PObjectId,
     private readonly options: {
       getSpec: () => PColumnSpec;
-      getData: () => ColumnLazyData;
+      getData: () => DataColumnData;
       getDataStatus: () => ColumnFieldStatus;
     },
   ) {}
@@ -84,8 +107,7 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
     return { type: "column", column: this.id } as SpecQuery;
   }
 
-  /** Leaf-only: not on the recipe interface — only the leaf can read data directly. */
-  getData(): ColumnLazyData {
+  getData(): DataColumnData {
     if (this.dataCache === undefined) this.dataCache = { value: this.options.getData() };
     return this.dataCache.value;
   }
@@ -99,7 +121,7 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
 
   /**
    * Overlay overrides → produces a {@link ColumnOverriddenRecipe} wrapping
-   * this leaf. ColumnLazy itself stays bare (id remains a plain PObjectId);
+   * this leaf. The leaf itself stays bare (id remains a plain PObjectId);
    * layering lives entirely in the recipe wrappers.
    */
   withSpecs(overrides: SpecOverrides): ColumnRecipe {
@@ -113,7 +135,10 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
    * and the column did not appear — the column will not exist in this ctx.
    * Data and dataStatus stay lazy.
    */
-  static fromId(id: PObjectId, { ctx }: { ctx?: GlobalCfgRenderCtx } = {}): undefined | ColumnLazy {
+  static fromId(
+    id: PObjectId,
+    { ctx }: { ctx?: GlobalCfgRenderCtx } = {},
+  ): undefined | DataColumn<PObjectId> {
     const registry = new ColumnRegistry(getCtxProviders({ ctx }));
     const leaf = registry.resolve(id);
     if (isNil(leaf)) {
@@ -126,7 +151,7 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
       return undefined;
     }
     if (!spec.hasData()) return undefined;
-    return new ColumnLazyImpl(id, {
+    return new DataColumnImpl(id, {
       getSpec: () => spec.getDataAsJson<PColumnSpec>(),
       getData: () => readDataAccessor(leaf),
       getDataStatus: () => readDataStatus(leaf),
@@ -134,8 +159,8 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
   }
 
   /** {@link PlRef} wrapper over {@link fromId}. */
-  static fromPlRef(ref: PlRef): undefined | ColumnLazy {
-    return ColumnLazyImpl.fromId(createGlobalPObjectId(ref.blockId, ref.name));
+  static fromPlRef(ref: PlRef): undefined | DataColumn<PObjectId> {
+    return DataColumnImpl.fromId(createGlobalPObjectId(ref.blockId, ref.name));
   }
 
   /**
@@ -143,14 +168,14 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
    * Throws {@link ColumnAbsentError} if the leaf has no spec field and its
    * accessor is `inputsLocked`. Returns `undefined` while still resolving.
    */
-  static fromAccessor(entry: LeafEntry<TreeNodeAccessor>): undefined | ColumnLazy {
+  static fromAccessor(entry: LeafEntry<TreeNodeAccessor>): undefined | DataColumn<PObjectId> {
     const spec = readSpecAccessor(entry);
     if (isNil(spec)) {
       if (entry.accessor.getInputsLocked()) throw new ColumnAbsentError(entry.id);
       return undefined;
     }
     if (!spec.hasData()) return undefined;
-    return new ColumnLazyImpl(entry.id, {
+    return new DataColumnImpl(entry.id, {
       getSpec: () => spec.getDataAsJson<PColumnSpec>(),
       getData: () => readDataAccessor(entry),
       getDataStatus: () => readDataStatus(entry),
@@ -159,13 +184,20 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
 
   /**
    * Wrap a materialised {@link PColumn}. If the input is already a
-   * {@link ColumnLazy} it is returned as-is.
+   * {@link DataColumn} leaf it is returned as-is.
    */
-  static fromColumn(column: PColumn<ColumnLazyData> | ColumnLazy): ColumnLazy {
-    if (column instanceof ColumnLazyImpl) return column;
-    return new ColumnLazyImpl(column.id, {
-      getSpec: () => column.spec,
-      getData: () => column.data,
+  static fromColumn(
+    column: PColumn<DataColumnData> | DataColumn<PObjectId>,
+  ): DataColumn<PObjectId> {
+    if (column instanceof DataColumnImpl) return column;
+    // `DataColumn` is an interface, so `instanceof` above does not remove it
+    // from the union. The only implementation carrying a bare `PObjectId` is
+    // `DataColumnImpl` (wrappers expose `ColumnUniversalId`), so anything
+    // reaching here is a materialised `PColumn`.
+    const pColumn = column as PColumn<DataColumnData>;
+    return new DataColumnImpl(pColumn.id, {
+      getSpec: () => pColumn.spec,
+      getData: () => pColumn.data,
       getDataStatus: () => "present",
     });
   }
@@ -191,7 +223,7 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
     ref: PlRef,
     opts: { ctx?: GlobalCfgRenderCtx } = {},
   ): ColumnResolutionStatus {
-    return ColumnLazyImpl.getStatusById(createGlobalPObjectId(ref.blockId, ref.name), opts);
+    return DataColumnImpl.getStatusById(createGlobalPObjectId(ref.blockId, ref.name), opts);
   }
 
   /** No registry — reads straight off the entry's accessor. */
@@ -200,68 +232,98 @@ export class ColumnLazyImpl implements ColumnRecipe<PObjectId> {
   }
 }
 
-/**
- * Public type alias — `ColumnLazy` (the type) refers to the underlying
- * {@link ColumnLazyImpl} class instance. `ColumnLazy` (the value) is the
- * callable below with the static factories attached.
- */
-export type ColumnLazy = ColumnLazyImpl;
+/** Anything the {@link DataColumn} dispatcher can build a leaf from. */
+export type DataColumnSource =
+  | PObjectId
+  | PlRef
+  | LeafEntry<TreeNodeAccessor>
+  | PColumn<DataColumnData>
+  | DataColumn<PObjectId>;
 
 /**
- * Unified dispatcher — picks the right `ColumnLazyImpl.fromX` by source
+ * Unified dispatcher — picks the right `DataColumnImpl.fromX` by source
  * shape. For ambiguous inputs callers can still use the explicit factories
- * (also attached as properties: `ColumnLazy.fromId`, `.fromPlRef`,
+ * (also attached as properties: `DataColumn.fromId`, `.fromPlRef`,
  * `.fromAccessor`, `.fromColumn`).
  */
-function ColumnLazyDispatch(
-  source: PObjectId | PlRef | LeafEntry<TreeNodeAccessor> | PColumn<ColumnLazyData> | ColumnLazy,
+function DataColumnDispatch(
+  source: DataColumnSource,
   opts: { ctx?: GlobalCfgRenderCtx } = {},
-): undefined | ColumnLazy {
-  if (typeof source === "string") return ColumnLazyImpl.fromId(source, opts);
-  if (source instanceof ColumnLazyImpl) return source;
-  if ("accessor" in source) return ColumnLazyImpl.fromAccessor(source);
-  if (isPlRef(source)) return ColumnLazyImpl.fromPlRef(source);
-  if (isPColumn(source)) return ColumnLazyImpl.fromColumn(source);
-  throw new Error("ColumnLazy: unknown source shape");
+): undefined | DataColumn<PObjectId> {
+  if (typeof source === "string") return DataColumnImpl.fromId(source, opts);
+  if (source instanceof DataColumnImpl) return source;
+  // `DataColumn` is an interface — `instanceof` above cannot remove it from
+  // the union, and only `DataColumnImpl` implements it with a bare id.
+  const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<DataColumnData>;
+  if ("accessor" in rest) return DataColumnImpl.fromAccessor(rest);
+  if (isPlRef(rest)) return DataColumnImpl.fromPlRef(rest);
+  if (isPColumn(rest)) return DataColumnImpl.fromColumn(rest);
+  throw new Error("DataColumn: unknown source shape");
 }
 
 /**
- * Polymorphic counterpart to {@link ColumnLazyDispatch}: returns the
+ * Polymorphic counterpart to {@link DataColumnDispatch}: returns the
  * {@link ColumnResolutionStatus} for any factory input without constructing
  * the recipe. For already-materialised sources ({@link PColumn} value,
- * existing {@link ColumnLazy}) status is `present` by construction.
+ * existing {@link DataColumn}) status is `present` by construction.
  */
-function ColumnLazyGetStatus(
-  source: PObjectId | PlRef | LeafEntry<TreeNodeAccessor> | PColumn<ColumnLazyData> | ColumnLazy,
+function DataColumnGetStatus(
+  source: DataColumnSource,
   opts: { ctx?: GlobalCfgRenderCtx } = {},
 ): ColumnResolutionStatus {
-  if (typeof source === "string") return ColumnLazyImpl.getStatusById(source, opts);
-  if (source instanceof ColumnLazyImpl) return "present";
-  if ("accessor" in source) return ColumnLazyImpl.getStatusByAccessor(source);
-  if (isPlRef(source)) return ColumnLazyImpl.getStatusByPlRef(source, opts);
-  if (isPColumn(source)) return "present";
-  throw new Error("ColumnLazy.getStatus: unknown source shape");
+  if (typeof source === "string") return DataColumnImpl.getStatusById(source, opts);
+  if (source instanceof DataColumnImpl) return "present";
+  const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<DataColumnData>;
+  if ("accessor" in rest) return DataColumnImpl.getStatusByAccessor(rest);
+  if (isPlRef(rest)) return DataColumnImpl.getStatusByPlRef(rest, opts);
+  if (isPColumn(rest)) return "present";
+  throw new Error("DataColumn.getStatus: unknown source shape");
 }
 
-export const ColumnLazy = Object.assign(ColumnLazyDispatch, {
-  fromId: ColumnLazyImpl.fromId,
-  fromPlRef: ColumnLazyImpl.fromPlRef,
-  fromAccessor: ColumnLazyImpl.fromAccessor,
-  fromColumn: ColumnLazyImpl.fromColumn,
-  getStatus: ColumnLazyGetStatus,
-  getStatusById: ColumnLazyImpl.getStatusById,
-  getStatusByPlRef: ColumnLazyImpl.getStatusByPlRef,
-  getStatusByAccessor: ColumnLazyImpl.getStatusByAccessor,
+export const DataColumn = Object.assign(DataColumnDispatch, {
+  fromId: DataColumnImpl.fromId,
+  fromPlRef: DataColumnImpl.fromPlRef,
+  fromAccessor: DataColumnImpl.fromAccessor,
+  fromColumn: DataColumnImpl.fromColumn,
+  getStatus: DataColumnGetStatus,
+  getStatusById: DataColumnImpl.getStatusById,
+  getStatusByPlRef: DataColumnImpl.getStatusByPlRef,
+  getStatusByAccessor: DataColumnImpl.getStatusByAccessor,
 });
 
 /**
- * Type-guard narrowing to the leaf recipe. Prefer this over
- * `instanceof ColumnLazyImpl` — `ColumnLazy` (the value) is the dispatcher
- * with statics, not the class, so `instanceof` requires the impl symbol.
+ * Type-guard narrowing to a bare leaf — a {@link DataColumn} whose `id` is a
+ * plain {@link PObjectId}.
+ *
+ * @deprecated Answers a question about the implementation, not about what you
+ * can do with the column. For reading data use `hasDirectData(recipe)`, which
+ * also accepts a spec-override over a leaf. The only remaining reason to reach
+ * for this guard is a legacy slot typed `PObjectId` (`PColumn.id`,
+ * `PColumnIdAndSpec.columnId`) — wrappers expose `ColumnUniversalId`.
  */
-export function isColumnLazy(value: unknown): value is ColumnLazy {
-  return value instanceof ColumnLazyImpl;
+export function isColumnLazy(value: unknown): value is DataColumn<PObjectId> {
+  return value instanceof DataColumnImpl;
 }
+
+// ---------------------------------------------------------------------------
+// Deprecated `ColumnLazy` aliases — kept so existing imports keep compiling.
+// ---------------------------------------------------------------------------
+
+/** @deprecated Renamed to {@link DataColumn}. */
+export type ColumnLazy = DataColumn<PObjectId>;
+/** @deprecated Renamed to {@link DataColumn}. */
+export const ColumnLazy = DataColumn;
+
+/** @deprecated Renamed to {@link DataColumnImpl}; prefer the {@link DataColumn} interface. */
+export type ColumnLazyImpl = DataColumnImpl;
+/** @deprecated Renamed to {@link DataColumnImpl}; prefer the {@link DataColumn} interface. */
+export const ColumnLazyImpl = DataColumnImpl;
+
+/** @deprecated Renamed to {@link DataColumnId}. */
+export type ColumnLazyId = DataColumnId;
+
+/** @deprecated Renamed to {@link DataColumnData}. */
+export type ColumnLazyData = DataColumnData;
 
 const readSpecAccessor = memoizeByEntry(
   ({ accessor, name }: LeafEntry<TreeNodeAccessor>): undefined | TreeNodeAccessor =>

--- a/sdk/model/src/columns/data_column.ts
+++ b/sdk/model/src/columns/data_column.ts
@@ -26,7 +26,7 @@ import type {
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
 
 export type DataColumnId = PObjectId;
-export type DataColumnData = undefined | PColumnDataUniversal;
+export type ColumnData = undefined | PColumnDataUniversal;
 export type { ColumnFieldStatus, ColumnResolutionStatus } from "./column_recipes/types";
 
 /**
@@ -40,13 +40,13 @@ export type { ColumnFieldStatus, ColumnResolutionStatus } from "./column_recipes
  * only materialises after a join; neither can be read here, so neither
  * implements this interface.
  *
- * Narrow to it with `hasDirectData(recipe)` rather than testing for a concrete
+ * Narrow to it with `hasReachableData(recipe)` rather than testing for a concrete
  * class — which recipe classes exist is an implementation detail behind
  * `recipe.id`.
  */
 export interface DataColumn<ID extends ColumnRecipeId = ColumnRecipeId> extends ColumnRecipe<ID> {
   /** Column data, consistent with {@link ColumnRecipe.getSpec}. */
-  getData(): DataColumnData;
+  getData(): ColumnData;
 }
 
 /**
@@ -78,14 +78,14 @@ export class ColumnAbsentError extends Error {
  */
 export class DataColumnImpl implements DataColumn<PObjectId> {
   private specCache?: { readonly value: PColumnSpec };
-  private dataCache?: { readonly value: DataColumnData };
+  private dataCache?: { readonly value: ColumnData };
   private dataStatusCache?: { readonly value: ColumnFieldStatus };
 
   private constructor(
     public readonly id: PObjectId,
     private readonly options: {
       getSpec: () => PColumnSpec;
-      getData: () => DataColumnData;
+      getData: () => ColumnData;
       getDataStatus: () => ColumnFieldStatus;
     },
   ) {}
@@ -107,7 +107,7 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
     return { type: "column", column: this.id } as SpecQuery;
   }
 
-  getData(): DataColumnData {
+  getData(): ColumnData {
     if (this.dataCache === undefined) this.dataCache = { value: this.options.getData() };
     return this.dataCache.value;
   }
@@ -186,15 +186,13 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
    * Wrap a materialised {@link PColumn}. If the input is already a
    * {@link DataColumn} leaf it is returned as-is.
    */
-  static fromColumn(
-    column: PColumn<DataColumnData> | DataColumn<PObjectId>,
-  ): DataColumn<PObjectId> {
+  static fromColumn(column: PColumn<ColumnData> | DataColumn<PObjectId>): DataColumn<PObjectId> {
     if (column instanceof DataColumnImpl) return column;
     // `DataColumn` is an interface, so `instanceof` above does not remove it
     // from the union. The only implementation carrying a bare `PObjectId` is
     // `DataColumnImpl` (wrappers expose `ColumnUniversalId`), so anything
     // reaching here is a materialised `PColumn`.
-    const pColumn = column as PColumn<DataColumnData>;
+    const pColumn = column as PColumn<ColumnData>;
     return new DataColumnImpl(pColumn.id, {
       getSpec: () => pColumn.spec,
       getData: () => pColumn.data,
@@ -237,7 +235,7 @@ export type DataColumnSource =
   | PObjectId
   | PlRef
   | LeafEntry<TreeNodeAccessor>
-  | PColumn<DataColumnData>
+  | PColumn<ColumnData>
   | DataColumn<PObjectId>;
 
 /**
@@ -254,7 +252,7 @@ function DataColumnDispatch(
   if (source instanceof DataColumnImpl) return source;
   // `DataColumn` is an interface — `instanceof` above cannot remove it from
   // the union, and only `DataColumnImpl` implements it with a bare id.
-  const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<DataColumnData>;
+  const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<ColumnData>;
   if ("accessor" in rest) return DataColumnImpl.fromAccessor(rest);
   if (isPlRef(rest)) return DataColumnImpl.fromPlRef(rest);
   if (isPColumn(rest)) return DataColumnImpl.fromColumn(rest);
@@ -273,7 +271,7 @@ function DataColumnGetStatus(
 ): ColumnResolutionStatus {
   if (typeof source === "string") return DataColumnImpl.getStatusById(source, opts);
   if (source instanceof DataColumnImpl) return "present";
-  const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<DataColumnData>;
+  const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<ColumnData>;
   if ("accessor" in rest) return DataColumnImpl.getStatusByAccessor(rest);
   if (isPlRef(rest)) return DataColumnImpl.getStatusByPlRef(rest, opts);
   if (isPColumn(rest)) return "present";
@@ -296,7 +294,7 @@ export const DataColumn = Object.assign(DataColumnDispatch, {
  * plain {@link PObjectId}.
  *
  * @deprecated Answers a question about the implementation, not about what you
- * can do with the column. For reading data use `hasDirectData(recipe)`, which
+ * can do with the column. For reading data use `hasReachableData(recipe)`, which
  * also accepts a spec-override over a leaf. The only remaining reason to reach
  * for this guard is a legacy slot typed `PObjectId` (`PColumn.id`,
  * `PColumnIdAndSpec.columnId`) — wrappers expose `ColumnUniversalId`.
@@ -322,8 +320,8 @@ export const ColumnLazyImpl = DataColumnImpl;
 /** @deprecated Renamed to {@link DataColumnId}. */
 export type ColumnLazyId = DataColumnId;
 
-/** @deprecated Renamed to {@link DataColumnData}. */
-export type ColumnLazyData = DataColumnData;
+/** @deprecated Renamed to {@link ColumnData}. */
+export type ColumnLazyData = ColumnData;
 
 const readSpecAccessor = memoizeByEntry(
   ({ accessor, name }: LeafEntry<TreeNodeAccessor>): undefined | TreeNodeAccessor =>

--- a/sdk/model/src/columns/data_column.ts
+++ b/sdk/model/src/columns/data_column.ts
@@ -44,7 +44,9 @@ export type { ColumnFieldStatus, ColumnResolutionStatus } from "./column_recipes
  * class — which recipe classes exist is an implementation detail behind
  * `recipe.id`.
  */
-export interface DataColumn<ID extends ColumnRecipeId = ColumnRecipeId> extends ColumnRecipe<ID> {
+export interface DataColumnRecipe<
+  ID extends ColumnRecipeId = ColumnRecipeId,
+> extends ColumnRecipe<ID> {
   /** Column data, consistent with {@link ColumnRecipe.getSpec}. */
   getData(): ColumnData;
 }
@@ -68,15 +70,15 @@ export class ColumnAbsentError extends Error {
 }
 
 /**
- * The leaf-recipe building block: a {@link DataColumn} whose `id` is a bare
+ * The leaf-recipe building block: a {@link DataColumnRecipe} whose `id` is a bare
  * {@link PObjectId} and whose readers are bound to a single tree-accessor
  * leaf. Layered encodings (Overridden / Discovered / Filtered) are reified
  * through their dedicated recipe classes and reference leaf columns by id.
  *
- * Internal — consumers hold the {@link DataColumn} interface and construct
- * through the {@link DataColumn} dispatcher.
+ * Internal — consumers hold the {@link DataColumnRecipe} interface and construct
+ * through the {@link DataColumnRecipe} dispatcher.
  */
-export class DataColumnImpl implements DataColumn<PObjectId> {
+export class DataColumnImpl implements DataColumnRecipe<PObjectId> {
   private specCache?: { readonly value: PColumnSpec };
   private dataCache?: { readonly value: ColumnData };
   private dataStatusCache?: { readonly value: ColumnFieldStatus };
@@ -138,7 +140,7 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
   static fromId(
     id: PObjectId,
     { ctx }: { ctx?: GlobalCfgRenderCtx } = {},
-  ): undefined | DataColumn<PObjectId> {
+  ): undefined | DataColumnRecipe<PObjectId> {
     const registry = new ColumnRegistry(getCtxProviders({ ctx }));
     const leaf = registry.resolve(id);
     if (isNil(leaf)) {
@@ -159,7 +161,7 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
   }
 
   /** {@link PlRef} wrapper over {@link fromId}. */
-  static fromPlRef(ref: PlRef): undefined | DataColumn<PObjectId> {
+  static fromPlRef(ref: PlRef): undefined | DataColumnRecipe<PObjectId> {
     return DataColumnImpl.fromId(createGlobalPObjectId(ref.blockId, ref.name));
   }
 
@@ -168,7 +170,7 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
    * Throws {@link ColumnAbsentError} if the leaf has no spec field and its
    * accessor is `inputsLocked`. Returns `undefined` while still resolving.
    */
-  static fromAccessor(entry: LeafEntry<TreeNodeAccessor>): undefined | DataColumn<PObjectId> {
+  static fromAccessor(entry: LeafEntry<TreeNodeAccessor>): undefined | DataColumnRecipe<PObjectId> {
     const spec = readSpecAccessor(entry);
     if (isNil(spec)) {
       if (entry.accessor.getInputsLocked()) throw new ColumnAbsentError(entry.id);
@@ -184,11 +186,13 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
 
   /**
    * Wrap a materialised {@link PColumn}. If the input is already a
-   * {@link DataColumn} leaf it is returned as-is.
+   * {@link DataColumnRecipe} leaf it is returned as-is.
    */
-  static fromColumn(column: PColumn<ColumnData> | DataColumn<PObjectId>): DataColumn<PObjectId> {
+  static fromColumn(
+    column: PColumn<ColumnData> | DataColumnRecipe<PObjectId>,
+  ): DataColumnRecipe<PObjectId> {
     if (column instanceof DataColumnImpl) return column;
-    // `DataColumn` is an interface, so `instanceof` above does not remove it
+    // `DataColumnRecipe` is an interface, so `instanceof` above does not remove it
     // from the union. The only implementation carrying a bare `PObjectId` is
     // `DataColumnImpl` (wrappers expose `ColumnUniversalId`), so anything
     // reaching here is a materialised `PColumn`.
@@ -230,13 +234,13 @@ export class DataColumnImpl implements DataColumn<PObjectId> {
   }
 }
 
-/** Anything the {@link DataColumn} dispatcher can build a leaf from. */
+/** Anything the {@link DataColumnRecipe} dispatcher can build a leaf from. */
 export type DataColumnSource =
   | PObjectId
   | PlRef
   | LeafEntry<TreeNodeAccessor>
   | PColumn<ColumnData>
-  | DataColumn<PObjectId>;
+  | DataColumnRecipe<PObjectId>;
 
 /**
  * Unified dispatcher — picks the right `DataColumnImpl.fromX` by source
@@ -247,10 +251,10 @@ export type DataColumnSource =
 function DataColumnDispatch(
   source: DataColumnSource,
   opts: { ctx?: GlobalCfgRenderCtx } = {},
-): undefined | DataColumn<PObjectId> {
+): undefined | DataColumnRecipe<PObjectId> {
   if (typeof source === "string") return DataColumnImpl.fromId(source, opts);
   if (source instanceof DataColumnImpl) return source;
-  // `DataColumn` is an interface — `instanceof` above cannot remove it from
+  // `DataColumnRecipe` is an interface — `instanceof` above cannot remove it from
   // the union, and only `DataColumnImpl` implements it with a bare id.
   const rest = source as LeafEntry<TreeNodeAccessor> | PlRef | PColumn<ColumnData>;
   if ("accessor" in rest) return DataColumnImpl.fromAccessor(rest);
@@ -263,7 +267,7 @@ function DataColumnDispatch(
  * Polymorphic counterpart to {@link DataColumnDispatch}: returns the
  * {@link ColumnResolutionStatus} for any factory input without constructing
  * the recipe. For already-materialised sources ({@link PColumn} value,
- * existing {@link DataColumn}) status is `present` by construction.
+ * existing {@link DataColumnRecipe}) status is `present` by construction.
  */
 function DataColumnGetStatus(
   source: DataColumnSource,
@@ -290,38 +294,12 @@ export const DataColumn = Object.assign(DataColumnDispatch, {
 });
 
 /**
- * Type-guard narrowing to a bare leaf — a {@link DataColumn} whose `id` is a
+ * Type-guard narrowing to a bare leaf — a {@link DataColumnRecipe} whose `id` is a
  * plain {@link PObjectId}.
- *
- * @deprecated Answers a question about the implementation, not about what you
- * can do with the column. For reading data use `hasReachableData(recipe)`, which
- * also accepts a spec-override over a leaf. The only remaining reason to reach
- * for this guard is a legacy slot typed `PObjectId` (`PColumn.id`,
- * `PColumnIdAndSpec.columnId`) — wrappers expose `ColumnUniversalId`.
  */
-export function isColumnLazy(value: unknown): value is DataColumn<PObjectId> {
+export function isDataColumn(value: unknown): value is DataColumnRecipe<PObjectId> {
   return value instanceof DataColumnImpl;
 }
-
-// ---------------------------------------------------------------------------
-// Deprecated `ColumnLazy` aliases — kept so existing imports keep compiling.
-// ---------------------------------------------------------------------------
-
-/** @deprecated Renamed to {@link DataColumn}. */
-export type ColumnLazy = DataColumn<PObjectId>;
-/** @deprecated Renamed to {@link DataColumn}. */
-export const ColumnLazy = DataColumn;
-
-/** @deprecated Renamed to {@link DataColumnImpl}; prefer the {@link DataColumn} interface. */
-export type ColumnLazyImpl = DataColumnImpl;
-/** @deprecated Renamed to {@link DataColumnImpl}; prefer the {@link DataColumn} interface. */
-export const ColumnLazyImpl = DataColumnImpl;
-
-/** @deprecated Renamed to {@link DataColumnId}. */
-export type ColumnLazyId = DataColumnId;
-
-/** @deprecated Renamed to {@link ColumnData}. */
-export type ColumnLazyData = ColumnData;
 
 const readSpecAccessor = memoizeByEntry(
   ({ accessor, name }: LeafEntry<TreeNodeAccessor>): undefined | TreeNodeAccessor =>

--- a/sdk/model/src/columns/derive_axis_values_labels.ts
+++ b/sdk/model/src/columns/derive_axis_values_labels.ts
@@ -18,7 +18,7 @@ const RT_JSON_PARTITIONED = "PColumnData/JsonPartitioned";
  * column-access mechanism (filtered {@link ColumnsCollection}) instead of
  * walking the raw result pool.
  *
- * Pair with {@link expandByPartition} (or any consumer expecting the
+ * Pair with {@link splitByAxes} (or any consumer expecting the
  * `(axisId) => Record<axisValue, label>` shape).
  *
  * Skips:

--- a/sdk/model/src/columns/derive_axis_values_labels.ts
+++ b/sdk/model/src/columns/derive_axis_values_labels.ts
@@ -4,7 +4,7 @@ import type { ColumnsSource } from "./column_providers";
 import { ColumnsCollection, isColumnsCollection } from "./columns_collection";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import { TreeNodeAccessor } from "../render";
-import { isColumnLazy } from "./column_lazy";
+import { hasDirectData } from "./utils";
 
 const RT_JSON = "PColumnData/Json";
 const RT_JSON_PARTITIONED = "PColumnData/JsonPartitioned";
@@ -22,7 +22,7 @@ const RT_JSON_PARTITIONED = "PColumnData/JsonPartitioned";
  * `(axisId) => Record<axisValue, label>` shape).
  *
  * Skips:
- *  - non-leaf recipes (only direct `ColumnLazy` data is read);
+ *  - recipes whose data is not directly readable (see `hasDirectData`);
  *  - label columns whose `axesSpec.length !== 1`;
  *  - label columns whose data resource type isn't `PColumnData/Json` /
  *    `PColumnData/JsonPartitioned`.
@@ -43,7 +43,7 @@ export function deriveAxisValuesLabels(
     .getColumns();
 
   const byAxis = labelCols.reduce<Map<string, Record<string | number, string>>>((map, col) => {
-    if (!isColumnLazy(col)) return map;
+    if (!hasDirectData(col)) return map;
     const spec = col.getSpec();
     if (spec.axesSpec.length !== 1) return map;
 

--- a/sdk/model/src/columns/derive_axis_values_labels.ts
+++ b/sdk/model/src/columns/derive_axis_values_labels.ts
@@ -4,7 +4,7 @@ import type { ColumnsSource } from "./column_providers";
 import { ColumnsCollection, isColumnsCollection } from "./columns_collection";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import { TreeNodeAccessor } from "../render";
-import { hasDirectData } from "./utils";
+import { hasReachableData } from "./utils";
 
 const RT_JSON = "PColumnData/Json";
 const RT_JSON_PARTITIONED = "PColumnData/JsonPartitioned";
@@ -22,7 +22,7 @@ const RT_JSON_PARTITIONED = "PColumnData/JsonPartitioned";
  * `(axisId) => Record<axisValue, label>` shape).
  *
  * Skips:
- *  - recipes whose data is not directly readable (see `hasDirectData`);
+ *  - recipes whose data is not directly readable (see `hasReachableData`);
  *  - label columns whose `axesSpec.length !== 1`;
  *  - label columns whose data resource type isn't `PColumnData/Json` /
  *    `PColumnData/JsonPartitioned`.
@@ -43,7 +43,7 @@ export function deriveAxisValuesLabels(
     .getColumns();
 
   const byAxis = labelCols.reduce<Map<string, Record<string | number, string>>>((map, col) => {
-    if (!hasDirectData(col)) return map;
+    if (!hasReachableData(col)) return map;
     const spec = col.getSpec();
     if (spec.axesSpec.length !== 1) return map;
 

--- a/sdk/model/src/columns/expand_by_partition.test.ts
+++ b/sdk/model/src/columns/expand_by_partition.test.ts
@@ -13,8 +13,8 @@ import {
 } from "@milaboratories/pl-model-common";
 import { describe, expect, test } from "vitest";
 import type { PColumnDataUniversal } from "../render/internal";
-import type { ColumnLazy } from "./column_lazy";
-import { ColumnLazyImpl } from "./column_lazy";
+import type { DataColumn } from "./data_column";
+import { DataColumnImpl } from "./data_column";
 import { expandByPartition } from "./expand_by_partition";
 
 // --- Helpers ---
@@ -33,13 +33,13 @@ function createSpec(name: string, axes: AxisSpec[]): PColumnSpec {
   } as PColumnSpec;
 }
 
-/** Build a synthetic ColumnLazy whose data is a JsonPartitioned DataInfoEntries. */
+/** Build a synthetic DataColumn whose data is a JsonPartitioned DataInfoEntries. */
 function createReadyLazy(
   id: string,
   spec: PColumnSpec,
   partitionKeyLength: number,
   parts: { key: (string | number)[]; value: unknown }[],
-): ColumnLazy {
+): DataColumn {
   const dataEntries: JsonPartitionedDataInfoEntries<unknown> = {
     type: "JsonPartitioned",
     partitionKeyLength,
@@ -48,15 +48,15 @@ function createReadyLazy(
   // `data` is typed `PColumnDataUniversal` but `getUniquePartitionKeys`
   // duck-types DataInfoEntries via `isDataInfoEntries`, so the JsonPartitioned
   // payload works at runtime.
-  return ColumnLazyImpl.fromColumn({
+  return DataColumnImpl.fromColumn({
     id: id as PObjectId,
     spec,
     data: dataEntries as unknown as PColumnDataUniversal,
   });
 }
 
-function createComputingLazy(id: string, spec: PColumnSpec): ColumnLazy {
-  return ColumnLazyImpl.fromColumn({
+function createComputingLazy(id: string, spec: PColumnSpec): DataColumn {
+  return DataColumnImpl.fromColumn({
     id: id as PObjectId,
     spec,
     data: undefined,

--- a/sdk/model/src/columns/expand_by_partition.test.ts
+++ b/sdk/model/src/columns/expand_by_partition.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@milaboratories/pl-model-common";
 import { describe, expect, test } from "vitest";
 import type { PColumnDataUniversal } from "../render/internal";
-import type { DataColumn } from "./data_column";
+import type { DataColumnRecipe } from "./data_column";
 import { DataColumnImpl } from "./data_column";
 import { expandByPartition } from "./expand_by_partition";
 
@@ -33,13 +33,13 @@ function createSpec(name: string, axes: AxisSpec[]): PColumnSpec {
   } as PColumnSpec;
 }
 
-/** Build a synthetic DataColumn whose data is a JsonPartitioned DataInfoEntries. */
+/** Build a synthetic DataColumnRecipe whose data is a JsonPartitioned DataInfoEntries. */
 function createReadyLazy(
   id: string,
   spec: PColumnSpec,
   partitionKeyLength: number,
   parts: { key: (string | number)[]; value: unknown }[],
-): DataColumn {
+): DataColumnRecipe {
   const dataEntries: JsonPartitionedDataInfoEntries<unknown> = {
     type: "JsonPartitioned",
     partitionKeyLength,
@@ -55,7 +55,7 @@ function createReadyLazy(
   });
 }
 
-function createComputingLazy(id: string, spec: PColumnSpec): DataColumn {
+function createComputingLazy(id: string, spec: PColumnSpec): DataColumnRecipe {
   return DataColumnImpl.fromColumn({
     id: id as PObjectId,
     spec,

--- a/sdk/model/src/columns/expand_by_partition.ts
+++ b/sdk/model/src/columns/expand_by_partition.ts
@@ -17,7 +17,7 @@ import type { ColumnRecipe } from "./column_recipes";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
 import { Column } from "./column";
-import { getLeafColumnData } from "./utils";
+import { hasDirectData } from "./utils";
 
 // --- Types ---
 
@@ -70,7 +70,7 @@ export function expandByPartition(
   const result: ColumnRecipe[] = [];
 
   for (const inner of inputs) {
-    const data = getLeafColumnData(inner);
+    const data = hasDirectData(inner) ? inner.getData() : undefined;
     // Partition inspection requires either a live tree-accessor or already
     // parsed DataInfoEntries. Anything else means the input is not yet ready.
     if (!(data instanceof TreeNodeAccessor) && !isDataInfoEntries(data)) {

--- a/sdk/model/src/columns/expand_by_partition.ts
+++ b/sdk/model/src/columns/expand_by_partition.ts
@@ -17,7 +17,7 @@ import type { ColumnRecipe } from "./column_recipes";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
 import { Column } from "./column";
-import { hasDirectData } from "./utils";
+import { hasReachableData } from "./utils";
 
 // --- Types ---
 
@@ -70,7 +70,7 @@ export function expandByPartition(
   const result: ColumnRecipe[] = [];
 
   for (const inner of inputs) {
-    const data = hasDirectData(inner) ? inner.getData() : undefined;
+    const data = hasReachableData(inner) ? inner.getData() : undefined;
     // Partition inspection requires either a live tree-accessor or already
     // parsed DataInfoEntries. Anything else means the input is not yet ready.
     if (!(data instanceof TreeNodeAccessor) && !isDataInfoEntries(data)) {

--- a/sdk/model/src/columns/index.ts
+++ b/sdk/model/src/columns/index.ts
@@ -1,5 +1,5 @@
 export * from "./column_providers";
-export * from "./expand_by_partition";
+export * from "./split_by_axes";
 export * from "./derive_axis_values_labels";
 export * from "./columns_collection";
 export * from "./data_column";

--- a/sdk/model/src/columns/index.ts
+++ b/sdk/model/src/columns/index.ts
@@ -2,7 +2,7 @@ export * from "./column_providers";
 export * from "./expand_by_partition";
 export * from "./derive_axis_values_labels";
 export * from "./columns_collection";
-export * from "./column_lazy";
+export * from "./data_column";
 export * from "./column_recipes";
 export * from "./column";
 export * from "./utils";

--- a/sdk/model/src/columns/predicates.test.ts
+++ b/sdk/model/src/columns/predicates.test.ts
@@ -6,10 +6,10 @@ import type {
   SpecOverrides,
 } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal } from "../render/internal";
-import { DataColumnImpl, type DataColumn } from "./data_column";
+import { DataColumnImpl, type DataColumnRecipe } from "./data_column";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
-import { getLeafColumnData, hasReachableData, isSelfContained } from "./utils";
+import { hasReachableData, hasSingleDataColumn } from "./utils";
 
 // --- Helpers ---
 
@@ -77,7 +77,7 @@ describe("hasReachableData", () => {
   test("an unreadable override has no getData at all — nothing to call, nothing to throw", () => {
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
     const col = ColumnOverriddenRecipe.wrap(filtered, overrides({ annotations: { tag: "1" } }));
-    expect((col as Partial<DataColumn>).getData).toBeUndefined();
+    expect((col as Partial<DataColumnRecipe>).getData).toBeUndefined();
   });
 
   test("merging overrides keeps the readable variant", () => {
@@ -99,42 +99,26 @@ describe("hasReachableData", () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// isSelfContained — "does this column need other columns to resolve?"
+// hasSingleDataColumn — "does this column read one data column, or several?"
 // ════════════════════════════════════════════════════════════════════════════
 
-describe("isSelfContained", () => {
-  test("bare leaf, override and axis filter are all self-contained", () => {
+describe("hasSingleDataColumn", () => {
+  test("bare leaf, override and axis filter all read a single data column", () => {
     const bare = leaf();
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
     const overridden = ColumnOverriddenRecipe.wrap(filtered, overrides({ domain: { d: "1" } }));
 
-    expect(isSelfContained(bare)).toBe(true);
-    expect(isSelfContained(filtered)).toBe(true);
-    expect(isSelfContained(overridden)).toBe(true);
+    expect(hasSingleDataColumn(bare)).toBe(true);
+    expect(hasSingleDataColumn(filtered)).toBe(true);
+    expect(hasSingleDataColumn(overridden)).toBe(true);
   });
 
   test("is a different question from hasReachableData", () => {
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
-    // Self-contained (no other column needed) yet not directly readable
-    // (the slice happens engine-side). Conflating the two is the bug this
-    // pair of predicates replaced.
-    expect(isSelfContained(filtered)).toBe(true);
+    // Reads a single data column, yet its data is not reachable here (the
+    // slice happens engine-side). Conflating the two is the bug this pair of
+    // predicates replaced.
+    expect(hasSingleDataColumn(filtered)).toBe(true);
     expect(hasReachableData(filtered)).toBe(false);
-  });
-});
-
-// ════════════════════════════════════════════════════════════════════════════
-// Regression: the deprecated reader must not hand back unsliced data
-// ════════════════════════════════════════════════════════════════════════════
-
-describe("getLeafColumnData (deprecated)", () => {
-  test("returns undefined for an axis-filtered recipe instead of the unsliced leaf data", () => {
-    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
-    expect(getLeafColumnData(filtered)).toBeUndefined();
-  });
-
-  test("still reads through an override over a leaf", () => {
-    const col = ColumnOverriddenRecipe.wrap(leaf(), overrides({ annotations: { tag: "1" } }));
-    expect(getLeafColumnData(col)).toBe(DATA);
   });
 });

--- a/sdk/model/src/columns/predicates.test.ts
+++ b/sdk/model/src/columns/predicates.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+import type {
+  AxisSpec,
+  PColumnSpec,
+  PObjectId,
+  SpecOverrides,
+} from "@milaboratories/pl-model-common";
+import type { PColumnDataUniversal } from "../render/internal";
+import { DataColumnImpl } from "./data_column";
+import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
+import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
+import { getLeafColumnData, hasDirectData, isSelfContained } from "./utils";
+
+// --- Helpers ---
+
+const axis = (name: string): AxisSpec => ({ name, type: "String" }) as AxisSpec;
+
+const twoAxisSpec: PColumnSpec = {
+  kind: "PColumn",
+  name: "count",
+  valueType: "Int",
+  axesSpec: [axis("sampleId"), axis("clonotypeKey")],
+  annotations: {},
+} as PColumnSpec;
+
+const overrides = (patch: Partial<SpecOverrides>): SpecOverrides => ({
+  annotations: patch.annotations ?? {},
+  domain: patch.domain ?? {},
+  contextDomain: patch.contextDomain ?? {},
+  axesSpec: patch.axesSpec ?? {},
+});
+
+const DATA = { marker: "leaf-data" } as unknown as PColumnDataUniversal;
+
+const leaf = () =>
+  DataColumnImpl.fromColumn({
+    id: "leafId" as PObjectId,
+    spec: twoAxisSpec,
+    data: DATA,
+  });
+
+// ════════════════════════════════════════════════════════════════════════════
+// hasDirectData — "can I read this column's data, consistent with its spec?"
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("hasDirectData", () => {
+  test("bare leaf: true, and getData returns the leaf payload", () => {
+    const col = leaf();
+    expect(hasDirectData(col)).toBe(true);
+    if (!hasDirectData(col)) throw new Error("unreachable");
+    expect(col.getData()).toBe(DATA);
+  });
+
+  test("override over a leaf: true — a spec patch never reshapes data", () => {
+    const col = ColumnOverriddenRecipe.wrap(leaf(), overrides({ annotations: { tag: "1" } }));
+    expect(hasDirectData(col)).toBe(true);
+    if (!hasDirectData(col)) throw new Error("unreachable");
+    expect(col.getData()).toBe(DATA);
+    // The patch landed on the spec while the data stayed the leaf's.
+    expect(col.getSpec().annotations?.tag).toBe("1");
+    expect(col.getSpec().axesSpec).toHaveLength(2);
+  });
+
+  test("axis-filtered leaf: false — spec drops an axis the data still carries", () => {
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    // The mismatch this guards against: one axis in the spec, two in the data.
+    expect(filtered.getSpec().axesSpec).toHaveLength(1);
+    expect(hasDirectData(filtered)).toBe(false);
+  });
+
+  test("override over an axis-filtered leaf: false", () => {
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    const col = ColumnOverriddenRecipe.wrap(filtered, overrides({ annotations: { tag: "1" } }));
+    expect(hasDirectData(col)).toBe(false);
+  });
+
+  test("ColumnOverriddenRecipe.getData throws when the inner carries no readable data", () => {
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    const col = ColumnOverriddenRecipe.wrap(filtered, overrides({ annotations: { tag: "1" } }));
+    expect(() => col.getData()).toThrow(/no directly readable data/);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// isSelfContained — "does this column need other columns to resolve?"
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("isSelfContained", () => {
+  test("bare leaf, override and axis filter are all self-contained", () => {
+    const bare = leaf();
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    const overridden = ColumnOverriddenRecipe.wrap(filtered, overrides({ domain: { d: "1" } }));
+
+    expect(isSelfContained(bare)).toBe(true);
+    expect(isSelfContained(filtered)).toBe(true);
+    expect(isSelfContained(overridden)).toBe(true);
+  });
+
+  test("is a different question from hasDirectData", () => {
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    // Self-contained (no other column needed) yet not directly readable
+    // (the slice happens engine-side). Conflating the two is the bug this
+    // pair of predicates replaced.
+    expect(isSelfContained(filtered)).toBe(true);
+    expect(hasDirectData(filtered)).toBe(false);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Regression: the deprecated reader must not hand back unsliced data
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("getLeafColumnData (deprecated)", () => {
+  test("returns undefined for an axis-filtered recipe instead of the unsliced leaf data", () => {
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    expect(getLeafColumnData(filtered)).toBeUndefined();
+  });
+
+  test("still reads through an override over a leaf", () => {
+    const col = ColumnOverriddenRecipe.wrap(leaf(), overrides({ annotations: { tag: "1" } }));
+    expect(getLeafColumnData(col)).toBe(DATA);
+  });
+});

--- a/sdk/model/src/columns/predicates.test.ts
+++ b/sdk/model/src/columns/predicates.test.ts
@@ -6,10 +6,10 @@ import type {
   SpecOverrides,
 } from "@milaboratories/pl-model-common";
 import type { PColumnDataUniversal } from "../render/internal";
-import { DataColumnImpl } from "./data_column";
+import { DataColumnImpl, type DataColumn } from "./data_column";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
-import { getLeafColumnData, hasDirectData, isSelfContained } from "./utils";
+import { getLeafColumnData, hasReachableData, isSelfContained } from "./utils";
 
 // --- Helpers ---
 
@@ -40,21 +40,21 @@ const leaf = () =>
   });
 
 // ════════════════════════════════════════════════════════════════════════════
-// hasDirectData — "can I read this column's data, consistent with its spec?"
+// hasReachableData — "can I read this column's data, consistent with its spec?"
 // ════════════════════════════════════════════════════════════════════════════
 
-describe("hasDirectData", () => {
+describe("hasReachableData", () => {
   test("bare leaf: true, and getData returns the leaf payload", () => {
     const col = leaf();
-    expect(hasDirectData(col)).toBe(true);
-    if (!hasDirectData(col)) throw new Error("unreachable");
+    expect(hasReachableData(col)).toBe(true);
+    if (!hasReachableData(col)) throw new Error("unreachable");
     expect(col.getData()).toBe(DATA);
   });
 
   test("override over a leaf: true — a spec patch never reshapes data", () => {
     const col = ColumnOverriddenRecipe.wrap(leaf(), overrides({ annotations: { tag: "1" } }));
-    expect(hasDirectData(col)).toBe(true);
-    if (!hasDirectData(col)) throw new Error("unreachable");
+    expect(hasReachableData(col)).toBe(true);
+    if (!hasReachableData(col)) throw new Error("unreachable");
     expect(col.getData()).toBe(DATA);
     // The patch landed on the spec while the data stayed the leaf's.
     expect(col.getSpec().annotations?.tag).toBe("1");
@@ -65,19 +65,36 @@ describe("hasDirectData", () => {
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
     // The mismatch this guards against: one axis in the spec, two in the data.
     expect(filtered.getSpec().axesSpec).toHaveLength(1);
-    expect(hasDirectData(filtered)).toBe(false);
+    expect(hasReachableData(filtered)).toBe(false);
   });
 
   test("override over an axis-filtered leaf: false", () => {
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
     const col = ColumnOverriddenRecipe.wrap(filtered, overrides({ annotations: { tag: "1" } }));
-    expect(hasDirectData(col)).toBe(false);
+    expect(hasReachableData(col)).toBe(false);
   });
 
-  test("ColumnOverriddenRecipe.getData throws when the inner carries no readable data", () => {
+  test("an unreadable override has no getData at all — nothing to call, nothing to throw", () => {
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
     const col = ColumnOverriddenRecipe.wrap(filtered, overrides({ annotations: { tag: "1" } }));
-    expect(() => col.getData()).toThrow(/no directly readable data/);
+    expect((col as Partial<DataColumn>).getData).toBeUndefined();
+  });
+
+  test("merging overrides keeps the readable variant", () => {
+    const once = leaf().withSpecs(overrides({ annotations: { a: "1" } }));
+    const twice = once.withSpecs(overrides({ annotations: { b: "2" } }));
+    expect(hasReachableData(twice)).toBe(true);
+    if (!hasReachableData(twice)) throw new Error("unreachable");
+    expect(twice.getData()).toBe(DATA);
+    expect(twice.getSpec().annotations).toMatchObject({ a: "1", b: "2" });
+  });
+
+  test("merging overrides does not resurrect readability over a filtered leaf", () => {
+    const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
+    const twice = filtered
+      .withSpecs(overrides({ annotations: { a: "1" } }))
+      .withSpecs(overrides({ annotations: { b: "2" } }));
+    expect(hasReachableData(twice)).toBe(false);
   });
 });
 
@@ -96,13 +113,13 @@ describe("isSelfContained", () => {
     expect(isSelfContained(overridden)).toBe(true);
   });
 
-  test("is a different question from hasDirectData", () => {
+  test("is a different question from hasReachableData", () => {
     const filtered = ColumnFilteredRecipe.wrap(leaf(), [[0, "s1"]]);
     // Self-contained (no other column needed) yet not directly readable
     // (the slice happens engine-side). Conflating the two is the bug this
     // pair of predicates replaced.
     expect(isSelfContained(filtered)).toBe(true);
-    expect(hasDirectData(filtered)).toBe(false);
+    expect(hasReachableData(filtered)).toBe(false);
   });
 });
 

--- a/sdk/model/src/columns/split_by_axes.test.ts
+++ b/sdk/model/src/columns/split_by_axes.test.ts
@@ -15,7 +15,8 @@ import { describe, expect, test } from "vitest";
 import type { PColumnDataUniversal } from "../render/internal";
 import type { DataColumnRecipe } from "./data_column";
 import { DataColumnImpl } from "./data_column";
-import { expandByPartition } from "./expand_by_partition";
+import type { SplitByAxesOpts } from "./split_by_axes";
+import { splitByAxes } from "./split_by_axes";
 
 // --- Helpers ---
 
@@ -74,14 +75,21 @@ function extractTrace(recipe: { getSpec(): PColumnSpec }): Trace[] {
   return raw ? (JSON.parse(raw) as Trace[]) : [];
 }
 
+/**
+ * `axisValuesLabels` defaults to `deriveAxisValuesLabels()`, which needs the
+ * ambient render ctx these unit tests deliberately run without. Every case
+ * below is about the split itself, so opt out of label resolution explicitly.
+ */
+const NO_LABELS: SplitByAxesOpts = { axisValuesLabels: () => undefined };
+
 // --- Tests ---
 
-describe("expandByPartition", () => {
+describe("splitByAxes", () => {
   test("no split axes returns inputs unchanged", () => {
     const s = createReadyLazy("col1", createSpec("c", [createAxis("a")]), 1, [
       { key: ["x"], value: {} },
     ]);
-    const result = expandByPartition([s], []);
+    const result = splitByAxes([s], []);
     expect(result).toBeDefined();
     expect(result).toHaveLength(1);
     expect(result![0]).toBe(s); // same reference
@@ -99,7 +107,7 @@ describe("expandByPartition", () => {
       ],
     );
 
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     // unique values on axis 0: s1, s2 → 2 recipes
     expect(result).toHaveLength(2);
@@ -124,7 +132,7 @@ describe("expandByPartition", () => {
       ],
     );
 
-    const result = expandByPartition([s], [{ idx: 0 }, { idx: 1 }]);
+    const result = splitByAxes([s], [{ idx: 0 }, { idx: 1 }], NO_LABELS);
     expect(result).toBeDefined();
     // a: a1, a2 (2) × b: b1, b2 (2) = 4
     expect(result).toHaveLength(4);
@@ -148,7 +156,7 @@ describe("expandByPartition", () => {
       ],
     );
 
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
 
@@ -183,7 +191,7 @@ describe("expandByPartition", () => {
     };
     const s = createReadyLazy("col1", spec, 1, [{ key: ["s1"], value: {} }]);
 
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     expect(result).toHaveLength(1);
 
@@ -205,7 +213,7 @@ describe("expandByPartition", () => {
       s2: "Sample Two",
     };
 
-    const result = expandByPartition([s], [{ idx: 0 }], {
+    const result = splitByAxes([s], [{ idx: 0 }], {
       axisValuesLabels: () => labels,
     });
 
@@ -216,7 +224,7 @@ describe("expandByPartition", () => {
 
   test("computing input (data undefined) returns undefined", () => {
     const s = createComputingLazy("col1", createSpec("c", [createAxis("a")]));
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeUndefined();
   });
 
@@ -228,7 +236,7 @@ describe("expandByPartition", () => {
       [], // no parts → no unique keys
     );
 
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     expect(result).toHaveLength(0);
   });
@@ -244,7 +252,7 @@ describe("expandByPartition", () => {
       ],
     );
 
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
 
@@ -274,7 +282,7 @@ describe("expandByPartition", () => {
       ],
     );
 
-    const result = expandByPartition([s], [{ idx: 0 }]);
+    const result = splitByAxes([s], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     expect(result).toHaveLength(2);
 
@@ -306,7 +314,7 @@ describe("expandByPartition", () => {
       ],
     );
 
-    const result = expandByPartition([s1, s2], [{ idx: 0 }]);
+    const result = splitByAxes([s1, s2], [{ idx: 0 }], NO_LABELS);
     expect(result).toBeDefined();
     // s1: 2 unique + s2: 3 unique = 5 total
     expect(result).toHaveLength(5);
@@ -320,6 +328,6 @@ describe("expandByPartition", () => {
       [{ key: ["x"], value: {} }],
     );
 
-    expect(() => expandByPartition([s], [{ idx: 1 }])).toThrow(/Not enough partition keys/);
+    expect(() => splitByAxes([s], [{ idx: 1 }], NO_LABELS)).toThrow(/Not enough partition keys/);
   });
 });

--- a/sdk/model/src/columns/split_by_axes.ts
+++ b/sdk/model/src/columns/split_by_axes.ts
@@ -13,6 +13,7 @@ import {
 } from "@milaboratories/pl-model-common";
 import { TreeNodeAccessor } from "../render/accessor";
 import { getUniquePartitionKeys } from "../render/util/pcolumn_data";
+import { deriveAxisValuesLabels } from "./derive_axis_values_labels";
 import type { ColumnRecipe } from "./column_recipes";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
@@ -26,8 +27,15 @@ export interface SplitAxis {
   readonly idx: number;
 }
 
-export interface ExpandByPartitionOpts {
-  /** Resolve axis values to human-readable labels. */
+export interface SplitByAxesOpts {
+  /**
+   * Resolve axis values to human-readable labels.
+   *
+   * Defaults to {@link deriveAxisValuesLabels} over the ambient render ctx
+   * (current block outputs + result pool), resolved lazily on the first
+   * lookup. Pass an explicit callback to narrow the label source, or
+   * `() => undefined` to keep raw axis values.
+   */
   axisValuesLabels?: (axisId: AxisId) => undefined | Record<string | number, string>;
 }
 
@@ -36,8 +44,11 @@ export interface ExpandByPartitionOpts {
 const MAX_KEY_COMBINATIONS = 10_000;
 
 /**
- * Expand each input column along the requested partition axes into one
- * {@link ColumnRecipe} per Cartesian combination of unique partition values.
+ * Split each input column along the requested axes into one
+ * {@link ColumnRecipe} per Cartesian combination of the axes' distinct values.
+ *
+ * The split axes must be partition-key axes of the input's data — the distinct
+ * values are read off the partition keys.
  *
  * Each split is produced as `ColumnOverriddenRecipe.wrap(ColumnFilteredRecipe.wrap(inner, axisFilters), { domain, annotations })`:
  *   - `ColumnFilteredRecipe` pins all split axes at once (one wrap call with
@@ -55,14 +66,16 @@ const MAX_KEY_COMBINATIONS = 10_000;
  * Returns `undefined` when any input's `getData()` is not a
  * {@link TreeNodeAccessor} — partition inspection is not yet possible.
  */
-export function expandByPartition(
+export function splitByAxes(
   inputs: Column[],
   splitAxes: SplitAxis[],
-  opts?: ExpandByPartitionOpts,
+  opts?: SplitByAxesOpts,
 ): ColumnRecipe[] | undefined {
   if (splitAxes.length === 0) {
     return [...inputs];
   }
+
+  const axisValuesLabels = opts?.axisValuesLabels ?? deriveAxisValuesLabels();
 
   const splitAxisIdxs = splitAxes.map((a) => a.idx).sort((a, b) => a - b);
   const maxSplitIdx = splitAxisIdxs[splitAxisIdxs.length - 1];
@@ -90,7 +103,7 @@ export function expandByPartition(
     const axesSpec = spec.axesSpec;
     const splitAxisSpecs = splitAxisIdxs.map((idx) => axesSpec[idx]);
     const splitAxisIds = splitAxisSpecs.map((axisSpec) => getAxisId(axisSpec));
-    const axesLabels = splitAxisIds.map((axisId) => opts?.axisValuesLabels?.(axisId));
+    const axesLabels = splitAxisIds.map((axisId) => axisValuesLabels(axisId));
 
     const existingTraceRaw = readAnnotation(spec, Annotation.Trace);
     const baseTrace: TraceEntry[] = existingTraceRaw

--- a/sdk/model/src/columns/utils.ts
+++ b/sdk/model/src/columns/utils.ts
@@ -11,7 +11,7 @@ import { throwError } from "@milaboratories/helpers";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import { TreeNodeAccessor } from "../render";
 import { deriveDistinctLabels, type DeriveLabelsOptions } from "../labels/derive_distinct_labels";
-import { DataColumnImpl, type DataColumn, type ColumnData } from "./data_column";
+import { DataColumnRecipe, DataColumnImpl, type ColumnData } from "./data_column";
 import { ColumnDiscoveredRecipe } from "./column_recipes/column_discovered_recipe";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import {
@@ -29,7 +29,7 @@ import type { ColumnsSource } from "./column_providers/types";
  * other engine-consumed column.
  *
  * Pure query walk — no registry access. Use {@link collectLinkerColumns} for
- * the resolved {@link DataColumn} variant.
+ * the resolved {@link DataColumnRecipe} variant.
  */
 export function collectLinkerIds(recipe: ColumnRecipe): PObjectId[] {
   const hit = extractPObjectId(recipe.id);
@@ -50,13 +50,13 @@ export function collectLinkerIds(recipe: ColumnRecipe): PObjectId[] {
 
 /**
  * {@link collectLinkerIds} resolved against the ambient context as
- * {@link DataColumn} leaves. Throws if any id fails to resolve —
+ * {@link DataColumnRecipe} leaves. Throws if any id fails to resolve —
  * matches the contract of the legacy `resolveLinkers` it replaces.
  */
 export function collectLinkerColumns(
   recipe: ColumnRecipe,
   opts: { ctx?: GlobalCfgRenderCtx } = {},
-): DataColumn<PObjectId>[] {
+): DataColumnRecipe<PObjectId>[] {
   return collectLinkerIds(recipe).map(
     (id) =>
       DataColumnImpl.fromId(id, opts) ??
@@ -98,7 +98,7 @@ export function queriesQualifications(
  *
  * Walks every physical leaf the recipe depends on via
  * {@link ColumnRecipe.getReferencedIds} (resolves each id back to a
- * {@link DataColumn} through the ambient ctx) and ANDs `hasData()` across
+ * {@link DataColumnRecipe} through the ambient ctx) and ANDs `hasData()` across
  * all of them. Inline {@link PColumnValues} payloads count as present.
  *
  * Returns `false` if any leaf cannot be re-resolved in `opts.ctx` (treat as
@@ -154,31 +154,38 @@ function findDiscovered(recipe: ColumnRecipe): undefined | ColumnDiscoveredRecip
 }
 
 /**
- * Whether the recipe resolves on its own, without pulling in other columns.
+ * Whether the recipe reads exactly one data column — its own — rather than
+ * reaching through others.
  *
- * A self-contained column is described entirely by its own source column plus
- * projections over it (spec overrides, axis slicing). A column that is *not*
- * self-contained reaches its data through other columns, so it only becomes
- * co-indexed after they are joined in — which is why it brings axes into a
- * join that its own spec does not mention, and cannot serve as a primary
- * column.
+ * True for a bare leaf and for projections over one (spec overrides, axis
+ * slicing): those add layers but no new columns. False when the recipe gets at
+ * its data through further columns, which happens when discovery reached it via
+ * a linker chain.
  *
- * The check walks the whole wrapper chain, not just the outermost layer.
+ * **Why callers care.** A recipe over a single data column is co-indexed by its
+ * own axes, so its spec is the whole truth about them. One that needs other
+ * columns only lines up after they are joined in, and therefore drags axes into
+ * the join that its own spec never mentions — which is why it cannot serve as a
+ * primary column, and why `createPlDataTableV3` splits on this.
+ *
+ * The count comes from {@link ColumnRecipe.getReferencedIds}, which resolves
+ * through the whole wrapper chain, so no class walk is involved and foreign
+ * `ColumnRecipe` implementations are handled too.
  */
-export function isSelfContained(recipe: ColumnRecipe): boolean {
-  return findDiscovered(recipe) === undefined;
+export function hasSingleDataColumn(recipe: ColumnRecipe): boolean {
+  return recipe.getReferencedIds().length === 1;
 }
 
 /**
- * @deprecated Renamed to {@link isSelfContained} — "leaf" read as "you can get
- * data out of it", which is a different question (see {@link hasReachableData}).
- * Same semantics.
+ * @deprecated Renamed to {@link hasSingleDataColumn} — "leaf" read as "you can
+ * get data out of it", which is a different question (see
+ * {@link hasReachableData}). Same semantics.
  */
-export const isLeafColumn = isSelfContained;
+export const isLeafColumn = hasSingleDataColumn;
 
 /**
  * Whether the column's data can be read here and now, consistent with its
- * spec — narrows to {@link DataColumn}, which exposes `getData()`.
+ * spec — narrows to {@link DataColumnRecipe}, which exposes `getData()`.
  *
  * True for a bare leaf and for a spec-override over a bare leaf. False for an
  * axis-filtered recipe (its spec has dropped axes the underlying data still
@@ -192,21 +199,8 @@ export const isLeafColumn = isSelfContained;
  * result narrows to a value that really has the method, and there is no
  * throwing path behind the guard.
  */
-export function hasReachableData(recipe: ColumnRecipe): recipe is DataColumn {
+export function hasReachableData(recipe: ColumnRecipe): recipe is DataColumnRecipe {
   return recipe instanceof DataColumnImpl || recipe instanceof DataColumnOverriddenRecipe;
-}
-
-/**
- * @deprecated Use {@link hasReachableData} and call `getData()` on the narrowed
- * column.
- *
- * Behaviour change: this used to walk past an axis-filtered layer and hand
- * back the *unsliced* data of the underlying leaf, which does not match the
- * recipe's spec. It now returns `undefined` for anything
- * {@link hasReachableData} rejects.
- */
-export function getLeafColumnData(recipe: ColumnRecipe): ColumnData {
-  return hasReachableData(recipe) ? recipe.getData() : undefined;
 }
 
 /** Drop-down option built over a {@link ColumnsCollection} — universal-id valued. */

--- a/sdk/model/src/columns/utils.ts
+++ b/sdk/model/src/columns/utils.ts
@@ -11,7 +11,7 @@ import { throwError } from "@milaboratories/helpers";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import { TreeNodeAccessor } from "../render";
 import { deriveDistinctLabels, type DeriveLabelsOptions } from "../labels/derive_distinct_labels";
-import { ColumnLazy, ColumnLazyImpl, type ColumnLazyData } from "./column_lazy";
+import { DataColumnImpl, type DataColumn, type DataColumnData } from "./data_column";
 import { ColumnDiscoveredRecipe } from "./column_recipes/column_discovered_recipe";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
 import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
@@ -26,7 +26,7 @@ import type { ColumnsSource } from "./column_providers/types";
  * other engine-consumed column.
  *
  * Pure query walk — no registry access. Use {@link collectLinkerColumns} for
- * the resolved {@link ColumnLazy} variant.
+ * the resolved {@link DataColumn} variant.
  */
 export function collectLinkerIds(recipe: ColumnRecipe): PObjectId[] {
   const hit = extractPObjectId(recipe.id);
@@ -47,16 +47,16 @@ export function collectLinkerIds(recipe: ColumnRecipe): PObjectId[] {
 
 /**
  * {@link collectLinkerIds} resolved against the ambient context as
- * {@link ColumnLazy} instances. Throws if any id fails to resolve —
+ * {@link DataColumn} leaves. Throws if any id fails to resolve —
  * matches the contract of the legacy `resolveLinkers` it replaces.
  */
 export function collectLinkerColumns(
   recipe: ColumnRecipe,
   opts: { ctx?: GlobalCfgRenderCtx } = {},
-): ColumnLazy[] {
+): DataColumn<PObjectId>[] {
   return collectLinkerIds(recipe).map(
     (id) =>
-      ColumnLazyImpl.fromId(id, opts) ??
+      DataColumnImpl.fromId(id, opts) ??
       throwError(`materializeLinkers: linker ${id} not resolvable`),
   );
 }
@@ -95,7 +95,7 @@ export function queriesQualifications(
  *
  * Walks every physical leaf the recipe depends on via
  * {@link ColumnRecipe.getReferencedIds} (resolves each id back to a
- * {@link ColumnLazy} through the ambient ctx) and ANDs `hasData()` across
+ * {@link DataColumn} through the ambient ctx) and ANDs `hasData()` across
  * all of them. Inline {@link PColumnValues} payloads count as present.
  *
  * Returns `false` if any leaf cannot be re-resolved in `opts.ctx` (treat as
@@ -107,15 +107,15 @@ export function hasColumnData(
   opts: { ctx?: GlobalCfgRenderCtx } = {},
 ): boolean {
   for (const id of recipe.getReferencedIds()) {
-    const lazy = ColumnLazyImpl.fromId(id, opts);
-    if (lazy === undefined) return false;
-    if (lazy.getDataStatus() !== "present") return false;
-    if (!isLazyDataPresent(lazy.getData())) return false;
+    const leaf = DataColumnImpl.fromId(id, opts);
+    if (leaf === undefined) return false;
+    if (leaf.getDataStatus() !== "present") return false;
+    if (!isLeafDataPresent(leaf.getData())) return false;
   }
   return true;
 }
 
-function isLazyDataPresent(data: ColumnLazyData): boolean {
+function isLeafDataPresent(data: DataColumnData): boolean {
   if (data === undefined) return false;
   if (Array.isArray(data)) return true;
   if (data instanceof TreeNodeAccessor) return data.hasData();
@@ -151,51 +151,56 @@ function findDiscovered(recipe: ColumnRecipe): undefined | ColumnDiscoveredRecip
 }
 
 /**
- * A recipe is a "leaf" (directly co-indexed on the anchor, reached without a
- * linker chain) iff its wrapper chain contains no {@link ColumnDiscoveredRecipe}.
+ * Whether the recipe resolves on its own, without pulling in other columns.
  *
- * `Filtered` / `Overridden` over a bare leaf stay leaves; anything wrapping a
- * `Discovered` (e.g. `Overridden(Discovered(...))`) is linked. Use this — not an
- * `instanceof ColumnLazyImpl` check — to split direct vs. linker-joined columns,
- * since projections over a plain leaf are still direct.
+ * A self-contained column is described entirely by its own source column plus
+ * projections over it (spec overrides, axis slicing). A column that is *not*
+ * self-contained reaches its data through other columns, so it only becomes
+ * co-indexed after they are joined in — which is why it brings axes into a
+ * join that its own spec does not mention, and cannot serve as a primary
+ * column.
+ *
+ * The check walks the whole wrapper chain, not just the outermost layer.
  */
-export function isLeafColumn(recipe: ColumnRecipe): boolean {
+export function isSelfContained(recipe: ColumnRecipe): boolean {
   return findDiscovered(recipe) === undefined;
 }
 
 /**
- * Data of the bare leaf a "leaf" recipe bottoms out at — reads the leaf-only
- * {@link ColumnLazy.getData} after walking the wrapper chain down via
- * {@link extractLeafColumn}. Returns `undefined` when the recipe is not a leaf (its
- * chain reaches a {@link ColumnDiscoveredRecipe}); the symmetric counterpart
- * of {@link isLeafColumn} returning `false`.
+ * @deprecated Renamed to {@link isSelfContained} — "leaf" read as "you can get
+ * data out of it", which is a different question (see {@link hasDirectData}).
+ * Same semantics.
  */
-export function getLeafColumnData(recipe: ColumnRecipe): ColumnLazyData {
-  if (!isLeafColumn(recipe)) {
-    throw new Error(`getLeafColumnData: recipe ${recipe.id} is not a leaf column`);
-  }
-  return extractLeafColumn(recipe)?.getData();
+export const isLeafColumn = isSelfContained;
+
+/**
+ * Whether the column's data can be read here and now, consistent with its
+ * spec — narrows to {@link DataColumn}, which exposes `getData()`.
+ *
+ * True for a bare leaf and for a spec-override over a bare leaf. False for an
+ * axis-filtered recipe (its spec has dropped axes the underlying data still
+ * carries, so the two no longer line up) and for anything reached through
+ * other columns (nothing to read until the engine joins them). In both of
+ * those cases the data exists only engine-side: pass `recipe.id` to
+ * `createPFrame` / `createPTable` instead of trying to read it.
+ */
+export function hasDirectData(recipe: ColumnRecipe): recipe is DataColumn {
+  if (recipe instanceof DataColumnImpl) return true;
+  if (recipe instanceof ColumnOverriddenRecipe) return recipe.getInner() instanceof DataColumnImpl;
+  return false;
 }
 
 /**
- * Walk wrapper layers (Overridden, Filtered) down to the bare {@link ColumnLazy}
- * leaf the chain bottoms out at. Returns `undefined` if the chain reaches a
- * {@link ColumnDiscoveredRecipe} instead — i.e. the recipe is not a leaf
- * ({@link isLeafColumn} would return `false`). Mirror of {@link findDiscovered}.
+ * @deprecated Use {@link hasDirectData} and call `getData()` on the narrowed
+ * column.
+ *
+ * Behaviour change: this used to walk past an axis-filtered layer and hand
+ * back the *unsliced* data of the underlying leaf, which does not match the
+ * recipe's spec. It now returns `undefined` for anything
+ * {@link hasDirectData} rejects.
  */
-function extractLeafColumn(recipe: ColumnRecipe): undefined | ColumnLazy {
-  let current: ColumnRecipe = recipe;
-  while (true) {
-    if (current instanceof ColumnLazyImpl) return current;
-    if (current instanceof ColumnOverriddenRecipe || current instanceof ColumnFilteredRecipe) {
-      current = current.getInner();
-      continue;
-    }
-    if (current instanceof ColumnDiscoveredRecipe) {
-      throw new Error(`extractLeafColumn: recipe ${recipe.id} is not a leaf column`);
-    }
-    throw new Error(`extractLeafColumn: unrecognized recipe layer for ${recipe.id}`);
-  }
+export function getLeafColumnData(recipe: ColumnRecipe): DataColumnData {
+  return hasDirectData(recipe) ? recipe.getData() : undefined;
 }
 
 /** Drop-down option built over a {@link ColumnsCollection} — universal-id valued. */

--- a/sdk/model/src/columns/utils.ts
+++ b/sdk/model/src/columns/utils.ts
@@ -11,10 +11,13 @@ import { throwError } from "@milaboratories/helpers";
 import type { GlobalCfgRenderCtx } from "../render/internal";
 import { TreeNodeAccessor } from "../render";
 import { deriveDistinctLabels, type DeriveLabelsOptions } from "../labels/derive_distinct_labels";
-import { DataColumnImpl, type DataColumn, type DataColumnData } from "./data_column";
+import { DataColumnImpl, type DataColumn, type ColumnData } from "./data_column";
 import { ColumnDiscoveredRecipe } from "./column_recipes/column_discovered_recipe";
 import { ColumnFilteredRecipe } from "./column_recipes/column_filtered_recipe";
-import { ColumnOverriddenRecipe } from "./column_recipes/column_overrided_recipe";
+import {
+  ColumnOverriddenRecipe,
+  DataColumnOverriddenRecipe,
+} from "./column_recipes/column_overrided_recipe";
 import type { ColumnRecipe } from "./column_recipes/types";
 import { ColumnsCollection, isColumnsCollection } from "./columns_collection";
 import type { ColumnsSource } from "./column_providers/types";
@@ -115,7 +118,7 @@ export function hasColumnData(
   return true;
 }
 
-function isLeafDataPresent(data: DataColumnData): boolean {
+function isLeafDataPresent(data: ColumnData): boolean {
   if (data === undefined) return false;
   if (Array.isArray(data)) return true;
   if (data instanceof TreeNodeAccessor) return data.hasData();
@@ -168,7 +171,7 @@ export function isSelfContained(recipe: ColumnRecipe): boolean {
 
 /**
  * @deprecated Renamed to {@link isSelfContained} — "leaf" read as "you can get
- * data out of it", which is a different question (see {@link hasDirectData}).
+ * data out of it", which is a different question (see {@link hasReachableData}).
  * Same semantics.
  */
 export const isLeafColumn = isSelfContained;
@@ -183,24 +186,27 @@ export const isLeafColumn = isSelfContained;
  * other columns (nothing to read until the engine joins them). In both of
  * those cases the data exists only engine-side: pass `recipe.id` to
  * `createPFrame` / `createPTable` instead of trying to read it.
+ *
+ * The distinction is settled when the recipe is built, not here — recipes that
+ * carry data are instances of a class that declares `getData`. So a `true`
+ * result narrows to a value that really has the method, and there is no
+ * throwing path behind the guard.
  */
-export function hasDirectData(recipe: ColumnRecipe): recipe is DataColumn {
-  if (recipe instanceof DataColumnImpl) return true;
-  if (recipe instanceof ColumnOverriddenRecipe) return recipe.getInner() instanceof DataColumnImpl;
-  return false;
+export function hasReachableData(recipe: ColumnRecipe): recipe is DataColumn {
+  return recipe instanceof DataColumnImpl || recipe instanceof DataColumnOverriddenRecipe;
 }
 
 /**
- * @deprecated Use {@link hasDirectData} and call `getData()` on the narrowed
+ * @deprecated Use {@link hasReachableData} and call `getData()` on the narrowed
  * column.
  *
  * Behaviour change: this used to walk past an axis-filtered layer and hand
  * back the *unsliced* data of the underlying leaf, which does not match the
  * recipe's spec. It now returns `undefined` for anything
- * {@link hasDirectData} rejects.
+ * {@link hasReachableData} rejects.
  */
-export function getLeafColumnData(recipe: ColumnRecipe): DataColumnData {
-  return hasDirectData(recipe) ? recipe.getData() : undefined;
+export function getLeafColumnData(recipe: ColumnRecipe): ColumnData {
+  return hasReachableData(recipe) ? recipe.getData() : undefined;
 }
 
 /** Drop-down option built over a {@link ColumnsCollection} — universal-id valued. */

--- a/sdk/model/src/components/PlDataTable/columnResolver.test.ts
+++ b/sdk/model/src/components/PlDataTable/columnResolver.test.ts
@@ -20,7 +20,7 @@ function wrap(id: PObjectId | SUniversalPColumnId, tag: string): SUniversalPColu
   });
 }
 
-// DataColumn constructor pulls `getCfgRenderCtx()` from globalThis on some
+// DataColumnRecipe constructor pulls `getCfgRenderCtx()` from globalThis on some
 // paths — keep a minimal mock the same way p_column_lazy.test.ts does.
 const mockCtx = {
   getAccessorHandleByName: () => undefined,

--- a/sdk/model/src/components/PlDataTable/columnResolver.test.ts
+++ b/sdk/model/src/components/PlDataTable/columnResolver.test.ts
@@ -9,7 +9,7 @@ import {
   type PTableColumnId,
   type SUniversalPColumnId,
 } from "@milaboratories/pl-model-common";
-import { ColumnLazyImpl } from "../../columns";
+import { DataColumnImpl } from "../../columns";
 import type { ColumnRecipe } from "../../columns";
 import { createColumnResolver } from "./columnResolver";
 
@@ -20,7 +20,7 @@ function wrap(id: PObjectId | SUniversalPColumnId, tag: string): SUniversalPColu
   });
 }
 
-// ColumnLazy constructor pulls `getCfgRenderCtx()` from globalThis on some
+// DataColumn constructor pulls `getCfgRenderCtx()` from globalThis on some
 // paths — keep a minimal mock the same way p_column_lazy.test.ts does.
 const mockCtx = {
   getAccessorHandleByName: () => undefined,
@@ -36,7 +36,7 @@ afterEach(() => {
 
 function lazyOf(id: PObjectId, axes: AxisSpec[] = []) {
   const spec = { kind: "PColumn", name: "stub", axesSpec: axes } as unknown as PColumnSpec;
-  return ColumnLazyImpl.fromColumn({
+  return DataColumnImpl.fromColumn({
     id,
     spec,
     data: undefined,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
@@ -10,7 +10,7 @@ import type { PColumnDataUniversal } from "../../../render";
 import { isFunction } from "es-toolkit";
 import type { PlDataTableFilters } from "../typesV8";
 import { createPTableDefV3 } from "./createPTableDefV3";
-import { DataColumnImpl } from "../../../columns";
+import { DataColumn } from "../../../columns";
 
 export function createPTableDefV2(params: {
   columns: PColumn<undefined | PColumnDataUniversal>[];
@@ -33,8 +33,8 @@ export function createPTableDefV2(params: {
   secondaryColumns.push(...params.labelColumns);
 
   return createPTableDefV3({
-    primary: coreColumns.map((column) => DataColumnImpl.fromColumn(column)),
-    secondary: secondaryColumns.map((column) => DataColumnImpl.fromColumn(column)),
+    primary: coreColumns.map((column) => DataColumn.fromColumn(column)),
+    secondary: secondaryColumns.map((column) => DataColumn.fromColumn(column)),
     primaryJoinType: params.coreJoinType,
     filters: params.filters,
     sorting: params.sorting,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPTableDefV2.ts
@@ -10,7 +10,7 @@ import type { PColumnDataUniversal } from "../../../render";
 import { isFunction } from "es-toolkit";
 import type { PlDataTableFilters } from "../typesV8";
 import { createPTableDefV3 } from "./createPTableDefV3";
-import { ColumnLazyImpl } from "../../../columns";
+import { DataColumnImpl } from "../../../columns";
 
 export function createPTableDefV2(params: {
   columns: PColumn<undefined | PColumnDataUniversal>[];
@@ -33,8 +33,8 @@ export function createPTableDefV2(params: {
   secondaryColumns.push(...params.labelColumns);
 
   return createPTableDefV3({
-    primary: coreColumns.map((column) => ColumnLazyImpl.fromColumn(column)),
-    secondary: secondaryColumns.map((column) => ColumnLazyImpl.fromColumn(column)),
+    primary: coreColumns.map((column) => DataColumnImpl.fromColumn(column)),
+    secondary: secondaryColumns.map((column) => DataColumnImpl.fromColumn(column)),
     primaryJoinType: params.coreJoinType,
     filters: params.filters,
     sorting: params.sorting,

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
@@ -31,7 +31,7 @@ import { getMatchingLabelColumns } from "../labels";
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
 import { createPTableDefV2 } from "./createPTableDefV2";
 import { isColumnOptional } from "./utils";
-import { ColumnLazyImpl } from "../../../columns";
+import { DataColumnImpl } from "../../../columns";
 import { createColumnResolver, type ColumnResolver } from "../columnResolver";
 import { isNil, type Nil } from "@milaboratories/helpers";
 
@@ -83,7 +83,7 @@ export function createPlDataTableV2<A, U>(
   const fullColumns = [...columns, ...fullLabelColumns];
 
   const resolver = createColumnResolver(
-    fullColumns.map((c) => ColumnLazyImpl.fromColumn(c)),
+    fullColumns.map((c) => DataColumnImpl.fromColumn(c)),
     { warn: ctx.logWarn.bind(ctx) },
   );
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
@@ -31,7 +31,7 @@ import { getMatchingLabelColumns } from "../labels";
 import { collectFilterSpecColumns, traverseFilterSpec } from "../../../filters/traverse";
 import { createPTableDefV2 } from "./createPTableDefV2";
 import { isColumnOptional } from "./utils";
-import { DataColumnImpl } from "../../../columns";
+import { DataColumn } from "../../../columns";
 import { createColumnResolver, type ColumnResolver } from "../columnResolver";
 import { isNil, type Nil } from "@milaboratories/helpers";
 
@@ -83,7 +83,7 @@ export function createPlDataTableV2<A, U>(
   const fullColumns = [...columns, ...fullLabelColumns];
 
   const resolver = createColumnResolver(
-    fullColumns.map((c) => DataColumnImpl.fromColumn(c)),
+    fullColumns.map((c) => DataColumn.fromColumn(c)),
     { warn: ctx.logWarn.bind(ctx) },
   );
 

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -27,7 +27,7 @@ import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import type { MatchingMode } from "@milaboratories/pl-model-common";
 import {
-  isSelfContained,
+  hasSingleDataColumn,
   hitQualifications,
   collectLinkerColumns,
   queriesQualifications,
@@ -261,7 +261,7 @@ function splitByTopology(columns: ColumnRecipe[]): {
   const direct: ColumnRecipe[] = [];
   const linked: ColumnRecipe[] = [];
   for (const c of columns) {
-    if (isSelfContained(c)) direct.push(c);
+    if (hasSingleDataColumn(c)) direct.push(c);
     else linked.push(c);
   }
   return { direct, linked };

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -27,7 +27,7 @@ import { upgradePlDataTableStateV2 } from "../state-migration";
 import type { PlDataTableStateV2 } from "../state-migration";
 import type { MatchingMode } from "@milaboratories/pl-model-common";
 import {
-  isLeafColumn,
+  isSelfContained,
   hitQualifications,
   collectLinkerColumns,
   queriesQualifications,
@@ -261,7 +261,7 @@ function splitByTopology(columns: ColumnRecipe[]): {
   const direct: ColumnRecipe[] = [];
   const linked: ColumnRecipe[] = [];
   for (const c of columns) {
-    if (isLeafColumn(c)) direct.push(c);
+    if (isSelfContained(c)) direct.push(c);
     else linked.push(c);
   }
   return { direct, linked };

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -7,7 +7,7 @@ import type {
 import { PColumnName } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
 import type { ColumnRecipe, ColumnsSource } from "../../../columns";
-import { ColumnsCollection, isLeafColumn } from "../../../columns";
+import { ColumnsCollection, isSelfContained } from "../../../columns";
 import type { ColumnsSelectorConfig } from "./createPlDataTableV3";
 
 export type DiscoverTableColumnOptions = {
@@ -38,7 +38,7 @@ export function discoverTableColumns(
   const primary: ColumnRecipe[] = [];
   const secondary: ColumnRecipe[] = [];
   for (const col of discoveredColumns) {
-    if (isLeafColumn(col)) primary.push(col);
+    if (isSelfContained(col)) primary.push(col);
     else secondary.push(col);
   }
   return { primary, secondary };

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/discoverColumns.ts
@@ -7,7 +7,7 @@ import type {
 import { PColumnName } from "@milaboratories/pl-model-common";
 import type { RenderCtxBase } from "../../../render";
 import type { ColumnRecipe, ColumnsSource } from "../../../columns";
-import { ColumnsCollection, isSelfContained } from "../../../columns";
+import { ColumnsCollection, hasSingleDataColumn } from "../../../columns";
 import type { ColumnsSelectorConfig } from "./createPlDataTableV3";
 
 export type DiscoverTableColumnOptions = {
@@ -38,7 +38,7 @@ export function discoverTableColumns(
   const primary: ColumnRecipe[] = [];
   const secondary: ColumnRecipe[] = [];
   for (const col of discoveredColumns) {
-    if (isSelfContained(col)) primary.push(col);
+    if (hasSingleDataColumn(col)) primary.push(col);
     else secondary.push(col);
   }
   return { primary, secondary };

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -7,7 +7,7 @@ import {
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { deriveAllLabels, evaluateRules, type LabelableColumn } from "./utils";
 import type { ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
-import { ColumnLazy } from "../../../columns";
+import { DataColumn } from "../../../columns";
 import {
   createTestCollectionDriver,
   type TestCollectionDriverHandle,
@@ -156,11 +156,11 @@ function gid(name: string): PObjectId {
   return createGlobalPObjectId("test-block", name);
 }
 
-function makeLazyColumn(name: string, spec: Partial<PColumnSpec> = {}): ColumnLazy {
+function makeLazyColumn(name: string, spec: Partial<PColumnSpec> = {}): DataColumn {
   const s = makeSpec({ axesSpec: [{ name: "id", type: "String" }], ...spec });
   const id = gid(name);
   driverHandle.register([{ id, spec: s }]);
-  return ColumnLazy.fromColumn({ id, spec: s, data: undefined as never });
+  return DataColumn.fromColumn({ id, spec: s, data: undefined as never });
 }
 
 describe("evaluateRules", () => {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -7,7 +7,7 @@ import {
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { deriveAllLabels, evaluateRules, type LabelableColumn } from "./utils";
 import type { ColumnOrderRule, ColumnVisibilityRule } from "./createPlDataTableV3";
-import { DataColumn } from "../../../columns";
+import { DataColumn, type DataColumnRecipe } from "../../../columns";
 import {
   createTestCollectionDriver,
   type TestCollectionDriverHandle,
@@ -156,7 +156,7 @@ function gid(name: string): PObjectId {
   return createGlobalPObjectId("test-block", name);
 }
 
-function makeLazyColumn(name: string, spec: Partial<PColumnSpec> = {}): DataColumn {
+function makeLazyColumn(name: string, spec: Partial<PColumnSpec> = {}): DataColumnRecipe {
   const s = makeSpec({ axesSpec: [{ name: "id", type: "String" }], ...spec });
   const id = gid(name);
   driverHandle.register([{ id, spec: s }]);

--- a/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
@@ -15,7 +15,7 @@ import type {
 } from "@milaboratories/pl-model-common";
 import type { ColumnRecipe, ColumnsSource } from "../../columns";
 import {
-  isSelfContained,
+  hasSingleDataColumn,
   ColumnsCollection,
   collectLinkerIds,
   hitQualifications,
@@ -67,7 +67,7 @@ export function findEnrichmentColumns(options: FindEnrichmentColumnsOptions): Co
 
   const predicate = options.predicate;
   return columns.filter((v) => {
-    if (isSelfContained(v)) return false;
+    if (hasSingleDataColumn(v)) return false;
     if (predicate !== undefined && !predicate(v.getSpec())) return false;
     if (!isGlobalPObjectId(extractPObjectId(v.id))) return false;
     if (collectLinkerIds(v).some((id) => !isGlobalPObjectId(id))) return false;

--- a/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
+++ b/sdk/model/src/components/PlDatasetSelector/enrichment_discovery.ts
@@ -15,7 +15,7 @@ import type {
 } from "@milaboratories/pl-model-common";
 import type { ColumnRecipe, ColumnsSource } from "../../columns";
 import {
-  isLeafColumn,
+  isSelfContained,
   ColumnsCollection,
   collectLinkerIds,
   hitQualifications,
@@ -67,7 +67,7 @@ export function findEnrichmentColumns(options: FindEnrichmentColumnsOptions): Co
 
   const predicate = options.predicate;
   return columns.filter((v) => {
-    if (isLeafColumn(v)) return false;
+    if (isSelfContained(v)) return false;
     if (predicate !== undefined && !predicate(v.getSpec())) return false;
     if (!isGlobalPObjectId(extractPObjectId(v.id))) return false;
     if (collectLinkerIds(v).some((id) => !isGlobalPObjectId(id))) return false;


### PR DESCRIPTION
## Problem

`isLeafColumn` and `isColumnLazy` answered two different questions under names that suggested a third one, so picking the right guard meant reading the implementation.

- `isLeafColumn` — "does this column need other columns to resolve?" (topology)
- `isColumnLazy` — "is this the concrete leaf class?" (implementation detail)
- neither — "can I read this column's data?" (what call sites actually want)

In `blocks/clonotype-browser`, the first real consumer, three of four `isLeafColumn` call sites answer the wrong question:

| Site | Intent | Used | Correct |
|---|---|---|---|
| `index.ts:138` → `expandByPartition` | read data | `isLeafColumn` | `hasReachableData` |
| `index.ts:232` → `expandByPartition` | read data | `isLeafColumn` | `hasReachableData` |
| `index.ts:203` `getLeafColumnData(...)` | read data | no guard at all | `hasReachableData` |
| `index.ts:366` | topology | `isLeafColumn` | correct |

`index.ts:203` is a live latent bug: it reads data off a persisted `ColumnUniversalId` of arbitrary shape. If a split column reaches it, `getLeafColumnData` walked past the axis-filtered layer and returned the leaf's **unsliced** data while `getSpec()` reported the sliced spec — the sheet is then built on the wrong axis, silently.

## Fix

Name each predicate after what the caller can do. Which recipe classes exist stays an implementation detail behind `recipe.id`.

```ts
isColumn(value)            // any recipe
isDataColumn(value)        // bare leaf — id names a real storage column
hasReachableData(recipe)   // data readable here, consistent with getSpec()
hasSingleDataColumn(recipe) // reads one data column, not several
```

**`hasReachableData`** narrows to `DataColumnRecipe`, the interface that exposes `getData()`. True for a bare leaf and a spec override over one — the only shapes whose data still matches their spec. An axis filter drops axes from the spec that the underlying data still carries, so the slice exists only engine-side.

**`hasSingleDataColumn`** is `getReferencedIds().length === 1`. Such a column is co-indexed by its own axes, so its spec is the whole truth about them; one that reads several only lines up after they are joined in and drags in axes its spec never mentions. That is the primary/secondary split in `createPlDataTableV3`.

This replaces a walk over recipe classes, and is both simpler and more correct: a discovered hit with an empty linker path is an ordinary column (`buildSpecQuery` emits no `linkerJoin` for it), and the class walk rejected it purely for being a `ColumnDiscoveredRecipe`. It also no longer depends on the class registry, so foreign `ColumnRecipe` implementations are handled.

**No throwing path behind the guard.** `ColumnOverriddenRecipe.wrap` picks a data-bearing variant when the wrapped recipe carries data, so `getData()` exists exactly where it can be called. The choice is structural — it follows from the id — so the same id always yields the same class whether it came from `withSpecs` or from parsing a string, and recipes stay value-objects equal iff their ids match. The branch lives in `wrap` because that is the single funnel all six construction paths go through.

### API changes

- `ColumnLazy` → the `DataColumnRecipe` interface plus the `DataColumn` dispatcher value; `ColumnLazyImpl` → `DataColumnImpl`; `ColumnLazyId` → `DataColumnId`; `ColumnLazyData` → `ColumnData`. `column_lazy.ts` → `data_column.ts`.
- Removed: `isColumnLazy` (→ `isDataColumn`), `isColumnRecipe` (→ `isColumn`), `getLeafColumnData`, and the `ColumnLazy*` names above — gone rather than aliased.
- `isLeafColumn` stays as a deprecated alias of `hasSingleDataColumn`.

The changeset is marked `minor` by decision, though the removals are breaking.

## Verification

- `types:check` — 0 errors
- `vitest` — 455 passed, 0 failed
- `linter:check` / `formatter:check` — clean
- `turbo build --filter=...@platforma-sdk/model` — 167 tasks, includes `types:check` of every dependent package

`predicates.test.ts` pins the contested boundaries: an axis-filtered column reads a single data column yet has no reachable data; an unreadable override has no `getData` at all; merging overrides neither loses nor resurrects readability.

## Out of scope

- **`blocks/clonotype-browser`** (separate repo) — its three wrong call sites need migrating once this SDK version publishes. `index.ts:203` is the one with user-visible impact.
- **`expandByPartition` signature** stays `Column[]` rather than `DataColumnRecipe[]`. A runtime guard now prevents silently-wrong data, but the contract is not yet type-enforced; tightening it would break `clonotype-browser` at compile time.
- **`types:check` does not cover `*.test.ts`** — during this work a type error in a test file passed the compiler and surfaced only at runtime. Worth a separate fix.
- Collapsing `createPlDataTableV3` Form B into a single list, which would remove the last consumer-side need for `hasSingleDataColumn`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces recipe-class-oriented column terminology with capability-oriented predicates and data-access types.
- `ColumnRecipe`: immutable description of how to obtain a logical column; unchanged conceptually, but its general predicate is now `isColumn`.
- `DataColumnRecipe`: capability interface for recipes whose data can be read directly and remains consistent with `getSpec()`; newly introduced for bare data columns and readable spec overrides.
- `DataColumn`: dispatcher for constructing bare storage-column recipes; replaces the `ColumnLazy` dispatcher.
- `DataColumnImpl`: concrete implementation of a bare storage column backed by a `PObjectId`; replaces `ColumnLazyImpl`.
- `ColumnData`: directly readable column payload type; replaces `ColumnLazyData`.
- `isDataColumn`: identifies a bare storage column with a physical `PObjectId`; replaces `isColumnLazy`.
- `hasReachableData`: identifies recipes exposing safe direct data access, including readable overrides over bare columns.
- `hasSingleDataColumn`: identifies recipes depending on exactly one physical data column and is now used for primary-versus-linker topology classification.
- `isLeafColumn`: retained as a deprecated alias of `hasSingleDataColumn`.
- `ColumnOverriddenRecipe`: now selects a data-bearing implementation when wrapping a bare data column, allowing metadata/spec overrides to preserve direct data access.
- `getLeafColumnData`: removed because traversing filtered wrappers could return unsliced data inconsistent with the exposed spec.
- `expandByPartition`: now checks `hasReachableData` before reading input data instead of traversing to an underlying leaf.
- Data-table discovery and construction now classify primary columns through `hasSingleDataColumn`.
- Documentation, migration guidance, tests, providers, and public exports are updated for the renamed API.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/columns/data_column.ts | Renames the bare-column implementation and introduces the `DataColumnRecipe` direct-data capability interface and dispatcher. |
| sdk/model/src/columns/column_recipes/column_overrided_recipe.ts | Adds a data-bearing override variant selected structurally when the wrapped recipe is a bare data column. |
| sdk/model/src/columns/utils.ts | Introduces capability-oriented predicates, retains the deprecated topology alias, and removes unsafe leaf-data traversal. |
| sdk/model/src/columns/expand_by_partition.ts | Restricts direct partition-data inspection to recipes accepted by `hasReachableData`. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Replaces recipe-class topology classification with the single-data-column capability predicate. |
| sdk/model/src/columns/predicates.test.ts | Covers readable overrides, unreadable axis filters, merged overrides, and the distinction between topology and direct data access. |
| sdk/model/src/columns/index.ts | Updates the public column API exports from the removed lazy-column module to the data-column module. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  R[ColumnRecipe] --> S{hasSingleDataColumn}
  S -->|true| P[Eligible as direct/primary column]
  S -->|false| L[Requires linker-aware handling]
  R --> D{hasReachableData}
  D -->|true| G[DataColumnRecipe.getData]
  D -->|false| H[Materialize recipe id host-side]
  B[Bare DataColumn] --> D
  O[Override over bare DataColumn] --> D
  F[Axis-filtered recipe] --> H
  J[Joined/discovered recipe] --> H
```
</details>

<sub>Reviews (2): Last reviewed commit: ["MILAB-6701: settle the column predicate ..."](https://github.com/milaboratory/platforma/commit/0dee70b9910c5e403610ed1fc20d34f46d3fae3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48687358)</sub>

**Context used:**

- Knowledge Base — [Block model](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-model.md)

<!-- /greptile_comment -->