### PR TITLE
MILAB-6707: structurer requires block package bump in block PRs

### DIFF
--- a/.changeset/structurer-require-block-bump.md
+++ b/.changeset/structurer-require-block-bump.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Structurer: the generated block CI (`build.yaml`) now sets `require-package-path-bump: true`, so a block PR must bump the published `block` package with a changeset (an empty changeset or the `skip-changelog` label waives it). Requires the `require-package-path-bump` input to be live on the pinned `@v4` reusable workflow before blocks are refreshed.

--- a/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
+++ b/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
@@ -37,6 +37,8 @@ describe("root CI workflows (fixed, generated)", () => {
     // Shared constants.
     expect(build).toContain("team-id: 'ciplopen'");
     expect(build).toContain("test: true");
+    // Opt-in gate: the published `block` package must be bumped on PRs.
+    expect(build).toContain("require-package-path-bump: true");
     // No bare `build` script exists (root-package-json removes it), so both
     // build legs must name scenario flavors: PR/test validates locally, the
     // publish leg builds the release channel.

--- a/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
@@ -39,6 +39,11 @@ jobs:
       package-path: 'block'
       create-tag: 'true'
 
+      # Require the published `block` package to be bumped by a changeset on
+      # PRs (empty changeset or the `skip-changelog` label waives it). Needs
+      # the input to exist on the pinned `@v4` reusable workflow.
+      require-package-path-bump: true
+
       npmrc-config: |
         {
           "registries": {


### PR DESCRIPTION
## What

The structurer's generated block CI (`build.yaml`) now sets `require-package-path-bump: true`, so a block PR must bump the published `block` package with a changeset. A sibling/devDependency bump does **not** count. Opt-outs: an empty changeset (`pnpm changeset --empty`) or a `skip-changelog` PR label.

## Changes

- `tools/block-tools/.../templates/text/workflows/build.tpl.yaml`: add `require-package-path-bump: true` to the reusable-workflow `with:` block (the file is `fixed`; `root-ci.ts` unchanged — a `block-tools structure refresh` re-delivers it).
- `root-ci-workflows.test.ts`: assert the generated `build.yaml` contains the input.
- Changeset for `@platforma-sdk/block-tools`.

Only affects standalone blocks (`!isSdkInternal`); `etc/blocks/*` get no `build.yaml`, so `check-blocks` is unaffected.

## Verified

- `vitest run src/structure/__tests__/root-ci-workflows.test.ts` → 3/3 pass (new assertion + `fixed` idempotency).
- `pnpm run fmt` clean.

## Rollout after merge

Each block enforces when it next runs `block-tools structure refresh` (or `upgrade-sdk`) and merges the regenerated `build.yaml` — gradual, block-by-block. `clonotype-clustering` has a pre-structurer hand-written `build.yaml` and must be regenerated. No branch-protection change needed (enforcement folds into the already-required `check for changesets` check).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates block-tools’ canonical standalone-block CI template so pull requests must bump the published `block` package, while adding focused generated-output coverage and releasing the behavior as a patch. Deployment is intentionally gated on github-ci#194 being promoted to the pinned `@v4` workflow.

- Adds `require-package-path-bump: true` to generated standalone-block `build.yaml` workflows.
- Verifies the generated workflow contains the new reusable-workflow input.
- Adds a patch changeset for `@platforma-sdk/block-tools`.
- Important touched terms:
  - **Structurer** — block-tools’ canonical repository-layout and file-generation engine. Its generated build workflow now enables package-path bump enforcement.
  - **Block package** — the publishable package under a standalone block repository’s `block/` directory. It must now receive the qualifying changeset bump.
  - **Reusable workflow** — the `milaboratory/github-ci` workflow pinned at `@v4` and invoked by generated block CI. It receives the new enforcement input after github-ci#194 is promoted.
  - **Changeset** — release metadata describing package version changes. A qualifying block changeset now satisfies the gate; an empty changeset provides an explicit opt-out.
  - **`skip-changelog` label** — the PR-level opt-out from changeset enforcement, unchanged in purpose but now applicable to this package-path requirement.
  - **`require-package-path-bump`** — the new reusable-workflow input enabling validation that the package selected by `package-path` is bumped.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge after its explicitly documented github-ci#194 promotion prerequisite is satisfied.

The template, generated-output assertion, and release note consistently introduce the intended standalone-block package-bump gate, and no actionable changed-code defect remains beyond the acknowledged external rollout dependency.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml | Enables the package-path bump requirement in generated standalone-block CI; the declared rollout dependency must be satisfied before release. |
| tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts | Adds focused coverage confirming the generated build workflow contains the new enforcement input. |
| .changeset/structurer-require-block-bump.md | Records a patch release and documents the behavior, opt-outs, and required reusable-workflow rollout order. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[block-tools structure refresh] --> B[Generate build.yaml]
  B --> C[node-simple-pnpm.yaml at v4]
  C --> D{Block package bumped?}
  D -->|Yes| E[Changeset check passes]
  D -->|Empty changeset or skip-changelog| E
  D -->|No| F[Changeset check fails]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6707: structurer sets require-pack..."](https://github.com/milaboratory/platforma/commit/fb643294d2f5d77f83d29f633bb742b065706f7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50009329)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Block Build Tooling](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-build-tooling.md)

<!-- /greptile_comment -->