### PR TITLE
MILAB-6700: raise HTTP/2 connection window + bump quickjs-emscripten

### DIFF
--- a/.changeset/grpc-connection-window.md
+++ b/.changeset/grpc-connection-window.md
@@ -1,0 +1,7 @@
+---
+"@milaboratories/pl-client": patch
+"@milaboratories/pl-drivers": patch
+"@milaboratories/pl-healthcheck": patch
+---
+
+Raise the HTTP/2 connection window to 16 MiB via `grpc-node.flow_control_window`, and bump `@grpc/grpc-js` to 1.14.4 where that option drives the connection-level window and not just the per-stream one. On a high-latency link a large project open was capped at window/RTT instead of link speed.

--- a/.changeset/quickjs-emscripten-032.md
+++ b/.changeset/quickjs-emscripten-032.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-middle-layer": patch
+"@milaboratories/pl-mcp-server": patch
+---
+
+Bump `quickjs-emscripten` to 0.32.0. quickjs (wasm) is the largest worker CPU cost, and 0.32.0 upgrades the underlying bellard/quickjs and reworks host function binding onto `HostRef`.

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -266,6 +266,10 @@ export class LLPlClient implements WireClientProviderFactory {
     const clientOptions: ClientOptions = {
       "grpc.keepalive_time_ms": 30_000, // 30 seconds
       "grpc.service_config_disable_resolution": 1, // Disable DNS TXT lookups for service config
+      // Raises the per-stream and connection-level HTTP/2 windows. Node's 64 KB default
+      // caps a big single-stream read (project open) at window/RTT rather than link speed,
+      // and a lost WINDOW_UPDATE can deadlock it under packet loss.
+      "grpc-node.flow_control_window": 16 * 1024 * 1024, // 16 MiB
       interceptors: this._grpcInterceptors,
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^9.2.0
       version: 9.2.0
     '@grpc/grpc-js':
-      specifier: ~1.13.4
-      version: 1.13.4
+      specifier: ~1.14.4
+      version: 1.14.4
     '@inquirer/prompts':
       specifier: ^7.0.1
       version: 7.0.1
@@ -2606,7 +2606,7 @@ importers:
     dependencies:
       '@grpc/grpc-js':
         specifier: 'catalog:'
-        version: 1.13.4
+        version: 1.14.4
       '@milaboratories/pl-http':
         specifier: workspace:*
         version: link:../pl-http
@@ -2618,7 +2618,7 @@ importers:
         version: link:../ts-helpers
       '@protobuf-ts/grpc-transport':
         specifier: 'catalog:'
-        version: 2.11.1(@grpc/grpc-js@1.13.4)
+        version: 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/runtime':
         specifier: 'catalog:'
         version: 2.11.1
@@ -2789,7 +2789,7 @@ importers:
     dependencies:
       '@grpc/grpc-js':
         specifier: 'catalog:'
-        version: 1.13.4
+        version: 1.14.4
       '@milaboratories/computable':
         specifier: workspace:*
         version: link:../computable
@@ -2810,7 +2810,7 @@ importers:
         version: link:../ts-helpers
       '@protobuf-ts/grpc-transport':
         specifier: 'catalog:'
-        version: 2.11.1(@grpc/grpc-js@1.13.4)
+        version: 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/plugin':
         specifier: 'catalog:'
         version: 2.11.1
@@ -2914,13 +2914,13 @@ importers:
     dependencies:
       '@grpc/grpc-js':
         specifier: 'catalog:'
-        version: 1.13.4
+        version: 1.14.4
       '@milaboratories/ts-helpers':
         specifier: workspace:*
         version: link:../ts-helpers
       '@protobuf-ts/grpc-transport':
         specifier: 'catalog:'
-        version: 2.11.1(@grpc/grpc-js@1.13.4)
+        version: 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/runtime':
         specifier: 'catalog:'
         version: 2.11.1
@@ -5253,12 +5253,12 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@grpc/grpc-js@1.13.4':
-    resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
-  '@grpc/proto-loader@0.7.13':
-    resolution: {integrity: sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==}
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -6015,20 +6015,17 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -6036,8 +6033,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@redocly/ajv@8.11.4':
     resolution: {integrity: sha512-77MhyFgZ1zGMwtCpqsk532SJEc3IJmSOXKTCeWoMTAvPnQOkuOgxEip1n5pG5YX1IzCTJ4kCvPKr8xYyzWFdhg==}
@@ -8729,8 +8726,8 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  protobufjs@7.4.0:
-    resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10794,16 +10791,16 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@grpc/grpc-js@1.13.4':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
-      '@grpc/proto-loader': 0.7.13
+      '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
 
-  '@grpc/proto-loader@0.7.13':
+  '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.4.0
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hono/node-server@1.19.11(hono@4.12.8)':
@@ -11537,9 +11534,9 @@ snapshots:
       '@platforma-open/milaboratories.software-test-utils.sleep': 1.1.3
       '@platforma-open/milaboratories.software-test-utils.small-asset': 1.1.6
 
-  '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
+  '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.14.4)':
     dependencies:
-      '@grpc/grpc-js': 1.13.4
+      '@grpc/grpc-js': 1.14.4
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
 
@@ -11566,24 +11563,21 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@redocly/ajv@8.11.4':
     dependencies:
@@ -14359,18 +14353,17 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  protobufjs@7.4.0:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 24.5.2
       long: 5.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,8 +229,8 @@ catalogs:
       specifier: 0.35.0
       version: 0.35.0
     quickjs-emscripten:
-      specifier: 0.31.0
-      version: 0.31.0
+      specifier: 0.32.0
+      version: 0.32.0
     readline-sync:
       specifier: ^1.4.10
       version: 1.4.10
@@ -2988,7 +2988,7 @@ importers:
         version: 1.27.1(zod@3.25.76)
       quickjs-emscripten:
         specifier: 'catalog:'
-        version: 0.31.0
+        version: 0.32.0
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -3106,7 +3106,7 @@ importers:
         version: 11.2.2
       quickjs-emscripten:
         specifier: 'catalog:'
-        version: 0.31.0
+        version: 0.32.0
       semver:
         specifier: 'catalog:'
         version: 7.7.2
@@ -3877,7 +3877,7 @@ importers:
         version: link:../../sdk/test
       quickjs-emscripten:
         specifier: 'catalog:'
-        version: 0.31.0
+        version: 0.32.0
       undici:
         specifier: 'catalog:'
         version: 7.16.0
@@ -5368,20 +5368,20 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jitl/quickjs-ffi-types@0.31.0':
-    resolution: {integrity: sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw==}
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
 
-  '@jitl/quickjs-wasmfile-debug-asyncify@0.31.0':
-    resolution: {integrity: sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==}
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
 
-  '@jitl/quickjs-wasmfile-debug-sync@0.31.0':
-    resolution: {integrity: sha512-8XvloaaWBONqcHXYs5tWOjdhQVxzULilIfB2hvZfS6S+fI4m2+lFiwQy7xeP8ExHmiZ7D8gZGChNkdLgjGfknw==}
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
 
-  '@jitl/quickjs-wasmfile-release-asyncify@0.31.0':
-    resolution: {integrity: sha512-uz0BbQYTxNsFkvkurd7vk2dOg57ElTBLCuvNtRl4rgrtbC++NIndD5qv2+AXb6yXDD3Uy1O2PCwmoaH0eXgEOg==}
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
 
-  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
-    resolution: {integrity: sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==}
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -8764,11 +8764,11 @@ packages:
   queue-tick@1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
 
-  quickjs-emscripten-core@0.31.0:
-    resolution: {integrity: sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==}
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
 
-  quickjs-emscripten@0.31.0:
-    resolution: {integrity: sha512-K7Yt78aRPLjPcqv3fIuLW1jW3pvwO21B9pmFOolsjM/57ZhdVXBr51GqJpalgBlkPu9foAvhEAuuQPnvIGvLvQ==}
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
     engines: {node: '>=16.0.0'}
 
   range-parser@1.2.1:
@@ -10934,23 +10934,23 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jitl/quickjs-ffi-types@0.31.0': {}
+  '@jitl/quickjs-ffi-types@0.32.0': {}
 
-  '@jitl/quickjs-wasmfile-debug-asyncify@0.31.0':
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  '@jitl/quickjs-wasmfile-debug-sync@0.31.0':
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  '@jitl/quickjs-wasmfile-release-asyncify@0.31.0':
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -14398,17 +14398,17 @@ snapshots:
 
   queue-tick@1.0.1: {}
 
-  quickjs-emscripten-core@0.31.0:
+  quickjs-emscripten-core@0.32.0:
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  quickjs-emscripten@0.31.0:
+  quickjs-emscripten@0.32.0:
     dependencies:
-      '@jitl/quickjs-wasmfile-debug-asyncify': 0.31.0
-      '@jitl/quickjs-wasmfile-debug-sync': 0.31.0
-      '@jitl/quickjs-wasmfile-release-asyncify': 0.31.0
-      '@jitl/quickjs-wasmfile-release-sync': 0.31.0
-      quickjs-emscripten-core: 0.31.0
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   range-parser@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -208,7 +208,7 @@ catalog:
 
   "@modelcontextprotocol/sdk": ^1.27.1
   "undici": ~7.16.0
-  "@grpc/grpc-js": ~1.13.4
+  "@grpc/grpc-js": ~1.14.4
   "@protobuf-ts/grpc-transport": *protobuf-ts
   "@protobuf-ts/runtime": *protobuf-ts
   "@protobuf-ts/runtime-rpc": *protobuf-ts

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -262,7 +262,7 @@ catalog:
   "@milaboratories/pframes-rs-wasip2": 1.1.56
   "@milaboratories/pframes-rs-wasm": 1.1.56
 
-  "quickjs-emscripten": 0.31.0
+  "quickjs-emscripten": 0.32.0
 
   # UI
 


### PR DESCRIPTION
The two Desktop-App-side items from [MILAB-6700](https://app.notion.com/p/3ad3a83ff4af80adbb25dde3c1e8eabb), one commit each. Both come out of the MILAB-6303 slow-network spec ([text#190](https://github.com/milaboratory/text/pull/190), A-0019 / A-0020).

## 1. HTTP/2 connection window (grpc-js 1.14.4)

The spec called this a blocked item needing an upstream grpc-js change plus a `patch-package` shim. **That upstream change has since landed**, so no patch is needed:

- [grpc/grpc-node#2971](https://github.com/grpc/grpc-node/pull/2971) ("Send connection-level WINDOW_UPDATE at session start") shipped in **grpc-js 1.14.0**.
- Since then, `grpc-node.flow_control_window` drives the connection-level window via `session.setLocalWindowSize()`, not just the per-stream initial window. Under 1.13.4 the option was per-stream only, which is why the spec assessed it as insufficient.
- 1.13.5 does not carry the fix, so the pin has to cross to 1.14.x.

Changes: catalog pin `~1.13.4` -> `~1.14.4`, and `grpc-node.flow_control_window: 16 MiB` on the client options in `pl-client`.

## 2. quickjs-emscripten 0.32.0

quickjs (wasm) is the top remaining worker CPU cost (~18% of active CPU under load, ~66% at baseline). 0.32.0 upgrades bellard/quickjs to 2025-09-13, moves to Emscripten 5.0.1, and reworks `newFunction` host binding onto a new `HostRef` abstraction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR increases the gRPC client’s HTTP/2 flow-control window and upgrades the QuickJS WebAssembly runtime.
- Raises `grpc-node.flow_control_window` to 16 MiB for `LLPlClient` gRPC transports and moves `@grpc/grpc-js` to 1.14.4, where the setting also initializes the connection-level window.
- Upgrades `quickjs-emscripten` from 0.31.0 to 0.32.0 for middle-layer rendering, MCP-server sandboxing, and integration-test consumers.
- Adds package changesets for the affected published packages.
- Important touched terms:
  - **HTTP/2 connection window** — connection-wide flow-control allowance shared by streams; changed from Node’s effective 64 KiB default to 16 MiB on `LLPlClient` gRPC channels.
  - **`grpc-node.flow_control_window`** — grpc-js channel option controlling stream and connection flow-control capacity; newly configured to 16 MiB.
  - **`@grpc/grpc-js`** — Node.js gRPC implementation used by Platforma clients; upgraded from 1.13.4 to 1.14.4 so the configured window applies at session start.
  - **QuickJS** — embedded JavaScript engine used for middle-layer rendering and sandbox execution; upgraded through `quickjs-emscripten` 0.32.0.
  - **HostRef** — quickjs-emscripten’s host-reference abstraction for bindings such as `newFunction`; introduced by the dependency upgrade without direct source changes in this PR.
  - **`LLPlClient`** — low-level Platforma backend client that creates gRPC or REST transports; its gRPC initialization now supplies the larger flow-control window.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the dependency resolutions and central gRPC transport configuration aligned with the stated changes.

The larger HTTP/2 window reaches the primary gRPC transport construction path, reconnect and proxy paths preserve the same options, supported runtime requirements remain compatible, and no concrete QuickJS ownership or packaging regression was established.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/ll_client.ts | Adds the 16 MiB grpc-js flow-control option to the central gRPC transport initialization path; no actionable defect was identified. |
| pnpm-workspace.yaml | Updates the central catalog pins for grpc-js and quickjs-emscripten consistently with the intended runtime changes. |
| pnpm-lock.yaml | Resolves all affected workspace importers and transitive snapshots to the new dependency versions without an identified incompatibility. |
| .changeset/grpc-connection-window.md | Records patch releases for the packages affected by the grpc-js transport update. |
| .changeset/quickjs-emscripten-032.md | Records patch releases for the packages affected by the QuickJS runtime upgrade. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant App as Desktop / middle layer
  participant Client as LLPlClient
  participant GRPC as grpc-js 1.14.4
  participant PL as Platforma backend
  App->>Client: Initialize gRPC connection
  Client->>GRPC: "ClientOptions(flow_control_window = 16 MiB)"
  GRPC->>PL: Open HTTP/2 session
  GRPC->>PL: Advertise connection-level window
  PL-->>GRPC: Stream project data
  GRPC-->>Client: Deliver data with larger flow-control allowance
  Client-->>App: Project response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6700: bump quickjs-emscripten to 0..."](https://github.com/milaboratory/platforma/commit/497ad122123b3c2243bbbd71bdee6b7f3b438c3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49998214)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [pl-client](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-client.md)

<!-- /greptile_comment -->