### PR TITLE
MILAB-6703: connect under load (adaptive unary deadline, bounded retry, backoff cap)

### DIFF
--- a/.changeset/adaptive-unary-deadline.md
+++ b/.changeset/adaptive-unary-deadline.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Derive the unary gRPC deadline from the observed round-trip time instead of a fixed 5s, and give login/refresh their own 120s deadline. On a high-latency link the fixed 5s aborted connect and login outright; the derived deadline is floored by the configured value, so fast links are unaffected.

--- a/.changeset/discovery-wall-clock-pacing.md
+++ b/.changeset/discovery-wall-clock-pacing.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-tree": patch
+---
+
+Pace shared-seed root discovery by wall clock rather than by a count of refresh iterations, so share-discovery latency no longer drifts with the refresh cadence.

--- a/.changeset/idempotent-unary-retry.md
+++ b/.changeset/idempotent-unary-retry.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Retry the connect-path ping and `getUserRoot` on transient transport failures (unreachable peer, elapsed deadline), bounded to 4 attempts. A single blip during DNS or load-balancer warm-up previously failed the whole connect. Real server answers such as auth and permission errors are never retried.

--- a/.changeset/idle-tree-sync-backoff.md
+++ b/.changeset/idle-tree-sync-backoff.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-tree": patch
+---
+
+Back off the tree-sync poll interval when a cycle reports no changes, up to a 5s ceiling, instead of re-polling an idle tree at full rate. Any change, or an observer asking for fresh state, resets it immediately.

--- a/.changeset/retry-max-delay-cap.md
+++ b/.changeset/retry-max-delay-cap.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Cap a single transaction-retry backoff delay at 5s (`retryMaxDelay`, overridable via the `retry-max-delay` url param). The exponential sequence previously grew unbounded across all 21 attempts, so a conflicting transaction could sleep ~66s in one step and several minutes in total.

--- a/.changeset/rtt-adaptive-poll-interval.md
+++ b/.changeset/rtt-adaptive-poll-interval.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-tree": patch
+"@milaboratories/pl-client": patch
+---
+
+Scale the tree-sync poll interval to the client's measured RTT instead of polling at a fixed interval regardless of link latency. Also exposes `PlClient.rttEstimateMs`. The configured interval remains the lower bound, so fast links are unaffected.

--- a/.changeset/rtt-adaptive-poll-interval.md
+++ b/.changeset/rtt-adaptive-poll-interval.md
@@ -3,4 +3,4 @@
 "@milaboratories/pl-client": patch
 ---
 
-Scale the tree-sync poll interval to the client's measured RTT instead of polling at a fixed interval regardless of link latency. Also exposes `PlClient.rttEstimateMs`. The configured interval remains the lower bound, so fast links are unaffected.
+Scale the tree-sync poll interval to the client's measured RTT instead of polling at a fixed interval regardless of link latency. Also exposes `PlClient.rttEstimateMs`. The configured interval remains the lower bound, so fast links are unaffected, and the derived floor is capped at 30s.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -145,6 +145,7 @@ export class PlClient {
           maxAttempts: conf.retryMaxAttempts,
           backoffMultiplier: conf.retryExponentialBackoffMultiplier,
           jitter: conf.retryJitter,
+          maxDelay: conf.retryMaxDelay,
         };
         break;
       case "linear":
@@ -154,6 +155,7 @@ export class PlClient {
           maxAttempts: conf.retryMaxAttempts,
           backoffStep: conf.retryLinearBackoffStep,
           jitter: conf.retryJitter,
+          maxDelay: conf.retryMaxDelay,
         };
         break;
       default:

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -187,6 +187,13 @@ export class PlClient {
     };
   }
 
+  /** Smoothed round-trip estimate in ms from ping timings, or undefined before the first
+   * ping. Exposed so latency-sensitive consumers (e.g. the tree-sync poll cadence) can scale
+   * their timing to the link instead of assuming a local server. */
+  public get rttEstimateMs(): number | undefined {
+    return this.ll.rttEstimateMs;
+  }
+
   public async ping(): Promise<MaintenanceAPI_Ping_Response> {
     return await this.ll.ping();
   }

--- a/lib/node/pl-client/src/core/config.test.ts
+++ b/lib/node/pl-client/src/core/config.test.ts
@@ -1,10 +1,16 @@
 import {
+  DEFAULT_REQUEST_TIMEOUT,
   DEFAULT_RETRY_MAX_ATTEMPTS,
   DEFAULT_RETRY_MAX_DELAY,
   DEFAULT_RO_TX_TIMEOUT,
   DEFAULT_RW_TX_TIMEOUT,
   DefaultRetryOptions,
+  MAX_ADAPTIVE_REQUEST_TIMEOUT,
+  RTT_DEADLINE_MULTIPLIER,
+  RTT_SMOOTHING_ALPHA,
+  deriveUnaryDeadline,
   plAddressToConfig,
+  smoothRtt,
 } from "./config";
 import { createRetryState, nextRetryStateOrError } from "@milaboratories/ts-helpers";
 import { test, expect } from "vitest";
@@ -114,6 +120,37 @@ test("retryMaxDelay defaults and is overridable via url", () => {
   expect(plAddressToConfig("http://127.0.0.1:6345/?retry-max-delay=1500").retryMaxDelay).toEqual(
     1500,
   );
+});
+
+test("unary deadline floors at the configured timeout on a fast link", () => {
+  // No sample yet, and small RTTs, must both leave the configured value untouched.
+  expect(deriveUnaryDeadline(DEFAULT_REQUEST_TIMEOUT, undefined)).toEqual(DEFAULT_REQUEST_TIMEOUT);
+  expect(deriveUnaryDeadline(DEFAULT_REQUEST_TIMEOUT, 5)).toEqual(DEFAULT_REQUEST_TIMEOUT);
+  expect(deriveUnaryDeadline(DEFAULT_REQUEST_TIMEOUT, 600)).toEqual(DEFAULT_REQUEST_TIMEOUT);
+});
+
+test("unary deadline scales with RTT and is capped", () => {
+  // The spec's target envelope is 1.4s RTT, where the old fixed 5s aborted connect.
+  expect(deriveUnaryDeadline(DEFAULT_REQUEST_TIMEOUT, 1400)).toEqual(
+    1400 * RTT_DEADLINE_MULTIPLIER,
+  );
+  expect(deriveUnaryDeadline(DEFAULT_REQUEST_TIMEOUT, 1400)).toBeGreaterThan(
+    DEFAULT_REQUEST_TIMEOUT,
+  );
+  // A pathological RTT must not produce an unbounded deadline.
+  expect(deriveUnaryDeadline(DEFAULT_REQUEST_TIMEOUT, 120_000)).toEqual(
+    MAX_ADAPTIVE_REQUEST_TIMEOUT,
+  );
+});
+
+test("rtt smoothing takes the first sample then converges", () => {
+  expect(smoothRtt(undefined, 800)).toEqual(800);
+  // One outlier moves the estimate only by alpha, so the deadline cannot swing on it.
+  expect(smoothRtt(100, 1100)).toBeCloseTo(100 + 1000 * RTT_SMOOTHING_ALPHA, 6);
+
+  let rtt = smoothRtt(undefined, 100);
+  for (let i = 0; i < 50; i++) rtt = smoothRtt(rtt, 1000);
+  expect(rtt).toBeCloseTo(1000, 1);
 });
 
 test("default retry backoff is bounded by maxDelay", () => {

--- a/lib/node/pl-client/src/core/config.test.ts
+++ b/lib/node/pl-client/src/core/config.test.ts
@@ -1,4 +1,12 @@
-import { DEFAULT_RO_TX_TIMEOUT, DEFAULT_RW_TX_TIMEOUT, plAddressToConfig } from "./config";
+import {
+  DEFAULT_RETRY_MAX_ATTEMPTS,
+  DEFAULT_RETRY_MAX_DELAY,
+  DEFAULT_RO_TX_TIMEOUT,
+  DEFAULT_RW_TX_TIMEOUT,
+  DefaultRetryOptions,
+  plAddressToConfig,
+} from "./config";
+import { createRetryState, nextRetryStateOrError } from "@milaboratories/ts-helpers";
 import { test, expect } from "vitest";
 
 test("config form url no auth", () => {
@@ -98,4 +106,28 @@ test("should throw an error for tls URL without an explicit port", () => {
   expect(() => plAddressToConfig("tls://example.com")).toThrow(
     "Port must be specified explicitly for tls: protocol.",
   );
+});
+
+test("retryMaxDelay defaults and is overridable via url", () => {
+  expect(plAddressToConfig("http://127.0.0.1:6345").retryMaxDelay).toEqual(DEFAULT_RETRY_MAX_DELAY);
+  expect(plAddressToConfig("127.0.0.1:6345").retryMaxDelay).toEqual(DEFAULT_RETRY_MAX_DELAY);
+  expect(plAddressToConfig("http://127.0.0.1:6345/?retry-max-delay=1500").retryMaxDelay).toEqual(
+    1500,
+  );
+});
+
+test("default retry backoff is bounded by maxDelay", () => {
+  // Without a cap the exponential sequence keeps growing for all 21 attempts, so a
+  // single sleep reaches ~66s and the total exceeds 3 minutes. Walk the real state
+  // machine and assert both stay bounded.
+  let state = createRetryState(DefaultRetryOptions);
+  let maxSingleDelay = state.nextDelay;
+  for (let i = 0; i < DEFAULT_RETRY_MAX_ATTEMPTS - 1; i++) {
+    state = nextRetryStateOrError(state);
+    maxSingleDelay = Math.max(maxSingleDelay, state.nextDelay);
+  }
+
+  expect(maxSingleDelay).toBeLessThanOrEqual(DEFAULT_RETRY_MAX_DELAY);
+  // 21 attempts capped at 5s each cannot exceed ~105s even with jitter.
+  expect(state.totalDelay).toBeLessThan(DEFAULT_RETRY_MAX_ATTEMPTS * DEFAULT_RETRY_MAX_DELAY);
 });

--- a/lib/node/pl-client/src/core/config.ts
+++ b/lib/node/pl-client/src/core/config.ts
@@ -113,6 +113,40 @@ export const DEFAULT_RETRY_LINEAR_BACKOFF_STEP = 50; // + 50 ms
 export const DEFAULT_RETRY_JITTER = 0.3; // 30%
 export const DEFAULT_RETRY_MAX_DELAY = 5_000; // 5 seconds
 
+/** Multiplier applied to the observed RTT when deriving the unary deadline. A unary call
+ * costs at least one round trip, plus connect/DNS/LB and server work on top, so the
+ * deadline needs sizeable headroom over the bare RTT. */
+export const RTT_DEADLINE_MULTIPLIER = 8;
+
+/** Ceiling for the RTT-derived unary deadline. Beyond this a call is stuck rather than
+ * slow, and waiting longer only delays the retry. */
+export const MAX_ADAPTIVE_REQUEST_TIMEOUT = 60_000;
+
+/** Weight of the newest RTT sample in the smoothed estimate. Low enough that one unlucky
+ * sample cannot swing the deadline, high enough to follow a real change. */
+export const RTT_SMOOTHING_ALPHA = 0.3;
+
+/** Login runs password hashing (and possibly an external IdP round trip) server side, so
+ * it is legitimately slow and gets its own deadline instead of the unary default. */
+export const DEFAULT_LOGIN_TIMEOUT = 120_000;
+
+/** Unary deadline for a given RTT estimate: floored by the configured timeout so a fast
+ * link behaves exactly as before, capped by {@link MAX_ADAPTIVE_REQUEST_TIMEOUT}.
+ * An undefined `rttMs` (no ping yet) yields the configured value unchanged. */
+export function deriveUnaryDeadline(configuredMs: number, rttMs: number | undefined): number {
+  if (rttMs === undefined) return configuredMs;
+  return Math.min(
+    MAX_ADAPTIVE_REQUEST_TIMEOUT,
+    Math.max(configuredMs, Math.ceil(rttMs * RTT_DEADLINE_MULTIPLIER)),
+  );
+}
+
+/** Folds a new round-trip sample into an exponentially smoothed estimate. */
+export function smoothRtt(previousMs: number | undefined, sampleMs: number): number {
+  if (previousMs === undefined) return sampleMs;
+  return previousMs * (1 - RTT_SMOOTHING_ALPHA) + sampleMs * RTT_SMOOTHING_ALPHA;
+}
+
 export const DefaultRetryOptions: ExponentialBackoffRetryOptions = {
   type: "exponentialBackoff",
   maxAttempts: DEFAULT_RETRY_MAX_ATTEMPTS,

--- a/lib/node/pl-client/src/core/config.ts
+++ b/lib/node/pl-client/src/core/config.ts
@@ -90,6 +90,11 @@ export interface PlClientConfig {
 
   /** Value from 0 to 1, determine level of randomness to introduce to the backoff delays sequence. (0 meaning no randomness) */
   retryJitter: number;
+
+  /** Upper bound for a single backoff delay, in ms. Without it the exponential
+   * sequence keeps growing across all attempts: at the defaults the last sleep
+   * alone reaches ~66s (~150s once jitter compounds). */
+  retryMaxDelay: number;
 }
 
 export const DEFAULT_REQUEST_TIMEOUT = 5_000;
@@ -106,6 +111,7 @@ export const DEFAULT_RETRY_INITIAL_DELAY = 20; // 20 ms * <jitter> of sleep afte
 export const DEFAULT_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER = 1.5; // + 50% on each round
 export const DEFAULT_RETRY_LINEAR_BACKOFF_STEP = 50; // + 50 ms
 export const DEFAULT_RETRY_JITTER = 0.3; // 30%
+export const DEFAULT_RETRY_MAX_DELAY = 5_000; // 5 seconds
 
 export const DefaultRetryOptions: ExponentialBackoffRetryOptions = {
   type: "exponentialBackoff",
@@ -113,6 +119,7 @@ export const DefaultRetryOptions: ExponentialBackoffRetryOptions = {
   initialDelay: DEFAULT_RETRY_INITIAL_DELAY,
   backoffMultiplier: DEFAULT_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER,
   jitter: DEFAULT_RETRY_JITTER,
+  maxDelay: DEFAULT_RETRY_MAX_DELAY,
 };
 
 type PlConfigOverrides = Partial<
@@ -161,6 +168,7 @@ export function plAddressToConfig(
       retryExponentialBackoffMultiplier: DEFAULT_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER,
       retryLinearBackoffStep: DEFAULT_RETRY_LINEAR_BACKOFF_STEP,
       retryJitter: DEFAULT_RETRY_JITTER,
+      retryMaxDelay: DEFAULT_RETRY_MAX_DELAY,
 
       ...overrides,
     };
@@ -234,6 +242,7 @@ export function plAddressToConfig(
       parseInt(url.searchParams.get("retry-linear-backoff-step")) ??
       DEFAULT_RETRY_LINEAR_BACKOFF_STEP,
     retryJitter: parseInt(url.searchParams.get("retry-backoff-jitter")) ?? DEFAULT_RETRY_JITTER,
+    retryMaxDelay: parseInt(url.searchParams.get("retry-max-delay")) ?? DEFAULT_RETRY_MAX_DELAY,
 
     ...overrides,
   };

--- a/lib/node/pl-client/src/core/error.test.ts
+++ b/lib/node/pl-client/src/core/error.test.ts
@@ -1,6 +1,28 @@
 import * as tp from "node:timers/promises";
-import { isTimeoutOrCancelError } from "./errors";
+import { isTimeoutOrCancelError, isTransientCallFailure } from "./errors";
 import { test, expect } from "vitest";
+
+/** Shapes the predicates match on: an RpcError-like from grpc, a RESTError-like from REST. */
+function rpcError(code: string) {
+  return { name: "RpcError", code };
+}
+
+test("only transport failures count as transient", () => {
+  // Worth retrying: the call never reached a verdict.
+  expect(isTransientCallFailure(rpcError("UNAVAILABLE"))).toBe(true);
+  expect(isTransientCallFailure(rpcError("DEADLINE_EXCEEDED"))).toBe(true);
+
+  // Real answers from the server. Retrying these would hide a genuine failure and,
+  // for auth, silently repeat a rejected credential.
+  expect(isTransientCallFailure(rpcError("UNAUTHENTICATED"))).toBe(false);
+  expect(isTransientCallFailure(rpcError("PERMISSION_DENIED"))).toBe(false);
+  expect(isTransientCallFailure(rpcError("NOT_FOUND"))).toBe(false);
+  expect(isTransientCallFailure(rpcError("UNIMPLEMENTED"))).toBe(false);
+
+  expect(isTransientCallFailure(undefined)).toBe(false);
+  expect(isTransientCallFailure(null)).toBe(false);
+  expect(isTransientCallFailure(new Error("plain"))).toBe(false);
+});
 
 test("timeout of sleep error type detection", async () => {
   let noError = false;

--- a/lib/node/pl-client/src/core/errors.ts
+++ b/lib/node/pl-client/src/core/errors.ts
@@ -82,6 +82,13 @@ export function isTimeoutOrCancelError(err: unknown, nested: boolean = false): b
   return false;
 }
 
+/** Failures worth another attempt on an idempotent call: the peer was unreachable, or the
+ * deadline elapsed. Everything else (auth, permission, not-found, unimplemented) is a real
+ * answer from the server, and retrying it only wastes the caller's time. */
+export function isTransientCallFailure(err: unknown): boolean {
+  return isConnectionProblem(err) || isTimeoutError(err);
+}
+
 export function isUnimplementedError(err: unknown, nested: boolean = false): boolean {
   if (err === undefined || err === null) return false;
 

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -13,7 +13,14 @@ import type {
   PlConnectionStatus,
   PlConnectionStatusListener,
 } from "./config";
-import { plAddressToConfig, type wireProtocol, SUPPORTED_WIRE_PROTOCOLS } from "./config";
+import {
+  plAddressToConfig,
+  type wireProtocol,
+  SUPPORTED_WIRE_PROTOCOLS,
+  DEFAULT_LOGIN_TIMEOUT,
+  deriveUnaryDeadline,
+  smoothRtt,
+} from "./config";
 import type { GrpcOptions } from "@protobuf-ts/grpc-transport";
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
 import { LLPlTransaction } from "./ll_transaction";
@@ -127,6 +134,15 @@ export class LLPlClient implements WireClientProviderFactory {
 
   private _wireProto: wireProtocol = "grpc";
   private _wireConn!: WireConnection;
+
+  /** The live GrpcOptions object handed to GrpcTransport. The transport keeps it by
+   * reference and re-reads it on every call, so mutating `timeout` here retunes
+   * subsequent deadlines without tearing down the connection. */
+  private _grpcOptions?: GrpcOptions;
+
+  /** Smoothed round-trip estimate in ms, from ping timings. Undefined until the first
+   * successful ping, in which case the configured deadline is used as-is. */
+  private _rttMs?: number;
 
   private readonly _restInterceptors: Dispatcher.DispatcherComposeInterceptor[];
   private readonly _restMiddlewares: Middleware[];
@@ -280,7 +296,7 @@ export class LLPlClient implements WireClientProviderFactory {
     //
     const grpcOptions: GrpcOptions = {
       host: this.conf.hostAndPort,
-      timeout: this.conf.defaultRequestTimeout,
+      timeout: this.unaryDeadline(),
       channelCredentials: this.conf.ssl
         ? ChannelCredentials.createSsl()
         : ChannelCredentials.createInsecure(),
@@ -305,7 +321,36 @@ export class LLPlClient implements WireClientProviderFactory {
       delete process.env.grpc_proxy;
     }
 
+    this._grpcOptions = grpcOptions;
     this._replaceWireConnection({ type: "grpc", Transport: new GrpcTransport(grpcOptions) });
+  }
+
+  /** Unary deadline derived from the observed RTT, floored by the configured value so
+   * a fast link behaves exactly as before, and capped by
+   * {@link MAX_ADAPTIVE_REQUEST_TIMEOUT}. */
+  private unaryDeadline(): number {
+    return deriveUnaryDeadline(this.conf.defaultRequestTimeout, this._rttMs);
+  }
+
+  /** Folds a fresh round-trip sample into the estimate and retunes the live unary
+   * deadline. Called after every successful ping. */
+  private recordRtt(sampleMs: number): void {
+    this._rttMs = smoothRtt(this._rttMs, sampleMs);
+
+    if (this._grpcOptions) {
+      const next = this.unaryDeadline();
+      if (next !== this._grpcOptions.timeout) {
+        this.ops.logger?.info(
+          `Unary deadline retuned to ${next}ms (rtt estimate ${Math.round(this._rttMs)}ms)`,
+        );
+        this._grpcOptions.timeout = next;
+      }
+    }
+  }
+
+  /** Smoothed round-trip estimate in ms, or undefined before the first ping. */
+  public get rttEstimateMs(): number | undefined {
+    return this._rttMs;
   }
 
   private _replaceWireConnection(newConn: WireConnection): void {
@@ -558,7 +603,7 @@ export class LLPlClient implements WireClientProviderFactory {
             expiration: { seconds: ttlSeconds, nanos: 0 },
             requestedRole: role,
           },
-          { meta },
+          { meta, timeout: DEFAULT_LOGIN_TIMEOUT },
         ).response
       ).token;
     } else {
@@ -584,14 +629,17 @@ export class LLPlClient implements WireClientProviderFactory {
 
     if (cl instanceof GrpcPlApiClient) {
       return (
-        await cl.login({
-          credentials: {
-            oneofKind: "basic",
-            basic: { login: user, password },
+        await cl.login(
+          {
+            credentials: {
+              oneofKind: "basic",
+              basic: { login: user, password },
+            },
+            expiration: { seconds: ttl, nanos: 0 },
+            requestedRole: role,
           },
-          expiration: { seconds: ttl, nanos: 0 },
-          requestedRole: role,
-        }).response
+          { timeout: DEFAULT_LOGIN_TIMEOUT },
+        ).response
       ).token;
     } else {
       const resp = cl.POST("/v1/auth/login", {
@@ -620,14 +668,17 @@ export class LLPlClient implements WireClientProviderFactory {
 
     if (cl instanceof GrpcPlApiClient) {
       return (
-        await cl.login({
-          credentials: {
-            oneofKind: "token",
-            token: { token: bytes },
+        await cl.login(
+          {
+            credentials: {
+              oneofKind: "token",
+              token: { token: bytes },
+            },
+            expiration: { seconds: ttl, nanos: 0 },
+            requestedRole: role,
           },
-          expiration: { seconds: ttl, nanos: 0 },
-          requestedRole: role,
-        }).response
+          { timeout: DEFAULT_LOGIN_TIMEOUT },
+        ).response
       ).token;
     } else {
       const resp = cl.POST("/v1/auth/login", {
@@ -649,12 +700,15 @@ export class LLPlClient implements WireClientProviderFactory {
     const cl = this.clientProvider.get();
     if (cl instanceof GrpcPlApiClient) {
       return (
-        await cl.login({
-          credentials: {
-            oneofKind: "sso",
-            sso: { tokenResponse },
+        await cl.login(
+          {
+            credentials: {
+              oneofKind: "sso",
+              sso: { tokenResponse },
+            },
           },
-        }).response
+          { timeout: DEFAULT_LOGIN_TIMEOUT },
+        ).response
       ).token;
     } else {
       const resp = cl.POST("/v1/auth/login", {
@@ -707,10 +761,13 @@ export class LLPlClient implements WireClientProviderFactory {
 
     if (cl instanceof GrpcPlApiClient) {
       return (
-        await cl.refreshToken({
-          token: currentToken,
-          expiration: { seconds: ttl, nanos: 0 },
-        }).response
+        await cl.refreshToken(
+          {
+            token: currentToken,
+            expiration: { seconds: ttl, nanos: 0 },
+          },
+          { timeout: DEFAULT_LOGIN_TIMEOUT },
+        ).response
       ).token;
     } else {
       const resp = cl.POST("/v1/auth/refresh", {
@@ -723,6 +780,8 @@ export class LLPlClient implements WireClientProviderFactory {
   public async ping(): Promise<grpcTypes.MaintenanceAPI_Ping_Response> {
     const cl = this.clientProvider.get();
     let resp: grpcTypes.MaintenanceAPI_Ping_Response;
+    // Ping is the cheapest call we make, so its duration is our best RTT proxy.
+    const startedAt = performance.now();
     if (cl instanceof GrpcPlApiClient) {
       resp = (await cl.ping({})).response;
     } else {
@@ -737,6 +796,7 @@ export class LLPlClient implements WireClientProviderFactory {
         capabilities: (pingData as any).capabilities ?? [],
       };
     }
+    this.recordRtt(performance.now() - startedAt);
     this._serverInfo = resp;
     return resp;
   }

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -49,13 +49,24 @@ import {
   TxAPI_ServerMessage,
 } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 import type { MiLogger } from "@milaboratories/ts-helpers";
-import { isAbortedError, isUnauthenticated } from "./errors";
+import { isAbortedError, isTransientCallFailure, isUnauthenticated } from "./errors";
 import { Timestamp } from "../proto-grpc/google/protobuf/timestamp";
 
 export interface PlCallOps {
   timeout?: number;
   abortSignal?: AbortSignal;
 }
+
+/** Bounded retry for idempotent unary calls. Deliberately short: these calls sit on the
+ * connect path and gate the UI, so a few quick attempts beat a long grind. */
+const IDEMPOTENT_RETRY_OPTIONS: RetryOptions = {
+  type: "exponentialBackoff",
+  maxAttempts: 4,
+  initialDelay: 200,
+  backoffMultiplier: 2,
+  jitter: 0.3,
+  maxDelay: 2_000,
+};
 
 // Parses leading "<major>.<minor>.<patch>" from a version string like
 // "3.1.1" or "3.1.1-rc1" and returns true if the parsed version is >= target.
@@ -176,7 +187,10 @@ export class LLPlClient implements WireClientProviderFactory {
     // Guarantee a ping happened so capability-gated paths (login, refresh) can branch synchronously.
     // In the autodetect path the loop's last successful ping already populated _serverInfo via the
     // side-effect in ping(); this fallback covers the path where autodetect is disabled.
-    if (!pl._serverInfo) await pl.ping();
+    // Retried, not bare: this ping is the first contact with the server, so DNS and LB
+    // warm-up land here. A single transient failure must not fail the whole connect.
+    // (Not inside ping() itself: the autodetect path already wraps it in its own retry.)
+    if (!pl._serverInfo) await pl.withIdempotentRetry("ping", () => pl.ping());
 
     // Install the process-global signature-strictness flag based on backend version.
     setResourceSignaturesRequired(pl.supportsResourceSignatures);
@@ -351,6 +365,16 @@ export class LLPlClient implements WireClientProviderFactory {
   /** Smoothed round-trip estimate in ms, or undefined before the first ping. */
   public get rttEstimateMs(): number | undefined {
     return this._rttMs;
+  }
+
+  /** Runs an idempotent unary call with a bounded retry on transient transport failures.
+   * Safe only for calls with no side effects, since a retry may duplicate the request. */
+  private async withIdempotentRetry<T>(name: string, cb: () => Promise<T>): Promise<T> {
+    return await retry(cb, IDEMPOTENT_RETRY_OPTIONS, (e: unknown) => {
+      if (!isTransientCallFailure(e)) return false;
+      this.ops.logger?.info(`${name}: transient failure, retrying. err=${String(e)}`);
+      return true;
+    });
   }
 
   private _replaceWireConnection(newConn: WireConnection): void {
@@ -954,6 +978,14 @@ export class LLPlClient implements WireClientProviderFactory {
   }
 
   public async getUserRoot(
+    opts: { login?: string; createIfNotExists?: boolean } = {},
+  ): Promise<grpcTypes.AuthAPI_GetUserRoot_Response> {
+    // Retryable even with createIfNotExists: the call is get-or-create keyed on login, so a
+    // second attempt returns the existing root rather than making another one.
+    return await this.withIdempotentRetry("getUserRoot", () => this.getUserRootOnce(opts));
+  }
+
+  private async getUserRootOnce(
     opts: { login?: string; createIfNotExists?: boolean } = {},
   ): Promise<grpcTypes.AuthAPI_GetUserRoot_Response> {
     const cl = this.clientProvider.get();

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -5,16 +5,64 @@ import { derivePollingInterval } from "./synchronized_tree";
 const FAST = 200;
 
 test("no rtt sample yet leaves the configured interval alone", () => {
-  expect(derivePollingInterval({ configuredMs: FAST, rttMs: undefined })).toEqual(FAST);
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: undefined, changed: true }),
+  ).toEqual(FAST);
 });
 
 test("a fast link keeps the configured interval", () => {
   // 10ms RTT would imply a 20ms floor, well under the configured value.
-  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 10 })).toEqual(FAST);
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: 10, changed: true }),
+  ).toEqual(FAST);
 });
 
 test("a slow link spaces polls by rtt", () => {
   // The spec's target envelope: 1.4s RTT against a 200ms fixed interval, which is the
   // regime where unconditional polling outran what the link could deliver.
-  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 1400 })).toEqual(2800);
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: 1400, changed: true }),
+  ).toEqual(2800);
+});
+
+test("idle cycles back off, and a change snaps straight back", () => {
+  const step = (currentMs: number, changed: boolean) =>
+    derivePollingInterval({ configuredMs: FAST, currentMs, rttMs: 10, changed });
+
+  // Nothing changed: the interval walks out, strictly increasing each time.
+  const first = step(FAST, false);
+  const second = step(first, false);
+  const third = step(second, false);
+  expect(first).toBeGreaterThan(FAST);
+  expect(second).toBeGreaterThan(first);
+  expect(third).toBeGreaterThan(second);
+
+  // One changed cycle returns to the floor immediately, no gradual recovery.
+  expect(step(third, true)).toEqual(FAST);
+});
+
+test("idle backoff is bounded", () => {
+  let interval = FAST;
+  for (let i = 0; i < 100; i++) {
+    interval = derivePollingInterval({
+      configuredMs: FAST,
+      currentMs: interval,
+      rttMs: 10,
+      changed: false,
+    });
+  }
+  // Must converge on the ceiling rather than growing without limit.
+  expect(interval).toEqual(5_000);
+});
+
+test("the rtt floor outranks the ceiling on a very slow link", () => {
+  // 4s RTT implies an 8s floor, past the 5s ceiling. Clamping to 5s would poll faster than
+  // the link can answer, so the floor has to win.
+  const interval = derivePollingInterval({
+    configuredMs: FAST,
+    currentMs: FAST,
+    rttMs: 4000,
+    changed: false,
+  });
+  expect(interval).toEqual(8_000);
 });

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -55,6 +55,15 @@ test("idle backoff is bounded", () => {
   expect(interval).toEqual(5_000);
 });
 
+test("resetting backoff keeps the rtt floor", () => {
+  // What an observer nudge does: reset to the floor, from a fully backed-off interval.
+  // The floor must stay RTT-derived, not drop to the raw configured value, or a nudge on a
+  // slow link would poll faster than the link can answer.
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: 5_000, rttMs: 1400, changed: true }),
+  ).toEqual(2800);
+});
+
 test("the rtt floor outranks the ceiling on a very slow link", () => {
   // 4s RTT implies an 8s floor, past the 5s ceiling. Clamping to 5s would poll faster than
   // the link can answer, so the floor has to win.

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "vitest";
+import { derivePollingInterval } from "./synchronized_tree";
+
+/** The project-list / sharing singleton trees run at 200ms; per-project trees at 1000ms. */
+const FAST = 200;
+
+test("no rtt sample yet leaves the configured interval alone", () => {
+  expect(derivePollingInterval({ configuredMs: FAST, rttMs: undefined })).toEqual(FAST);
+});
+
+test("a fast link keeps the configured interval", () => {
+  // 10ms RTT would imply a 20ms floor, well under the configured value.
+  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 10 })).toEqual(FAST);
+});
+
+test("a slow link spaces polls by rtt", () => {
+  // The spec's target envelope: 1.4s RTT against a 200ms fixed interval, which is the
+  // regime where unconditional polling outran what the link could deliver.
+  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 1400 })).toEqual(2800);
+});

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -64,6 +64,19 @@ test("resetting backoff keeps the rtt floor", () => {
   ).toEqual(2800);
 });
 
+test("the rtt floor is itself bounded", () => {
+  // A ping sampled during connect can legitimately take tens of seconds, and the estimate is
+  // never re-sampled. Unbounded, a 40s sample would pin the interval at 80s for the session.
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: 40_000, changed: true }),
+  ).toEqual(30_000);
+
+  // The bound holds against the idle backoff too, which compounds on the previous interval.
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: 30_000, rttMs: 40_000, changed: false }),
+  ).toEqual(30_000);
+});
+
 test("the rtt floor outranks the ceiling on a very slow link", () => {
   // 4s RTT implies an 8s floor, past the 5s ceiling. Clamping to 5s would poll faster than
   // the link can answer, so the floor has to win.

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -25,6 +25,15 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
  * preventing tight polling loops during rapid state transitions. */
 const MIN_POLLING_INTERVAL_MS = 100;
 
+/** Ceiling for the adaptive poll interval. Caps how stale an idle tree can get before the
+ * next look, and bounds how far the idle backoff can push the interval out. */
+const MAX_POLLING_INTERVAL_MS = 5_000;
+
+/** Applied to the interval after a cycle that changed nothing. An idle tree walks its
+ * interval out towards {@link MAX_POLLING_INTERVAL_MS} instead of re-polling at full rate;
+ * the first cycle that changes anything resets it. */
+const IDLE_BACKOFF_MULTIPLIER = 1.5;
+
 /** The client's measured RTT becomes an interval floor, scaled by this. Every refresh costs
  * at least one round trip, so polling faster than a small multiple of the RTT only queues
  * round-trips the link cannot service. This is what replaces the fixed interval on a
@@ -86,29 +95,46 @@ function normalizeSeeds(seeds: SignedResourceId | TreeSeed | TreeSeed[]): TreeSe
  *
  * Discovery (a full ListUserResources stream) is far heavier than an ordinary incremental
  * refresh, so it must NOT run on every refresh tick. This is a wall-clock interval rather
- * than a count of iterations, so it pins the latency of noticing a new/removed share
- * regardless of the refresh cadence. Counting iterations ties the two together: anything that
- * slows the refresh loop (a high-latency link, or the adaptive cadence that follows) silently
- * drags share-discovery latency out with it. 3s keeps the previous effective behaviour, where
- * 15 iterations at the 200ms default worked out to roughly the same figure.
+ * than a count of iterations: the refresh cadence is adaptive (it stretches towards
+ * {@link MAX_POLLING_INTERVAL_MS} on an idle tree and scales with RTT on a slow link),
+ * so a fixed iteration count would let discovery latency drift out with it. Keeping it in
+ * milliseconds pins the latency of noticing a new/removed share regardless of cadence, which
+ * is what a human-driven share flow cares about.
  *
  * Only trees with shared-type seeds gate on this; {@link discover} is a no-op for single-root
  * and explicit-seed trees (empty `sharedSeeds`), so the value never affects them. */
 const DISCOVERY_INTERVAL_MS = 3_000;
 
-/** The poll-cadence policy, as a pure function.
+/** Counters that mean "this cycle brought something new". Deliberately not the full change
+ * breakdown: those fields are sub-counts of `resourcesChanged` and would double-count.
+ * `resourcesUnchanged` is excluded by design, since a cycle that only re-fetched unchanged
+ * state is exactly the idle case the backoff exists for. */
+function countedChanges(stat: TreeLoadingStat): number {
+  return stat.resourcesNew + stat.resourcesChanged + stat.resourcesMarkedFinal;
+}
+
+/** The poll-cadence policy, as a pure function of the last cycle's outcome.
  *
  * `configuredMs` is the tree's static `pollingInterval` and acts as the lower bound, so no
- * link is ever polled faster than configured. `rttMs` raises that bound on a slow link. */
+ * link can be polled faster than configured. `rttMs` raises that bound on a slow link.
+ * `currentMs` is the interval in force for the cycle that just finished, which is what the
+ * idle backoff compounds on. */
 export function derivePollingInterval(opts: {
   configuredMs: number;
+  currentMs: number;
   rttMs: number | undefined;
+  changed: boolean;
 }): number {
-  const { configuredMs, rttMs } = opts;
+  const { configuredMs, currentMs, rttMs, changed } = opts;
 
-  return rttMs === undefined
-    ? configuredMs
-    : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+  const floor =
+    rttMs === undefined ? configuredMs : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+
+  const next = changed ? floor : Math.max(floor, currentMs * IDLE_BACKOFF_MULTIPLIER);
+
+  // The ceiling never cuts below the floor: a link slower than MAX_POLLING_INTERVAL_MS still
+  // gets its RTT-derived spacing rather than being forced to re-poll early.
+  return Math.max(floor, Math.min(MAX_POLLING_INTERVAL_MS, next));
 }
 
 type ScheduledRefresh = {
@@ -228,11 +254,19 @@ export class SynchronizedTreeState {
    * and is re-derived after every cycle by {@link updatePollingInterval}. */
   private effectivePollingInterval: number;
 
-  /** Re-derives {@link effectivePollingInterval} from the link's current RTT. */
-  private updatePollingInterval(): void {
+  /** Re-derives {@link effectivePollingInterval} after a cycle.
+   *
+   * Two independent effects. The floor scales with the client's measured RTT, so a
+   * high-latency link stops queueing round-trips it cannot service. On top of that, a cycle
+   * that changed nothing multiplies the interval out towards
+   * {@link MAX_POLLING_INTERVAL_MS}, while any change snaps it straight back to the floor so
+   * an active tree stays responsive. */
+  private updatePollingInterval(changed: boolean): void {
     this.effectivePollingInterval = derivePollingInterval({
       configuredMs: this.pollingInterval,
+      currentMs: this.effectivePollingInterval,
       rttMs: this.pl.rttEstimateMs,
+      changed,
     });
   }
 
@@ -241,6 +275,9 @@ export class SynchronizedTreeState {
     if (this.terminated) reject(new Error("tree synchronization is terminated"));
     else {
       this.scheduledOnNextState.push({ resolve, reject });
+      // Someone is waiting on fresh state, so this tree is not idle after all: drop any
+      // accumulated backoff, otherwise the cycles right after a nudge stay slow.
+      this.effectivePollingInterval = this.pollingInterval;
       if (this.currentLoopDelayInterrupt) {
         this.currentLoopDelayInterrupt.abort();
         this.currentLoopDelayInterrupt = undefined;
@@ -345,8 +382,9 @@ export class SynchronizedTreeState {
   private terminated = false;
 
   private async mainLoop() {
-    // will hold request stats
-    let stat = this.logStat ? initialTreeLoadingStat() : undefined;
+    // Always collected, even when not logging: the change counters drive the idle backoff
+    // below. Counter bumps are cheap next to the round trip they describe.
+    let stat = initialTreeLoadingStat();
 
     let lastUpdate = Date.now();
 
@@ -376,13 +414,17 @@ export class SynchronizedTreeState {
           lastDiscovery = Date.now();
         }
 
+        // Change counters before the refresh, so the delta tells us whether this single cycle
+        // brought anything new. Works in both stat modes: "per-request" resets to 0 above.
+        const changesBefore = countedChanges(stat);
+
         // actual tree synchronization
         await this.refresh(stat);
 
-        this.updatePollingInterval();
+        this.updatePollingInterval(countedChanges(stat) > changesBefore);
 
         // logging stats if we were asked to
-        if (stat && this.logger)
+        if (this.logStat && this.logger)
           this.logger.info(
             `Tree stat (success, after ${Date.now() - lastUpdate}ms): ${JSON.stringify(stat)}`,
           );
@@ -392,7 +434,7 @@ export class SynchronizedTreeState {
         if (toNotify !== undefined) for (const n of toNotify) n.resolve();
       } catch (e: any) {
         // logging stats if we were asked to (even if error occured)
-        if (stat && this.logger)
+        if (this.logStat && this.logger)
           this.logger.info(
             `Tree stat (error, after ${Date.now() - lastUpdate}ms): ${JSON.stringify(stat)}`,
           );

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -276,8 +276,13 @@ export class SynchronizedTreeState {
     else {
       this.scheduledOnNextState.push({ resolve, reject });
       // Someone is waiting on fresh state, so this tree is not idle after all: drop any
-      // accumulated backoff, otherwise the cycles right after a nudge stay slow.
-      this.effectivePollingInterval = this.pollingInterval;
+      // accumulated backoff, otherwise the cycles right after a nudge stay slow. Routed
+      // through the policy rather than assigning the configured value directly, so the RTT
+      // floor survives the reset. Assigning it raw would poll a high-latency link faster than
+      // it can answer, and the interval would stay there until the next cycle that completes:
+      // the error path never reaches updatePollingInterval, so a failing nudged refresh would
+      // keep retrying at the un-floored rate.
+      this.updatePollingInterval(true);
       if (this.currentLoopDelayInterrupt) {
         this.currentLoopDelayInterrupt.abort();
         this.currentLoopDelayInterrupt = undefined;

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -40,6 +40,12 @@ const IDLE_BACKOFF_MULTIPLIER = 1.5;
  * high-latency link; on a fast link the configured `pollingInterval` still dominates. */
 const RTT_POLL_FACTOR = 2;
 
+/** Ceiling for the RTT-derived floor. The estimate is sampled at connect time and never
+ * re-sampled, so without a bound one slow ping pins the cadence high for the whole session.
+ * Mirrors `MAX_ADAPTIVE_REQUEST_TIMEOUT` on the deadline side: past this the link is stuck
+ * rather than slow, and spacing polls further only delays noticing it recovered. */
+const MAX_RTT_POLL_INTERVAL_MS = 30_000;
+
 type StatLoggingMode = "cumulative" | "per-request";
 
 export type SynchronizedTreeOps = {
@@ -127,8 +133,15 @@ export function derivePollingInterval(opts: {
 }): number {
   const { configuredMs, currentMs, rttMs, changed } = opts;
 
+  // The cap applies to the RTT-derived part only, so `configuredMs` stays an absolute lower
+  // bound even if it is ever set above the cap.
   const floor =
-    rttMs === undefined ? configuredMs : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+    rttMs === undefined
+      ? configuredMs
+      : Math.max(
+          configuredMs,
+          Math.min(MAX_RTT_POLL_INTERVAL_MS, Math.ceil(rttMs * RTT_POLL_FACTOR)),
+        );
 
   const next = changed ? floor : Math.max(floor, currentMs * IDLE_BACKOFF_MULTIPLIER);
 

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -25,6 +25,12 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
  * preventing tight polling loops during rapid state transitions. */
 const MIN_POLLING_INTERVAL_MS = 100;
 
+/** The client's measured RTT becomes an interval floor, scaled by this. Every refresh costs
+ * at least one round trip, so polling faster than a small multiple of the RTT only queues
+ * round-trips the link cannot service. This is what replaces the fixed interval on a
+ * high-latency link; on a fast link the configured `pollingInterval` still dominates. */
+const RTT_POLL_FACTOR = 2;
+
 type StatLoggingMode = "cumulative" | "per-request";
 
 export type SynchronizedTreeOps = {
@@ -90,6 +96,21 @@ function normalizeSeeds(seeds: SignedResourceId | TreeSeed | TreeSeed[]): TreeSe
  * and explicit-seed trees (empty `sharedSeeds`), so the value never affects them. */
 const DISCOVERY_INTERVAL_MS = 3_000;
 
+/** The poll-cadence policy, as a pure function.
+ *
+ * `configuredMs` is the tree's static `pollingInterval` and acts as the lower bound, so no
+ * link is ever polled faster than configured. `rttMs` raises that bound on a slow link. */
+export function derivePollingInterval(opts: {
+  configuredMs: number;
+  rttMs: number | undefined;
+}): number {
+  const { configuredMs, rttMs } = opts;
+
+  return rttMs === undefined
+    ? configuredMs
+    : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+}
+
 type ScheduledRefresh = {
   resolve: () => void;
   reject: (err: any) => void;
@@ -135,6 +156,7 @@ export class SynchronizedTreeState {
     this.traverseStopRules = traverseStopRules;
     this.traversalMode = traversalMode ?? "auto";
     this.pollingInterval = pollingInterval;
+    this.effectivePollingInterval = pollingInterval;
     this.finalPredicate = finalPredicateOverride ?? pl.finalPredicate;
     this.logStat = logStat;
 
@@ -201,6 +223,18 @@ export class SynchronizedTreeState {
 
   private currentLoopDelayInterrupt: AbortController | undefined = undefined;
   private scheduledOnNextState: ScheduledRefresh[] = [];
+
+  /** Interval actually used for the current wait. Starts at the configured `pollingInterval`
+   * and is re-derived after every cycle by {@link updatePollingInterval}. */
+  private effectivePollingInterval: number;
+
+  /** Re-derives {@link effectivePollingInterval} from the link's current RTT. */
+  private updatePollingInterval(): void {
+    this.effectivePollingInterval = derivePollingInterval({
+      configuredMs: this.pollingInterval,
+      rttMs: this.pl.rttEstimateMs,
+    });
+  }
 
   /** Called from computable hooks when external observer asks for state refresh */
   private scheduleOnNextState(resolve: () => void, reject: (err: any) => void): void {
@@ -345,6 +379,8 @@ export class SynchronizedTreeState {
         // actual tree synchronization
         await this.refresh(stat);
 
+        this.updatePollingInterval();
+
         // logging stats if we were asked to
         if (stat && this.logger)
           this.logger.info(
@@ -403,7 +439,7 @@ export class SynchronizedTreeState {
       // Phase 2: optional remainder up to pollingInterval — interruptible by
       // scheduleOnNextState so that an external nudge wakes the loop promptly.
       if (this.scheduledOnNextState.length === 0) {
-        const remaining = Math.max(0, this.pollingInterval - MIN_POLLING_INTERVAL_MS);
+        const remaining = Math.max(0, this.effectivePollingInterval - MIN_POLLING_INTERVAL_MS);
         if (remaining > 0) {
           try {
             this.currentLoopDelayInterrupt = new AbortController();

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -75,19 +75,20 @@ function normalizeSeeds(seeds: SignedResourceId | TreeSeed | TreeSeed[]): TreeSe
   return [{ kind: "resource", root: seeds }];
 }
 
-/** How often, in main-loop iterations, a tree with shared-type seeds re-polls
- * ListUserResources to reconcile its discovered roots. 1 would mean every iteration.
+/** How often a tree with shared-type seeds re-polls ListUserResources to reconcile its
+ * discovered roots.
  *
  * Discovery (a full ListUserResources stream) is far heavier than an ordinary incremental
- * refresh, so it must NOT run on every fast refresh tick. The refresh cadence is the tree's
- * `pollingInterval` floored by {@link MIN_POLLING_INTERVAL_MS} (~200ms-1s in practice — the
- * shared-seed discovery tree runs at the 200ms default). At N = 15 discovery fires roughly
- * every 15 × 200ms ≈ 3s, decoupling it from the fast refresh loop while keeping the latency
- * of noticing a new/removed share to a few seconds — acceptable for a human-driven share flow.
+ * refresh, so it must NOT run on every refresh tick. This is a wall-clock interval rather
+ * than a count of iterations, so it pins the latency of noticing a new/removed share
+ * regardless of the refresh cadence. Counting iterations ties the two together: anything that
+ * slows the refresh loop (a high-latency link, or the adaptive cadence that follows) silently
+ * drags share-discovery latency out with it. 3s keeps the previous effective behaviour, where
+ * 15 iterations at the 200ms default worked out to roughly the same figure.
  *
  * Only trees with shared-type seeds gate on this; {@link discover} is a no-op for single-root
  * and explicit-seed trees (empty `sharedSeeds`), so the value never affects them. */
-const DISCOVERY_EVERY_N_REFRESHES = 15;
+const DISCOVERY_INTERVAL_MS = 3_000;
 
 type ScheduledRefresh = {
   resolve: () => void;
@@ -315,8 +316,8 @@ export class SynchronizedTreeState {
 
     let lastUpdate = Date.now();
 
-    // counts refresh iterations to pace the discovery poll for shared-type seeds.
-    let iteration = 0;
+    // paces the discovery poll for shared-type seeds; 0 forces discovery on the first pass.
+    let lastDiscovery = 0;
 
     while (true) {
       if (!this.keepRunning || this.terminated) break;
@@ -336,10 +337,10 @@ export class SynchronizedTreeState {
 
         // discovery sync for shared-type seeds: reconcile the discovered root set before
         // refreshing, so newly discovered roots are materialized in this same iteration.
-        if (this.sharedSeeds.length > 0 && iteration % DISCOVERY_EVERY_N_REFRESHES === 0) {
+        if (this.sharedSeeds.length > 0 && Date.now() - lastDiscovery >= DISCOVERY_INTERVAL_MS) {
           await this.discover();
+          lastDiscovery = Date.now();
         }
-        iteration++;
 
         // actual tree synchronization
         await this.refresh(stat);


### PR DESCRIPTION
The **connect-under-load** half of [MILAB-6703](https://app.notion.com/p/3b13a83ff4af803193f6f19ebaaa8754) (spec atom A-0013), one commit per item. From the MILAB-6303 slow-network spec ([text#190](https://github.com/milaboratory/text/pull/190)).

## 1. Cap the transaction retry backoff delay

`DefaultRetryOptions` omitted `maxDelay` even though the helper has always supported it (`temporal.ts:119`), so the exponential sequence grew across all 21 attempts. Simulating the real state machine:

| | total sleep | worst single sleep |
| --- | --- | --- |
| no jitter | 199.5s | 66.5s |
| jitter, upper tail over 2000 runs | **413.8s** | **149.5s** |

Jitter is applied to the *accumulating* delta, so positive draws compound. A conflicting write transaction could stall for minutes.

Capped at 5s per delay (~47s worst-case total), overridable via a new `retry-max-delay` url param.

## 2. Derive the unary deadline from observed RTT

`GrpcOptions.timeout` was a fixed 5s set once for the whole transport (`ll_client.ts`), so every unary call inherited it, including `loginBasic`, which passes no override and waits on server-side password hashing. This is the `Deadline exceeded after 5.001s` abort on DNS + LB in the spec's evidence.

Ping timings now feed a smoothed RTT estimate (alpha 0.3), and the deadline becomes `max(configured, 8 x RTT)` capped at 60s. Login, SSO login, JWT issue and refresh get an explicit 120s deadline per the A-0020 checklist.

Two things worth noting for review:

- **No reconnect needed.** `GrpcTransport` keeps its `GrpcOptions` object by reference, `mergeOptions` re-reads it per call, and `pickCallOptions` computes `deadline = Date.now() + timeout` at call time. Mutating `timeout` therefore retunes later calls without tearing down the connection, which is what avoided a per-call-site refactor across ~20 unary calls.
- **Fast links are unaffected.** The derived value is floored by the configured timeout, so it only exceeds 5s above ~625ms RTT. At 100ms RTT it stays exactly 5s; at the spec's 1.4s target envelope it becomes 11.2s.

## 3. Bounded retry for idempotent unary calls

The connect-path `ping` and `getUserRoot` had no retry at all, so a single transient failure during DNS or load-balancer warm-up failed the whole connect. Both now retry up to 4 attempts, and only on `UNAVAILABLE` / `DEADLINE_EXCEEDED`. Auth, permission and not-found are real answers from the server and pass straight through, so a rejected credential is never silently repeated.

The retry wraps `ping` at the `build()` call site rather than inside `ping()`, because `detectOptimalWireProtocol` already wraps ping in a 30-attempt retry; nesting would have multiplied to 120 attempts if that path is ever re-enabled.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds adaptive unary deadlines, bounded retries for idempotent connect-path RPCs, and a cap for transaction retry delays. The file-based configuration path needs to propagate the new `retryMaxDelay` field.

- **PlClientConfig** — the complete client connection, timeout, and retry configuration type; it gains `retryMaxDelay`.
- **retryMaxDelay** — the maximum duration of one transaction-retry sleep; it defaults to 5 seconds and can be set through the `retry-max-delay` URL parameter, but is currently omitted from file-config overrides.
- **Unary deadline** — the maximum duration allowed for a unary gRPC request; it is now derived from the configured floor and smoothed RTT, with a 60-second ceiling.
- **RTT estimate** — an exponentially smoothed measurement obtained from successful ping calls; it now retunes subsequent unary deadlines.
- **Idempotent unary retry** — a four-attempt retry policy for `ping` and `getUserRoot`, restricted to connection and deadline failures.
- **Transient call failure** — the protocol-normalized error category used to decide whether an idempotent unary call can be retried.
- **Login timeout** — a dedicated 120-second per-call deadline now applied to login, token issue, SSO, and refresh RPCs.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The file-based configuration omission should be fixed before merging because it silently ignores the newly introduced retryMaxDelay setting.

Transaction retry capping works for URL-derived and directly constructed configurations, but defaultPlClient applies file settings through an allow-list that does not contain the new field.

**Files Needing Attention:** lib/node/pl-client/src/core/config.ts and lib/node/pl-client/src/core/default_client.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/config.ts | Adds retry-delay and adaptive-deadline policy configuration, but the new retryMaxDelay field is not propagated through file-based overrides. |
| lib/node/pl-client/src/core/client.ts | Passes the configured maximum delay into both exponential and linear transaction retry policies. |
| lib/node/pl-client/src/core/errors.ts | Adds a shared transient-failure predicate based on existing connection and timeout classifiers. |
| lib/node/pl-client/src/core/ll_client.ts | Adds RTT sampling, live unary-timeout adjustment, explicit auth deadlines, and bounded retries around ping and getUserRoot. |
| lib/node/pl-client/src/core/config.test.ts | Covers URL parsing, deadline derivation, RTT smoothing, and the default transaction backoff cap, but not file-config propagation. |
| lib/node/pl-client/src/core/error.test.ts | Verifies retry classification for representative gRPC-style status codes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[Create transport with configured deadline] --> P[Mandatory ping]
  P -->|Transient failure| R[Bounded retry, up to 4 attempts]
  R --> P
  P -->|Success| S[Record and smooth RTT]
  S --> D[Derive deadline: max configured, 8 x RTT; cap 60s]
  D --> U[Retune subsequent unary calls]
  U --> G[getUserRoot with bounded retry]
  U --> A[Auth RPCs with explicit 120s timeout]
  T[Transaction conflict] --> B[Retry backoff capped by retryMaxDelay]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Fconfig.ts%3A93-96%0A**File%20config%20drops%20retry%20cap**%0A%0AWhen%20%60retryMaxDelay%60%20is%20set%20in%20%60pl.json%60%20or%20%60pl.yaml%60%2C%20%60defaultPlClient%60%20omits%20it%20from%20%60FILE_CONFIG_OVERRIDE_FIELDS%60%2C%20so%20the%20configured%20value%20is%20silently%20ignored%20and%20transaction%20retries%20use%20the%20URL-derived%20or%20default%205-second%20cap%20instead.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1773&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/node/pl-client/src/core/config.ts:93-96
**File config drops retry cap**

When `retryMaxDelay` is set in `pl.json` or `pl.yaml`, `defaultPlClient` omits it from `FILE_CONFIG_OVERRIDE_FIELDS`, so the configured value is silently ignored and transaction retries use the URL-derived or default 5-second cap instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6703: bounded retry for idempotent..."](https://github.com/milaboratory/platforma/commit/1a172593ede6a68b2aebb9b9ea393d3989399746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50013257)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [pl-client](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-client.md)

<!-- /greptile_comment -->