### PR TITLE
MILAB-6703: RTT-adaptive tree-sync cadence with idle backoff

### DIFF
--- a/.changeset/discovery-wall-clock-pacing.md
+++ b/.changeset/discovery-wall-clock-pacing.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-tree": patch
+---
+
+Pace shared-seed root discovery by wall clock rather than by a count of refresh iterations, so share-discovery latency no longer drifts with the refresh cadence.

--- a/.changeset/idle-tree-sync-backoff.md
+++ b/.changeset/idle-tree-sync-backoff.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-tree": patch
+---
+
+Back off the tree-sync poll interval when a cycle reports no changes, up to a 5s ceiling, instead of re-polling an idle tree at full rate. Any change, or an observer asking for fresh state, resets it immediately.

--- a/.changeset/rtt-adaptive-poll-interval.md
+++ b/.changeset/rtt-adaptive-poll-interval.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-tree": patch
+"@milaboratories/pl-client": patch
+---
+
+Scale the tree-sync poll interval to the client's measured RTT instead of polling at a fixed interval regardless of link latency. Also exposes `PlClient.rttEstimateMs`. The configured interval remains the lower bound, so fast links are unaffected.

--- a/lib/node/pl-client/src/core/client.ts
+++ b/lib/node/pl-client/src/core/client.ts
@@ -187,6 +187,13 @@ export class PlClient {
     };
   }
 
+  /** Smoothed round-trip estimate in ms from ping timings, or undefined before the first
+   * ping. Exposed so latency-sensitive consumers (e.g. the tree-sync poll cadence) can scale
+   * their timing to the link instead of assuming a local server. */
+  public get rttEstimateMs(): number | undefined {
+    return this.ll.rttEstimateMs;
+  }
+
   public async ping(): Promise<MaintenanceAPI_Ping_Response> {
     return await this.ll.ping();
   }

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -5,16 +5,64 @@ import { derivePollingInterval } from "./synchronized_tree";
 const FAST = 200;
 
 test("no rtt sample yet leaves the configured interval alone", () => {
-  expect(derivePollingInterval({ configuredMs: FAST, rttMs: undefined })).toEqual(FAST);
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: undefined, changed: true }),
+  ).toEqual(FAST);
 });
 
 test("a fast link keeps the configured interval", () => {
   // 10ms RTT would imply a 20ms floor, well under the configured value.
-  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 10 })).toEqual(FAST);
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: 10, changed: true }),
+  ).toEqual(FAST);
 });
 
 test("a slow link spaces polls by rtt", () => {
   // The spec's target envelope: 1.4s RTT against a 200ms fixed interval, which is the
   // regime where unconditional polling outran what the link could deliver.
-  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 1400 })).toEqual(2800);
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: FAST, rttMs: 1400, changed: true }),
+  ).toEqual(2800);
+});
+
+test("idle cycles back off, and a change snaps straight back", () => {
+  const step = (currentMs: number, changed: boolean) =>
+    derivePollingInterval({ configuredMs: FAST, currentMs, rttMs: 10, changed });
+
+  // Nothing changed: the interval walks out, strictly increasing each time.
+  const first = step(FAST, false);
+  const second = step(first, false);
+  const third = step(second, false);
+  expect(first).toBeGreaterThan(FAST);
+  expect(second).toBeGreaterThan(first);
+  expect(third).toBeGreaterThan(second);
+
+  // One changed cycle returns to the floor immediately, no gradual recovery.
+  expect(step(third, true)).toEqual(FAST);
+});
+
+test("idle backoff is bounded", () => {
+  let interval = FAST;
+  for (let i = 0; i < 100; i++) {
+    interval = derivePollingInterval({
+      configuredMs: FAST,
+      currentMs: interval,
+      rttMs: 10,
+      changed: false,
+    });
+  }
+  // Must converge on the ceiling rather than growing without limit.
+  expect(interval).toEqual(5_000);
+});
+
+test("the rtt floor outranks the ceiling on a very slow link", () => {
+  // 4s RTT implies an 8s floor, past the 5s ceiling. Clamping to 5s would poll faster than
+  // the link can answer, so the floor has to win.
+  const interval = derivePollingInterval({
+    configuredMs: FAST,
+    currentMs: FAST,
+    rttMs: 4000,
+    changed: false,
+  });
+  expect(interval).toEqual(8_000);
 });

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -55,6 +55,15 @@ test("idle backoff is bounded", () => {
   expect(interval).toEqual(5_000);
 });
 
+test("resetting backoff keeps the rtt floor", () => {
+  // What an observer nudge does: reset to the floor, from a fully backed-off interval.
+  // The floor must stay RTT-derived, not drop to the raw configured value, or a nudge on a
+  // slow link would poll faster than the link can answer.
+  expect(
+    derivePollingInterval({ configuredMs: FAST, currentMs: 5_000, rttMs: 1400, changed: true }),
+  ).toEqual(2800);
+});
+
 test("the rtt floor outranks the ceiling on a very slow link", () => {
   // 4s RTT implies an 8s floor, past the 5s ceiling. Clamping to 5s would poll faster than
   // the link can answer, so the floor has to win.

--- a/lib/node/pl-tree/src/polling_interval.test.ts
+++ b/lib/node/pl-tree/src/polling_interval.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "vitest";
+import { derivePollingInterval } from "./synchronized_tree";
+
+/** The project-list / sharing singleton trees run at 200ms; per-project trees at 1000ms. */
+const FAST = 200;
+
+test("no rtt sample yet leaves the configured interval alone", () => {
+  expect(derivePollingInterval({ configuredMs: FAST, rttMs: undefined })).toEqual(FAST);
+});
+
+test("a fast link keeps the configured interval", () => {
+  // 10ms RTT would imply a 20ms floor, well under the configured value.
+  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 10 })).toEqual(FAST);
+});
+
+test("a slow link spaces polls by rtt", () => {
+  // The spec's target envelope: 1.4s RTT against a 200ms fixed interval, which is the
+  // regime where unconditional polling outran what the link could deliver.
+  expect(derivePollingInterval({ configuredMs: FAST, rttMs: 1400 })).toEqual(2800);
+});

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -25,6 +25,15 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
  * preventing tight polling loops during rapid state transitions. */
 const MIN_POLLING_INTERVAL_MS = 100;
 
+/** Ceiling for the adaptive poll interval. Caps how stale an idle tree can get before the
+ * next look, and bounds how far the idle backoff can push the interval out. */
+const MAX_POLLING_INTERVAL_MS = 5_000;
+
+/** Applied to the interval after a cycle that changed nothing. An idle tree walks its
+ * interval out towards {@link MAX_POLLING_INTERVAL_MS} instead of re-polling at full rate;
+ * the first cycle that changes anything resets it. */
+const IDLE_BACKOFF_MULTIPLIER = 1.5;
+
 /** The client's measured RTT becomes an interval floor, scaled by this. Every refresh costs
  * at least one round trip, so polling faster than a small multiple of the RTT only queues
  * round-trips the link cannot service. This is what replaces the fixed interval on a
@@ -86,29 +95,46 @@ function normalizeSeeds(seeds: SignedResourceId | TreeSeed | TreeSeed[]): TreeSe
  *
  * Discovery (a full ListUserResources stream) is far heavier than an ordinary incremental
  * refresh, so it must NOT run on every refresh tick. This is a wall-clock interval rather
- * than a count of iterations, so it pins the latency of noticing a new/removed share
- * regardless of the refresh cadence. Counting iterations ties the two together: anything that
- * slows the refresh loop (a high-latency link, or the adaptive cadence that follows) silently
- * drags share-discovery latency out with it. 3s keeps the previous effective behaviour, where
- * 15 iterations at the 200ms default worked out to roughly the same figure.
+ * than a count of iterations: the refresh cadence is adaptive (it stretches towards
+ * {@link MAX_POLLING_INTERVAL_MS} on an idle tree and scales with RTT on a slow link),
+ * so a fixed iteration count would let discovery latency drift out with it. Keeping it in
+ * milliseconds pins the latency of noticing a new/removed share regardless of cadence, which
+ * is what a human-driven share flow cares about.
  *
  * Only trees with shared-type seeds gate on this; {@link discover} is a no-op for single-root
  * and explicit-seed trees (empty `sharedSeeds`), so the value never affects them. */
 const DISCOVERY_INTERVAL_MS = 3_000;
 
-/** The poll-cadence policy, as a pure function.
+/** Counters that mean "this cycle brought something new". Deliberately not the full change
+ * breakdown: those fields are sub-counts of `resourcesChanged` and would double-count.
+ * `resourcesUnchanged` is excluded by design, since a cycle that only re-fetched unchanged
+ * state is exactly the idle case the backoff exists for. */
+function countedChanges(stat: TreeLoadingStat): number {
+  return stat.resourcesNew + stat.resourcesChanged + stat.resourcesMarkedFinal;
+}
+
+/** The poll-cadence policy, as a pure function of the last cycle's outcome.
  *
  * `configuredMs` is the tree's static `pollingInterval` and acts as the lower bound, so no
- * link is ever polled faster than configured. `rttMs` raises that bound on a slow link. */
+ * link can be polled faster than configured. `rttMs` raises that bound on a slow link.
+ * `currentMs` is the interval in force for the cycle that just finished, which is what the
+ * idle backoff compounds on. */
 export function derivePollingInterval(opts: {
   configuredMs: number;
+  currentMs: number;
   rttMs: number | undefined;
+  changed: boolean;
 }): number {
-  const { configuredMs, rttMs } = opts;
+  const { configuredMs, currentMs, rttMs, changed } = opts;
 
-  return rttMs === undefined
-    ? configuredMs
-    : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+  const floor =
+    rttMs === undefined ? configuredMs : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+
+  const next = changed ? floor : Math.max(floor, currentMs * IDLE_BACKOFF_MULTIPLIER);
+
+  // The ceiling never cuts below the floor: a link slower than MAX_POLLING_INTERVAL_MS still
+  // gets its RTT-derived spacing rather than being forced to re-poll early.
+  return Math.max(floor, Math.min(MAX_POLLING_INTERVAL_MS, next));
 }
 
 type ScheduledRefresh = {
@@ -228,11 +254,19 @@ export class SynchronizedTreeState {
    * and is re-derived after every cycle by {@link updatePollingInterval}. */
   private effectivePollingInterval: number;
 
-  /** Re-derives {@link effectivePollingInterval} from the link's current RTT. */
-  private updatePollingInterval(): void {
+  /** Re-derives {@link effectivePollingInterval} after a cycle.
+   *
+   * Two independent effects. The floor scales with the client's measured RTT, so a
+   * high-latency link stops queueing round-trips it cannot service. On top of that, a cycle
+   * that changed nothing multiplies the interval out towards
+   * {@link MAX_POLLING_INTERVAL_MS}, while any change snaps it straight back to the floor so
+   * an active tree stays responsive. */
+  private updatePollingInterval(changed: boolean): void {
     this.effectivePollingInterval = derivePollingInterval({
       configuredMs: this.pollingInterval,
+      currentMs: this.effectivePollingInterval,
       rttMs: this.pl.rttEstimateMs,
+      changed,
     });
   }
 
@@ -241,6 +275,9 @@ export class SynchronizedTreeState {
     if (this.terminated) reject(new Error("tree synchronization is terminated"));
     else {
       this.scheduledOnNextState.push({ resolve, reject });
+      // Someone is waiting on fresh state, so this tree is not idle after all: drop any
+      // accumulated backoff, otherwise the cycles right after a nudge stay slow.
+      this.effectivePollingInterval = this.pollingInterval;
       if (this.currentLoopDelayInterrupt) {
         this.currentLoopDelayInterrupt.abort();
         this.currentLoopDelayInterrupt = undefined;
@@ -345,8 +382,9 @@ export class SynchronizedTreeState {
   private terminated = false;
 
   private async mainLoop() {
-    // will hold request stats
-    let stat = this.logStat ? initialTreeLoadingStat() : undefined;
+    // Always collected, even when not logging: the change counters drive the idle backoff
+    // below. Counter bumps are cheap next to the round trip they describe.
+    let stat = initialTreeLoadingStat();
 
     let lastUpdate = Date.now();
 
@@ -376,13 +414,17 @@ export class SynchronizedTreeState {
           lastDiscovery = Date.now();
         }
 
+        // Change counters before the refresh, so the delta tells us whether this single cycle
+        // brought anything new. Works in both stat modes: "per-request" resets to 0 above.
+        const changesBefore = countedChanges(stat);
+
         // actual tree synchronization
         await this.refresh(stat);
 
-        this.updatePollingInterval();
+        this.updatePollingInterval(countedChanges(stat) > changesBefore);
 
         // logging stats if we were asked to
-        if (stat && this.logger)
+        if (this.logStat && this.logger)
           this.logger.info(
             `Tree stat (success, after ${Date.now() - lastUpdate}ms): ${JSON.stringify(stat)}`,
           );
@@ -392,7 +434,7 @@ export class SynchronizedTreeState {
         if (toNotify !== undefined) for (const n of toNotify) n.resolve();
       } catch (e: any) {
         // logging stats if we were asked to (even if error occured)
-        if (stat && this.logger)
+        if (this.logStat && this.logger)
           this.logger.info(
             `Tree stat (error, after ${Date.now() - lastUpdate}ms): ${JSON.stringify(stat)}`,
           );

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -276,8 +276,13 @@ export class SynchronizedTreeState {
     else {
       this.scheduledOnNextState.push({ resolve, reject });
       // Someone is waiting on fresh state, so this tree is not idle after all: drop any
-      // accumulated backoff, otherwise the cycles right after a nudge stay slow.
-      this.effectivePollingInterval = this.pollingInterval;
+      // accumulated backoff, otherwise the cycles right after a nudge stay slow. Routed
+      // through the policy rather than assigning the configured value directly, so the RTT
+      // floor survives the reset. Assigning it raw would poll a high-latency link faster than
+      // it can answer, and the interval would stay there until the next cycle that completes:
+      // the error path never reaches updatePollingInterval, so a failing nudged refresh would
+      // keep retrying at the un-floored rate.
+      this.updatePollingInterval(true);
       if (this.currentLoopDelayInterrupt) {
         this.currentLoopDelayInterrupt.abort();
         this.currentLoopDelayInterrupt = undefined;

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -25,6 +25,12 @@ import type { MiLogger } from "@milaboratories/ts-helpers";
  * preventing tight polling loops during rapid state transitions. */
 const MIN_POLLING_INTERVAL_MS = 100;
 
+/** The client's measured RTT becomes an interval floor, scaled by this. Every refresh costs
+ * at least one round trip, so polling faster than a small multiple of the RTT only queues
+ * round-trips the link cannot service. This is what replaces the fixed interval on a
+ * high-latency link; on a fast link the configured `pollingInterval` still dominates. */
+const RTT_POLL_FACTOR = 2;
+
 type StatLoggingMode = "cumulative" | "per-request";
 
 export type SynchronizedTreeOps = {
@@ -90,6 +96,21 @@ function normalizeSeeds(seeds: SignedResourceId | TreeSeed | TreeSeed[]): TreeSe
  * and explicit-seed trees (empty `sharedSeeds`), so the value never affects them. */
 const DISCOVERY_INTERVAL_MS = 3_000;
 
+/** The poll-cadence policy, as a pure function.
+ *
+ * `configuredMs` is the tree's static `pollingInterval` and acts as the lower bound, so no
+ * link is ever polled faster than configured. `rttMs` raises that bound on a slow link. */
+export function derivePollingInterval(opts: {
+  configuredMs: number;
+  rttMs: number | undefined;
+}): number {
+  const { configuredMs, rttMs } = opts;
+
+  return rttMs === undefined
+    ? configuredMs
+    : Math.max(configuredMs, Math.ceil(rttMs * RTT_POLL_FACTOR));
+}
+
 type ScheduledRefresh = {
   resolve: () => void;
   reject: (err: any) => void;
@@ -135,6 +156,7 @@ export class SynchronizedTreeState {
     this.traverseStopRules = traverseStopRules;
     this.traversalMode = traversalMode ?? "auto";
     this.pollingInterval = pollingInterval;
+    this.effectivePollingInterval = pollingInterval;
     this.finalPredicate = finalPredicateOverride ?? pl.finalPredicate;
     this.logStat = logStat;
 
@@ -201,6 +223,18 @@ export class SynchronizedTreeState {
 
   private currentLoopDelayInterrupt: AbortController | undefined = undefined;
   private scheduledOnNextState: ScheduledRefresh[] = [];
+
+  /** Interval actually used for the current wait. Starts at the configured `pollingInterval`
+   * and is re-derived after every cycle by {@link updatePollingInterval}. */
+  private effectivePollingInterval: number;
+
+  /** Re-derives {@link effectivePollingInterval} from the link's current RTT. */
+  private updatePollingInterval(): void {
+    this.effectivePollingInterval = derivePollingInterval({
+      configuredMs: this.pollingInterval,
+      rttMs: this.pl.rttEstimateMs,
+    });
+  }
 
   /** Called from computable hooks when external observer asks for state refresh */
   private scheduleOnNextState(resolve: () => void, reject: (err: any) => void): void {
@@ -345,6 +379,8 @@ export class SynchronizedTreeState {
         // actual tree synchronization
         await this.refresh(stat);
 
+        this.updatePollingInterval();
+
         // logging stats if we were asked to
         if (stat && this.logger)
           this.logger.info(
@@ -403,7 +439,7 @@ export class SynchronizedTreeState {
       // Phase 2: optional remainder up to pollingInterval — interruptible by
       // scheduleOnNextState so that an external nudge wakes the loop promptly.
       if (this.scheduledOnNextState.length === 0) {
-        const remaining = Math.max(0, this.pollingInterval - MIN_POLLING_INTERVAL_MS);
+        const remaining = Math.max(0, this.effectivePollingInterval - MIN_POLLING_INTERVAL_MS);
         if (remaining > 0) {
           try {
             this.currentLoopDelayInterrupt = new AbortController();

--- a/lib/node/pl-tree/src/synchronized_tree.ts
+++ b/lib/node/pl-tree/src/synchronized_tree.ts
@@ -75,19 +75,20 @@ function normalizeSeeds(seeds: SignedResourceId | TreeSeed | TreeSeed[]): TreeSe
   return [{ kind: "resource", root: seeds }];
 }
 
-/** How often, in main-loop iterations, a tree with shared-type seeds re-polls
- * ListUserResources to reconcile its discovered roots. 1 would mean every iteration.
+/** How often a tree with shared-type seeds re-polls ListUserResources to reconcile its
+ * discovered roots.
  *
  * Discovery (a full ListUserResources stream) is far heavier than an ordinary incremental
- * refresh, so it must NOT run on every fast refresh tick. The refresh cadence is the tree's
- * `pollingInterval` floored by {@link MIN_POLLING_INTERVAL_MS} (~200ms-1s in practice — the
- * shared-seed discovery tree runs at the 200ms default). At N = 15 discovery fires roughly
- * every 15 × 200ms ≈ 3s, decoupling it from the fast refresh loop while keeping the latency
- * of noticing a new/removed share to a few seconds — acceptable for a human-driven share flow.
+ * refresh, so it must NOT run on every refresh tick. This is a wall-clock interval rather
+ * than a count of iterations, so it pins the latency of noticing a new/removed share
+ * regardless of the refresh cadence. Counting iterations ties the two together: anything that
+ * slows the refresh loop (a high-latency link, or the adaptive cadence that follows) silently
+ * drags share-discovery latency out with it. 3s keeps the previous effective behaviour, where
+ * 15 iterations at the 200ms default worked out to roughly the same figure.
  *
  * Only trees with shared-type seeds gate on this; {@link discover} is a no-op for single-root
  * and explicit-seed trees (empty `sharedSeeds`), so the value never affects them. */
-const DISCOVERY_EVERY_N_REFRESHES = 15;
+const DISCOVERY_INTERVAL_MS = 3_000;
 
 type ScheduledRefresh = {
   resolve: () => void;
@@ -315,8 +316,8 @@ export class SynchronizedTreeState {
 
     let lastUpdate = Date.now();
 
-    // counts refresh iterations to pace the discovery poll for shared-type seeds.
-    let iteration = 0;
+    // paces the discovery poll for shared-type seeds; 0 forces discovery on the first pass.
+    let lastDiscovery = 0;
 
     while (true) {
       if (!this.keepRunning || this.terminated) break;
@@ -336,10 +337,10 @@ export class SynchronizedTreeState {
 
         // discovery sync for shared-type seeds: reconcile the discovered root set before
         // refreshing, so newly discovered roots are materialized in this same iteration.
-        if (this.sharedSeeds.length > 0 && iteration % DISCOVERY_EVERY_N_REFRESHES === 0) {
+        if (this.sharedSeeds.length > 0 && Date.now() - lastDiscovery >= DISCOVERY_INTERVAL_MS) {
           await this.discover();
+          lastDiscovery = Date.now();
         }
-        iteration++;
 
         // actual tree synchronization
         await this.refresh(stat);


### PR DESCRIPTION
Part of the **adaptive cadence** half of [MILAB-6703](https://app.notion.com/p/3b13a83ff4af803193f6f19ebaaa8754) (spec atom A-0010). From the MILAB-6303 slow-network spec ([text#190](https://github.com/milaboratory/text/pull/190)).

> **Stacked on [#1773](https://github.com/milaboratory/platforma/pull/1773)** (the connect-under-load half), because it consumes the RTT estimate that PR introduces. Base is `MILAB-6703_connect-under-load`, not `main`. Merge #1773 first.

## RTT-adaptive poll interval

The loop polled at a fixed interval regardless of link latency, so at high RTT it queued round-trips the link could not service (measured: cadence collapses around 1.4s RTT). The interval floor is now `max(pollingInterval, 2 x RTT)`, reading the RTT that `pl-client` already measures from ping timings, newly exposed as `PlClient.rttEstimateMs`.

The configured `pollingInterval` stays the lower bound, so **fast links keep their current behaviour exactly**: at 10ms RTT the floor works out to 20ms, far under the 200ms/1000ms configured values, so nothing changes. At the spec's 1.4s target envelope the 200ms singleton trees move to 2.8s spacing, roughly a 14x cut in round-trips.

## Back off on zero-change cycles

52-100% of steady-state fetches came back unchanged (A-0016), yet the loop re-polled at full rate regardless. A cycle whose change counters do not move now multiplies the interval by 1.5 towards a 5s ceiling. Any change, or an observer asking for fresh state, resets it to the floor immediately rather than recovering gradually.

Change detection was free: the `resourcesNew` / `resourcesChanged` / `resourcesMarkedFinal` counters added by the tree-sync metrics work (#1760) are exactly the "did this cycle bring anything" signal. The one cost is that stats are now collected unconditionally rather than only when logging is enabled, which is a handful of counter bumps against the round trip they describe.

One deliberate ordering subtlety: the RTT floor outranks the ceiling. On a link slower than 2.5s RTT the derived floor exceeds `MAX_POLLING_INTERVAL_MS`, and clamping to 5s would poll faster than the link can answer, so the floor wins. There is a test pinning this.