### PR TITLE
fix(uikit): honour valueless required and clearable

### DIFF
--- a/.changeset/olive-donuts-shave.md
+++ b/.changeset/olive-donuts-shave.md
@@ -1,0 +1,16 @@
+---
+"@milaboratories/uikit": patch
+---
+
+Fix `required` and `clearable` ignoring valueless attributes on PlTextField and PlNumberField
+
+`<PlTextField required />` had no effect: neither the required marker nor the "Value is required"
+check fired. A valueless attribute compiles to the empty string, and Vue coerces that to `true`
+only when the prop's declared runtime type includes `Boolean` — but the SFC compiler cannot resolve
+a bare type parameter, so `required?: R` emitted a typeless `required: {}` and the prop stayed
+`""`. `clearable` hit the same rule from the other side: its conditional type erased the boolean
+arm, leaving `{ type: Function }`, so a valueless `clearable` warned and did nothing.
+
+Both props now intersect with `boolean`, which the compiler can resolve, restoring
+`{ type: Boolean }` and `{ type: [Boolean, Function] }`. The type-level guard that forbids
+`clearable` alongside `required` is unchanged.

--- a/lib/ui/uikit/src/__tests__/valueless-attribute.test.ts
+++ b/lib/ui/uikit/src/__tests__/valueless-attribute.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import PlTextField from "../components/PlTextField/PlTextField.vue";
+import PlNumberField from "../components/PlNumberField/PlNumberField.vue";
+
+/**
+ * A valueless attribute (`<PlTextField required />`) passes the empty string, and Vue coerces that
+ * to `true` only for props whose runtime type includes Boolean. A prop declared as a bare type
+ * parameter or as a conditional type compiles to one with no runtime type, which silently keeps
+ * the `""` and reads as false everywhere it is used.
+ *
+ * Passed through `attrs`, because that is what a valueless attribute in a template produces, and
+ * because the empty string is deliberately not a valid value for either prop.
+ */
+describe.each([
+  ["PlTextField", PlTextField, ""],
+  ["PlNumberField", PlNumberField, undefined],
+])("%s coerces valueless attributes", (_name, Component, emptyValue) => {
+  it("treats a valueless `required` as true", () => {
+    const w = mount(Component, {
+      props: { modelValue: emptyValue, label: "L" },
+      attrs: { required: "" },
+    });
+    expect(w.props("required")).toBe(true);
+    expect(w.text()).toContain("Value is required");
+  });
+
+  it("treats a valueless `clearable` as true", () => {
+    const w = mount(Component, {
+      props: { modelValue: emptyValue, label: "L" },
+      attrs: { clearable: "" },
+    });
+    expect(w.props("clearable")).toBe(true);
+  });
+
+  it("leaves both falsy when the attribute is absent", () => {
+    const w = mount(Component, { props: { modelValue: emptyValue, label: "L" } });
+    expect(w.props("required")).toBeFalsy();
+    expect(w.props("clearable")).toBeFalsy();
+    expect(w.text()).not.toContain("Value is required");
+  });
+});

--- a/lib/ui/uikit/src/components/PlNumberField/PlNumberField.vue
+++ b/lib/ui/uikit/src/components/PlNumberField/PlNumberField.vue
@@ -28,6 +28,7 @@ export default {
 >
 import "./pl-number-field.scss";
 import DoubleContour from "../../utils/DoubleContour.vue";
+import type { BooleanProp, BooleanPropUnless } from "../../utils/booleanProps";
 import { useLabelNotch } from "../../utils/useLabelNotch";
 import { computed, ref, useSlots, watch } from "vue";
 import { PlTooltip } from "../PlTooltip";
@@ -45,7 +46,7 @@ const emit = defineEmits<{
 const props = withDefaults(
   defineProps<{
     /** If `true`, the field is required and will show an error if left empty. */
-    required?: R;
+    required?: BooleanProp<R>;
     /** Label on the top border of the field, empty by default */
     label?: string;
     /** Input placeholder, empty by default */
@@ -65,7 +66,7 @@ const props = withDefaults(
     /** Additional validity check for input value that must return an error text if failed */
     validate?: (v: number) => string | undefined;
     /** If `true`, shows a clear button that resets value to `undefined`. If a function, calls it to get the reset value. */
-    clearable?: (R extends true ? never : boolean) | (() => C);
+    clearable?: BooleanPropUnless<R> | (() => C);
     /** Makes some of corners not rounded */
     groupPosition?:
       | "top"

--- a/lib/ui/uikit/src/components/PlTextField/PlTextField.vue
+++ b/lib/ui/uikit/src/components/PlTextField/PlTextField.vue
@@ -20,6 +20,7 @@ import { computed, ref, useSlots } from "vue";
 import SvgRequired from "../../assets/images/required.svg?raw";
 import { getErrorMessage } from "../../helpers/error.ts";
 import DoubleContour from "../../utils/DoubleContour.vue";
+import type { BooleanProp, BooleanPropUnless } from "../../utils/booleanProps";
 import { useLabelNotch } from "../../utils/useLabelNotch";
 import { PlIcon16 } from "../PlIcon16";
 import { PlIcon24 } from "../PlIcon24";
@@ -42,7 +43,7 @@ const props = defineProps<{
   /** The label to display above the input field. */
   label?: string;
   /** If `true`, the input field is marked as required and will show an error if left empty. */
-  required?: R;
+  required?: BooleanProp<R>;
   /** An error message to display below the input field. */
   error?: unknown;
   /** A helper text to display below the input field when there are no errors. */
@@ -59,7 +60,7 @@ const props = defineProps<{
    * If `true`, a clear icon will appear in the input field to clear the value (set it to empty string).
    * If a function, calls it to get the reset value.
    */
-  clearable?: ([R] extends [true] ? never : boolean) | (() => C);
+  clearable?: BooleanPropUnless<R> | (() => C);
   /** Additional validity check for input value that must return an error text if failed */
   validate?: (v: V) => string | undefined;
   /** Makes some of corners not rounded */

--- a/lib/ui/uikit/src/utils/booleanProps.ts
+++ b/lib/ui/uikit/src/utils/booleanProps.ts
@@ -1,0 +1,18 @@
+/**
+ * Boolean prop types for components that are generic over one of their boolean props.
+ *
+ * A valueless attribute (`<PlTextField required />`) passes the empty string, and Vue coerces that
+ * to `true` only for props whose *runtime* type includes `Boolean`. The SFC compiler derives those
+ * runtime types from the source, and it cannot resolve either a bare type parameter or a
+ * conditional type — it emits a prop with no type at all, which silently ignores the attribute.
+ *
+ * Both aliases below keep `boolean` at the top level of the type so the compiler still emits
+ * `Boolean`, without giving up the type parameter that correlates the props.
+ */
+
+/** A `boolean` prop whose literal value is still inferred into `Flag`. */
+export type BooleanProp<Flag extends boolean> = Flag & boolean;
+
+/** A `boolean` prop that is not accepted at all when `Condition` is `true`. */
+export type BooleanPropUnless<Condition extends boolean> = boolean &
+  ([Condition] extends [true] ? never : unknown);


### PR DESCRIPTION
`<PlTextField required />` did nothing -- no required marker, no "Value is required" check -- and `<PlTextField clearable />` warned and did nothing. PlNumberField had both faults too.

A valueless attribute passes the empty string, and Vue coerces that to `true` only for props whose declared runtime type includes Boolean. The SFC compiler cannot resolve a bare type parameter, so `required?: R` emitted a typeless `required: {}`: no coercion, and no declared type for validation to complain about either, so it failed silently. `clearable` lost Boolean from the other direction -- its conditional erased the boolean arm, leaving `{ type: Function }`, which at least warned.

Two aliases in utils/booleanProps.ts keep `boolean` at the top level of each type, which the compiler can resolve, while preserving the type parameter that correlates the two props:

  required?:  BooleanProp<R>
  clearable?: BooleanPropUnless<R> | (() => C)

That restores `{ type: Boolean }` and `{ type: [Boolean, Function] }`. The module is deliberately not re-exported from the index, so the public type surface is unchanged.

Type behaviour is unchanged. The guard that forbids `clearable` alongside `required` still fires, and inference of `R` from the prop still works -- an intersection is a valid inference site where a conditional type is not. Checked by diffing the whole package's type-check output against the unmodified tree: identical, error for error. A generic default was tried first and does not help; the parameter stays unresolvable.

Covered by a test that mounts both components with the empty string a valueless attribute actually passes, via `attrs` rather than `props` since that is where such a value really comes from. It fails four ways without this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes valueless `required` and `clearable` attributes on `PlTextField` and `PlNumberField` by preserving Boolean in their compiler-visible prop types, with regression tests for coercion and absent attributes.
- **BooleanProp** — an intersection type that retains generic Boolean-literal inference while making the runtime Boolean type visible to Vue’s SFC compiler; newly introduced and applied to `required`.
- **BooleanPropUnless** — a conditional intersection that exposes a runtime Boolean type while continuing to reject Boolean `clearable` when `required` is true; newly introduced and applied to `clearable`.
- **Valueless attribute** — a template attribute such as `<PlTextField required />` represented as an empty string before Boolean prop coercion; both field components now coerce it to `true`.
- **required** — marks an empty field invalid and displays its required indicator/error; its generic declaration now uses `BooleanProp<R>`.
- **clearable** — enables the default clear action or accepts a custom reset factory; its declaration now preserves both Boolean and Function runtime types.
- Adds a patch changeset and tests both components’ `required`, `clearable`, and absent-attribute behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or compatibility failures identified.

The new aliases preserve the existing generic restrictions while exposing Boolean to Vue’s runtime prop generation, and the regression tests cover both affected components and absent-attribute behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/ui/uikit/src/utils/booleanProps.ts | Introduces compiler-visible generic Boolean aliases while retaining the required/clearable type correlation. |
| lib/ui/uikit/src/components/PlTextField/PlTextField.vue | Applies the aliases so valueless required and clearable attributes receive Boolean runtime coercion. |
| lib/ui/uikit/src/components/PlNumberField/PlNumberField.vue | Applies the same runtime-prop correction to the numeric field. |
| lib/ui/uikit/src/__tests__/valueless-attribute.test.ts | Covers valueless and absent required/clearable attributes on both affected components. |
| .changeset/olive-donuts-shave.md | Records the runtime Boolean-prop fix as a uikit patch release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Valueless required or clearable attribute] --> B[Empty-string attribute value]
  B --> C[Vue runtime prop declaration includes Boolean]
  C --> D[Vue coerces value to true]
  D --> E[Required validation or clear behavior activates]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(uikit): honour valueless required an..."](https://github.com/milaboratory/platforma/commit/462418f3e56499eca055b4f3e49b73815b6689f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50304961)</sub>

**Context used:**

- Knowledge Base — [UI Vue SDK and Component Library](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/ui-vue-sdk.md)

<!-- /greptile_comment -->