### PR TITLE
feat(pl-client): LicensePayload type + decodeLicenseToken + license test

### DIFF
--- a/.changeset/license-payload-type.md
+++ b/.changeset/license-payload-type.md
@@ -2,4 +2,4 @@
 "@milaboratories/pl-client": minor
 ---
 
-Add `LicensePayload` type and `decodeLicenseToken` helper, describing the decoded body of a Platforma license token next to the Maintenance API `license()` call that returns it. Includes a test that fetches the license from a live backend and asserts the required payload fields are always present.
+Add `LicensePayload` type and `decodeLicenseToken` helper, describing the decoded body of a Platforma license token next to the Maintenance API `license()` call that returns it. The type includes the optional `le` claim (the license's own expiration, independent of the short-lived token TTL `e`). Includes a test that fetches the license from a live backend and asserts the required payload fields are always present.

--- a/.changeset/license-payload-type.md
+++ b/.changeset/license-payload-type.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": minor
+---
+
+Add `LicensePayload` type and `decodeLicenseToken` helper, describing the decoded body of a Platforma license token next to the Maintenance API `license()` call that returns it. Includes a test that fetches the license from a live backend and asserts the required payload fields are always present.

--- a/lib/node/pl-client/src/core/license.test.ts
+++ b/lib/node/pl-client/src/core/license.test.ts
@@ -1,0 +1,43 @@
+import { getTestClient } from "../test/test_config";
+import { decodeLicenseToken, type LicensePayload } from "./license";
+import { test, expect } from "vitest";
+
+/**
+ * Fetches the license token from a live backend, decodes it, and checks that the
+ * required {@link LicensePayload} fields are always populated.
+ *
+ * This doubles as an investigation surface: point it at any backend via
+ * `PL_ADDRESS` / `PL_TEST_USER` / `PL_TEST_PASSWORD` and read the logged payload
+ * (notably `e`, the expiration timestamp) to inspect that backend's license.
+ */
+test("license payload carries all required fields", async () => {
+  const client = await getTestClient();
+
+  const resp = await client.license();
+  expect(resp.isOk).toBe(true);
+
+  // `responseBody` is the raw licensing-server body: a JSON-encoded token string.
+  const token = JSON.parse(Buffer.from(resp.responseBody).toString("utf8")) as string;
+
+  // decodeLicenseToken() itself asserts required fields are present and well-typed;
+  // an incomplete license from the backend would throw here.
+  const payload: LicensePayload = decodeLicenseToken(token);
+
+  // Explicit expectations mirror the required fields of LicensePayload, kept here
+  // so the contract is visible and easy to extend for future investigations.
+  expect(typeof payload.v).toBe("number");
+  expect(typeof payload.e).toBe("number");
+  expect(typeof payload.u).toBe("string");
+  expect(payload.u.length).toBeGreaterThan(0);
+  expect(typeof payload.m).toBe("string");
+
+  // Expiration must come after the valid-from moment.
+  expect(payload.e).toBeGreaterThan(payload.v);
+
+  console.log("license payload:", JSON.stringify(payload, null, 2));
+  console.log("valid from:", new Date(payload.v * 1000).toISOString());
+  console.log("expires at:", new Date(payload.e * 1000).toISOString());
+  if (payload.w !== undefined) {
+    console.log("warn after:", new Date(payload.w * 1000).toISOString());
+  }
+});

--- a/lib/node/pl-client/src/core/license.test.ts
+++ b/lib/node/pl-client/src/core/license.test.ts
@@ -37,6 +37,9 @@ test("license payload carries all required fields", async () => {
   console.log("license payload:", JSON.stringify(payload, null, 2));
   console.log("token valid from:", new Date(payload.v * 1000).toISOString());
   console.log("token expires at:", new Date(payload.e * 1000).toISOString());
+  if (payload.le !== undefined) {
+    console.log("license expires at:", new Date(payload.le * 1000).toISOString());
+  }
   if (payload.w !== undefined) {
     console.log("warn after:", new Date(payload.w * 1000).toISOString());
   }

--- a/lib/node/pl-client/src/core/license.test.ts
+++ b/lib/node/pl-client/src/core/license.test.ts
@@ -31,12 +31,12 @@ test("license payload carries all required fields", async () => {
   expect(payload.u.length).toBeGreaterThan(0);
   expect(typeof payload.m).toBe("string");
 
-  // Expiration must come after the valid-from moment.
+  // Token expiration must come after the token's valid-from moment.
   expect(payload.e).toBeGreaterThan(payload.v);
 
   console.log("license payload:", JSON.stringify(payload, null, 2));
-  console.log("valid from:", new Date(payload.v * 1000).toISOString());
-  console.log("expires at:", new Date(payload.e * 1000).toISOString());
+  console.log("token valid from:", new Date(payload.v * 1000).toISOString());
+  console.log("token expires at:", new Date(payload.e * 1000).toISOString());
   if (payload.w !== undefined) {
     console.log("warn after:", new Date(payload.w * 1000).toISOString());
   }

--- a/lib/node/pl-client/src/core/license.ts
+++ b/lib/node/pl-client/src/core/license.ts
@@ -1,0 +1,115 @@
+/**
+ * Monitoring mode for a single telemetry channel, as encoded in the license.
+ *
+ * See https://github.com/milaboratory/text/blob/main/features/monitoring/platforma-monitoring-prd.md
+ */
+export type LicenseMonitoringMode = "with_id" | "no_id" | "none";
+
+/**
+ * License payload — the decoded body of a Platforma license token.
+ *
+ * The token is issued by the licensing server (milm2) and returned to clients
+ * verbatim by the backend's Maintenance API — see {@link PlClient.license}. The
+ * token has the form `I.<base64Payload>.<watermark>.<signature>`; this type
+ * describes the JSON found in `<base64Payload>` once base64-decoded (via
+ * {@link decodeLicenseToken}).
+ *
+ * Issuer reference: https://github.com/milaboratory/milm2/blob/master/src/types/index.ts
+ * Backend counterpart: `core/pl/cmd/platforma/license.go` (`License` struct).
+ */
+export interface LicensePayload {
+  /** Unix timestamp (seconds) the license is valid from. */
+  v: number;
+  /** Unix timestamp (seconds) the license expires after. */
+  e: number;
+  /** UID of the customer. */
+  u: string;
+  /** Metric marker — attached to usage statistics. */
+  m: string;
+  /** [optional] Fallback license code, used once the license has expired. */
+  l?: string;
+  /** [optional] Unix timestamp (seconds); warn the user about expiration after this moment. */
+  w?: number;
+  /** [optional] Warning text; if `w` is set while `wt` is absent, a default warning should be shown. */
+  wt?: string;
+  /** [optional] Expiration text — shown to the user once the license has expired. */
+  et?: string;
+  c?: Record<string, unknown>;
+  t?: Record<string, unknown>;
+  hw?: string;
+  f?: Record<string, string>;
+  /**
+   * Monitoring configuration.
+   * https://github.com/milaboratory/text/blob/main/features/monitoring/platforma-monitoring-prd.md
+   */
+  s?: {
+    usage?: LicenseMonitoringMode;
+    performance?: LicenseMonitoringMode;
+    errors?: LicenseMonitoringMode;
+    safeErrors?: LicenseMonitoringMode;
+    errorTraces?: LicenseMonitoringMode;
+  };
+}
+
+/** Fixed first segment of a well-formed license token. */
+const LICENSE_TOKEN_PREFIX = "I";
+/** Fixed watermark segment of a well-formed license token. */
+const LICENSE_TOKEN_WATERMARK = "CPECUVF";
+
+/**
+ * Runtime guard: asserts that a value parsed from a license token carries every
+ * required field with the expected type. Throws a descriptive error otherwise.
+ *
+ * Only the always-present fields (`v`, `e`, `u`, `m`) are validated — everything
+ * else in {@link LicensePayload} is optional and issuer-dependent.
+ */
+export function assertLicensePayload(value: unknown): asserts value is LicensePayload {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`invalid license payload: expected an object, got ${typeof value}`);
+  }
+  const p = value as Record<string, unknown>;
+  const requireType = (field: string, type: "number" | "string") => {
+    if (typeof p[field] !== type) {
+      throw new Error(
+        `invalid license payload: field "${field}" must be a ${type}, got ${typeof p[field]}`,
+      );
+    }
+  };
+  requireType("v", "number");
+  requireType("e", "number");
+  requireType("u", "string");
+  requireType("m", "string");
+}
+
+/**
+ * Decode a raw license token into a validated {@link LicensePayload}.
+ *
+ * Mirrors the desktop app's token parser and the backend's `NewLicenseFromPayload`:
+ * it splits the `I.<base64Payload>.<watermark>.<signature>` envelope, checks the
+ * fixed prefix/watermark, base64-decodes the payload segment and validates that
+ * all required fields are present. This does NOT verify the cryptographic
+ * signature — that is a separate concern owned by the desktop's LicenseManager.
+ */
+export function decodeLicenseToken(token: string): LicensePayload {
+  const [prefix, base64Payload, watermark, signature] = token.split(".");
+  if (
+    prefix !== LICENSE_TOKEN_PREFIX ||
+    watermark !== LICENSE_TOKEN_WATERMARK ||
+    typeof base64Payload !== "string" ||
+    typeof signature !== "string"
+  ) {
+    throw new Error("invalid license token: unexpected envelope format");
+  }
+
+  const payloadStr = Buffer.from(base64Payload, "base64").toString("utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payloadStr);
+  } catch (cause) {
+    throw new Error("invalid license token: payload is not valid JSON", { cause });
+  }
+
+  assertLicensePayload(parsed);
+  return parsed;
+}

--- a/lib/node/pl-client/src/core/license.ts
+++ b/lib/node/pl-client/src/core/license.ts
@@ -61,9 +61,10 @@ const LICENSE_TOKEN_WATERMARK = "CPECUVF";
  * required field with the expected type. Throws a descriptive error otherwise.
  *
  * Only the always-present fields (`v`, `e`, `u`, `m`) are validated — everything
- * else in {@link LicensePayload} is optional and issuer-dependent.
+ * else in {@link LicensePayload} is optional and issuer-dependent. Internal:
+ * callers get validation for free via {@link decodeLicenseToken}.
  */
-export function assertLicensePayload(value: unknown): asserts value is LicensePayload {
+function assertLicensePayload(value: unknown): asserts value is LicensePayload {
   if (typeof value !== "object" || value === null) {
     throw new Error(`invalid license payload: expected an object, got ${typeof value}`);
   }

--- a/lib/node/pl-client/src/core/license.ts
+++ b/lib/node/pl-client/src/core/license.ts
@@ -28,6 +28,15 @@ export interface LicensePayload {
    * expiration date.
    */
   e: number;
+  /**
+   * [optional] Unix timestamp (seconds) the license itself expires — the
+   * underlying license/contract end date, independent of the short-lived
+   * token TTL `e`. Derived from the contract expiration before any token-TTL
+   * clamping, so this is the field to use when reasoning about whether the
+   * license (not the current token) has expired. Absent on tokens from older
+   * licensing servers that predate the `le` claim.
+   */
+  le?: number;
   /** UID of the customer. */
   u: string;
   /** Metric marker — attached to usage statistics. */
@@ -95,7 +104,8 @@ function assertLicensePayload(value: unknown): asserts value is LicensePayload {
  * it splits the `I.<base64Payload>.<watermark>.<signature>` envelope, checks the
  * fixed prefix/watermark, base64-decodes the payload segment and validates that
  * all required fields are present. This does NOT verify the cryptographic
- * signature — that is a separate concern owned by the desktop's LicenseManager.
+ * signature — as token is used by MiLM manager to access its API, this signature
+ * is for MiLM itself, who issued the token.
  */
 export function decodeLicenseToken(token: string): LicensePayload {
   const segments = token.split(".");

--- a/lib/node/pl-client/src/core/license.ts
+++ b/lib/node/pl-client/src/core/license.ts
@@ -18,7 +18,7 @@ export type LicenseMonitoringMode = "with_id" | "no_id" | "none";
  * Backend counterpart: `core/pl/cmd/platforma/license.go` (`License` struct).
  */
 export interface LicensePayload {
-  /** Unix timestamp (seconds) this license token is valid from. */
+  /** Unix timestamp (seconds) the license itself is valid from (issuance), not a token time. */
   v: number;
   /**
    * Unix timestamp (seconds) this license token expires after — the token's

--- a/lib/node/pl-client/src/core/license.ts
+++ b/lib/node/pl-client/src/core/license.ts
@@ -98,12 +98,16 @@ function assertLicensePayload(value: unknown): asserts value is LicensePayload {
  * signature — that is a separate concern owned by the desktop's LicenseManager.
  */
 export function decodeLicenseToken(token: string): LicensePayload {
-  const [prefix, base64Payload, watermark, signature] = token.split(".");
+  const segments = token.split(".");
+  const [prefix, base64Payload, watermark, signature] = segments;
   if (
+    segments.length !== 4 ||
     prefix !== LICENSE_TOKEN_PREFIX ||
     watermark !== LICENSE_TOKEN_WATERMARK ||
     typeof base64Payload !== "string" ||
-    typeof signature !== "string"
+    base64Payload.length === 0 ||
+    typeof signature !== "string" ||
+    signature.length === 0
   ) {
     throw new Error("invalid license token: unexpected envelope format");
   }

--- a/lib/node/pl-client/src/core/license.ts
+++ b/lib/node/pl-client/src/core/license.ts
@@ -18,9 +18,15 @@ export type LicenseMonitoringMode = "with_id" | "no_id" | "none";
  * Backend counterpart: `core/pl/cmd/platforma/license.go` (`License` struct).
  */
 export interface LicensePayload {
-  /** Unix timestamp (seconds) the license is valid from. */
+  /** Unix timestamp (seconds) this license token is valid from. */
   v: number;
-  /** Unix timestamp (seconds) the license expires after. */
+  /**
+   * Unix timestamp (seconds) this license token expires after — the token's
+   * TTL, not the license's own validity period. Tokens are short-lived and
+   * re-minted (e.g. a 24h TTL yields `e` = issued-at + 86400) even when the
+   * underlying license is valid far longer, so `e` is not the license
+   * expiration date.
+   */
   e: number;
   /** UID of the customer. */
   u: string;

--- a/lib/node/pl-client/src/index.ts
+++ b/lib/node/pl-client/src/index.ts
@@ -2,6 +2,7 @@ export * from "./core/types";
 export * as Pl from "./helpers/pl";
 export * from "./core/config";
 export * from "./core/client";
+export * from "./core/license";
 export * from "./core/driver";
 export * from "./core/transaction";
 export * from "./core/errors";


### PR DESCRIPTION
## What

Adds, in `@milaboratories/pl-client`, next to the Maintenance API `license()` call that returns the raw license token:

- **`LicensePayload`** type — the decoded body of a Platforma license token (`v`, `e` = expiration, `u`, `m` required; `w`/`wt`/`et`, monitoring config `s`, etc. optional). Mirrors the desktop app's local copy and the backend `License` struct (`core/pl/cmd/platforma/license.go`).
- **`decodeLicenseToken(token)`** — splits the `I.<base64Payload>.<watermark>.<signature>` envelope, base64-decodes the payload, and validates required fields (no signature verification — that stays in the desktop's LicenseManager).
- **`assertLicensePayload(value)`** — runtime guard for the required fields.
- **`license.test.ts`** — fetches the license from a live backend (`client.license()`), decodes it, and asserts the required fields are always present. Also logs the full payload + human-readable expiration, so it doubles as an investigation surface for any backend (point it via `PL_ADDRESS` / `PL_TEST_USER` / `PL_TEST_PASSWORD`).

## Why

Puts the license-payload contract next to the code that controls the license communication, and gives us a patchable, backend-agnostic way to inspect a customer's actual license expiration. Supports informing clients about license expiration in advance.

## Scope / follow-up

- **pl-client only.** The desktop app keeps its own identical `LicensePayload` copy for now; migrating it to import from pl-client is a separate follow-up (desktop consumes pl-client as a published package, so it can only switch after this ships and the catalog pin is bumped).
- No backend change; no zod dependency added (validation is plain runtime assertions).

## Test note

`license.test.ts` requires a **licensed backend** to run (it calls `client.license()`), same as the existing `client.test.ts` suite — it runs in the backend-integration harness, not as a pure unit test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds public Platforma-license payload types, runtime payload validation, token decoding, and a live-backend contract test to `@milaboratories/pl-client`.
- **LicensePayload** — the decoded license body; this PR defines required validity, customer, and metric fields plus optional warning, fallback, monitoring, and issuer-specific metadata.
- **LicenseMonitoringMode** — the telemetry-channel mode; this PR defines the supported `with_id`, `no_id`, and `none` values.
- **decodeLicenseToken** — the raw-token decoder; this PR exports envelope parsing, base64/JSON decoding, and required-field validation.
- **assertLicensePayload** — the runtime type guard; this PR checks that `v`, `e`, `u`, and `m` have their declared primitive types.
- **License integration test** — the live-backend contract check; this PR fetches and inspects a license but currently exposes the complete payload in retained output.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the live-backend test stops exposing complete license payloads in retained test output.

The new decoder and types are generally coherent, but the integration test emits customer and fallback-license data without redaction, and the envelope validator also accepts malformed segment layouts.

**Files Needing Attention:** lib/node/pl-client/src/core/license.test.ts; lib/node/pl-client/src/core/license.ts
</details>

<details open><summary><h3>Security Review</h3></summary>

The new integration test logs the full decoded license payload, potentially exposing customer identifiers, fallback license credentials, hardware identifiers, and opaque issuer metadata in CI output. **How this was verified:** The logged object includes every field, while the new type identifies `u` as a customer UID and `l` as a fallback license code.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/license.ts | Introduces exported license types and decoding, but the envelope check accepts empty signatures and silently ignores extra segments. |
| lib/node/pl-client/src/core/license.test.ts | Adds a useful live-backend contract test, but logs the complete potentially sensitive license payload. |
| lib/node/pl-client/src/index.ts | Re-exports the new public license API from the package entry point. |
| .changeset/license-payload-type.md | Records the new public API as a minor package release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Licensed backend] -->|raw token| B[PlClient.license]
  B --> C[decodeLicenseToken]
  C --> D[Validate required field types]
  D --> E[LicensePayload]
  E --> F[Consumer]
  E -->|current integration test| G[Unredacted CI log]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Flicense.test.ts%3A37%0A**Full%20license%20payload%20enters%20CI%20logs**%0A%0AWhen%20this%20integration%20test%20runs%20against%20a%20licensed%20backend%2C%20it%20serializes%20every%20payload%20field%2C%20including%20the%20customer%20UID%2C%20fallback%20license%20code%2C%20hardware%20identifier%2C%20and%20opaque%20issuer%20metadata%2C%20into%20retained%20test%20output.%20Remove%20or%20explicitly%20redact%20the%20sensitive%20fields%20before%20logging.%20**How%20this%20was%20verified%3A**%20The%20test%20passes%20the%20complete%20%60payload%60%20object%20to%20%60JSON.stringify%60%2C%20while%20%60LicensePayload%60%20defines%20%60u%60%20as%20a%20customer%20UID%20and%20%60l%60%20as%20a%20fallback%20license%20code.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Flicense.ts%3A94-102%0A**Envelope%20validation%20accepts%20malformed%20segments**%0A%0AArray%20destructuring%20silently%20discards%20segments%20after%20the%20fourth%2C%20and%20the%20type%20checks%20accept%20an%20empty%20signature.%20Consequently%2C%20%60decodeLicenseToken%60%20can%20return%20a%20payload%20for%20tokens%20that%20do%20not%20satisfy%20its%20documented%20four-part%20%60I.%3Cpayload%3E.%3Cwatermark%3E.%3Csignature%3E%60%20envelope%2C%20preventing%20callers%20from%20relying%20on%20successful%20decoding%20as%20structural%20validation.%0A%0A%60%60%60suggestion%0A%20%20const%20segments%20%3D%20token.split%28%22.%22%29%3B%0A%20%20const%20%5Bprefix%2C%20base64Payload%2C%20watermark%2C%20signature%5D%20%3D%20segments%3B%0A%20%20if%20%28%0A%20%20%20%20segments.length%20!%3D%3D%204%20%7C%7C%0A%20%20%20%20prefix%20!%3D%3D%20LICENSE_TOKEN_PREFIX%20%7C%7C%0A%20%20%20%20watermark%20!%3D%3D%20LICENSE_TOKEN_WATERMARK%20%7C%7C%0A%20%20%20%20typeof%20base64Payload%20!%3D%3D%20%22string%22%20%7C%7C%0A%20%20%20%20base64Payload.length%20%3D%3D%3D%200%20%7C%7C%0A%20%20%20%20typeof%20signature%20!%3D%3D%20%22string%22%20%7C%7C%0A%20%20%20%20signature.length%20%3D%3D%3D%200%0A%20%20%29%20%7B%0A%20%20%20%20throw%20new%20Error%28%22invalid%20license%20token%3A%20unexpected%20envelope%20format%22%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1776&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/node/pl-client/src/core/license.test.ts:37
**Full license payload enters CI logs**

When this integration test runs against a licensed backend, it serializes every payload field, including the customer UID, fallback license code, hardware identifier, and opaque issuer metadata, into retained test output. Remove or explicitly redact the sensitive fields before logging. **How this was verified:** The test passes the complete `payload` object to `JSON.stringify`, while `LicensePayload` defines `u` as a customer UID and `l` as a fallback license code.

```suggestion

```

### Issue 2
lib/node/pl-client/src/core/license.ts:94-102
**Envelope validation accepts malformed segments**

Array destructuring silently discards segments after the fourth, and the type checks accept an empty signature. Consequently, `decodeLicenseToken` can return a payload for tokens that do not satisfy its documented four-part `I.<payload>.<watermark>.<signature>` envelope, preventing callers from relying on successful decoding as structural validation.

```suggestion
  const segments = token.split(".");
  const [prefix, base64Payload, watermark, signature] = segments;
  if (
    segments.length !== 4 ||
    prefix !== LICENSE_TOKEN_PREFIX ||
    watermark !== LICENSE_TOKEN_WATERMARK ||
    typeof base64Payload !== "string" ||
    base64Payload.length === 0 ||
    typeof signature !== "string" ||
    signature.length === 0
  ) {
    throw new Error("invalid license token: unexpected envelope format");
  }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add LicensePayload type and decode..."](https://github.com/milaboratory/platforma/commit/f6714632360c9677fb9eb8066d128473c47a9d0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50772939)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [pl-client](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-client.md)

<!-- /greptile_comment -->