### PR TITLE
fix(model): empty selector rule no longer discards all display rules

### DIFF
--- a/.changeset/fix-evaluate-rules-empty-selector.md
+++ b/.changeset/fix-evaluate-rules-empty-selector.md
@@ -1,0 +1,8 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Fix `evaluateRules` discarding every display rule when one selector matches
+nothing. A rule whose selector hits zero columns is now skipped instead of
+aborting the whole evaluation, so the remaining `displayOptions.ordering` /
+`displayOptions.visibility` rules still apply.

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts
@@ -207,6 +207,37 @@ describe("evaluateRules", () => {
     expect(result.get(gid("b"))?.priority).toBe(50);
   });
 
+  test("a rule matching zero columns does not suppress the other rules", () => {
+    const rules: ColumnOrderRule[] = [
+      { match: { name: "^nothing-matches-this$" }, priority: 999 },
+      { match: { name: "^alpha$" }, priority: 100 },
+      { match: { name: "^beta$" }, priority: 50 },
+    ];
+    const columns = [makeLazyColumn("a", { name: "alpha" }), makeLazyColumn("b", { name: "beta" })];
+
+    const result = evaluateRules(rules, columns);
+
+    expect(result.get(gid("a"))?.priority).toBe(100);
+    expect(result.get(gid("b"))?.priority).toBe(50);
+    expect(result.size).toBe(2);
+  });
+
+  test("rules matching zero columns are skipped regardless of their position", () => {
+    const rules: ColumnVisibilityRule[] = [
+      { match: { name: "^ghost-a$" }, visibility: "hidden" },
+      { match: { name: "^note$" }, visibility: "hidden" },
+      { match: { name: "^ghost-b$" }, visibility: "hidden" },
+      { match: { name: "^score$" }, visibility: "optional" },
+      { match: { name: "^ghost-c$" }, visibility: "hidden" },
+    ];
+    const columns = [makeLazyColumn("n", { name: "note" }), makeLazyColumn("s", { name: "score" })];
+
+    const result = evaluateRules(rules, columns);
+
+    expect(result.get(gid("n"))?.visibility).toBe("hidden");
+    expect(result.get(gid("s"))?.visibility).toBe("optional");
+  });
+
   test("dedupes columns by id before building spec frame (no duplicate-key crash)", () => {
     const rules: ColumnVisibilityRule[] = [{ match: { name: "^dup$" }, visibility: "hidden" }];
     const dup = makeLazyColumn("d", { name: "dup" });

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts
@@ -88,7 +88,10 @@ export function evaluateRules<R extends { match: ColumnSelector }>(
     const baseCollection = ColumnsCollection([{ columns: baseColumns, isFinal: true }]);
     for (const rule of selectorRules) {
       const hitIds = baseCollection.filter({ include: rule.match }).getColumnIds();
-      if (hitIds.length === 0) return result;
+      // A rule matching nothing simply contributes no entries — it must not
+      // discard the rules evaluated alongside it. The lookup below is
+      // null-safe, so leaving this rule out of the map is enough.
+      if (hitIds.length === 0) continue;
       selectorHitsByRule.set(rule, new Set(hitIds.map((id) => extractPObjectId(id))));
     }
   }


### PR DESCRIPTION
## Problem

`evaluateRules` (`sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts`) pre-computes selector hits per rule:

```ts
for (const rule of selectorRules) {
  const hitIds = baseCollection.filter({ include: rule.match }).getColumnIds();
  if (hitIds.length === 0) return result;   // returns the EMPTY map
  selectorHitsByRule.set(rule, new Set(hitIds.map((id) => extractPObjectId(id))));
}
```

The early `return result` bails out of the whole function with an empty map. So the first rule whose selector matches zero columns silently discards **every** rule in the set — the caller loses all of its `displayOptions.ordering` and `displayOptions.visibility` rules, with no error and no warning.

## Real-world impact

In the `antibody-tcr-lead-selection` block several rules legitimately match nothing in many projects:

- a cluster-id-column rule, when there is no clustering upstream;
- a runtime-computed filter/ranking highlight rule, before the user has configured either.

Whenever one of those is empty, the block's entire table ordering and visibility configuration is dropped. The block currently ships a `keepMatchingRules()` workaround that pre-checks every rule host-side and drops the empty ones; that workaround exists only because of this bug and can be retired once this lands.

## Fix

`continue` instead of `return`. A rule that matches nothing simply contributes no entries; the per-column lookup further down is already null-safe (`selectorHitsByRule.get(rule)?.has(colKey) ?? false`), so leaving the rule out of the map is sufficient. First-match-wins ordering across the remaining rules is unchanged.

## Tests

Two regression cases added to `utils.test.ts`, both verified to fail on the pre-fix code (`expected undefined to be 100`, `expected undefined to be 'hidden'`):

- **`a rule matching zero columns does not suppress the other rules`** — an empty rule first, followed by two matching order rules; asserts both surviving rules still land (`priority` 100 / 50) and that the result has exactly 2 entries.
- **`rules matching zero columns are skipped regardless of their position`** — empty rules interleaved at the head, middle and tail of a visibility rule list; asserts the two real rules still resolve to `hidden` / `optional`.

## Verification

Scoped to the `@platforma-sdk/model` package:

- `pnpm --filter @platforma-sdk/model run test` — 27 files, 457 passed | 3 todo
- `pnpm --filter @platforma-sdk/model run types:check` — clean
- `pnpm --filter @platforma-sdk/model run linter:check` — 0 warnings, 0 errors
- `pnpm --filter @platforma-sdk/model run formatter:check` — all files correctly formatted

Includes a `patch` changeset for `@platforma-sdk/model`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects display-rule evaluation so an empty selector rule is skipped rather than aborting evaluation of every rule, with regression coverage and a patch changeset.

- Changes `evaluateRules` to continue after selectors that match no columns.
- Tests empty rules at the beginning, middle, and end of ordering and visibility rule lists.
- Important touched terms:
  - **`evaluateRules`** — resolves ordered column display rules into a per-column rule map; changed to preserve evaluation after a zero-hit selector.
  - **`ColumnSelector`** — selects columns by metadata constraints; selectors with no hits now contribute no entries instead of clearing the overall outcome.
  - **`ColumnOrderRule`** — assigns ordering priority to matching columns; unaffected matching rules now retain their priorities when another selector is empty.
  - **`ColumnVisibilityRule`** — assigns visibility states such as `hidden` or `optional`; unaffected matching rules now remain effective around empty selectors.
  - **`selectorHitsByRule`** — caches physical column IDs matched by selector rules; empty selectors are intentionally omitted because downstream lookup is null-safe.
  - **`PObjectId`** — physical column identity used as the result-map key; extraction and identity behavior are unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the corrected behavior covered across both ordering and visibility rules.

The zero-hit branch now skips only the ineffective selector, and the downstream null-safe lookup continues applying remaining rules in their existing first-match order.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.ts | Replaces the incorrect whole-function exit with a null-safe skip while preserving rule order and per-column first-match behavior. |
| sdk/model/src/components/PlDataTable/createPlDataTable/utils.test.ts | Adds focused regressions for empty selectors interleaved with effective ordering and visibility rules. |
| .changeset/fix-evaluate-rules-empty-selector.md | Correctly records the externally observable model-package fix as a patch release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Display rules] --> B[Evaluate selector hits]
  B --> C{Any matching columns?}
  C -- No --> D[Skip this rule]
  C -- Yes --> E[Cache matching column IDs]
  D --> F[Evaluate remaining rules]
  E --> F
  F --> G[Apply first matching rule per column]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(model): skip empty selector rules in..."](https://github.com/milaboratory/platforma/commit/252a3d26f52d568d4120d797108e5867082fd2a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51835338)</sub>

**Context used:**

- Knowledge Base — [Block model](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-model.md)

<!-- /greptile_comment -->