### PR TITLE
MILAB-6714: fail CI builds that never push their docker images

### DIFF
--- a/.changeset/docker-push-intent-guard.md
+++ b/.changeset/docker-push-intent-guard.md
@@ -1,0 +1,7 @@
+---
+"@platforma-sdk/package-builder-lib": minor
+"@platforma-sdk/package-builder": minor
+"@platforma-sdk/block-tools": minor
+---
+
+Fail CI builds that produce docker images without pushing them. A stray `"private": true` on a software package silently disabled auto-push while the entrypoint descriptor still referenced the image tag, so CI went green and the block 404'd pulling the image at runtime. Opt out with `--docker-no-autopush` when a package really must build images it does not publish.

--- a/lib/node/package-builder-lib/src/core/__tests__/publish-docker-images.test.ts
+++ b/lib/node/package-builder-lib/src/core/__tests__/publish-docker-images.test.ts
@@ -307,3 +307,66 @@ describe("Core.buildDockerImages + publishDockerImages", () => {
     }
   });
 });
+
+// selectedDockerPackages answers "what docker images would this build produce?"
+// for a given --package-id selection. Callers use it to reason about a build
+// before running it, so it must mirror buildDockerImages' own id resolution:
+// a plain intersection with dockerPackages would miss the `:docker` virtual
+// entrypoint that python autogen produces.
+describe("Core.selectedDockerPackages", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "selected-docker-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function mixedPackageRoot(): string {
+    return makePackageRoot(
+      tempDir,
+      {
+        name: "@test/mixed",
+        version: "1.0.0",
+        "block-software": {
+          entrypoints: { pyep: pythonEntrypoint, javaep: javaEntrypoint },
+        },
+      },
+      { requirementsTxt: true, runenv: { ref: RUNENV_REF, pythonVersion: "3.12.10" } },
+    );
+  }
+
+  it("counts every docker artifact when nothing is selected", () => {
+    const core = new Core(mockLogger, { packageRoot: mixedPackageRoot() });
+    expect(core.selectedDockerPackages()).toHaveLength(1);
+  });
+
+  it("returns none when the selection has no docker artifact", () => {
+    const core = new Core(mockLogger, { packageRoot: mixedPackageRoot() });
+    expect(core.selectedDockerPackages(["javaep"])).toHaveLength(0);
+  });
+
+  it("resolves the virtual :docker entrypoint for a selected python entrypoint", () => {
+    const core = new Core(mockLogger, { packageRoot: mixedPackageRoot() });
+    expect(core.selectedDockerPackages(["pyep"])).toHaveLength(1);
+  });
+
+  it("returns none for a package with no docker artifacts at all", () => {
+    const root = makePackageRoot(tempDir, {
+      name: "@test/java-only-selection",
+      version: "1.0.0",
+      "block-software": { entrypoints: { main: javaEntrypoint } },
+    });
+
+    const core = new Core(mockLogger, { packageRoot: root });
+    expect(core.selectedDockerPackages()).toHaveLength(0);
+    expect(core.selectedDockerPackages(["main"])).toHaveLength(0);
+  });
+});

--- a/lib/node/package-builder-lib/src/core/__tests__/push-guard.test.ts
+++ b/lib/node/package-builder-lib/src/core/__tests__/push-guard.test.ts
@@ -1,0 +1,62 @@
+// Regression tests for the "built but never pushed" guard (MILAB-6714).
+//
+// The trap: `"private": true` on a software package flips the auto-push default
+// off, the descriptor is still written with the image tag, CI goes green, and
+// the block 404s pulling the image at runtime.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertDockerPushIntent, type PushIntent } from "../push-guard";
+
+const PUSH_SUPPRESSED: PushIntent = {
+  buildDocker: true,
+  pushDocker: false,
+  pushDisabledExplicitly: false,
+  dockerPackageCount: 1,
+};
+
+describe("assertDockerPushIntent", () => {
+  let ci: string | undefined;
+
+  beforeEach(() => {
+    ci = process.env.CI;
+    process.env.CI = "true";
+  });
+
+  afterEach(() => {
+    if (ci === undefined) delete process.env.CI;
+    else process.env.CI = ci;
+  });
+
+  it("throws when CI builds docker images it will not push", () => {
+    expect(() => assertDockerPushIntent(PUSH_SUPPRESSED)).toThrow(/without pushing them/);
+  });
+
+  it("names private as the likely cause", () => {
+    expect(() => assertDockerPushIntent(PUSH_SUPPRESSED)).toThrow(/"private": true/);
+  });
+
+  it("accepts an explicit --docker-no-autopush", () => {
+    expect(() =>
+      assertDockerPushIntent({ ...PUSH_SUPPRESSED, pushDisabledExplicitly: true }),
+    ).not.toThrow();
+  });
+
+  it("accepts a run that does push", () => {
+    expect(() => assertDockerPushIntent({ ...PUSH_SUPPRESSED, pushDocker: true })).not.toThrow();
+  });
+
+  it("accepts a run that builds no docker images", () => {
+    expect(() => assertDockerPushIntent({ ...PUSH_SUPPRESSED, buildDocker: false })).not.toThrow();
+  });
+
+  it("accepts a package with no docker entrypoints", () => {
+    expect(() =>
+      assertDockerPushIntent({ ...PUSH_SUPPRESSED, dockerPackageCount: 0 }),
+    ).not.toThrow();
+  });
+
+  it("stays out of the way outside CI, where dev iteration never pushes", () => {
+    delete process.env.CI;
+    expect(() => assertDockerPushIntent(PUSH_SUPPRESSED)).not.toThrow();
+  });
+});

--- a/lib/node/package-builder-lib/src/core/core.ts
+++ b/lib/node/package-builder-lib/src/core/core.ts
@@ -148,6 +148,20 @@ export class Core {
     );
   }
 
+  /**
+   * The docker artifacts a build would actually produce for this selection.
+   *
+   * Mirrors the resolution `buildDockerImages` performs, so callers can reason
+   * about a build before running it. Note that `ids` are entrypoint names, not
+   * docker package keys: `getArtifact(id, "docker")` resolves the `:docker`
+   * virtual entrypoint, so a plain set intersection with `dockerPackages`
+   * would be wrong.
+   */
+  public selectedDockerPackages(ids?: string[]): string[] {
+    const selected = ids ?? Array.from(this.dockerPackages.keys());
+    return selected.filter((id) => this.getArtifact(id, "docker") !== undefined);
+  }
+
   public packageHasType(id: string, type: artifacts.artifactType): boolean {
     const pkg = this.packages.get(id);
     if (pkg && pkg.type === type) {

--- a/lib/node/package-builder-lib/src/core/push-guard.ts
+++ b/lib/node/package-builder-lib/src/core/push-guard.ts
@@ -1,0 +1,42 @@
+// Guard against the silent "image built, never pushed" outcome.
+//
+// Docker auto-push defaults to `isCI() && !isPrivate`, but the entrypoint
+// descriptor is written with the image tag either way. A stray
+// `"private": true` on a software package therefore yields a green CI run and
+// a published block that 404s pulling its image at runtime — the failure only
+// surfaces when a user runs the block (MILAB-6714).
+//
+// So: in CI, building docker images without pushing them is an error unless
+// the caller says it meant to, via `--docker-no-autopush` /
+// `PL_DOCKER_NO_AUTOPUSH=1`.
+
+import * as envs from "./envs";
+import * as util from "./util";
+
+export type PushIntent = {
+  /** Docker images were built in this run. */
+  buildDocker: boolean;
+  /** Resolved auto-push decision. */
+  pushDocker: boolean;
+  /** Caller passed `--docker-no-autopush` / `PL_DOCKER_NO_AUTOPUSH=1`. */
+  pushDisabledExplicitly: boolean;
+  /** How many entrypoints produce a docker image. */
+  dockerPackageCount: number;
+};
+
+/** Throws when a CI run is about to reference docker images it never pushed. */
+export function assertDockerPushIntent(intent: PushIntent): void {
+  if (!envs.isCI()) return;
+  if (!intent.buildDocker || intent.pushDocker) return;
+  if (intent.dockerPackageCount === 0) return;
+  if (intent.pushDisabledExplicitly) return;
+
+  throw util.CLIError(
+    `This CI run would build docker images without pushing them, while still writing ` +
+      `entrypoint descriptors that reference them. Consumers would fail to pull the images.\n` +
+      `  The usual cause is "private": true in package.json: auto-push is gated on ` +
+      `!isPrivate, and software packages must never be private.\n` +
+      `  If this package really must build images without publishing them, say so with ` +
+      `--docker-no-autopush (or ${envs.PL_DOCKER_NO_AUTOPUSH}=1).`,
+  );
+}

--- a/lib/node/package-builder-lib/src/index.ts
+++ b/lib/node/package-builder-lib/src/index.ts
@@ -4,6 +4,7 @@ import { Core } from "./core/core";
 export * as util from "./core/util";
 export * as envs from "./core/envs";
 export * as defaults from "./defaults";
+export { assertDockerPushIntent, type PushIntent } from "./core/push-guard";
 
 /** The logger the engine and its callers pass around. */
 export type Logger = winston.Logger;
@@ -22,6 +23,7 @@ export type Builder = Pick<
   | "fullDirHash"
   | "version"
   | "isPrivate"
+  | "dockerPackages"
   | "buildDockerImages"
   | "buildSoftwareArchives"
   | "buildSwJsonFiles"

--- a/lib/node/package-builder-lib/src/index.ts
+++ b/lib/node/package-builder-lib/src/index.ts
@@ -23,7 +23,7 @@ export type Builder = Pick<
   | "fullDirHash"
   | "version"
   | "isPrivate"
-  | "dockerPackages"
+  | "selectedDockerPackages"
   | "buildDockerImages"
   | "buildSoftwareArchives"
   | "buildSwJsonFiles"

--- a/tests/package-builder/10.asset/package.json
+++ b/tests/package-builder/10.asset/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "cleanup": "rm -rf ./dist/ && rm -f ./pkg-*.tgz",
     "reset": "npm run cleanup && rm -rf ./node_modules/",
-    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build --entrypoint=1.2.3 && node ./verify.mjs"
+    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build --entrypoint=1.2.3 --docker-no-autopush && node ./verify.mjs"
   },
   "block-software": {
     "registries": {

--- a/tests/package-builder/20.runenv/package.json
+++ b/tests/package-builder/20.runenv/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "cleanup": "rm -rf ./dist/ && rm -f ./pkg-*.tgz",
     "reset": "npm run cleanup && rm -rf ./node_modules/",
-    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build && node ./verify.mjs"
+    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build --docker-no-autopush && node ./verify.mjs"
   },
   "block-software": {
     "entrypoints": {

--- a/tests/package-builder/30.software-pkg/package.json
+++ b/tests/package-builder/30.software-pkg/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "cleanup": "rm -rf ./dist/ && rm -f ./pkg-*.tgz",
     "reset": "npm run cleanup && rm -rf ./node_modules/",
-    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build --docker-build && node ./verify.mjs"
+    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build --docker-build --docker-no-autopush && node ./verify.mjs"
   },
   "block-software": {
     "registries": {

--- a/tests/package-builder/90.catalogue/package.json
+++ b/tests/package-builder/90.catalogue/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "cleanup": "rm -rf ./dist/ && rm -f ./pkg-*.tgz",
     "reset": "npm run cleanup && rm -rf ./node_modules/",
-    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build"
+    "test:check": "rm -rf dist && env -u PL_PKG_DEV pl-pkg build --docker-no-autopush"
   },
   "block-software": {
     "entrypoints": {

--- a/tests/tengo-builder/2-artifacts/package.json
+++ b/tests/tengo-builder/2-artifacts/package.json
@@ -5,7 +5,7 @@
     "description": "Simple static artifacts for tests (assets and software)",
     "scripts": {
         "cleanup": "rm -rf ./dist/ && rm -f ./pkg-*.tgz",
-        "test:check": "pnpm run cleanup && pl-pkg build"
+        "test:check": "pnpm run cleanup && pl-pkg build --docker-no-autopush"
     },
     "block-software": {
         "entrypoints": {

--- a/tools/block-tools/src/cmd/software/build.ts
+++ b/tools/block-tools/src/cmd/software/build.ts
@@ -156,7 +156,7 @@ export function softwareBuildCommand(): Command {
           buildDocker,
           pushDocker,
           pushDisabledExplicitly: Boolean(o.dockerNoAutopush),
-          dockerPackageCount: core.dockerPackages.size,
+          dockerPackageCount: core.selectedDockerPackages(o.packageId).length,
         });
       }
 

--- a/tools/block-tools/src/cmd/software/build.ts
+++ b/tools/block-tools/src/cmd/software/build.ts
@@ -1,5 +1,10 @@
 import { Command, Option } from "commander";
-import { util, envs, createBuilder } from "@platforma-sdk/package-builder-lib";
+import {
+  util,
+  envs,
+  createBuilder,
+  assertDockerPushIntent,
+} from "@platforma-sdk/package-builder-lib";
 import { parseScenario, channels, variants, locations } from "./knobs";
 import { runBuild } from "./run-build";
 import {
@@ -143,6 +148,17 @@ export function softwareBuildCommand(): Command {
           enable: o.dockerAutopush,
           disable: o.dockerNoAutopush,
         });
+
+      // Only the bare (pl-pkg-parity) scenario derives its push from isPrivate; the
+      // target scenarios push on location=remote and never consult it.
+      if (scenario.kind === "bare") {
+        assertDockerPushIntent({
+          buildDocker,
+          pushDocker,
+          pushDisabledExplicitly: Boolean(o.dockerNoAutopush),
+          dockerPackageCount: core.dockerPackages.size,
+        });
+      }
 
       await runBuild({
         core,

--- a/tools/package-builder/src/commands/build/all.ts
+++ b/tools/package-builder/src/commands/build/all.ts
@@ -1,6 +1,12 @@
 import { Command } from "commander";
 import * as cmdOpts from "../../cmd-opts";
-import { util, envs, defaults, createBuilder } from "@platforma-sdk/package-builder-lib";
+import {
+  util,
+  envs,
+  defaults,
+  createBuilder,
+  assertDockerPushIntent,
+} from "@platforma-sdk/package-builder-lib";
 
 // Registered twice: as the top-level `build` command and as the `build all`
 // subcommand. Both run the same build-all action with the same flags.
@@ -61,6 +67,25 @@ export function buildAllCommand(name = "build"): Command {
         flags["docker-registry"] ??
         (isDevLocal && buildDocker ? defaults.DEV_DOCKER_REGISTRY : undefined);
 
+      // Auto-push defaults to OFF outside CI. Dev iteration doesn't push;
+      // explicit opt-in via --docker-autopush / PL_DOCKER_AUTOPUSH=1 (which
+      // 'build:dev-remote' sets) flips it. Private packages never push by
+      // default — the dev ECR is public.
+      const autopush = cmdOpts.shouldDoAction({
+        default: envs.isCI() && !core.isPrivate,
+        enable: flags["docker-autopush"],
+        disable: flags["docker-no-autopush"],
+      });
+
+      // Before the build, not after: a CI run that would discard its images
+      // should not spend minutes cross-compiling them first.
+      assertDockerPushIntent({
+        buildDocker,
+        pushDocker: autopush,
+        pushDisabledExplicitly: flags["docker-no-autopush"],
+        dockerPackageCount: core.dockerPackages.size,
+      });
+
       if (buildDocker) {
         core.buildDockerImages({
           ids: flags["package-id"],
@@ -89,15 +114,6 @@ export function buildAllCommand(name = "build"): Command {
         packageIds: flags["package-id"] ? flags["package-id"] : undefined,
       });
 
-      // Auto-push defaults to OFF outside CI. Dev iteration doesn't push;
-      // explicit opt-in via --docker-autopush / PL_DOCKER_AUTOPUSH=1 (which
-      // 'build:dev-remote' sets) flips it. Private packages never push by
-      // default — the dev ECR is public.
-      const autopush = cmdOpts.shouldDoAction({
-        default: envs.isCI() && !core.isPrivate,
-        enable: flags["docker-autopush"],
-        disable: flags["docker-no-autopush"],
-      });
       if (buildDocker && autopush) {
         // TODO: as we do not create content-addressable archives for binary packages, we should not upload them
         //       for each build to not spoil release process with dev archives cached by CDN.

--- a/tools/package-builder/src/commands/build/all.ts
+++ b/tools/package-builder/src/commands/build/all.ts
@@ -83,7 +83,7 @@ export function buildAllCommand(name = "build"): Command {
         buildDocker,
         pushDocker: autopush,
         pushDisabledExplicitly: flags["docker-no-autopush"],
-        dockerPackageCount: core.dockerPackages.size,
+        dockerPackageCount: core.selectedDockerPackages(flags["package-id"]).length,
       });
 
       if (buildDocker) {

--- a/tools/package-builder/src/commands/build/docker.ts
+++ b/tools/package-builder/src/commands/build/docker.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import * as cmdOpts from "../../cmd-opts";
-import { util, envs, createBuilder } from "@platforma-sdk/package-builder-lib";
+import {
+  util,
+  envs,
+  createBuilder,
+  assertDockerPushIntent,
+} from "@platforma-sdk/package-builder-lib";
 
 export function buildDockerCommand(): Command {
   const cmd = new Command("docker").description("build docker images");
@@ -23,17 +28,29 @@ export function buildDockerCommand(): Command {
 
     core.version = flags.version;
 
-    core.buildDockerImages({
-      ids: flags["package-id"],
-      strictPlatformMatching: envs.isCI(),
-    });
-
     const autopush = cmdOpts.shouldDoAction({
       default: envs.isCI() && !core.isPrivate, // do not push docker images of private packages
       enable: flags["docker-autopush"],
       disable: flags["docker-no-autopush"],
     });
-    if (autopush && !core.isPrivate) {
+
+    // Before the build, not after: a CI run that would discard its images should
+    // not spend minutes cross-compiling them first.
+    assertDockerPushIntent({
+      buildDocker: true,
+      pushDocker: autopush,
+      pushDisabledExplicitly: flags["docker-no-autopush"],
+      dockerPackageCount: core.dockerPackages.size,
+    });
+
+    core.buildDockerImages({
+      ids: flags["package-id"],
+      strictPlatformMatching: envs.isCI(),
+    });
+
+    // No extra !isPrivate check here: it is already in the default above, and
+    // repeating it made the documented --docker-autopush opt-in a silent no-op.
+    if (autopush) {
       core.publishDockerImages({
         ids: flags["package-id"],
         strictPlatformMatching: envs.isCI(),

--- a/tools/package-builder/src/commands/build/docker.ts
+++ b/tools/package-builder/src/commands/build/docker.ts
@@ -40,7 +40,7 @@ export function buildDockerCommand(): Command {
       buildDocker: true,
       pushDocker: autopush,
       pushDisabledExplicitly: flags["docker-no-autopush"],
-      dockerPackageCount: core.dockerPackages.size,
+      dockerPackageCount: core.selectedDockerPackages(flags["package-id"]).length,
     });
 
     core.buildDockerImages({


### PR DESCRIPTION
## Problem

Docker auto-push defaults to `isCI() && !isPrivate`, but the entrypoint descriptor is written with the image tag either way. A stray `"private": true` on a software package therefore produces a green CI run and a published block that 404s pulling its image at runtime, with nothing in the logs indicating anything went wrong.

This is what happened to `gpu-test` (MILAB-6714). The structurer stopped emitting `private` on software packages in `block-tools@2.11.6`, but that only helps blocks someone refreshes with the released tool. gpu-test was refreshed four weeks after that fix and still got the flag, because the refresh ran a stale local build.

## Change

`assertDockerPushIntent` in `lib/node/package-builder-lib/src/core/push-guard.ts`. In CI, building docker images without pushing them is now an error. Wired into the three CLI boundaries that resolve the push decision:

- `tools/package-builder/src/commands/build/all.ts`
- `tools/package-builder/src/commands/build/docker.ts`
- `tools/block-tools/src/cmd/software/build.ts` (bare scenario only; the `target` scenarios push on `location=remote` and never consult `isPrivate`, so they were already immune)

The check runs before the build, not after, so a doomed run does not cross-compile first.

## On the fixture changes

`!isPrivate` entered the autopush default in 7b8fcc427 / #1183 (2025-10-10). At that commit the only private packages carrying `block-software` in this repo were exactly five test fixtures, so `private` was adopted as an implicit "do not push" signal, and at the time it was correct.

What changed since is that the structurer started stamping `private: true` onto every block's software package, so a signal meaning "test fixture" landed on real blocks. This PR migrates those five fixtures onto the explicit `--docker-no-autopush` flag, which is what they always meant. `private` stops being load-bearing for push suppression, and the leftover case can then be an error rather than silence.

## Also

Drops the redundant `&& !core.isPrivate` in `pl-pkg build docker`. The default above already encodes it, and repeating it made the documented `--docker-autopush` opt-in a silent no-op for exactly the packages that most needed it.

## Verification

- 7 new unit tests; package-builder-lib suite 128/128; block-tools 327 passed / 2 skipped
- `turbo run check` clean on all three packages
- End to end against the real private fixture with `CI=true`: the guard fires immediately with the message below, and passes through to the docker build once `--docker-no-autopush` is given

```
error: This CI run would build docker images without pushing them, while still
writing entrypoint descriptors that reference them. Consumers would fail to pull
the images.
  The usual cause is "private": true in package.json: auto-push is gated on
  !isPrivate, and software packages must never be private.
  If this package really must build images without publishing them, say so with
  --docker-no-autopush (or PL_DOCKER_NO_AUTOPUSH=1).
```

The `tests/package-builder` integration fixtures could not be run to completion locally: this machine's docker daemon cannot create veth pairs, so `pip install` inside the image build fails. Environmental and pre-existing, but worth a run on a normal machine.

Ticket: MILAB-6714

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a shared CI guard that rejects implicit Docker build-without-push decisions and wires it into the package-builder and block-tools CLI boundaries. It also migrates private test fixtures to an explicit no-push option and permits explicit autopush for private packages in `pl-pkg build docker`.

**Important touched terms**
- **Push intent** — the resolved combination of whether Docker images will be built, pushed, or intentionally left unpublished; this PR introduces `PushIntent` and validates it before builds begin.
- **Docker package** — a `block-software` entrypoint that produces a Docker image; its count is now exposed through the public `Builder` type and supplied to the guard.
- **Autopush** — automatic image publication, normally enabled in CI for non-private packages; this PR rejects implicit suppression and makes explicit `--docker-autopush` effective for private packages in `pl-pkg build docker`.
- **Explicit no-autopush** — `--docker-no-autopush` or `PL_DOCKER_NO_AUTOPUSH=1`; this is now the supported CI opt-out and replaces implicit suppression in five private fixtures.
- **Bare software-build scenario** — block-tools' compatibility mode that derives Docker push behavior from CI/private state; this PR applies the new guard to that scenario.
- **Entrypoint descriptor** — the generated `.sw.json` reference consumed at runtime; the guard prevents CI from silently generating one that points to an image it did not intend to publish.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the guard accounts for selected package IDs, otherwise valid non-Docker CI builds can fail in mixed private packages.

The new guard uses a package-wide Docker count while every affected command can restrict actual work with `--package-id`, creating a concrete false-positive failure before the filtered build starts.

**Files Needing Attention:** tools/package-builder/src/commands/build/all.ts, tools/package-builder/src/commands/build/docker.ts, tools/block-tools/src/cmd/software/build.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/package-builder-lib/src/core/push-guard.ts | Introduces the shared CI push-intent validation and its diagnostic error. |
| tools/package-builder/src/commands/build/all.ts | Adds pre-build validation, but passes an unfiltered Docker count when package IDs restrict the actual build. |
| tools/package-builder/src/commands/build/docker.ts | Adds the same guard and enables explicit autopush for private packages; selected IDs are likewise omitted from the count. |
| tools/block-tools/src/cmd/software/build.ts | Applies push-intent validation to bare scenarios, with the same package-selection mismatch. |
| lib/node/package-builder-lib/src/core/__tests__/push-guard.test.ts | Covers the guard's boolean branches but not CLI package-ID filtering. |
| lib/node/package-builder-lib/src/index.ts | Exports the guard types and exposes Docker package metadata on the public builder surface. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  CLI[Package-builder or block-tools CLI] --> Resolve[Resolve build and push intent]
  Resolve --> Guard{CI guard}
  Guard -->|Implicit build without push| Error[Fail before compilation]
  Guard -->|Push enabled or explicit opt-out| Build[Build selected artifacts]
  Build --> Push{Push enabled?}
  Push -->|Yes| Registry[Publish Docker images]
  Push -->|No, explicit| Descriptor[Write entrypoint descriptors]
  Registry --> Descriptor
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Fpackage-builder%2Fsrc%2Fcommands%2Fbuild%2Fall.ts%3A86%0A**Guard%20Counts%20Unselected%20Docker%20Packages**%0A%0AWhen%20a%20private%20mixed-artifact%20package%20is%20built%20in%20CI%20with%20%60--package-id%60%20selecting%20only%20non-Docker%20entrypoints%2C%20the%20guard%20still%20uses%20the%20package-wide%20%60core.dockerPackages.size%60%2C%20causing%20the%20valid%20filtered%20build%20to%20fail%20before%20any%20work%20begins.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/package-builder/src/commands/build/all.ts:86
**Guard Counts Unselected Docker Packages**

When a private mixed-artifact package is built in CI with `--package-id` selecting only non-Docker entrypoints, the guard still uses the package-wide `core.dockerPackages.size`, causing the valid filtered build to fail before any work begins.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6714: fail CI builds that never pu..."](https://github.com/milaboratory/platforma/commit/d9753309a9d17c2985cb20963a25921d5b3e7174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52121983)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Block Build Tooling](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-build-tooling.md)

<!-- /greptile_comment -->