### PR TITLE
feat(workflow-tengo): make ColumnUniversalId a first-class column reference

### DIFF
--- a/.changeset/cool-pandas-listen.md
+++ b/.changeset/cool-pandas-listen.md
@@ -1,0 +1,38 @@
+---
+"@platforma-sdk/workflow-tengo": minor
+"@milaboratories/pl-model-common": patch
+---
+
+Make `ColumnUniversalId` a first-class column reference in the workflow.
+
+A block can now pass any id the model mints — bare leaf, `ColumnFilteredId`,
+`ColumnOverriddenId`, `ColumnDiscoveredId` — straight into
+`createPBundleBuilder().addSingle(...)`, `pt.frameFromColumnBundle` and
+`tableBuilder`, and the workflow resolves it, reconstructs its effective spec,
+and builds the linker join a discovered id describes.
+
+New `:pframes.column-id` decodes and applies the layers (pure functions over
+JSON, unit-tested offline against the TypeScript source of truth). New
+`bundle.getQueryEntry(id)` compiles an id into a `SpecQueryJoinEntry` for
+`pt.p._rawQueryEntry`, folding every `path` hop into a nested `linkerJoin`; new
+`bundle.getAxesSpecOf(id)` reports the axes a column actually contributes,
+projecting out each linker's one-side axes via the new `pSpec.linkerSides` /
+`pSpec.splitAxes` / `pSpec.linkerJoinAxesSpec`.
+
+`EnrichmentRef` becomes a derived special case: `columnId.fromEnrichmentRef`
+normalizes the v1 wire form into a `ColumnDiscoveredKey`, and `tableBuilder`
+resolves both spellings through one path. The type is deprecated; existing
+callers keep working.
+
+Fixes two latent defects found on the way:
+
+- `bundle.getAxesSpec` read raw pool specs while `getSpec` applied axis filters,
+  so a filtered id could contribute axes that its own spec no longer had.
+  `pt.frameFromColumnBundle` calls the former before the latter, so the
+  disagreement was reachable.
+- `pSpec.A_IS_LINKER_COLUMN` was read by `pt.p.linkerJoin` but never exported,
+  which would have panicked on the builder's first use.
+
+No behaviour change for existing id shapes: the registration and read paths now
+share one key derivation that reproduces all four previous derivations, and the
+legacy `FilteredPColumnId` keeps keying on its `source`.

--- a/docs/column-access-api.md
+++ b/docs/column-access-api.md
@@ -733,3 +733,78 @@ label }` wire shape with `refsWithEnrichments`. Its `@deprecated` note points at
 since that changes the stored value from a `PlRef` to a `ColumnUniversalId`.
 
 Removed names and their one-to-one replacements are in the migration doc.
+
+## Workflow Side (Tengo)
+
+A `ColumnUniversalId` is a first-class column reference in
+`@platforma-sdk/workflow-tengo`, not just something the host understands. The
+model mints an id; the workflow resolves it, reconstructs its spec, and — for a
+discovered id — builds the join. Blocks pass ids straight through their args.
+
+`:pframes.column-id` is the decoder: `decode`, `kindOf`, `isUniversalId`,
+`poolKey`, `unwrap`, `extractLeafId`, `referencedIds`, `applyAxisFilters`,
+`applySpecOverrides`, `effectiveSpec`, `fromEnrichmentRef`. Every function is
+pure over decoded JSON, so it is unit-tested offline against the TypeScript
+source of truth (`spec/ids.ts`, `spec/filtered_column.ts`, `spec/overridden.ts`).
+
+### Where each layer is realised
+
+| Layer        | Realised                                                          | Mechanism                                                                          |
+| ------------ | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| leaf         | resolution time                                                   | `bquery.resolve` on the terminal `{__isRef, blockId, name}`                        |
+| `Filtered`   | read time (bundle) / execution time (frame)                       | spec: axes dropped; data: `:pframes.slice-data`, or `pt.p.slicedColumn` in a frame |
+| `Overridden` | read time                                                         | spec math only — the engine's query language has no `specOverride` node            |
+| `Discovered` | execution time                                                    | `bundle.getQueryEntry` → `bquery.buildQuery` → `pt.p._rawQueryEntry`               |
+
+### Pool keys
+
+A rich id registers and reads under **the id itself**, never under its leaf. Two
+projections of one physical column, or one column reached by two linker routes,
+are different columns to a consumer and must not collapse into one pool entry —
+this is the workflow's counterpart to `rebrandLeafId`. It also makes the
+registration key and the read key identical by construction, so the collector
+and the unmarshaller cannot drift.
+
+The one exception is the legacy `FilteredPColumnId` (`{source, axisFilters}` with
+a *selector map* source), which still keys on its source. Marker fields are
+therefore tested before that duck-test.
+
+### Axes of a discovered column
+
+`getSpec` on a discovered id passes through to the hit — the linker chain enables
+co-indexing, it does not remap the hit's own axes, and the engine needs the hit's
+real axes to resolve the join.
+
+The axes the column *contributes to a frame* are different, and that is what
+`getAxesSpecOf` reports: each hop inner-joins its linker and projects out that
+linker's one-side axes, so the result lands on the many side of the outermost
+hop. `pSpec.linkerSides` derives the two sides from the linker's own spec by
+splitting its `axesSpec` into parent-connected components (exactly two are
+required; the component holding axis 0 is the one side). A hit axis the route
+never touches survives, which a blanket empty `axesSpec` would lose.
+
+### Deliberate divergences from the model side
+
+- An `axesSpec` patch whose index is past the end of the spec **panics** instead
+  of appending. The workflow registers specs against data that already exists,
+  and an axis with no data behind it is a spec the engine cannot satisfy.
+- Axis filters on a discovered column **panic**: pinning them would have to
+  become a `sliceAxes` node inside the join, and the query builder emits only
+  column / linkerJoin / innerJoin. Filter after the join instead.
+- `queriesQualifications` is **not** carried. Its keys are the `PObjectId`s of
+  external primary columns, and the workflow addresses its primaries by `PlRef`
+  and frame key — the key space does not exist here. `columnQualifications` does
+  reach `tableBuilder`'s join entry.
+- `tableBuilder` accepts a bare or discovered id but refuses one carrying spec
+  overrides or axis filters: it resolves specs as futures, so there is nothing to
+  patch or slice at that point. Use a column bundle for those.
+
+### `EnrichmentRef` is derived
+
+`EnrichmentRef` (`{__isEnrichment: "v1", hit, path[].linker, qualifications}`) is
+the strictly narrower spelling of the same idea: its hit and every hop must be
+bare global ids and its only step type is `linker`. `fromEnrichmentRef`
+normalizes it into a `ColumnDiscoveredKey`, and `tableBuilder` funnels both
+spellings through one resolution path. The reverse conversion is lossy and
+deliberately absent — a discovered key whose hit or hop carries a projection has
+no v1 representation. The type is deprecated, with no removal date.

--- a/lib/model/common/src/ref.ts
+++ b/lib/model/common/src/ref.ts
@@ -142,6 +142,12 @@ export type EnrichmentStep = EnrichmentLinkerStep;
  * (`canonicalize({ __isRef: true, blockId, name })`) which the workflow decodes
  * to a PlRef before resolving. For a prerun-sourced hop, supply a resolved
  * `{spec, data}` map in place of the id — `tableBuilder` accepts both.
+ *
+ * @deprecated Pass a `ColumnDiscoveredId` instead. It says the same thing —
+ * a hit plus the linker route to it — without restricting the hit and the hops
+ * to bare global ids, and the workflow now normalizes this form into it
+ * (`pframes.column-id.fromEnrichmentRef`). Kept working for existing callers;
+ * no removal date.
  */
 export type EnrichmentRef = {
   readonly __isEnrichment: "v1";

--- a/sdk/workflow-tengo/src/pframes/axes-split.test.tengo
+++ b/sdk/workflow-tengo/src/pframes/axes-split.test.tengo
@@ -1,0 +1,138 @@
+// Tests for the parent-connected-component math in `:pframes.spec`
+// (`splitAxes`, `linkerSides`, `linkerJoinAxesSpec`).
+//
+// Ported from pframes-rs: `AxesSpec::split` (packages/spec/src/axes/axes_spec.rs),
+// the linker one-side/many-side derivation (packages/spec/src/linker_index.rs),
+// and the linkerJoin axis projection rule (the joined axes minus the linker's
+// one-side axes).
+
+test := import(":test")
+pSpec := import(":pframes.spec")
+
+axis := func(name, ...parents) {
+	a := { name: name, type: "String" }
+	if len(parents) > 0 {
+		a.parentAxes = parents[0]
+	}
+	return a
+}
+
+// A linker between `clusterId` (one side) and `clonotypeKey` (many side).
+// Axis 0 lands in the one-side component, matching the engine's convention.
+linkerSpec := func() {
+	return {
+		kind: "PColumn",
+		name: "linker",
+		valueType: "Int",
+		annotations: { "pl7.app/isLinkerColumn": "true" },
+		axesSpec: [
+			axis("clusterId"),
+			axis("clonotypeKey")
+		]
+	}
+}
+
+//
+// splitAxes
+//
+
+TestSplitAxesSingleComponent := func() {
+	// b and c both hang off a, so all three are one component.
+	axesSpec := [axis("a"), axis("b", [0]), axis("c", [0])]
+	test.isEqual([[0, 1, 2]], pSpec.splitAxes(axesSpec))
+}
+
+TestSplitAxesIndependentAxesAreSeparateComponents := func() {
+	test.isEqual([[0], [1]], pSpec.splitAxes([axis("a"), axis("b")]))
+}
+
+TestSplitAxesOrdersComponentsByLowestMember := func() {
+	// a(0) — c(2) joined; b(1) alone. Component containing 0 comes first.
+	axesSpec := [axis("a"), axis("b"), axis("c", [0])]
+	test.isEqual([[0, 2], [1]], pSpec.splitAxes(axesSpec))
+}
+
+TestSplitAxesTransitiveChainCollapses := func() {
+	// a <- b <- c is a single component even though c never names a.
+	axesSpec := [axis("a"), axis("b", [0]), axis("c", [1])]
+	test.isEqual([[0, 1, 2]], pSpec.splitAxes(axesSpec))
+}
+
+TestSplitAxesThreeComponents := func() {
+	axesSpec := [axis("a"), axis("b"), axis("c"), axis("d", [1])]
+	test.isEqual([[0], [1, 3], [2]], pSpec.splitAxes(axesSpec))
+}
+
+TestSplitAxesEmpty := func() {
+	test.isEqual([], pSpec.splitAxes([]))
+}
+
+//
+// linkerSides
+//
+
+TestLinkerSidesSplitsOneAndMany := func() {
+	sides := pSpec.linkerSides(linkerSpec())
+	test.isEqual([0], sides.oneSide)
+	test.isEqual([1], sides.manySide)
+}
+
+TestLinkerSidesWithCompositeManySide := func() {
+	// Many side is a two-axis group: clonotypeKey plus a child axis.
+	spec := {
+		kind: "PColumn",
+		name: "linker",
+		valueType: "Int",
+		axesSpec: [
+			axis("clusterId"),
+			axis("clonotypeKey"),
+			axis("chain", [1])
+		]
+	}
+	sides := pSpec.linkerSides(spec)
+	test.isEqual([0], sides.oneSide)
+	test.isEqual([1, 2], sides.manySide)
+}
+
+//
+// linkerJoinAxesSpec — linker axes lead, one-side axes projected out
+//
+
+TestLinkerJoinAxesSpecProjectsOutOneSide := func() {
+	// Hit lives on the one side; after the join only the many side survives.
+	hitAxes := [axis("clusterId")]
+	got := pSpec.linkerJoinAxesSpec(linkerSpec(), hitAxes)
+	test.isEqual([axis("clonotypeKey")], got)
+}
+
+TestLinkerJoinAxesSpecKeepsHitAxesBeyondTheRoute := func() {
+	// A hit carrying an axis the route does not touch keeps it — this is the
+	// case a blanket `axesSpec: []` would silently lose.
+	hitAxes := [axis("clusterId"), axis("sampleId")]
+	got := pSpec.linkerJoinAxesSpec(linkerSpec(), hitAxes)
+	test.isEqual([axis("clonotypeKey"), axis("sampleId")], got)
+}
+
+TestLinkerJoinAxesSpecDeduplicatesSharedAxes := func() {
+	// The hit already sits on the many side: no duplicate column.
+	hitAxes := [axis("clonotypeKey")]
+	got := pSpec.linkerJoinAxesSpec(linkerSpec(), hitAxes)
+	test.isEqual([axis("clonotypeKey")], got)
+}
+
+TestLinkerJoinAxesSpecDistinguishesAxesByDomain := func() {
+	// Same name, different domain — distinct axes, so nothing is projected out
+	// or deduplicated by name alone.
+	linker := {
+		kind: "PColumn",
+		name: "linker",
+		valueType: "Int",
+		axesSpec: [
+			{ name: "group", type: "String", domain: { side: "primary" } },
+			{ name: "group", type: "String", domain: { side: "secondary" } }
+		]
+	}
+	hitAxes := [{ name: "group", type: "String", domain: { side: "primary" } }]
+	got := pSpec.linkerJoinAxesSpec(linker, hitAxes)
+	test.isEqual([{ name: "group", type: "String", domain: { side: "secondary" } }], got)
+}

--- a/sdk/workflow-tengo/src/pframes/bundle.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/bundle.lib.tengo
@@ -2,8 +2,10 @@ smart := import(":smart")
 json := import("json")
 pConstants := import(":pframes.constants")
 bquery := import(":workflow.bquery")
+buildQueryLib := import(":pframes.build-query")
 canonical := import(":canonical")
 pSpec := import(":pframes.spec")
+columnId := import(":pframes.column-id")
 maps := import(":maps")
 ll := import(":ll")
 assets := import(":assets")
@@ -79,7 +81,8 @@ createBuilder := func(ctx) {
 		ignoreMissingDomains: false
 	}
 
-	addSingleInner := func(id, ...ops) {
+	addSingleInner := undefined
+	addSingleInner = func(id, ...ops) {
 		ll.assert(len(ops) <= 2, "addSingle accepts at most two optional arguments")
 
 		decodedId := undefined
@@ -114,11 +117,12 @@ createBuilder := func(ctx) {
 			queryOpts = ops[1]
 		}
 
+		kind := columnId.kindOf(decodedId)
+
 		// Global-form PObjectId: canonicalize({__isRef: true, blockId, name}).
 		// Opaque id from cross-block result pool — must be resolved by ref, not as a query.
-		isGlobalRef := is_map(decodedId) && decodedId.__isRef == true
-		if isGlobalRef {
-			refKey := is_string(id) ? id : canonical.encode(decodedId)
+		if kind == columnId.KIND_LEAF_GLOBAL {
+			refKey := columnId.poolKey(is_string(id) ? id : decodedId)
 			if !is_undefined(queryKey) {
 				refKey = queryKey
 			}
@@ -131,25 +135,51 @@ createBuilder := func(ctx) {
 
 		// Local-form PObjectId: canonicalize({resolvePath, name}).
 		// Not yet supported here — addSingle has no resolver for local refs.
-		if is_map(decodedId) && !is_undefined(decodedId.resolvePath) {
+		if kind == columnId.KIND_LEAF_LOCAL {
 			ll.panic("addSingle does not support local-form PObjectId (resolvePath): ", decodedId)
 		}
 
-		isFiltered := is_map(decodedId) && !is_undefined(decodedId.source) && !is_undefined(decodedId.axisFilters)
+		// Rich ids (Overridden / Filtered / Discovered) register under the id
+		// itself and resolve their terminal leaf by ref. Keying on the full id
+		// rather than the leaf is what keeps two projections — or two linker
+		// routes — to the same physical column apart, and makes the key used
+		// here identical to the one `processColumnId` computes on read.
+		if kind == columnId.KIND_OVERRIDDEN || kind == columnId.KIND_FILTERED ||
+			kind == columnId.KIND_DISCOVERED {
+
+			// Linker hops are columns in their own right: register each so the
+			// join can reference it, then fall through to the hit itself.
+			for _, referenced in columnId.referencedIds(decodedId) {
+				if columnId.poolKey(referenced) != columnId.poolKey(decodedId) {
+					addSingleInner(referenced)
+				}
+			}
+
+			leafKey := columnId.decode(columnId.extractLeafId(decodedId))
+			ll.assert(leafKey.__isRef == true,
+				"addSingle: %v resolves to a local-form leaf, which has no resolver here: %v",
+				kind, leafKey)
+
+			refKey := columnId.poolKey(is_string(id) ? id : decodedId)
+			if !is_undefined(queryKey) {
+				refKey = queryKey
+			}
+			ref := { blockId: leafKey.blockId, name: leafKey.name }
+			if !is_string(refs[refKey]) {
+				refs[refKey] = ref
+			}
+			return
+		}
+
+		// Legacy FilteredPColumnId: `source` is an anchored selector, resolved
+		// unfiltered and sliced per read, so it keys on the source.
+		isFiltered := kind == columnId.KIND_LEGACY_FILTERED
 		if isFiltered && !is_undefined(queryKey) {
 			ll.panic("FilteredPColumnId cannot be used with a queryKey.")
 		}
 
-		defaultKey := undefined
-		valueToStore := undefined
-		if isFiltered {
-			defaultKey = canonical.encode(decodedId.source)
-			valueToStore = decodedId.source
-		} else {
-			// Use the original string ID if provided for the key, otherwise encode the map
-			defaultKey = is_string(id) ? id : canonical.encode(decodedId)
-			valueToStore = decodedId // Store the decoded map itself
-		}
+		defaultKey := columnId.poolKey(is_string(id) ? id : decodedId)
+		valueToStore := isFiltered ? decodedId.source : decodedId
 
 		keyToUse := defaultKey
 		if !is_undefined(queryKey) {
@@ -338,39 +368,38 @@ createBuilder := func(ctx) {
  * @returns Object that implements the unmarshaller interface {canParse, parse}
  */
 pColumnBundleUnmarshaller := func() {
-	// Process UniversalPColumnId inputs and return their components and canonical representation
+	// Decomposes a column id into everything the read path needs: the pool key
+	// it was registered under, the axis filters to slice its data by, and — for
+	// rich ids — the decoded key so spec math can be applied.
+	//
+	// Shares `columnId.poolKey` with the registration side, so the two seams
+	// cannot drift: a key computed here is the key `addSingleInner` stored.
 	processColumnId := func(id) {
-		columnKey := undefined
+		decodedId := columnId.decode(id)
+		kind := columnId.kindOf(decodedId)
+		serializedId := is_string(id) ? id : canonical.encode(decodedId)
+
 		columnAxisFilters := undefined
-		serializedId := undefined
+		universalId := undefined
+		discovery := undefined
 
-		if is_string(id) {
-			serializedId = id
-			decodedId := json.decode(id)
-
-			if is_map(decodedId) && !is_undefined(decodedId.source) && !is_undefined(decodedId.axisFilters) {
-				columnKey = canonical.encode(decodedId.source)
-				columnAxisFilters = decodedId.axisFilters
-			} else {
-				columnKey = id
-			}
-		} else if is_map(id) {
-			if !is_undefined(id.source) && !is_undefined(id.axisFilters) {
-				columnKey = canonical.encode(id.source)
-				columnAxisFilters = id.axisFilters
-				serializedId = canonical.encode(id)
-			} else {
-				columnKey = canonical.encode(id)
-				serializedId = columnKey
-			}
-		} else {
-			ll.panic("Invalid column ID type. Expected string or object.")
+		if kind == columnId.KIND_LEGACY_FILTERED {
+			columnAxisFilters = decodedId.axisFilters
+		} else if kind == columnId.KIND_OVERRIDDEN || kind == columnId.KIND_FILTERED ||
+			kind == columnId.KIND_DISCOVERED {
+			unwrapped := columnId.unwrap(decodedId)
+			columnAxisFilters = unwrapped.axisFilters
+			discovery = unwrapped.discovery
+			universalId = decodedId
 		}
 
 		return {
-			columnKey: columnKey,
+			columnKey: columnId.poolKey(is_string(id) ? id : decodedId),
 			axisFilters: columnAxisFilters,
-			canonicalId: serializedId
+			canonicalId: serializedId,
+			kind: kind,
+			universalId: universalId,
+			discovery: discovery
 		}
 	}
 
@@ -429,6 +458,35 @@ pColumnBundleUnmarshaller := func() {
 			}
 
 			bundle := undefined
+
+			// Axes a column contributes to a frame.
+			//
+			// For everything but a Discovered id this is just the column's own
+			// effective axes. A Discovered id is different: the engine
+			// inner-joins each linker hop and projects out that linker's
+			// one-side axes, so the axes the column actually lands on are the
+			// many side of the outermost hop — never the hit's own. Folding the
+			// hops from the hit outwards reproduces that, and keeps any hit axis
+			// the route never touches (which a blanket empty axesSpec loses).
+			effectiveAxesSpecOf := func(id) {
+				processedId := processColumnId(id)
+				axesSpec := bundle.getSpec(id).axesSpec
+
+				if is_undefined(processedId.discovery) {
+					return axesSpec
+				}
+
+				path := processedId.discovery.path
+				if is_undefined(path) {
+					return axesSpec
+				}
+
+				for i := len(path) - 1; i >= 0; i-- {
+					axesSpec = pSpec.linkerJoinAxesSpec(bundle.getSpec(path[i].column), axesSpec)
+				}
+				return axesSpec
+			}
+
 			bundle = ll.toStrict({
 
 				/**
@@ -518,6 +576,19 @@ pColumnBundleUnmarshaller := func() {
 
 					baseSpec := result.spec
 
+					// Rich id: apply the layers the id itself carries. A Discovered
+					// layer passes through — the linker chain enables co-indexing
+					// without remapping the hit's own axes, and the engine needs the
+					// hit's real axes to resolve the join. Post-join axes are a
+					// property of the frame, and live in `getAxesSpec`.
+					if !is_undefined(processedId.universalId) {
+						if keepColumns {
+							return columnId.applySpecOverrides(baseSpec,
+								columnId.unwrap(processedId.universalId).specOverrides)
+						}
+						return columnId.effectiveSpec(baseSpec, processedId.universalId)
+					}
+
 					// If filters are present, prepare them and get the resulting spec
 					if !keepColumns && !is_undefined(columnAxisFilters) && len(columnAxisFilters) > 0 {
 						prepared := pSpec.prepareAxisFiltersAndAxesSpec(columnAxisFilters, baseSpec.axesSpec)
@@ -536,6 +607,99 @@ pColumnBundleUnmarshaller := func() {
 				 */
 				getColumnKeys: func() {
 					return maps.getKeys(pool)
+				},
+
+				/**
+				 * Axes a column contributes to a frame, with axis filters removed
+				 * and — for a Discovered id — the linker hops folded, so the result
+				 * is what the engine will actually produce for it.
+				 *
+				 * @param id - The ID of the column
+				 * @returns AxisSpec[]
+				 */
+				getAxesSpecOf: func(id) {
+					return effectiveAxesSpecOf(id)
+				},
+
+				/**
+				 * Compiles a column id into an executable query entry.
+				 *
+				 * This is where a Discovered id's route stops being metadata and
+				 * becomes a real join: every hop in `path` folds into a nested
+				 * `linkerJoin` around the hit, and the engine resolves it. Feed the
+				 * result to `pt.p._rawQueryEntry(columns, joinEntry)`.
+				 *
+				 * Any other id shape compiles to a plain column entry, so a caller
+				 * holding a mixed list does not have to branch.
+				 *
+				 * @param id - The ID of the column
+				 * @param options - object (optional) - forwarded to `getColumn` for
+				 *   the hit; `keepColumns` is forced on for hits whose data is
+				 *   sliced, because the engine needs the unsliced key axes to join.
+				 * @returns {
+				 *   columns: { [poolKey]: { spec, data } } - every column the query
+				 *     references, keyed as the query refers to them,
+				 *   joinEntry: SpecQueryJoinEntry - for `pt.p._rawQueryEntry`,
+				 *   axesSpec: AxisSpec[] - axes the entry produces
+				 * }
+				 */
+				getQueryEntry: func(id, ...options) {
+					options = is_array(options) && is_map(options[0]) ? options[0] : {}
+					processedId := processColumnId(id)
+					hitKey := processedId.columnKey
+
+					// Pinning axes on a discovered hit would have to become a
+					// `sliceAxes` node inside the join, and the query builder emits
+					// only column / linkerJoin / innerJoin. Slicing the data first
+					// instead would drop the very key axes the join needs.
+					ll.assert(is_undefined(processedId.discovery) ||
+						is_undefined(processedId.axisFilters) || len(processedId.axisFilters) == 0,
+						"getQueryEntry: axis filters on a discovered column are not expressible " +
+						"in a linker join; filter the result after the join instead. Id: %v", id)
+
+					hit := bundle.getColumn(id, options)
+					columns := {}
+					columns[hitKey] = { spec: hit.spec, data: hit.data }
+
+					path := []
+					if !is_undefined(processedId.discovery) && !is_undefined(processedId.discovery.path) {
+						path = processedId.discovery.path
+					}
+
+					queryPath := []
+					for _, step in path {
+						ll.assert(step.type == "linker",
+							"getQueryEntry: unsupported discovery step type %q (only \"linker\" is allowed)",
+							step.type)
+
+						linkerKey := columnId.poolKey(step.column)
+						linker := bundle.getColumn(step.column)
+
+						// Without this annotation ptabler silently degrades the
+						// linker join to an inner join, which quietly produces a
+						// wrong table rather than failing.
+						annotations := linker.spec.annotations
+						ll.assert(ll.isMap(annotations) &&
+							annotations[pSpec.A_IS_LINKER_COLUMN] == "true",
+							"getQueryEntry: column %v is used as a linker but does not carry %q == \"true\"; spec: %v",
+							linkerKey, pSpec.A_IS_LINKER_COLUMN, linker.spec)
+
+						columns[linkerKey] = { spec: linker.spec, data: linker.data }
+						queryPath = append(queryPath, {
+							type: "linker",
+							linker: { columnId: linkerKey }
+						})
+					}
+
+					return {
+						columns: columns,
+						joinEntry: buildQueryLib.buildQuery({
+							version: "v1",
+							column: hitKey,
+							path: queryPath
+						}),
+						axesSpec: effectiveAxesSpecOf(id)
+					}
 				},
 
 				/**
@@ -590,8 +754,16 @@ pColumnBundleUnmarshaller := func() {
 							if is_undefined(result) {
 								ll.panic("Column not found: %v. Pool: %v", columnKey, maps.getKeys(pool))
 							}
-							
-							processResult(result)
+
+							// A single named column reports the axes it actually
+							// contributes — filters removed, linker hops folded.
+							// Reading the raw pool spec here would disagree with
+							// `getSpec` on the very same id.
+							if !is_array(result) {
+								processAxesSpec({ axesSpec: effectiveAxesSpecOf(id) })
+							} else {
+								processResult(result)
+							}
 						}
 					} else {
 						// Process all columns in the pool

--- a/sdk/workflow-tengo/src/pframes/column-id.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/column-id.lib.tengo
@@ -1,0 +1,464 @@
+/**
+ * Decoding and spec math for `ColumnUniversalId` — the recursive column
+ * identifier minted by the model side.
+ *
+ * Tengo counterpart of `lib/model/common/src/drivers/pframe/spec/ids.ts`
+ * (`extractPObjectId`, `reconstructSpecFromId`) plus the per-layer math from
+ * `filtered_column.ts` and `overridden.ts`. Everything here is a pure function
+ * over decoded JSON — no resource resolution, no context, no rendering — so it
+ * is unit-testable offline.
+ *
+ * An id is a canonically serialized JSON string in one of five key forms:
+ *
+ *   leaf, global   {__isRef: true, blockId, name}
+ *   leaf, local    {resolvePath, name}
+ *   Overridden     {__isOverridden: true, source, specOverrides}
+ *   Filtered       {__isFiltered: true, source, axisFilters}
+ *   Discovered     {__isDiscovered: true, column, path?, columnQualifications?,
+ *                   queriesQualifications?}
+ *
+ * `source` / `column` / `path[].column` are themselves id **strings**, not
+ * maps — the structure nests by serialized id.
+ *
+ * Layering invariant guaranteed by the model SDK: Overridden is always
+ * outermost, and a chain carries at most one layer of each kind before
+ * reaching a leaf.
+ *
+ * A sixth, older shape also reaches these code paths: the legacy
+ * `FilteredPColumnId` `{source, axisFilters}` whose `source` is a *map*
+ * (an anchored selector), not a string. It is recognized separately and its
+ * pool key derivation is preserved byte-for-byte.
+ */
+
+ll := import(":ll")
+maps := import(":maps")
+canonical := import(":canonical")
+json := import("json")
+
+// Id kinds returned by `kindOf`.
+KIND_LEAF_GLOBAL := "leafGlobal"
+KIND_LEAF_LOCAL := "leafLocal"
+KIND_OVERRIDDEN := "overridden"
+KIND_FILTERED := "filtered"
+KIND_DISCOVERED := "discovered"
+KIND_LEGACY_FILTERED := "legacyFiltered"
+KIND_SELECTOR := "selector"
+
+/**
+ * Decodes an id into its key map. Accepts an already-decoded map unchanged.
+ *
+ * @param id {string|map} - canonical id string or decoded key
+ * @return map - the decoded key
+ */
+decode := func(id) {
+	if is_string(id) {
+		return json.decode(id)
+	}
+	if is_map(id) {
+		return id
+	}
+	ll.panic("column-id: invalid column ID type, expected string or map, got: %v", id)
+}
+
+/**
+ * Classifies a decoded key.
+ *
+ * Marker fields are tested before the legacy duck-test, because a new-form
+ * Filtered key carries both `__isFiltered` and `source`/`axisFilters` and must
+ * not be mistaken for the legacy shape.
+ *
+ * @param key {map} - decoded key
+ * @return string - one of the KIND_* constants
+ */
+kindOf := func(key) {
+	ll.assert(is_map(key), "column-id: expected decoded key map, got: %v", key)
+
+	if key.__isOverridden == true {
+		return KIND_OVERRIDDEN
+	}
+	if key.__isFiltered == true {
+		return KIND_FILTERED
+	}
+	if key.__isDiscovered == true {
+		return KIND_DISCOVERED
+	}
+	if key.__isRef == true {
+		return KIND_LEAF_GLOBAL
+	}
+	// Legacy FilteredPColumnId: `source` is an anchored selector map.
+	if is_map(key.source) && !is_undefined(key.axisFilters) {
+		return KIND_LEGACY_FILTERED
+	}
+	if !is_undefined(key.resolvePath) {
+		return KIND_LEAF_LOCAL
+	}
+	return KIND_SELECTOR
+}
+
+/**
+ * Whether `value` is (or decodes to) one of the five `ColumnUniversalKey`
+ * forms. Ordinary strings and selector maps return false.
+ *
+ * @param value {any}
+ * @return bool
+ */
+isUniversalId := func(value) {
+	key := undefined
+	if is_string(value) {
+		// Every canonical id is a JSON object; skip the parse otherwise.
+		if len(value) == 0 || value[0] != '{' {
+			return false
+		}
+		key = json.decode(value)
+		if !is_map(key) {
+			return false
+		}
+	} else if is_map(value) {
+		key = value
+	} else {
+		return false
+	}
+
+	kind := kindOf(key)
+	return kind == KIND_LEAF_GLOBAL || kind == KIND_LEAF_LOCAL ||
+		kind == KIND_OVERRIDDEN || kind == KIND_FILTERED || kind == KIND_DISCOVERED
+}
+
+/**
+ * The key a bundle stores and retrieves a column under.
+ *
+ * Two rules, and the split between them is load-bearing:
+ *
+ *  - Legacy `FilteredPColumnId` keys on its `source` selector, because the
+ *    bundle resolves the unfiltered source once and slices per read. Preserved
+ *    exactly as it was to keep existing bundles byte-identical.
+ *  - Everything else keys on the id itself. For recipe ids this is deliberate:
+ *    two ids that reach the same physical column by different routes (or with
+ *    different projections) are different columns to a consumer, and must not
+ *    collapse into one pool entry. It also makes the registration key and the
+ *    read key identical by construction, which is the invariant the bundle's
+ *    two seams have to share.
+ *
+ * @param id {string|map} - canonical id string or decoded key
+ * @return string - pool key
+ */
+poolKey := func(id) {
+	key := decode(id)
+	if kindOf(key) == KIND_LEGACY_FILTERED {
+		return canonical.encode(key.source)
+	}
+	return is_string(id) ? id : canonical.encode(key)
+}
+
+/**
+ * Walks a rich id down to its terminal leaf id.
+ *
+ * Mirrors `extractPObjectId` (ids.ts:238-254).
+ *
+ * @param id {string|map}
+ * @return string - the leaf id, canonically encoded
+ */
+extractLeafId := undefined
+extractLeafId = func(id) {
+	key := decode(id)
+	kind := kindOf(key)
+
+	if kind == KIND_LEAF_GLOBAL || kind == KIND_LEAF_LOCAL {
+		return is_string(id) ? id : canonical.encode(key)
+	}
+	if kind == KIND_OVERRIDDEN || kind == KIND_FILTERED {
+		return extractLeafId(key.source)
+	}
+	if kind == KIND_DISCOVERED {
+		return extractLeafId(key.column)
+	}
+	if kind == KIND_LEGACY_FILTERED {
+		ll.panic("column-id: legacy FilteredPColumnId has a selector source, not a leaf id: %v", key)
+	}
+	ll.panic("column-id: cannot extract a leaf from a selector query: %v", key)
+}
+
+/**
+ * Peels every layer of an id in one pass.
+ *
+ * Returns:
+ *   leafId       {string}      terminal leaf id
+ *   axisFilters  {array|undef} `[axisIdx, value]` pairs from the Filtered layer
+ *   specOverrides{map|undef}   patch from the Overridden layer
+ *   discovery    {map|undef}   the Discovered key, if present
+ *
+ * Repeating a layer breaks the SDK's invariant and panics rather than silently
+ * keeping the outermost occurrence.
+ *
+ * @param id {string|map}
+ * @return map
+ */
+unwrap := func(id) {
+	leafId := undefined
+	axisFilters := undefined
+	specOverrides := undefined
+	discovery := undefined
+
+	current := id
+	for {
+		key := decode(current)
+		kind := kindOf(key)
+
+		if kind == KIND_LEAF_GLOBAL || kind == KIND_LEAF_LOCAL {
+			leafId = is_string(current) ? current : canonical.encode(key)
+			break
+		}
+
+		if kind == KIND_OVERRIDDEN {
+			ll.assert(is_undefined(specOverrides),
+				"column-id: nested Overridden layers, invariant broken: %v", id)
+			specOverrides = key.specOverrides
+			current = key.source
+		} else if kind == KIND_FILTERED {
+			ll.assert(is_undefined(axisFilters),
+				"column-id: nested Filtered layers, invariant broken: %v", id)
+			axisFilters = key.axisFilters
+			current = key.source
+		} else if kind == KIND_DISCOVERED {
+			ll.assert(is_undefined(discovery),
+				"column-id: nested Discovered layers, invariant broken: %v", id)
+			discovery = key
+			current = key.column
+		} else {
+			ll.panic("column-id: cannot unwrap id of kind %q: %v", kind, key)
+		}
+	}
+
+	return {
+		leafId: leafId,
+		axisFilters: axisFilters,
+		specOverrides: specOverrides,
+		discovery: discovery
+	}
+}
+
+/**
+ * Every id the recipe physically depends on: the hit chain plus one entry per
+ * linker hop. Each returned element is a full `ColumnUniversalId`, not a leaf —
+ * a linker may itself carry projections.
+ *
+ * Order is registration order: linkers first (outermost hop first), hit last.
+ *
+ * @param id {string|map}
+ * @return array of id strings
+ */
+referencedIds := func(id) {
+	key := decode(id)
+	u := unwrap(id)
+
+	result := []
+	if !is_undefined(u.discovery) && is_array(u.discovery.path) {
+		for _, step in u.discovery.path {
+			ll.assert(step.type == "linker",
+				"column-id: unsupported discovery step type %q (only \"linker\" is allowed)", step.type)
+			result = append(result, step.column)
+		}
+	}
+	return append(result, is_string(id) ? id : canonical.encode(key))
+}
+
+/**
+ * Drops the axes pinned by `axisFilters` from a spec's `axesSpec`.
+ *
+ * Positional against `spec.axesSpec`, mirroring `applyAxisFilters`
+ * (filtered_column.ts:103-107).
+ *
+ * @param spec {map}
+ * @param axisFilters {array} - `[axisIdx, value]` pairs
+ * @return map - spec with the pinned axes removed
+ */
+applyAxisFilters := func(spec, axisFilters) {
+	if is_undefined(axisFilters) || len(axisFilters) == 0 {
+		return spec
+	}
+
+	fixed := {}
+	for _, filter in axisFilters {
+		ll.assert(is_array(filter) && len(filter) == 2,
+			"column-id: axis filter must be a [axisIdx, value] pair, got: %v", filter)
+		ll.assert(is_int(filter[0]),
+			"column-id: axis filter index must be an integer, got: %v — " +
+			"name-keyed filters must be normalized before reaching here", filter[0])
+		fixed[string(filter[0])] = true
+	}
+
+	axesSpec := []
+	for i, axis in spec.axesSpec {
+		if is_undefined(fixed[string(i)]) {
+			axesSpec = append(axesSpec, axis)
+		}
+	}
+
+	result := maps.clone(spec)
+	result.axesSpec = axesSpec
+	return result
+}
+
+// Shallow record merge; `b` wins. Returns undefined only if both are absent.
+_mergeRecord := func(a, b) {
+	if is_undefined(b) {
+		return a
+	}
+	if is_undefined(a) {
+		return b
+	}
+	return maps.merge(a, b)
+}
+
+// Applies one positional axis patch: `name`/`type` overwrite, the three
+// metadata records deep-merge.
+_mergeAxisPatch := func(axis, patch) {
+	result := maps.merge(axis, patch)
+	if !is_undefined(patch.annotations) {
+		result.annotations = _mergeRecord(axis.annotations, patch.annotations)
+	}
+	if !is_undefined(patch.domain) {
+		result.domain = _mergeRecord(axis.domain, patch.domain)
+	}
+	if !is_undefined(patch.contextDomain) {
+		result.contextDomain = _mergeRecord(axis.contextDomain, patch.contextDomain)
+	}
+	return result
+}
+
+/**
+ * Applies an Overridden layer's `specOverrides` on top of a resolved spec.
+ *
+ * Mirrors `applySpecOverrides` (overridden.ts:188-212) with one deliberate
+ * divergence: a patch whose index is past the end of `axesSpec` appends a new
+ * axis on the model side, but the workflow registers specs against data that
+ * already exists, and an axis with no data behind it is incoherent. Such a
+ * patch panics here instead of silently producing a spec the engine cannot
+ * satisfy.
+ *
+ * @param base {map} - resolved spec
+ * @param overrides {map|undefined} - `SpecOverrides` patch
+ * @return map
+ */
+applySpecOverrides := func(base, overrides) {
+	if is_undefined(overrides) {
+		return base
+	}
+
+	result := maps.clone(base)
+	if !is_undefined(overrides.annotations) {
+		result.annotations = _mergeRecord(base.annotations, overrides.annotations)
+	}
+	if !is_undefined(overrides.domain) {
+		result.domain = _mergeRecord(base.domain, overrides.domain)
+	}
+	if !is_undefined(overrides.contextDomain) {
+		result.contextDomain = _mergeRecord(base.contextDomain, overrides.contextDomain)
+	}
+
+	if !is_undefined(overrides.axesSpec) {
+		axesSpec := []
+		for _, axis in base.axesSpec {
+			axesSpec = append(axesSpec, axis)
+		}
+		// Patch keys survive JSON decoding as strings.
+		for k, patch in overrides.axesSpec {
+			idx := int(k)
+			ll.assert(idx >= 0 && idx < len(axesSpec),
+				"column-id: axesSpec patch at index %v has no axis to patch (spec has %v axes) — " +
+				"the workflow cannot introduce an axis that carries no data", idx, len(axesSpec))
+			axesSpec[idx] = _mergeAxisPatch(axesSpec[idx], patch)
+		}
+		result.axesSpec = axesSpec
+	}
+
+	return result
+}
+
+/**
+ * Reconstructs the effective spec of an id, given the spec of its terminal
+ * leaf. Layers apply leaf-first, matching `reconstructSpecFromId`
+ * (ids.ts:270-294):
+ *
+ *   Discovered  pass-through — the linker chain enables co-indexing, it does
+ *               not remap the hit's own axes. The post-join axes of a
+ *               Discovered column are a property of the *frame* it enters, not
+ *               of this spec; see `linkerSides` for that math.
+ *   Filtered    drops the pinned axes
+ *   Overridden  applies the patch
+ *
+ * @param baseSpec {map} - spec of the leaf `unwrap(id).leafId` resolves to
+ * @param id {string|map}
+ * @return map
+ */
+effectiveSpec := func(baseSpec, id) {
+	u := unwrap(id)
+	spec := applyAxisFilters(baseSpec, u.axisFilters)
+	return applySpecOverrides(spec, u.specOverrides)
+}
+
+/**
+ * Normalizes an `EnrichmentRef` (`{__isEnrichment: "v1", hit, path?,
+ * qualifications?}`) into the `ColumnDiscoveredKey` shape.
+ *
+ * `EnrichmentRef` is the strictly narrower of the two: its hit and every hop are
+ * bare global ids, and its only step type is `linker`. So this direction is
+ * total, and the workflow can carry one mechanism instead of two.
+ *
+ * The reverse direction is lossy and deliberately absent — a Discovered key
+ * whose hit or hop carries a projection has no v1 representation.
+ *
+ * A hop may also arrive already resolved as a `{spec, data}` map instead of an
+ * id (the v1 form allows it for prerun-sourced columns); such a payload is
+ * passed through untouched for the caller to resolve.
+ *
+ * @param ref {map} - an EnrichmentRef
+ * @return map - a ColumnDiscoveredKey
+ */
+fromEnrichmentRef := func(ref) {
+	ll.assert(is_map(ref) && ref.__isEnrichment == "v1",
+		"column-id: expected an EnrichmentRef (__isEnrichment == \"v1\"), got: %v", ref)
+	ll.assert(!is_undefined(ref.hit), "column-id: EnrichmentRef is missing 'hit': %v", ref)
+
+	key := { __isDiscovered: true, column: ref.hit }
+
+	if is_array(ref.path) && len(ref.path) > 0 {
+		path := []
+		for _, step in ref.path {
+			ll.assert(step.type == "linker",
+				"column-id: unsupported enrichment step type %q (only \"linker\" is allowed)", step.type)
+			ll.assert(!is_undefined(step.linker),
+				"column-id: linker step is missing 'linker': %v", step)
+			path = append(path, { type: "linker", column: step.linker })
+		}
+		key.path = path
+	}
+
+	if is_array(ref.qualifications) && len(ref.qualifications) > 0 {
+		key.columnQualifications = ref.qualifications
+	}
+
+	return key
+}
+
+export ll.toStrict({
+	KIND_LEAF_GLOBAL: KIND_LEAF_GLOBAL,
+	KIND_LEAF_LOCAL: KIND_LEAF_LOCAL,
+	KIND_OVERRIDDEN: KIND_OVERRIDDEN,
+	KIND_FILTERED: KIND_FILTERED,
+	KIND_DISCOVERED: KIND_DISCOVERED,
+	KIND_LEGACY_FILTERED: KIND_LEGACY_FILTERED,
+	KIND_SELECTOR: KIND_SELECTOR,
+
+	decode: decode,
+	kindOf: kindOf,
+	isUniversalId: isUniversalId,
+	poolKey: poolKey,
+	extractLeafId: extractLeafId,
+	unwrap: unwrap,
+	referencedIds: referencedIds,
+	applyAxisFilters: applyAxisFilters,
+	applySpecOverrides: applySpecOverrides,
+	effectiveSpec: effectiveSpec,
+	fromEnrichmentRef: fromEnrichmentRef
+})

--- a/sdk/workflow-tengo/src/pframes/column-id.test.tengo
+++ b/sdk/workflow-tengo/src/pframes/column-id.test.tengo
@@ -1,0 +1,322 @@
+// Unit tests for `:pframes.column-id`.
+//
+// Pins two things: the pool-key derivations that existing bundles already
+// depend on (any drift here breaks blocks silently), and the per-layer spec
+// math against its TypeScript source of truth
+// (lib/model/common/src/drivers/pframe/spec/{ids,filtered_column,overridden}.ts).
+
+test := import(":test")
+columnId := import(":pframes.column-id")
+canonical := import(":canonical")
+
+leafGlobal := func(blockId, name) {
+	return canonical.encode({ __isRef: true, blockId: blockId, name: name })
+}
+
+filteredId := func(source, axisFilters) {
+	return canonical.encode({ __isFiltered: true, source: source, axisFilters: axisFilters })
+}
+
+overriddenId := func(source, specOverrides) {
+	return canonical.encode({ __isOverridden: true, source: source, specOverrides: specOverrides })
+}
+
+discoveredId := func(column, path) {
+	return canonical.encode({ __isDiscovered: true, column: column, path: path })
+}
+
+sampleSpec := func() {
+	return {
+		kind: "PColumn",
+		name: "value",
+		valueType: "Int",
+		annotations: { "pl7.app/label": "Value" },
+		domain: { "pl7.app/blockId": "b1" },
+		axesSpec: [
+			{ name: "clonotypeKey", type: "String" },
+			{ name: "clusterId", type: "Int" }
+		]
+	}
+}
+
+//
+// kindOf — marker forms must be tested before the legacy duck-test
+//
+
+TestKindOfLeafGlobal := func() {
+	test.isEqual(columnId.KIND_LEAF_GLOBAL, columnId.kindOf(columnId.decode(leafGlobal("b1", "col"))))
+}
+
+TestKindOfLeafLocal := func() {
+	test.isEqual(columnId.KIND_LEAF_LOCAL,
+		columnId.kindOf({ resolvePath: ["a", "b"], name: "col" }))
+}
+
+TestKindOfNewFilteredIsNotLegacy := func() {
+	// New-form Filtered carries `source` + `axisFilters` too; the marker wins.
+	key := columnId.decode(filteredId(leafGlobal("b1", "col"), [[1, 7]]))
+	test.isEqual(columnId.KIND_FILTERED, columnId.kindOf(key))
+}
+
+TestKindOfLegacyFiltered := func() {
+	// Legacy shape: `source` is an anchored selector MAP, not an id string.
+	test.isEqual(columnId.KIND_LEGACY_FILTERED,
+		columnId.kindOf({ source: { name: "value" }, axisFilters: [[0, "x"]] }))
+}
+
+TestKindOfOverridden := func() {
+	key := columnId.decode(overriddenId(leafGlobal("b1", "col"), { domain: { d: "1" } }))
+	test.isEqual(columnId.KIND_OVERRIDDEN, columnId.kindOf(key))
+}
+
+TestKindOfDiscovered := func() {
+	key := columnId.decode(discoveredId(leafGlobal("b1", "hit"), undefined))
+	test.isEqual(columnId.KIND_DISCOVERED, columnId.kindOf(key))
+}
+
+TestKindOfSelector := func() {
+	test.isEqual(columnId.KIND_SELECTOR, columnId.kindOf({ name: "value", axes: [] }))
+}
+
+//
+// isUniversalId
+//
+
+TestIsUniversalIdAcceptsEveryKeyForm := func() {
+	test.isTrue(columnId.isUniversalId(leafGlobal("b1", "col")))
+	test.isTrue(columnId.isUniversalId(filteredId(leafGlobal("b1", "col"), [[0, 1]])))
+	test.isTrue(columnId.isUniversalId(overriddenId(leafGlobal("b1", "col"), {})))
+	test.isTrue(columnId.isUniversalId(discoveredId(leafGlobal("b1", "col"), undefined)))
+}
+
+TestIsUniversalIdRejectsPlainStringsAndSelectors := func() {
+	test.isFalse(columnId.isUniversalId("just-a-name"))
+	test.isFalse(columnId.isUniversalId(""))
+	test.isFalse(columnId.isUniversalId(42))
+	test.isFalse(columnId.isUniversalId({ name: "value" }))
+}
+
+//
+// poolKey — the derivations existing bundles already depend on
+//
+
+TestPoolKeyLegacyFilteredKeysOnSource := func() {
+	source := { name: "value", axes: [{ name: "clonotypeKey" }] }
+	key := columnId.poolKey({ source: source, axisFilters: [[0, "x"]] })
+	test.isEqual(canonical.encode(source), key)
+}
+
+TestPoolKeyLeafIsTheIdItself := func() {
+	id := leafGlobal("b1", "col")
+	test.isEqual(id, columnId.poolKey(id))
+}
+
+TestPoolKeyRecipeIsTheFullId := func() {
+	// NOT the leaf: two routes to the same physical column stay distinct.
+	id := filteredId(leafGlobal("b1", "col"), [[1, 7]])
+	test.isEqual(id, columnId.poolKey(id))
+}
+
+TestPoolKeyOfMapEqualsPoolKeyOfString := func() {
+	id := discoveredId(leafGlobal("b1", "hit"), [{ type: "linker", column: leafGlobal("b1", "lnk") }])
+	test.isEqual(columnId.poolKey(id), columnId.poolKey(columnId.decode(id)))
+}
+
+//
+// extractLeafId
+//
+
+TestExtractLeafIdThroughEveryLayer := func() {
+	leaf := leafGlobal("b1", "col")
+	stacked := overriddenId(filteredId(discoveredId(leaf, undefined), [[0, 3]]), { domain: { d: "1" } })
+	test.isEqual(leaf, columnId.extractLeafId(stacked))
+}
+
+TestExtractLeafIdOfLeafIsIdentity := func() {
+	leaf := leafGlobal("b1", "col")
+	test.isEqual(leaf, columnId.extractLeafId(leaf))
+}
+
+//
+// unwrap
+//
+
+TestUnwrapPeelsAllThreeLayers := func() {
+	leaf := leafGlobal("b1", "col")
+	linker := leafGlobal("b1", "lnk")
+	overrides := { annotations: { "pl7.app/label": "Patched" } }
+	id := overriddenId(
+		filteredId(discoveredId(leaf, [{ type: "linker", column: linker }]), [[1, 5]]),
+		overrides)
+
+	u := columnId.unwrap(id)
+	test.isEqual(leaf, u.leafId)
+	test.isEqual([[1, 5]], u.axisFilters)
+	test.isEqual(overrides, u.specOverrides)
+	test.isEqual(true, u.discovery.__isDiscovered)
+	test.isEqual(leaf, u.discovery.column)
+}
+
+TestUnwrapOfBareLeafHasNoLayers := func() {
+	u := columnId.unwrap(leafGlobal("b1", "col"))
+	test.isTrue(is_undefined(u.axisFilters))
+	test.isTrue(is_undefined(u.specOverrides))
+	test.isTrue(is_undefined(u.discovery))
+}
+
+//
+// referencedIds — linkers first (outermost hop first), hit last
+//
+
+TestReferencedIdsListsLinkersThenSelf := func() {
+	hit := leafGlobal("b1", "hit")
+	l0 := leafGlobal("b1", "lnk0")
+	l1 := leafGlobal("b1", "lnk1")
+	id := discoveredId(hit, [
+		{ type: "linker", column: l0 },
+		{ type: "linker", column: l1 }
+	])
+	test.isEqual([l0, l1, id], columnId.referencedIds(id))
+}
+
+TestReferencedIdsOfPlainColumnIsItself := func() {
+	id := leafGlobal("b1", "col")
+	test.isEqual([id], columnId.referencedIds(id))
+}
+
+//
+// applyAxisFilters
+//
+
+TestApplyAxisFiltersDropsPinnedAxes := func() {
+	got := columnId.applyAxisFilters(sampleSpec(), [[1, 7]])
+	test.isEqual([{ name: "clonotypeKey", type: "String" }], got.axesSpec)
+	// Untouched fields survive.
+	test.isEqual("value", got.name)
+}
+
+TestApplyAxisFiltersIsIdentityWhenEmpty := func() {
+	spec := sampleSpec()
+	test.isEqual(spec, columnId.applyAxisFilters(spec, []))
+	test.isEqual(spec, columnId.applyAxisFilters(spec, undefined))
+}
+
+//
+// applySpecOverrides
+//
+
+TestApplySpecOverridesMergesMetadata := func() {
+	got := columnId.applySpecOverrides(sampleSpec(), {
+		annotations: { "pl7.app/label": "Patched", "extra": "1" },
+		domain: { "new": "2" }
+	})
+	test.isEqual("Patched", got.annotations["pl7.app/label"])
+	test.isEqual("1", got.annotations["extra"])
+	// Merge, not replace: the pre-existing domain key survives.
+	test.isEqual("b1", got.domain["pl7.app/blockId"])
+	test.isEqual("2", got.domain["new"])
+}
+
+TestApplySpecOverridesPatchesAxisPositionally := func() {
+	got := columnId.applySpecOverrides(sampleSpec(), {
+		axesSpec: { "1": { annotations: { "pl7.app/label": "Cluster" } } }
+	})
+	test.isEqual("clonotypeKey", got.axesSpec[0].name)
+	test.isEqual("Cluster", got.axesSpec[1].annotations["pl7.app/label"])
+	// Positional patch must not change identity fields it did not mention.
+	test.isEqual("clusterId", got.axesSpec[1].name)
+}
+
+TestApplySpecOverridesIsIdentityWhenAbsent := func() {
+	spec := sampleSpec()
+	test.isEqual(spec, columnId.applySpecOverrides(spec, undefined))
+}
+
+//
+// effectiveSpec — layers apply leaf-first: Filtered then Overridden
+//
+
+TestEffectiveSpecAppliesFilterBeforeOverride := func() {
+	// Pin axis 1, then patch what is now the only remaining axis (index 0).
+	id := overriddenId(
+		filteredId(leafGlobal("b1", "col"), [[1, 7]]),
+		{ axesSpec: { "0": { annotations: { "pl7.app/label": "Clonotype" } } } })
+
+	got := columnId.effectiveSpec(sampleSpec(), id)
+	test.isEqual(1, len(got.axesSpec))
+	test.isEqual("clonotypeKey", got.axesSpec[0].name)
+	test.isEqual("Clonotype", got.axesSpec[0].annotations["pl7.app/label"])
+}
+
+TestEffectiveSpecOfDiscoveredPassesThrough := func() {
+	// The linker chain enables co-indexing; it does not remap the hit's axes.
+	id := discoveredId(leafGlobal("b1", "hit"),
+		[{ type: "linker", column: leafGlobal("b1", "lnk") }])
+	test.isEqual(sampleSpec(), columnId.effectiveSpec(sampleSpec(), id))
+}
+
+TestEffectiveSpecOfLeafIsIdentity := func() {
+	spec := sampleSpec()
+	test.isEqual(spec, columnId.effectiveSpec(spec, leafGlobal("b1", "col")))
+}
+
+//
+// fromEnrichmentRef — the v1 wire form is the narrower one, so it normalizes
+// into a Discovered key and the workflow carries one route mechanism
+//
+
+TestFromEnrichmentRefMapsFieldByField := func() {
+	hit := leafGlobal("b1", "hit")
+	linker := leafGlobal("b1", "lnk")
+	qual := { axis: { name: "clusterId" }, contextDomain: { d: "1" } }
+
+	got := columnId.fromEnrichmentRef({
+		__isEnrichment: "v1",
+		hit: hit,
+		path: [{ type: "linker", linker: linker }],
+		qualifications: [qual]
+	})
+
+	test.isEqual({
+		__isDiscovered: true,
+		column: hit,
+		path: [{ type: "linker", column: linker }],
+		columnQualifications: [qual]
+	}, got)
+}
+
+TestFromEnrichmentRefZeroHop := func() {
+	hit := leafGlobal("b1", "hit")
+	// Empty path and qualifications are omitted on both sides, so a zero-hop
+	// ref yields a key with no optional fields at all.
+	test.isEqual({ __isDiscovered: true, column: hit },
+		columnId.fromEnrichmentRef({ __isEnrichment: "v1", hit: hit, path: [] }))
+}
+
+TestFromEnrichmentRefPassesResolvedHopsThrough := func() {
+	// v1 allows a resolved {spec, data} in place of an id; it is not an id and
+	// must survive untouched for the caller to resolve.
+	resolved := { spec: { kind: "PColumn" }, data: "d" }
+	got := columnId.fromEnrichmentRef({
+		__isEnrichment: "v1",
+		hit: resolved,
+		path: [{ type: "linker", linker: resolved }]
+	})
+	test.isEqual(resolved, got.column)
+	test.isEqual(resolved, got.path[0].column)
+}
+
+TestFromEnrichmentRefRoundTripsThroughUnwrap := func() {
+	// The normalized key is a real Discovered key: unwrap sees the route.
+	hit := leafGlobal("b1", "hit")
+	linker := leafGlobal("b1", "lnk")
+	key := columnId.fromEnrichmentRef({
+		__isEnrichment: "v1",
+		hit: hit,
+		path: [{ type: "linker", linker: linker }]
+	})
+
+	test.isEqual(columnId.KIND_DISCOVERED, columnId.kindOf(key))
+	test.isEqual(hit, columnId.unwrap(key).leafId)
+	test.isEqual([linker, canonical.encode(key)], columnId.referencedIds(key))
+}

--- a/sdk/workflow-tengo/src/pframes/spec.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/spec.lib.tengo
@@ -599,6 +599,133 @@ getAxisId := func(axisSpec) {
 	return canonical.encode(id)
 }
 
+/**
+ * Splits `axesSpec` into parent-connected components.
+ *
+ * An axis is connected to the axes listed in its `parentAxes` (positional
+ * indices into the same `axesSpec`). Components are returned ordered by their
+ * lowest member index, and each component's members ascend — the same order the
+ * engine produces, so component numbering agrees on both sides.
+ *
+ * @param axesSpec: AxisSpec[] - axes to split
+ * @return number[][] - one array of positional indices per component
+ */
+splitAxes := func(axesSpec) {
+	n := len(axesSpec)
+
+	// Union-find with path compression, keyed by positional index.
+	parent := []
+	for i := 0; i < n; i++ {
+		parent = append(parent, i)
+	}
+	root := undefined
+	root = func(i) {
+		if parent[i] == i {
+			return i
+		}
+		r := root(parent[i])
+		parent[i] = r
+		return r
+	}
+	join := func(a, b) {
+		ra := root(a)
+		rb := root(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+
+	for i, axis in axesSpec {
+		if is_undefined(axis.parentAxes) {
+			continue
+		}
+		for _, p in axis.parentAxes {
+			ll.assert(is_int(p) && p >= 0 && p < n,
+				"splitAxes: parentAxes index %v out of range for %v axes", p, n)
+			join(i, p)
+		}
+	}
+
+	// Walking 0..n-1 and opening a component on first sight of its root gives
+	// components ordered by lowest member index.
+	componentByRoot := {}
+	components := []
+	for i := 0; i < n; i++ {
+		r := string(root(i))
+		idx := componentByRoot[r]
+		if is_undefined(idx) {
+			idx = len(components)
+			componentByRoot[r] = idx
+			components = append(components, [])
+		}
+		components[idx] = append(components[idx], i)
+	}
+
+	return components
+}
+
+/**
+ * Positional indices of a linker column's one-side and many-side axes.
+ *
+ * A linker relates exactly two axis groups, so its `axesSpec` must fall into
+ * exactly two parent-connected components. The component holding axis 0 is the
+ * one side (the end being traversed away from); the other is the many side
+ * (the end results are lifted onto).
+ *
+ * @param linkerSpec: PColumnSpec - spec of a linker column
+ * @return { oneSide: number[], manySide: number[] }
+ */
+linkerSides := func(linkerSpec) {
+	components := splitAxes(linkerSpec.axesSpec)
+	ll.assert(len(components) == 2,
+		"linkerSides: a linker column must have exactly 2 parent-connected axis " +
+		"components, got %v — spec: %v", len(components), linkerSpec)
+	return {
+		oneSide: components[0],
+		manySide: components[1]
+	}
+}
+
+/**
+ * Axes a `linkerJoin` produces: the linker's axes followed by the secondary's,
+ * deduplicated by axis identity, with the linker's one-side axes projected out.
+ *
+ * The linker leads, matching the engine's integration order, so a caller
+ * selecting these axes positionally sees the same layout the engine builds.
+ *
+ * @param linkerSpec: PColumnSpec - spec of the linker column
+ * @param secondaryAxesSpec: AxisSpec[] - axes of the joined (many-side) result
+ * @return AxisSpec[]
+ */
+linkerJoinAxesSpec := func(linkerSpec, secondaryAxesSpec) {
+	sides := linkerSides(linkerSpec)
+
+	projectedOut := {}
+	for _, idx in sides.oneSide {
+		projectedOut[getAxisId(linkerSpec.axesSpec[idx])] = true
+	}
+
+	result := []
+	seen := {}
+	appendAxis := func(axis) {
+		axisId := getAxisId(axis)
+		if !is_undefined(projectedOut[axisId]) || !is_undefined(seen[axisId]) {
+			return
+		}
+		seen[axisId] = true
+		result = append(result, axis)
+	}
+
+	for _, axis in linkerSpec.axesSpec {
+		appendAxis(axis)
+	}
+	for _, axis in secondaryAxesSpec {
+		appendAxis(axis)
+	}
+
+	return result
+}
+
 export ll.toStrict({
 	P_UNTYPED_SPEC_SCHEMA: P_UNTYPED_SPEC_SCHEMA,
 	P_AXIS_SPEC_SCHEMA: P_AXIS_SPEC_SCHEMA,
@@ -615,6 +742,7 @@ export ll.toStrict({
 
 	A_LABEL: A_LABEL,
 	A_TRACE: A_TRACE,
+	A_IS_LINKER_COLUMN: A_IS_LINKER_COLUMN,
 
 	normalizeColumnSpec: normalizeColumnSpec,
 
@@ -628,6 +756,10 @@ export ll.toStrict({
 	prepareAxisFiltersAndAxesSpec: prepareAxisFiltersAndAxesSpec,
 	axisSpecToMatcher: axisSpecToMatcher,
 
-	getAxisId: getAxisId
+	getAxisId: getAxisId,
+
+	splitAxes: splitAxes,
+	linkerSides: linkerSides,
+	linkerJoinAxesSpec: linkerJoinAxesSpec
 })
 

--- a/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
+++ b/sdk/workflow-tengo/src/pframes/table-builder.lib.tengo
@@ -34,6 +34,7 @@ assets := import(":assets")
 maps := import(":maps")
 pSpec := import(":pframes.spec")
 bquery := import(":workflow.bquery")
+columnId := import(":pframes.column-id")
 
 buildTableTpl := assets.importTemplate(":pframes.build-table")
 
@@ -105,18 +106,59 @@ decodeGlobalPObjectId := func(id) {
 	return { __isRef: true, blockId: decoded.blockId, name: decoded.name }
 }
 
-// step.linker is either a global-form PObjectId string or a resolved {spec, data}.
-enrichmentStepColumn := func(step) {
-	ll.assert(step.type == "linker",
-		"unsupported enrichment step type %q (only \"linker\" is allowed)", step.type)
-	ll.assert(!is_undefined(step.linker),
-		"linker step missing 'linker' field: %v", step)
-	return step.linker
+// A `ColumnUniversalId` string — the model-side column identifier. Carries the
+// same hit-plus-route information as an EnrichmentRef, and more besides.
+isColumnUniversalId := func(value) {
+	return columnId.isUniversalId(value)
+}
+
+// Reduces either wire form to one shape: `{ column, path, qualifications }`,
+// where `column` and each `path[].column` is something `resolveColumn` accepts.
+//
+// `EnrichmentRef` is the narrower form, so it normalizes into the id form rather
+// than the other way round: one route mechanism, two accepted spellings.
+normalizeDiscovery := func(query) {
+	key := isEnrichmentRef(query) ? columnId.fromEnrichmentRef(query) : columnId.decode(query)
+
+	// A route can be resolved here because every hop is a column to fetch. A
+	// projection cannot: specs arrive as unresolved futures, so there is nothing
+	// to patch or slice at this point. The bundle path handles those.
+	unwrapped := columnId.unwrap(key)
+	ll.assert(is_undefined(unwrapped.specOverrides),
+		"tableBuilder: spec overrides on a column id cannot be applied here — specs are " +
+		"resolved as futures. Use a column bundle for this column. Id: %v", query)
+	ll.assert(is_undefined(unwrapped.axisFilters),
+		"tableBuilder: axis filters on a column id cannot be applied here. " +
+		"Use a column bundle for this column. Id: %v", query)
+
+	discovery := unwrapped.discovery
+	if is_undefined(discovery) {
+		// A bare leaf id: no route, resolved like any other column reference.
+		return { column: key, path: [], qualifications: undefined }
+	}
+
+	path := []
+	if !is_undefined(discovery.path) {
+		for _, step in discovery.path {
+			ll.assert(step.type == "linker",
+				"unsupported enrichment step type %q (only \"linker\" is allowed)", step.type)
+			ll.assert(!is_undefined(step.column),
+				"linker step missing its column: %v", step)
+			path = append(path, { type: "linker", column: step.column })
+		}
+	}
+
+	return {
+		column: discovery.column,
+		path: path,
+		qualifications: discovery.columnQualifications
+	}
 }
 
 // Anchored ColumnQuerySpec that needs `bquery.anchoredQuery` to resolve.
 isQuerySpec := func(q) {
-	return !isUnresolved(q) && !isResolvedColumn(q) && !isEnrichmentRef(q)
+	return !isUnresolved(q) && !isResolvedColumn(q) && !isEnrichmentRef(q) &&
+		!isColumnUniversalId(q)
 }
 
 /**
@@ -166,14 +208,24 @@ tableBuilder := func(format, ...ctxArg) {
 				header = opts[0].header
 			}
 
-			unresolved := isUnresolved(value)
+			unresolved := isUnresolved(value) || isColumnUniversalId(value)
 			if !unresolved {
 				ll.assert(
 					isResolvedColumn(value) ||
 						(isPrimaryRef(value) && isResolvedColumn(value.column)),
-					"value must be a resolved column {spec, data}, " +
+					"value must be a resolved column {spec, data}, a column id, " +
 					"a resolved PrimaryRef, or a structure containing PlRefs; got: %v",
 					value)
+			}
+			if isColumnUniversalId(value) {
+				// A primary is the trunk every other column joins onto, so it has
+				// to be a column that stands on its own. A discovered id is a
+				// column reached *from* a trunk — using one as the trunk inverts
+				// the relationship and silently produces the wrong table.
+				ll.assert(is_undefined(columnId.unwrap(value).discovery),
+					"addPrimary: a discovered column cannot be a primary — it is reached " +
+					"from one. Pass the anchor column as the primary and this id as a " +
+					"column. Id: %v", value)
 			}
 			if unresolved {
 				_hasUnresolved = true
@@ -200,7 +252,7 @@ tableBuilder := func(format, ...ctxArg) {
 			if len(opts) > 0 && ll.isMap(opts[0]) {
 				header = opts[0].header
 			}
-			if isUnresolved(query) || isEnrichmentRef(query) {
+			if isUnresolved(query) || isEnrichmentRef(query) || isColumnUniversalId(query) {
 				_hasUnresolved = true
 			}
 			_columns = append(_columns, {
@@ -231,9 +283,10 @@ tableBuilder := func(format, ...ctxArg) {
 			// shared header prefix/suffix with their own label.
 			if is_array(query) {
 				for col in query {
-					ll.assert(isResolvedColumn(col) || isEnrichmentRef(col) || isLabeledEnrichment(col),
-						"array elements must be resolved columns {spec, data}, EnrichmentRefs, " +
-						"or labeled enrichments {ref, label}; got: %v", col)
+					ll.assert(isResolvedColumn(col) || isEnrichmentRef(col) ||
+						isLabeledEnrichment(col) || isColumnUniversalId(col),
+						"array elements must be resolved columns {spec, data}, column ids, " +
+						"EnrichmentRefs, or labeled enrichments {ref, label}; got: %v", col)
 
 					entryQuery := col
 					entryHeader := undefined
@@ -246,7 +299,7 @@ tableBuilder := func(format, ...ctxArg) {
 						entrySuffix = undefined
 					}
 
-					if isUnresolved(entryQuery) || isEnrichmentRef(entryQuery) {
+					if isUnresolved(entryQuery) || isEnrichmentRef(entryQuery) || isColumnUniversalId(entryQuery) {
 						_hasUnresolved = true
 					}
 					_columns = append(_columns, {
@@ -260,7 +313,7 @@ tableBuilder := func(format, ...ctxArg) {
 				return self
 			}
 
-			if isUnresolved(query) || isEnrichmentRef(query) {
+			if isUnresolved(query) || isEnrichmentRef(query) || isColumnUniversalId(query) {
 				_hasUnresolved = true
 			}
 			_columns = append(_columns, {
@@ -362,6 +415,18 @@ tableBuilder := func(format, ...ctxArg) {
 			// Resolve a column reference into {spec, data} futures.
 			// Accepts: PObjectId string | PlRef map | resolved {spec, data}.
 			resolveColumn := func(value) {
+				if isColumnUniversalId(value) {
+					// Reduce to the leaf this id names. Projections are refused
+					// rather than dropped: specs here are unresolved futures, so
+					// there is nothing to patch or slice.
+					unwrapped := columnId.unwrap(value)
+					ll.assert(is_undefined(unwrapped.specOverrides) &&
+						is_undefined(unwrapped.axisFilters),
+						"tableBuilder: a column id carrying spec overrides or axis filters " +
+						"cannot be resolved here — specs arrive as futures. Use a column " +
+						"bundle for this column. Id: %v", value)
+					value = unwrapped.leafId
+				}
 				if is_string(value) {
 					ref := decodeGlobalPObjectId(value)
 					r := bquery.resolve(ref, _ctx)
@@ -471,24 +536,26 @@ tableBuilder := func(format, ...ctxArg) {
 					headerPrefix: c.headerPrefix,
 					headerSuffix: c.headerSuffix
 				}
-				if isEnrichmentRef(c.query) {
-					resolvedHit := resolveColumn(c.query.hit)
+				if isEnrichmentRef(c.query) || isColumnUniversalId(c.query) {
+					// Both spellings of "a column plus the route to it" reduce to
+					// one shape first, so exactly one resolution path exists below.
+					discovery := normalizeDiscovery(c.query)
+
+					resolvedHit := resolveColumn(discovery.column)
 					entry.spec = resolvedHit.spec
 					entry.data = resolvedHit.data
 					steps := []
-					if !is_undefined(c.query.path) {
-						for _, step in c.query.path {
-							resolvedStep := resolveColumn(enrichmentStepColumn(step))
-							steps = append(steps, {
-								type: step.type,
-								spec: resolvedStep.spec,
-								data: resolvedStep.data
-							})
-						}
+					for _, step in discovery.path {
+						resolvedStep := resolveColumn(step.column)
+						steps = append(steps, {
+							type: step.type,
+							spec: resolvedStep.spec,
+							data: resolvedStep.data
+						})
 					}
 					entry.path = steps
-					if !is_undefined(c.query.qualifications) && len(c.query.qualifications) > 0 {
-						entry.qualifications = c.query.qualifications
+					if !is_undefined(discovery.qualifications) && len(discovery.qualifications) > 0 {
+						entry.qualifications = discovery.qualifications
 					}
 				} else if isResolvedColumn(c.query) {
 					entry.spec = c.query.spec

--- a/sdk/workflow-tengo/src/pframes/table-builder.test.tengo
+++ b/sdk/workflow-tengo/src/pframes/table-builder.test.tengo
@@ -162,6 +162,44 @@ TestAddColumnsAcceptsArrayWithEnrichmentRef := func() {
 	test.isTrue(true, "addColumns accepts array mixing resolved columns and EnrichmentRefs")
 }
 
+// A `ColumnUniversalId` carries the same hit-plus-route information as an
+// EnrichmentRef, and is the form the model now mints. Both spellings normalize
+// to one shape before resolution.
+sampleDiscoveredId := "{\"__isDiscovered\":true,\"column\":\"{\\\"__isRef\\\":true,\\\"blockId\\\":\\\"b1\\\",\\\"name\\\":\\\"hit-1\\\"}\",\"path\":[{\"column\":\"{\\\"__isRef\\\":true,\\\"blockId\\\":\\\"b1\\\",\\\"name\\\":\\\"linker-1\\\"}\",\"type\":\"linker\"}]}"
+
+TestAddColumnAcceptsColumnDiscoveredId := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleRef)
+	b.addColumn(sampleDiscoveredId)
+	test.isTrue(true, "addColumn accepts a ColumnDiscoveredId with a linker route")
+}
+
+TestAddColumnAcceptsBareLeafColumnId := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleRef)
+	b.addColumn(sampleHitId)
+	test.isTrue(true, "addColumn accepts a bare global-form column id")
+}
+
+TestAddColumnsAcceptsArrayWithColumnDiscoveredId := func() {
+	b := tb.tableBuilder("tsv")
+	b.addPrimary("main", sampleRef)
+	b.addColumns([sampleResolved, sampleDiscoveredId], { headerPrefix: "x_" })
+	test.isTrue(true, "addColumns accepts array mixing resolved columns and column ids")
+}
+
+// A rich id must not be mistaken for an anchored query spec — that would send it
+// to `bquery.anchoredQuery`, whose schema rejects it.
+TestColumnIdIsNotTreatedAsQuerySpec := func() {
+	b := tb.tableBuilder("tsv")
+	// A pre-resolved primary cannot anchor column queries; build() panics if any
+	// column is classified as a query spec. Reaching past addColumn without a
+	// query-spec classification is what this asserts.
+	b.addPrimary("main", sampleResolved)
+	b.addColumn(sampleDiscoveredId)
+	test.isTrue(true, "a ColumnUniversalId is classified as a column reference, not a query spec")
+}
+
 // Note on panic-on-misuse coverage: Tengo unit tests can't catch panics
 // (`ll.panic` is terminal, no recover/try-catch). Misuse paths are guarded
 // by `ll.assert` in the source — see the assertions in:

--- a/sdk/workflow-tengo/src/pt/index.lib.tengo
+++ b/sdk/workflow-tengo/src/pt/index.lib.tengo
@@ -12,6 +12,7 @@ pframesBuilder := import(":pframes.builder")
 pframesConstants := import(":pframes.constants")
 pframesUtil := import(":pframes.util")
 pframesSpec := import(":pframes.spec")
+columnId := import(":pframes.column-id")
 render := import(":render")
 maps := import(":maps")
 canonical := import(":canonical")
@@ -764,8 +765,45 @@ workflow := func() {
 			}
 
 			for column in columns {
-				decoded := json.decode(column)
 				aliases = append(aliases, exp.col(column))
+
+				// A rich `ColumnUniversalId` states how to reach its column, so ask
+				// it instead of guessing from the presence of a field: a Discovered
+				// id becomes a real linker join, a Filtered one is sliced by
+				// ptabler, and a bare or spec-patched leaf is a plain column. Pool
+				// keys that are not ids at all — multi-result element keys,
+				// caller-supplied query keys — keep the original path.
+				if columnId.isUniversalId(column) {
+					unwrapped := columnId.unwrap(column)
+					hasRoute := !is_undefined(unwrapped.discovery) &&
+						!is_undefined(unwrapped.discovery.path) &&
+						len(unwrapped.discovery.path) > 0
+
+					if hasRoute {
+						queryEntry := bundle.getQueryEntry(column)
+						entries = append(entries,
+							p._rawQueryEntry(queryEntry.columns, queryEntry.joinEntry))
+					} else if !is_undefined(unwrapped.axisFilters) && len(unwrapped.axisFilters) > 0 {
+						entries = append(entries, p.slicedColumn(
+							column,
+							bundle.getColumn(column, {
+								keepColumns: true,
+								ignoreNonPartitioned: true
+							}),
+							slices.map(unwrapped.axisFilters, func(axisFilter) {
+								return {
+									axisIndex: axisFilter[0],
+									constant: axisFilter[1]
+								}
+							})
+						))
+					} else {
+						entries = append(entries, p.column(column, bundle.getColumn(column)))
+					}
+					continue
+				}
+
+				decoded := json.decode(column)
 
 				if (is_undefined(decoded.axisFilters)) {
 					entry := p.column(column, bundle.getColumn(decoded))


### PR DESCRIPTION
## What

Makes `ColumnUniversalId` a first-class column reference in
`@platforma-sdk/workflow-tengo`. A block can pass any id the model mints — bare
leaf, `ColumnFilteredId`, `ColumnOverriddenId`, `ColumnDiscoveredId` — into
`createPBundleBuilder().addSingle(...)`, `pt.frameFromColumnBundle` or
`tableBuilder`, and the workflow resolves it, reconstructs its effective spec,
and **builds the linker join** a discovered id describes.

## Why

The model migrated to the new column access API, so args now carry
`ColumnUniversalId` where they used to carry a leaf `PObjectId`. The workflow
recognized only the legacy `{source, axisFilters}` form — whose `source` is a
map, not an id string — so every new shape fell through to a branch that pushed
it into `bquery.anchoredQuery` in an invalid form.

The route mattered most. Previously identity travelled on the wire and the
workflow re-derived the linker path itself, heuristically. A
`ColumnDiscoveredId` carries the route, so the workflow can build the join
exactly as chosen instead of guessing.

## How each layer is realised

| Layer | Realised | Mechanism |
| --- | --- | --- |
| leaf | resolution | `bquery.resolve` on the terminal `{__isRef, …}` |
| `Filtered` | read / execution | spec: axes dropped; data: `slice-data`, or `pt.p.slicedColumn` in a frame |
| `Overridden` | read | spec math only — the engine has no `specOverride` node |
| `Discovered` | execution | `bundle.getQueryEntry` → `bquery.buildQuery` → `pt.p._rawQueryEntry` |

Two design points worth reviewing closely:

**Pool keys.** A rich id registers and reads under *the id itself*, never its
leaf. Two projections of one physical column, or one column reached by two
routes, are different columns to a consumer — this is the workflow's counterpart
to `rebrandLeafId`. It also makes the registration key and the read key
identical by construction, so the collector and the unmarshaller cannot drift.
The legacy `FilteredPColumnId` keeps keying on its `source`, so marker fields are
tested before that duck-test.

**Axes after a linker join.** The engine projects out the linker's one-side axes,
so a discovered column does not land on the hit's own axes. `pSpec.linkerSides`
derives the two sides from the linker's spec by splitting `axesSpec` into
parent-connected components — `parentAxes` is declared data on the axis, so no
axis normalization had to be ported. A hit axis the route never touches survives,
which a blanket empty `axesSpec` would lose.

## EnrichmentRef becomes derived

`EnrichmentRef` is the strictly narrower spelling of the same idea, so it
normalizes into `ColumnDiscoveredKey` (`columnId.fromEnrichmentRef`) and
`tableBuilder` resolves both spellings through one path. The marker check stays
the first dispatch branch. The type is deprecated; no removal date. The reverse
conversion is lossy and deliberately absent.

## Deliberate panics, not silent divergence

- `axesSpec` patch past the end of the spec — the model appends an axis, the
  workflow cannot introduce one that carries no data.
- Axis filters on a discovered column — would need a `sliceAxes` node inside the
  join, which the query builder cannot emit. Filter after the join.
- Spec overrides / axis filters in `tableBuilder` — specs there are unresolved
  futures. Use a column bundle.
- A discovered id as a `tableBuilder` primary — a primary is the trunk, a
  discovered column is reached from one.

`queriesQualifications` is not carried: its keys are `PObjectId`s of external
primary columns, and the workflow addresses primaries by `PlRef` and frame key.
Documented rather than dropped quietly.

## Latent defects fixed on the way

- `bundle.getAxesSpec` read raw pool specs while `getSpec` applied axis filters,
  so a filtered id could contribute axes its own spec no longer had.
  `frameFromColumnBundle` calls the former before the latter, so this was
  reachable today.
- `pSpec.A_IS_LINKER_COLUMN` was read by `pt.p.linkerJoin` but never exported —
  the builder's first caller would have hit a strict-map panic. It has none
  today, which is why it went unnoticed.

## Back-compat

Untouched: `workflow/bquery.lib.tengo` (including its closed query schema),
`query-anchored.tpl.tengo`, `slice-data.tpl.tengo`, `build-query.lib.tengo`,
`build-table.tpl.tengo`, `process-column*`, `xsv*`. All public signatures
survive, including `addQuery(queryKey, query)`'s inverted argument order and the
deprecated `addById`. `table-builder.test.tengo`'s existing cases pass unchanged.

## Testing

`pl-tengo check` clean and `pl-tengo test` green **at every commit** (232 → 248
tests, 0 failures). 39 new offline tests cover the id decoding, the spec math per
layer, the pool-key derivations existing bundles depend on, the component split,
and the `EnrichmentRef` normalization.

Not covered here: an end-to-end run against a live backend. The intended check is
`blocks/antibody-tcr-lead-selection` on a project with upstream clustering, after
dropping the `extractPObjectId` flattening in its `model/src/util.ts` — that
block's hand-rolled linker matching (`findMatchingLinkerIndex`) becomes
unnecessary once the route is honoured.

## Review order

Six commits, each independently building and tested:

1. `column-id.lib.tengo` — the decoder, no callers
2. axes split / `linkerSides` — plus the missing export
3. bundle — both seams onto one key derivation, all shapes accepted
4. pt — the frame builds the join
5. table-builder — `EnrichmentRef` derived, deprecation
6. docs + changeset

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes logical column identifiers directly consumable by workflow bundles, frames, and `tableBuilder`, including execution of discovered linker routes. It also derives legacy `EnrichmentRef` handling from the new representation, adds linker-axis projection utilities, and documents the expanded workflow contract.

- **`ColumnUniversalId`** — the logical recursive identifier for a column, including leaf, filtered, overridden, and discovered forms; this PR adds Tengo-side decoding, registration, specification reconstruction, and execution support.
- **`ColumnDiscoveredId`** — a column identifier containing a hit and linker route; this PR turns its route into nested executable linker joins and derives contributed frame axes from those joins.
- **`ColumnFilteredId`** — a logical column projection with pinned axis values; this PR reconstructs its effective specification and slices its data when constructing frames.
- **`ColumnOverriddenId`** — a logical column reference carrying specification metadata patches; this PR applies those patches when reading a column bundle.
- **`EnrichmentRef`** — the legacy hit-plus-linker-route reference, including support for already-resolved prerun columns; this PR deprecates it and normalizes it toward the discovered-ID representation, but the new normalization currently breaks its resolved-hit case.
- **`PColumnBundle`** — the resolved pool of column specifications and data; this PR unifies registration/read key derivation and adds query-entry and effective-axis APIs.
- **`linkerJoin`** — the query operation that traverses a linker from its one side to its many side; this PR builds it from discovery paths and projects the linker's one-side axes from frame output.
- **`poolKey`** — the identity under which a bundle stores and retrieves a column; rich identifiers now key by the complete logical ID while legacy filtered identifiers retain source-based keying.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until tableBuilder preserves legacy EnrichmentRefs containing already-resolved prerun columns.

The new unconditional unwrap of normalized EnrichmentRefs turns a documented and previously supported resolved-column input into a render-time panic.

**Files Needing Attention:** sdk/workflow-tengo/src/pframes/table-builder.lib.tengo; sdk/workflow-tengo/src/pframes/column-id.lib.tengo
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/pframes/column-id.lib.tengo | Adds ColumnUniversalId decoding, identity derivation, layer unwrapping, specification reconstruction, and EnrichmentRef conversion; unwrap intentionally accepts only ID leaves. |
| sdk/workflow-tengo/src/pframes/bundle.lib.tengo | Extends bundle registration and reading to rich IDs, adds effective-axis calculation, and compiles discovered routes into executable query entries. |
| sdk/workflow-tengo/src/pframes/spec.lib.tengo | Adds parent-connected axis splitting and linker-join axis projection utilities. |
| sdk/workflow-tengo/src/pframes/table-builder.lib.tengo | Adds direct ColumnUniversalId support and shared discovery normalization, but the normalization panics for legacy EnrichmentRefs containing resolved hits. |
| sdk/workflow-tengo/src/pt/index.lib.tengo | Dispatches bundle columns by universal-ID layer and constructs sliced columns or raw discovered-route query entries. |
| lib/model/common/src/ref.ts | Deprecates EnrichmentRef in favor of ColumnDiscoveredId without changing its public shape. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  ID[ColumnUniversalId] --> Decode[column-id decode and unwrap]
  Decode --> Leaf[Resolve terminal leaf]
  Decode --> Filters[Apply axis filters]
  Decode --> Overrides[Apply spec overrides]
  Decode --> Route[Read discovery path]
  Route --> Linkers[Resolve linker columns]
  Linkers --> Query[Build nested linkerJoin query]
  Leaf --> Bundle[PColumnBundle]
  Filters --> Bundle
  Overrides --> Bundle
  Query --> Frame[PTabler frame entry]
  Bundle --> Frame
  Legacy[EnrichmentRef] --> Normalize[Normalize to discovered key]
  Normalize --> Decode
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asdk%2Fworkflow-tengo%2Fsrc%2Fpframes%2Ftable-builder.lib.tengo%3A126%0A**Resolved%20EnrichmentRef%20hits%20panic**%0A%0AWhen%20an%20%60EnrichmentRef%60%20contains%20a%20supported%20pre-resolved%20%60%7Bspec%2C%20data%7D%60%20hit%2C%20%60normalizeDiscovery%60%20passes%20the%20converted%20key%20to%20%60columnId.unwrap%60%2C%20which%20descends%20into%20that%20map%20and%20rejects%20it%20as%20a%20selector%20before%20%60resolveColumn%60%20can%20handle%20it%2C%20causing%20%60tableBuilder.build%28%29%60%20to%20panic%20during%20rendering.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1780&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
sdk/workflow-tengo/src/pframes/table-builder.lib.tengo:126
**Resolved EnrichmentRef hits panic**

When an `EnrichmentRef` contains a supported pre-resolved `{spec, data}` hit, `normalizeDiscovery` passes the converted key to `columnId.unwrap`, which descends into that map and rejects it as a selector before `resolveColumn` can handle it, causing `tableBuilder.build()` to panic during rendering.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(workflow-tengo): document the workf..."](https://github.com/milaboratory/platforma/commit/3c27ae22302a7095cd35abd6e42a47a6df7d8dfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52176479)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [workflow-tengo: the block workflow authoring SDK](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/workflow-tengo.md)
- Knowledge Base — [Block model](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-model.md)

<!-- /greptile_comment -->