### PR TITLE
MILAB-6648: failing test — export and import disagree about a block id inside a column id

### DIFF
--- a/lib/node/pl-middle-layer/src/model/template_export_import_asymmetry.bug.test.ts
+++ b/lib/node/pl-middle-layer/src/model/template_export_import_asymmetry.bug.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "vitest";
+import canonicalize from "canonicalize";
+import type {
+  BlockKindReference,
+  BlockKindSelectorReference,
+  ProjectTemplateV1,
+} from "@milaboratories/pl-model-common";
+import {
+  PROJECT_TEMPLATE_SCHEMA_V1,
+  createTemplateLocalRef,
+} from "@milaboratories/pl-model-common";
+import type { ProjectStructure } from "./project_model";
+import type { TemplateExportEntry, TemplateParamsResult } from "./template_export";
+import { walkProjectForTemplateExport } from "./template_export";
+import { assembleProjectTemplateV1, stringifyProjectTemplateV1 } from "./template_serializer";
+import { parseProjectTemplateV1Yaml } from "./template_parser";
+import { validateTemplateV1ForApply } from "./template_validate";
+
+/**
+ * BUG DEMO — export and import disagree about a block id inside a column id.
+ *
+ * Export tests MEMBERSHIP: a block id found in template-form params is a fault only if
+ * the document does not describe that block (`unrewrittenBlockIds`, template_export.ts).
+ * Import tests PRESENCE, subtracting nothing (`foreignBlockIds`, template_validate.ts).
+ *
+ * So a project whose params carry a PColumn id exports cleanly and is refused on import.
+ * That is the motivating case of the commit "remap the block ids buried inside a column
+ * id", whose message reads: "clonotype-browser's annotation filters reference result-pool
+ * columns. This is not hypothetical."
+ *
+ * These tests drive the REAL exporter and the REAL validator back to back — no mocks of
+ * either side.
+ */
+
+const KIND = "@platforma-open/milaboratories.demo.kind@^1.0.0" as BlockKindSelectorReference;
+
+function simpleStructure(...ids: string[]): ProjectStructure {
+  return {
+    groups: [
+      {
+        id: "g1",
+        label: "G1",
+        blocks: ids.map((id) => ({ id, label: id, renderingMode: "Heavy" })),
+      },
+    ],
+  };
+}
+
+function providerFrom(params: Record<string, TemplateParamsResult>) {
+  return (blockId: string): TemplateParamsResult | undefined => params[blockId];
+}
+
+const ok = (value: unknown): TemplateParamsResult => ({ value });
+
+/**
+ * A PColumn id as it actually appears in params: a canonicalized-JSON string embedding
+ * `{ __isRef: true, blockId, name }`. It has to keep that shape or it stops being a
+ * column id a block can resolve.
+ */
+const columnIdNaming = (blockId: string, name: string): string =>
+  canonicalize({ __isRef: true, blockId, name })!;
+
+/** Turn what the exporter produced into the document the importer would be handed. */
+function documentFromWalk(entries: readonly TemplateExportEntry[]) {
+  return {
+    schema: PROJECT_TEMPLATE_SCHEMA_V1,
+    blocks: entries.map((e) => ({ id: e.blockId, kind: KIND, params: e.params })),
+  } as ProjectTemplateV1;
+}
+
+describe("export → import asymmetry", () => {
+  test("CONTROL: a plain template-local reference survives the trip", () => {
+    // Establishes that the harness is sound and the round trip works in general.
+    const walk = walkProjectForTemplateExport(
+      simpleStructure("a", "b"),
+      providerFrom({
+        a: ok({}),
+        b: ok({ input: createTemplateLocalRef("a", "reads") }),
+      }),
+    );
+
+    expect(walk.problems).toEqual([]);
+    expect(validateTemplateV1ForApply(documentFromWalk(walk.entries))).toEqual([]);
+  });
+
+  test("BUG: a column id naming an in-document entry exports, then is refused on import", () => {
+    const anchor = columnIdNaming("a", "clonotypes");
+
+    const walk = walkProjectForTemplateExport(
+      simpleStructure("a", "b"),
+      providerFrom({ a: ok({}), b: ok({ anchor }) }),
+    );
+
+    // Export accepts it — deliberately. Its own suite asserts this exact case is legal:
+    // "a column id naming a block the template describes is a wire, not a fault".
+    expect(walk.problems).toEqual([]);
+
+    // The importer is handed precisely what the exporter just produced. It should accept
+    // it. It does not — this is the bug.
+    expect(validateTemplateV1ForApply(documentFromWalk(walk.entries))).toEqual([]);
+  });
+
+  test("BUG, at file level: the real YAML a real export writes cannot be re-imported", () => {
+    // Same case, but through the ENTIRE shipped pipeline rather than just the walk:
+    // assemble → stringify to YAML → parse the YAML back → validate for apply.
+    // This rules out "some later export stage would have caught it" and shows the
+    // artifact a user actually holds — a .yaml file on disk — is the thing refused.
+    const anchor = columnIdNaming("a", "clonotypes");
+
+    const walk = walkProjectForTemplateExport(
+      simpleStructure("a", "b"),
+      providerFrom({ a: ok({}), b: ok({ anchor }) }),
+    );
+
+    const assembled = assembleProjectTemplateV1(
+      walk,
+      () => "@platforma-open/milaboratories.demo.kind@1.0.0" as BlockKindReference,
+      // A registry block, so the emitted entry stays portable — no `location`.
+      (blockId) => ({
+        type: "from-registry-v2",
+        registryUrl: "https://block.registry.platforma.bio/releases",
+        id: { organization: "milaboratories", name: blockId, version: "1.2.3" },
+        channel: "stable",
+      }),
+    );
+
+    // Export completes with no problems and produces a real file.
+    expect(assembled.problems).toEqual([]);
+    const yaml = stringifyProjectTemplateV1(assembled.document);
+    console.log("exported template-v1 YAML:\n" + yaml);
+
+    // The file parses cleanly — the format is not in question.
+    const parsed = parseProjectTemplateV1Yaml(yaml);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    // ...and is then refused by the apply-time validator. This is the bug, at the level
+    // the user experiences it: export succeeded, the file is well-formed, import says no.
+    expect(validateTemplateV1ForApply(parsed.document)).toEqual([]);
+  });
+
+  test("DIAGNOSTIC: the exact refusal the importer produces", () => {
+    const anchor = columnIdNaming("a", "clonotypes");
+    const walk = walkProjectForTemplateExport(
+      simpleStructure("a", "b"),
+      providerFrom({ a: ok({}), b: ok({ anchor }) }),
+    );
+
+    const problems = validateTemplateV1ForApply(documentFromWalk(walk.entries));
+
+    // Printed so the failure above is self-explanatory: the id it calls "from another
+    // project" is `a`, which is the FIRST ENTRY OF THE SAME DOCUMENT.
+    console.log("importer said:", JSON.stringify(problems, null, 2));
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]?.entryId).toBe("b");
+    expect(problems[0]?.error).toMatch(/from another project/);
+    // The offending id is an entry the document itself describes.
+    expect(walk.entries.map((e) => e.blockId)).toContain("a");
+  });
+});


### PR DESCRIPTION
Targets `MILAB-6648_block-kind-prototype` rather than `main`: this is a repro for #1767, not a fix.

**Two of the four tests fail on purpose.** They demonstrate that export and import answer the same question opposite ways.

- **Export tests membership.** `unrewrittenBlockIds` (`template_export.ts:176-182`) treats a block id found in already-template-form params as a fault only if the document does *not* describe that block. Its own comment: *"a hit naming an exported entry is a wire"*, and `template_export.test.ts:217` asserts exactly that case is legal.
- **Import tests presence**, subtracting nothing. `foreignBlockIds` (`template_validate.ts:78-85`) reports every id it finds and rejects the entry.

So a project whose params carry a PColumn id exports cleanly and is then refused on import, with the id named as coming *"from another project"* — while it is an entry of the same document. The advice in that message is also unfollowable: removing the value removes the block's configuration.

This is the case `bf60d7bc3` ("remap the block ids buried inside a column id") was written for — *"clonotype-browser's annotation filters reference result-pool columns. This is not hypothetical."* Because the validator runs before the codec (`middle_layer.ts:419`), that commit's import-side remap is unreachable through the driver.

### The tests

| Test | Result |
|---|---|
| `CONTROL` — a plain template-local reference survives export → import | **passes**, so the harness is sound |
| `BUG` — at walk level: the real exporter accepts params the real validator rejects | **fails** |
| `BUG, at file level` — the whole pipeline: assemble → stringify → parse → validate | **fails** |
| `DIAGNOSTIC` — prints the refusal so the failures read on their own | passes |

No mocks of either side. The file-level test rules out "a later export stage would have caught it" and shows the artifact a user actually holds. What export writes:

```yaml
schema: template-v1
blocks:
  - id: a
    kind: "@platforma-open/milaboratories.demo.kind@1.0.0"
    params: {}
  - id: b
    kind: "@platforma-open/milaboratories.demo.kind@1.0.0"
    params:
      anchor: '{"__isRef":true,"blockId":"a","name":"clonotypes"}'
```

That file parses cleanly and is then rejected.

### Why CI is green today

Each side tests its own half; neither covers the crossing. `template_validate.test.ts` only uses foreign ids, and its one "not mistaken for a foreign one" case uses the plain `{block, output}` form. `template-round-trip.test.ts` passes against a live backend because both its blocks carry flat primitive params with no column ids.

### Suggested fix

Give the import guard the document's own entry ids and apply the same membership subtraction export already uses — `inferAllReferencedBlocks` already takes an optional `allowed` set (`args.ts:30`). Then flip the two failing assertions into regression tests and add the crossing case to both suites.

Verified locally: `pnpm check` passes for `pl-middle-layer` (types, lint, format); the surrounding suites are unaffected — 230 of 232 tests pass across `src/model/`, `src/mutator/template_construct.test.ts` and `src/block_registry/`, the two failures being the ones above.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a focused reproduction demonstrating that template export accepts an in-document block reference embedded in a PColumn ID while template import rejects the resulting document. Two failing assertions are intentionally retained to expose the export/import asymmetry at both the traversal and serialized-YAML levels.
- Adds a passing control for ordinary template-local references.
- Adds walk-level and file-level reproductions using the real exporter, serializer, parser, and validator.
- Adds a diagnostic test that verifies the misleading “from another project” rejection.
- **Important touched terms:**
  - **PColumn ID** — A canonicalized JSON string identifying a data column and embedding its producing block ID; the new tests demonstrate its treatment during template export and import.
  - **Template-local reference** — A structured reference from one template block to another block in the same document; the control test confirms this form still completes the round trip.
  - **Project template v1** — The serialized document containing block definitions, kinds, and parameters; the new file-level test constructs, serializes, parses, and validates this artifact.
  - **Template export walk** — The traversal that gathers export entries and reports unresolved references; the tests show it permits a PColumn ID naming an exported entry.
  - **Apply-time template validation** — The import guard run before applying a parsed template; the tests show it currently classifies the same in-document PColumn reference as foreign.
  - **Block kind selector/reference** — The package-and-version identifiers attached to template blocks; the reproduction supplies selector references during validation and concrete references during assembly.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge as a deliberate test-only reproduction whose intentionally failing cases are clearly documented.

The change modifies no production path and accurately captures the acknowledged exporter/importer disagreement through both direct and serialized-template tests.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/model/template_export_import_asymmetry.bug.test.ts | Adds an intentional regression reproduction, a passing control, full YAML-pipeline coverage, and diagnostic assertions without changing production behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Project params contain PColumn ID naming block a] --> B[Export walk accepts in-document membership]
  B --> C[Assemble template-v1]
  C --> D[Serialize to YAML]
  D --> E[Parse YAML successfully]
  E --> F[Apply-time validator reports block a as foreign]
  F --> G[Template import is refused]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6648: failing test for the export/..."](https://github.com/milaboratory/platforma/commit/d22afc9808f11d0e40641e461aca9a7d5887261f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52273244)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [pl-middle-layer](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-middle-layer.md)

<!-- /greptile_comment -->