### PR TITLE
Template pack v4: flat template node map

### DIFF
--- a/.changeset/template-pack-v4-flat-node-map.md
+++ b/.changeset/template-pack-v4-flat-node-map.md
@@ -1,0 +1,73 @@
+---
+'@milaboratories/pl-model-backend': major
+'@platforma-sdk/tengo-builder': major
+'@platforma-sdk/workflow-tengo': major
+'@milaboratories/pl-middle-layer': major
+'@platforma-sdk/block-tools': major
+---
+
+Template pack format v4: store the template graph as a flat node map, and
+compress packs with zstd.
+
+`CompiledTemplateV3.template` nests each sub-template inline, so a template
+shared by N parents is serialised once per path that reaches it. Sharing is
+common and the graph is deep, so the expansion is multiplicative. The
+published `sequence-embeddings` block held 39 distinct templates expanded
+into 11,672 nodes; 87 % of its pack was the same `libs` metadata records
+repeated at every node.
+
+`pl.tengo-template.v4` adds `hashToTemplate`, keyed by a node's content hash,
+and `templates` now holds hash references. This is the same trick
+`hashToSource` already used for source text, applied to the nodes.
+
+Packs are also now zstd (level 19) instead of gzip, and are named
+`main.plj.zst`. The extension is the codec: readers pick gzip or zstd from
+the file name, so packs published as `.plj.gz` stay readable indefinitely.
+
+Measured on `@platforma-open/milaboratories.sequence-embeddings@1.4.1`:
+
+| | v3 + gzip | v4 + zstd |
+|---|---|---|
+| on disk | 802 KiB | 128 KiB |
+| decompressed | 29.10 MiB | 1.01 MiB |
+| load (decompress + parse) | 93.3 ms | 2.7 ms |
+| retained heap | 93.1 MiB | 3.1 MiB |
+
+The layout carries the load and memory win; zstd carries most of the
+remaining size win. zstd alone on a v3 pack reaches 134 KiB but improves
+load by only 1.1x and heap not at all, because the cost is `JSON.parse` of
+29 MiB.
+
+Across `@platforma-sdk/workflow-tengo`'s own 45 packs, decompressed size
+drops from 41.65 MiB to 12.55 MiB.
+
+Rendering a v4 pack is also cheaper. A v3 cache key had to walk the expanded
+subtree on every lookup, including cache hits; a v4 child's hash already
+covers its subtree, so the walk is gone. For the same block that was 35,920
+node visits and 2.8M hash updates to produce 39 resources.
+
+Readers reject `templates` reference cycles instead of recursing into them.
+v3 could not express a cycle — it nested children inline, so one would have
+been an infinite document. v4's hash references make it representable in a
+corrupt pack.
+
+Breaking:
+
+- `tengo-builder` now emits v4. A pack built with this version cannot be read
+  by a middle layer older than this release, which parses `main.plj.gz`
+  itself. The backend is unaffected — it only ever sees the unpacked resource
+  tree.
+- `parseTemplate` can now return `CompiledTemplateV4`; use the exported
+  `AnyCompiledTemplate` union. Exhaustive switches over the result need a v4
+  arm.
+- `parseTemplate`, `decompressTemplate` and `deriveRequiredCapabilities` take
+  the codec as a required argument, and `ExplicitTemplate` carries a required
+  `codec` field. Compressed bytes are never inspected to guess how they were
+  written — the caller read them from a path or URL and passes what that name
+  says. `templateCodecForPath` derives it.
+- Building a block emits `main.plj.zst`, and the generated
+  `components.workflow` path in a block's `package.json` changes with it.
+- `@platforma-sdk/tengo-builder` now needs Node >= 22.15 for `node:zlib` zstd.
+- `TemplateDataV3` is unchanged and still parsed. `pl-middle-layer` and
+  `block-tools` read v2, v3 and v4, so already-published blocks keep working
+  and keep their `requiredCapabilities` install gate.

--- a/etc/blocks/blob-url-custom-protocol/block/package.json
+++ b/etc/blocks/blob-url-custom-protocol/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-blob-url-custom-protocol.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-blob-url-custom-protocol.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-blob-url-custom-protocol.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-blob-url-custom-protocol.ui/dist"
     },

--- a/etc/blocks/download-file/block/package.json
+++ b/etc/blocks/download-file/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-download-file.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-download-file.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-download-file.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-download-file.ui/dist"
     },

--- a/etc/blocks/enter-numbers-v3/block/package.json
+++ b/etc/blocks/enter-numbers-v3/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-enter-numbers-v3.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-enter-numbers-v3.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-enter-numbers-v3.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-enter-numbers-v3.ui/dist"
     },

--- a/etc/blocks/enter-numbers/block/package.json
+++ b/etc/blocks/enter-numbers/block/package.json
@@ -36,7 +36,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-enter-numbers.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-enter-numbers.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-enter-numbers.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-enter-numbers.ui/dist"
     },

--- a/etc/blocks/filter-column-test/block/package.json
+++ b/etc/blocks/filter-column-test/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-filter-column.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-filter-column.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-filter-column.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-filter-column.ui/dist"
     },

--- a/etc/blocks/model-test/block/package.json
+++ b/etc/blocks/model-test/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-block-model.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-block-model.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-block-model.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-block-model.ui/dist"
     },

--- a/etc/blocks/monetization-test/block/package.json
+++ b/etc/blocks/monetization-test/block/package.json
@@ -37,7 +37,7 @@
   "packageManager": "pnpm@9.12.0",
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.monetization-test.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.monetization-test.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.monetization-test.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.monetization-test.ui/dist"
     },

--- a/etc/blocks/pool-explorer/block/package.json
+++ b/etc/blocks/pool-explorer/block/package.json
@@ -36,7 +36,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.pool-explorer.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.pool-explorer.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.pool-explorer.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.pool-explorer.ui/dist"
     },

--- a/etc/blocks/read-logs/block/package.json
+++ b/etc/blocks/read-logs/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-read-logs.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-read-logs.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-read-logs.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-read-logs.ui/dist"
     },

--- a/etc/blocks/sum-numbers-v3/block/package.json
+++ b/etc/blocks/sum-numbers-v3/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-sum-numbers-v3.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-sum-numbers-v3.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-sum-numbers-v3.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-sum-numbers-v3.ui/dist"
     },

--- a/etc/blocks/sum-numbers/block/package.json
+++ b/etc/blocks/sum-numbers/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-sum-numbers.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-sum-numbers.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-sum-numbers.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-sum-numbers.ui/dist"
     },

--- a/etc/blocks/table-test/block/package.json
+++ b/etc/blocks/table-test/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-block-table.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-block-table.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-block-table.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-block-table.ui/dist"
     },

--- a/etc/blocks/transfer-files/block/package.json
+++ b/etc/blocks/transfer-files/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.transfer-files.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.transfer-files.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.transfer-files.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.transfer-files.ui/dist"
     },

--- a/etc/blocks/ui-examples/block/package.json
+++ b/etc/blocks/ui-examples/block/package.json
@@ -36,7 +36,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.ui-examples.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.ui-examples.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.ui-examples.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.ui-examples.ui/dist"
     },

--- a/etc/blocks/upload-file/block/package.json
+++ b/etc/blocks/upload-file/block/package.json
@@ -37,7 +37,7 @@
   },
   "block": {
     "components": {
-      "workflow": "@milaboratories/milaboratories.test-upload-file.workflow/dist/tengo/tpl/main.plj.gz",
+      "workflow": "@milaboratories/milaboratories.test-upload-file.workflow/dist/tengo/tpl/main.plj.zst",
       "model": "@milaboratories/milaboratories.test-upload-file.model/dist/model.json",
       "ui": "@milaboratories/milaboratories.test-upload-file.ui/dist"
     },

--- a/lib/model/backend/src/index.ts
+++ b/lib/model/backend/src/index.ts
@@ -2,4 +2,5 @@ export * from "./capabilities";
 export * from "./serde";
 export * from "./template_data_v2";
 export * from "./template_data_v3";
+export * from "./template_data_v4";
 export * from "./template_resources_v1";

--- a/lib/model/backend/src/serde.ts
+++ b/lib/model/backend/src/serde.ts
@@ -1,7 +1,8 @@
-import { gunzipSync, gzipSync } from "node:zlib";
+import { constants, gunzipSync, zstdCompressSync, zstdDecompressSync } from "node:zlib";
 import canonicalize from "canonicalize";
 import type { TemplateData } from "./template_data_v2";
 import type { CompiledTemplateV3 } from "./template_data_v3";
+import type { CompiledTemplateV4 } from "./template_data_v4";
 import { z } from "zod";
 
 const TypeSchema = z
@@ -13,18 +14,55 @@ const TypeSchema = z
 const templateArchiveEncoder = new TextEncoder();
 const templateArchiveDecoder = new TextDecoder();
 
-export function parseTemplate(content: Uint8Array): TemplateData | CompiledTemplateV3 {
-  const data = TypeSchema.parse(JSON.parse(templateArchiveDecoder.decode(gunzipSync(content))));
-  if (data.type !== "pl.tengo-template.v2" && data.type !== "pl.tengo-template.v3") {
+// Level 19 rather than the default 3. Packs are written once at block build
+// time and read on every install, so compression time is close to free and
+// decompression is what repeats. On a real block: 171 KB at level 3, 132 KB at
+// level 19; level 22 saves a further 128 bytes for 40 % more compression time.
+const zstdLevel = 19;
+
+/**
+ * How a template pack is compressed. The file extension is the source of
+ * truth: `.plj.zst` is zstd, `.plj.gz` is gzip. Packs published before the
+ * switch are gzip and stay reachable under their original name, so both
+ * codecs are readable indefinitely.
+ *
+ * Carried explicitly rather than detected from the bytes. A pack always
+ * arrives from somewhere that knows its name — a file path, or a registry
+ * URL — and threading that through keeps the extension meaningful instead of
+ * decorative.
+ */
+export type TemplateCodec = "gzip" | "zstd";
+
+export const TemplatePackSuffix = ".plj.zst";
+
+/** Codec a pack file uses, from its name. */
+export function templateCodecForPath(path: string): TemplateCodec {
+  return path.endsWith(".zst") ? "zstd" : "gzip";
+}
+
+export function decompressTemplate(content: Uint8Array, codec: TemplateCodec): Buffer {
+  return codec === "zstd" ? zstdDecompressSync(content) : gunzipSync(content);
+}
+
+export type AnyCompiledTemplate = TemplateData | CompiledTemplateV3 | CompiledTemplateV4;
+
+export function parseTemplate(content: Uint8Array, codec: TemplateCodec): AnyCompiledTemplate {
+  const data = TypeSchema.parse(
+    JSON.parse(templateArchiveDecoder.decode(decompressTemplate(content, codec))),
+  );
+  if (
+    data.type !== "pl.tengo-template.v2" &&
+    data.type !== "pl.tengo-template.v3" &&
+    data.type !== "pl.tengo-template.v4"
+  ) {
     throw new Error("malformed template");
   }
 
-  return data as unknown as TemplateData | CompiledTemplateV3;
+  return data as unknown as AnyCompiledTemplate;
 }
 
-export function serializeTemplate(data: TemplateData | CompiledTemplateV3): Uint8Array {
-  return gzipSync(templateArchiveEncoder.encode(canonicalize(data)), {
-    chunkSize: 256 * 1024,
-    level: 9,
+export function serializeTemplate(data: AnyCompiledTemplate): Uint8Array {
+  return zstdCompressSync(templateArchiveEncoder.encode(canonicalize(data)), {
+    params: { [constants.ZSTD_c_compressionLevel]: zstdLevel },
   });
 }

--- a/lib/model/backend/src/template_data_v4.ts
+++ b/lib/model/backend/src/template_data_v4.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+
+import type { BackendCapability } from "./capabilities";
+import type {
+  TemplateAssetDataV3,
+  TemplateLibDataV3,
+  TemplateSoftwareDataV3,
+  TemplateWasmDataV3,
+} from "./template_data_v3";
+
+/**
+ * A single template node.
+ *
+ * Identical to {@link TemplateDataV3} except for `templates`, which holds
+ * hash references instead of nested nodes. That one field is the whole
+ * difference between the two formats: v3 stores the template graph as a
+ * tree, so a sub-template shared by N parents is serialised N times, once
+ * per path that reaches it. Sharing is common and the graph is deep, so the
+ * expansion is multiplicative rather than additive.
+ */
+export interface TemplateNodeV4 {
+  /** i.e. @milaboratory/some-package:template */
+  name: string;
+  /** i.e. 1.2.3 */
+  version: string;
+  /** Hash of the source, resolved through CompiledTemplateV4.hashToSource. */
+  sourceHash: string;
+
+  /**
+   * Custom hash token of the template for deduplication purposes. Can be set with 'hash_override' compiler option.
+   * Dangerous! Remember: great power comes with great responsibility.
+   */
+  hashOverride?: string;
+
+  libs: Record<string, TemplateLibDataV3>;
+  software: Record<string, TemplateSoftwareDataV3>;
+  assets: Record<string, TemplateAssetDataV3>;
+  wasm?: Record<string, TemplateWasmDataV3>;
+
+  /**
+   * i.e. @milaboratory/some-package:some-template -> key into
+   * {@link CompiledTemplateV4.hashToTemplate}.
+   */
+  templates: Record<string, string>;
+
+  /**
+   * Backend capability tokens this template (and its transitively-imported
+   * sub-templates) requires to run. Populated by `tengo-builder` at compile
+   * time and unioned upward, so the root node carries the full set. Same
+   * vocabulary the backend advertises in
+   * `MaintenanceAPI.Ping.Response.capabilities` — see `./capabilities.ts`.
+   */
+  requiredCapabilities?: BackendCapability[];
+}
+
+export interface CompiledTemplateV4 {
+  /** Discriminator for future use */
+  type: "pl.tengo-template.v4";
+
+  /** Hashes of all artifact sources to the sources themselves. */
+  hashToSource: Record<string, string>;
+
+  /**
+   * Content hash to template node, for every node in the graph. Sharing is
+   * preserved: a node reached by many parents is stored once.
+   */
+  hashToTemplate: Record<string, TemplateNodeV4>;
+
+  /** Key into {@link hashToTemplate} for the root node. */
+  template: string;
+}
+
+/**
+ * Content hash of a finished node, and the key it is stored under in
+ * `hashToTemplate`.
+ *
+ * The node's `templates` values are already hashes of its children, so this
+ * covers the whole subtree. Two nodes collide exactly when their subtrees are
+ * identical, which is the sharing we want to keep.
+ *
+ * Keyed on content rather than on `sourceHash` because `hashOverride` exists
+ * to give two templates with the same source distinct identities.
+ */
+export function templateNodeHash(node: TemplateNodeV4): string {
+  const canonical = canonicalize(node);
+  if (canonical === undefined) throw new Error("template node is not serializable");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/** Root node of a compiled pack. Throws when the pack is internally inconsistent. */
+export function rootTemplate(pack: CompiledTemplateV4): TemplateNodeV4 {
+  return resolveTemplate(pack, pack.template);
+}
+
+/** Follows one `templates` reference. Throws when the pack is internally inconsistent. */
+export function resolveTemplate(pack: CompiledTemplateV4, hash: string): TemplateNodeV4 {
+  const node = pack.hashToTemplate[hash];
+  if (node === undefined) {
+    throw new Error(`malformed template pack: no template node for hash ${hash}`);
+  }
+  return node;
+}
+
+/**
+ * Raised when a pack's `templates` references form a cycle.
+ *
+ * The compiler cannot produce one: a node's hash covers its children's
+ * hashes, so closing a cycle would need a hash preimage. Only a corrupt or
+ * hand-edited pack can contain one, and readers walk the graph recursively —
+ * so detect it and say so, rather than overflowing the stack.
+ *
+ * v3 could not represent this at all: it nested children inline, so a cycle
+ * would have been an infinite document.
+ */
+export function templateCycleError(node: TemplateNodeV4): Error {
+  return new Error(
+    `malformed template pack: template reference cycle through ${node.name}@${node.version}`,
+  );
+}

--- a/lib/model/backend/src/template_resources_v1.ts
+++ b/lib/model/backend/src/template_resources_v1.ts
@@ -2,6 +2,12 @@ import type { AnyFieldRef, AnyResourceRef } from "@milaboratories/pl-client";
 import { field, resourceType } from "@milaboratories/pl-client";
 import type * as infoV2 from "./template_data_v2";
 import type * as infoV3 from "./template_data_v3";
+import type * as infoV4 from "./template_data_v4";
+
+/** The fields these resource builders read are the same in v3 and v4 — only
+ *  the shape of `templates` differs between the two, and none of them touch
+ *  it. Accepting both keeps one builder per resource type. */
+type AnyTemplateNode = infoV3.TemplateDataV3 | infoV4.TemplateNodeV4;
 export namespace PlTemplateLibV1 {
   export const type = resourceType("TengoLib", "1");
 
@@ -133,7 +139,7 @@ export namespace PlTemplateV1 {
     };
   }
 
-  export function fromV3Data(info: infoV3.TemplateDataV3, sourceCode: string): ResourceStructure {
+  export function fromV3Data(info: AnyTemplateNode, sourceCode: string): ResourceStructure {
     return {
       data: {
         Name: info.name,
@@ -220,7 +226,7 @@ export namespace PlTemplateOverrideV1 {
     };
   }
 
-  export function fromV3Data(info: infoV3.TemplateDataV3): ResourceStructure {
+  export function fromV3Data(info: AnyTemplateNode): ResourceStructure {
     if (!info.hashOverride) {
       throw new Error(
         `template tree rendering error: template has no hash override, cannot generate PlTemplateOverrideV1.ResourceStructure from template data`,

--- a/lib/node/pl-middle-layer/src/block_registry/registry.ts
+++ b/lib/node/pl-middle-layer/src/block_registry/registry.ts
@@ -9,6 +9,7 @@ import { assertNever } from "@milaboratories/ts-helpers";
 import { LegacyDevBlockPackFiles } from "../dev_env";
 import { tryLoadPackDescription } from "@platforma-sdk/block-tools";
 import { deriveRequiredCapabilities } from "../mutator/block-pack/required_capabilities";
+import { templateCodecForPath } from "@milaboratories/pl-model-backend";
 import type { V2RegistryProvider } from "./registry-v2-provider";
 import type {
   BlockPackId,
@@ -239,10 +240,12 @@ export class BlockPackRegistry {
               // developer to re-pack on every workflow change, derive from
               // the compiled workflow bytes directly.
               if (meta.requiredCapabilities === undefined) {
-                const workflowBytes = await fs.promises.readFile(
-                  v2Description.components.workflow.main.file,
+                const workflowFile = v2Description.components.workflow.main.file;
+                const workflowBytes = await fs.promises.readFile(workflowFile);
+                const derived = deriveRequiredCapabilities(
+                  workflowBytes,
+                  templateCodecForPath(workflowFile),
                 );
-                const derived = deriveRequiredCapabilities(workflowBytes);
                 if (derived !== undefined) meta.requiredCapabilities = derived;
               }
 

--- a/lib/node/pl-middle-layer/src/dev_env/index.ts
+++ b/lib/node/pl-middle-layer/src/dev_env/index.ts
@@ -2,6 +2,7 @@ import { RegistryV1 } from "@platforma-sdk/block-tools";
 import path from "node:path";
 import { tryStat } from "./util";
 import { tryResolve } from "@milaboratories/resolve-helper";
+import { TemplatePackSuffix } from "@milaboratories/pl-model-backend";
 
 export const LegacyDevBlockPackMetaYaml = [RegistryV1.PlPackageYamlConfigFile];
 export const LegacyDevBlockPackMetaJson = [RegistryV1.PlPackageJsonConfigFile];
@@ -9,7 +10,7 @@ export const LegacyDevBlockPackTemplate = ["backend", "dist", "tengo", "tpl", "m
 export const LegacyDevBlockPackConfig = ["config", "dist", "config.json"];
 export const LegacyDevBlockPackFrontendFolder = ["frontend", "dist"];
 
-export const CanonicalBlockWorkflowRequest = "block-workflow/dist/tengo/tpl/main.plj.gz";
+export const CanonicalBlockWorkflowRequest = `block-workflow/dist/tengo/tpl/main${TemplatePackSuffix}`;
 export const CanonicalBlockConfigRequest = "block-model/dist/config.json";
 export const CanonicalBlockUiRequestPackageJson = "block-ui/package.json";
 
@@ -22,7 +23,7 @@ export const LegacyDevBlockPackFiles = [
 ];
 
 export type DevPacketPaths = {
-  /** main.plj.gz */
+  /** main.plj.zst, or main.plj.gz for a legacy dev pack */
   readonly workflow: string;
   /** config.json */
   readonly config: string;

--- a/lib/node/pl-middle-layer/src/model/template_spec.ts
+++ b/lib/node/pl-middle-layer/src/model/template_spec.ts
@@ -1,5 +1,5 @@
 import type { SignedResourceId } from "@milaboratories/pl-client";
-import type { CompiledTemplateV3, TemplateData } from "@milaboratories/pl-model-backend";
+import type { AnyCompiledTemplate, TemplateCodec } from "@milaboratories/pl-model-backend";
 
 export interface TemplateFromRegistry {
   readonly type: "from-registry";
@@ -10,11 +10,17 @@ export interface TemplateFromRegistry {
 export interface ExplicitTemplate {
   readonly type: "explicit";
   content: Uint8Array;
+  /**
+   * How `content` is compressed. Set by whoever read the bytes, from the name
+   * they read them under — a `.plj.zst` file or a `.plj.gz` registry URL.
+   * Required so the bytes never have to be guessed at.
+   */
+  codec: TemplateCodec;
 }
 
 export interface PreparedTemplate {
   readonly type: "prepared";
-  data: TemplateData | CompiledTemplateV3;
+  data: AnyCompiledTemplate;
 }
 
 export interface CachedTemplate {

--- a/lib/node/pl-middle-layer/src/mutator/block-pack/block_pack.ts
+++ b/lib/node/pl-middle-layer/src/mutator/block-pack/block_pack.ts
@@ -4,6 +4,7 @@ import { loadTemplate } from "../template/template_loading";
 import type { BlockPackExplicit, BlockPackSpecAny, BlockPackSpecPrepared } from "../../model";
 import type { Signer } from "@milaboratories/ts-helpers";
 import { assertNever } from "@milaboratories/ts-helpers";
+import { templateCodecForPath } from "@milaboratories/pl-model-backend";
 import type { Branded } from "@milaboratories/pl-model-common";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -160,7 +161,11 @@ export class BlockPackPreparer {
 
     await using workerManager = new WorkerManager();
 
-    const parsed = await workerManager.process("parseTemplate", explicit.template.content);
+    const parsed = await workerManager.process(
+      "parseTemplate",
+      explicit.template.content,
+      explicit.template.codec,
+    );
 
     const result: BlockPackSpecPrepared = {
       ...explicit,
@@ -203,6 +208,7 @@ export class BlockPackPreparer {
           template: {
             type: "explicit",
             content: templateContent,
+            codec: templateCodecForPath(devPaths.workflow),
           },
           config,
           frontend: {
@@ -234,6 +240,7 @@ export class BlockPackPreparer {
           template: {
             type: "explicit",
             content: workflowContent,
+            codec: templateCodecForPath(description.components.workflow.main.file),
           },
           config,
           frontend: {
@@ -276,6 +283,7 @@ export class BlockPackPreparer {
           template: {
             type: "explicit",
             content: workflowContent,
+            codec: templateCodecForPath(description.components.workflow.main.file),
           },
           config,
           frontend: {
@@ -307,6 +315,9 @@ export class BlockPackPreparer {
           template: {
             type: "explicit",
             content: templateContent,
+            // v1 registry packs predate the codec switch and stay gzip under
+            // their published name.
+            codec: templateCodecForPath(templateUrl),
           },
           config,
           frontend: {
@@ -333,6 +344,7 @@ export class BlockPackPreparer {
           template: {
             type: "explicit",
             content: workflowContent,
+            codec: templateCodecForPath(components.workflow.main.url),
           },
           config: model,
           frontend: {

--- a/lib/node/pl-middle-layer/src/mutator/block-pack/required_capabilities.test.ts
+++ b/lib/node/pl-middle-layer/src/mutator/block-pack/required_capabilities.test.ts
@@ -1,0 +1,84 @@
+import { gzipSync, zstdCompressSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import type { CompiledTemplateV3, CompiledTemplateV4 } from "@milaboratories/pl-model-backend";
+import {
+  deriveRequiredCapabilities,
+  requiredCapabilitiesFromTemplate,
+} from "./required_capabilities";
+
+const v4: CompiledTemplateV4 = {
+  type: "pl.tengo-template.v4",
+  hashToSource: {},
+  hashToTemplate: {
+    root: {
+      name: "@t/pkg:main",
+      version: "1.0.0",
+      sourceHash: "src",
+      libs: {},
+      templates: {},
+      software: {},
+      assets: {},
+      requiredCapabilities: ["wasm:v1"],
+    },
+  },
+  template: "root",
+};
+
+const v3: CompiledTemplateV3 = {
+  type: "pl.tengo-template.v3",
+  hashToSource: {},
+  template: {
+    name: "@t/pkg:main",
+    version: "1.0.0",
+    sourceHash: "src",
+    libs: {},
+    templates: {},
+    software: {},
+    assets: {},
+    requiredCapabilities: ["wasm:v1"],
+  },
+};
+
+describe("requiredCapabilitiesFromTemplate", () => {
+  it("reads the root node of a v4 pack", () => {
+    expect(requiredCapabilitiesFromTemplate(v4)).toEqual(["wasm:v1"]);
+  });
+
+  // Regression guard: every block published before v4 carries its
+  // requirements in a v3 pack. Reading only v4 would report "no
+  // requirements" and let a WASM block install on a backend without the
+  // runtime.
+  it("still reads a v3 pack", () => {
+    expect(requiredCapabilitiesFromTemplate(v3)).toEqual(["wasm:v1"]);
+  });
+
+  it("returns undefined when a v4 pack declares nothing", () => {
+    const bare: CompiledTemplateV4 = {
+      ...v4,
+      hashToTemplate: { root: { ...v4.hashToTemplate.root, requiredCapabilities: undefined } },
+    };
+    expect(requiredCapabilitiesFromTemplate(bare)).toBeUndefined();
+  });
+
+  it("returns undefined for a v2 pack", () => {
+    const v2 = { type: "pl.tengo-template.v2", name: "@t/pkg:main", version: "1.0.0" };
+    expect(requiredCapabilitiesFromTemplate(v2 as never)).toBeUndefined();
+  });
+});
+
+describe("deriveRequiredCapabilities", () => {
+  const zstd = (value: unknown) => zstdCompressSync(Buffer.from(JSON.stringify(value)));
+
+  it("reads a zstd v4 pack", () => {
+    expect(deriveRequiredCapabilities(zstd(v4), "zstd")).toEqual(["wasm:v1"]);
+  });
+
+  // Published blocks are gzip and stay readable under their original name.
+  it("reads a gzip v3 pack", () => {
+    expect(deriveRequiredCapabilities(gzipSync(JSON.stringify(v3)), "gzip")).toEqual(["wasm:v1"]);
+  });
+
+  it("returns undefined for bytes that are not a pack", () => {
+    expect(deriveRequiredCapabilities(Buffer.from("not a pack"), "gzip")).toBeUndefined();
+  });
+});

--- a/lib/node/pl-middle-layer/src/mutator/block-pack/required_capabilities.ts
+++ b/lib/node/pl-middle-layer/src/mutator/block-pack/required_capabilities.ts
@@ -1,9 +1,9 @@
-import { gunzipSync } from "node:zlib";
-import type { CompiledTemplateV3, TemplateData } from "@milaboratories/pl-model-backend";
+import { decompressTemplate } from "@milaboratories/pl-model-backend";
+import type { AnyCompiledTemplate, TemplateCodec } from "@milaboratories/pl-model-backend";
 
 /**
  * Reads the capability tokens a template declares it requires via
- * `TemplateDataV3.requiredCapabilities` (populated by `tengo-builder` at
+ * `TemplateNodeV4.requiredCapabilities` (populated by `tengo-builder` at
  * compile time).
  *
  * Use this on the install path: `BlockPackPreparer.prepare` parses the
@@ -12,33 +12,45 @@ import type { CompiledTemplateV3, TemplateData } from "@milaboratories/pl-model-
  * thread, no recursive walk to re-derive what the compiler already wrote
  * down.
  *
- * Returns `undefined` for v2 templates (no compile-time capability
- * field) and for v3 templates that declare no requirements; otherwise
- * the array as the compiler wrote it.
+ * Reads both v3 and v4. v3 must stay supported: every block published
+ * before v4 carries its requirements in a v3 pack, and treating those as
+ * "no requirements" would let a WASM block install on a backend that
+ * cannot run it.
+ *
+ * Returns `undefined` for v2 templates (no compile-time capability field)
+ * and for templates that declare no requirements; otherwise the array as
+ * the compiler wrote it.
  */
 export function requiredCapabilitiesFromTemplate(
-  parsed: TemplateData | CompiledTemplateV3,
+  parsed: AnyCompiledTemplate,
 ): string[] | undefined {
-  if (parsed.type !== "pl.tengo-template.v3") return undefined;
-  return parsed.template.requiredCapabilities;
+  switch (parsed.type) {
+    case "pl.tengo-template.v4":
+      return parsed.hashToTemplate[parsed.template]?.requiredCapabilities;
+    case "pl.tengo-template.v3":
+      return parsed.template.requiredCapabilities;
+    default:
+      return undefined;
+  }
 }
 
 /**
- * Same lookup, starting from raw `main.plj.gz` bytes. Used only at
- * catalog-listing time for local-dev blocks where the worker pipeline
- * isn't in play (`block_registry/registry.ts`). Install paths go through
- * `requiredCapabilitiesFromTemplate` instead to avoid parsing the
+ * Same lookup, starting from raw pack bytes and the codec they were stored
+ * under. Used only at catalog-listing time for local-dev blocks where the
+ * worker pipeline isn't in play (`block_registry/registry.ts`). Install paths
+ * go through `requiredCapabilitiesFromTemplate` instead to avoid parsing the
  * workflow twice.
  */
 export function deriveRequiredCapabilities(
   workflowContent: Uint8Array | Buffer,
+  codec: TemplateCodec,
 ): string[] | undefined {
   let parsed: unknown;
   try {
-    const json = gunzipSync(workflowContent).toString("utf-8");
+    const json = decompressTemplate(workflowContent, codec).toString("utf-8");
     parsed = JSON.parse(json);
   } catch {
     return undefined;
   }
-  return requiredCapabilitiesFromTemplate(parsed as TemplateData | CompiledTemplateV3);
+  return requiredCapabilitiesFromTemplate(parsed as AnyCompiledTemplate);
 }

--- a/lib/node/pl-middle-layer/src/mutator/template/direct_template_loader.ts
+++ b/lib/node/pl-middle-layer/src/mutator/template/direct_template_loader.ts
@@ -16,9 +16,10 @@ import {
   parseTemplate,
 } from "@milaboratories/pl-model-backend";
 import { createTemplateV3Tree } from "./direct_template_loader_v3";
+import { createTemplateV4Tree } from "./direct_template_loader_v4";
 
 export function loadTemplateFromExplicitDirect(tx: PlTransaction, spec: ExplicitTemplate): AnyRef {
-  const templateInfo = parseTemplate(spec.content);
+  const templateInfo = parseTemplate(spec.content, spec.codec);
 
   const templateFormat = templateInfo.type;
   switch (templateFormat) {
@@ -26,6 +27,8 @@ export function loadTemplateFromExplicitDirect(tx: PlTransaction, spec: Explicit
       return createTemplateV2Tree(tx, templateInfo);
     case "pl.tengo-template.v3":
       return createTemplateV3Tree(tx, templateInfo);
+    case "pl.tengo-template.v4":
+      return createTemplateV4Tree(tx, templateInfo);
     default:
       assertNever(templateFormat);
   }
@@ -40,6 +43,8 @@ export function loadTemplateFromPrepared(tx: PlTransaction, spec: PreparedTempla
       return createTemplateV2Tree(tx, templateData);
     case "pl.tengo-template.v3":
       return createTemplateV3Tree(tx, templateData);
+    case "pl.tengo-template.v4":
+      return createTemplateV4Tree(tx, templateData);
     default:
       assertNever(templateFormat);
   }

--- a/lib/node/pl-middle-layer/src/mutator/template/direct_template_loader_v4.ts
+++ b/lib/node/pl-middle-layer/src/mutator/template/direct_template_loader_v4.ts
@@ -1,0 +1,265 @@
+import type { AnyRef, AnyResourceRef, PlTransaction } from "@milaboratories/pl-client";
+import type { Hash } from "node:crypto";
+import { createHash } from "node:crypto";
+import type {
+  CompiledTemplateV4,
+  TemplateLibDataV3,
+  TemplateNodeV4,
+  TemplateSoftwareDataV3,
+  TemplateWasmDataV3,
+} from "@milaboratories/pl-model-backend";
+import {
+  PlTemplateLibV1,
+  PlTemplateSoftwareV1,
+  PlTemplateV1,
+  PlTemplateOverrideV1,
+  PlWasmV1,
+  resolveTemplate,
+  templateCycleError,
+} from "@milaboratories/pl-model-backend";
+import { notEmpty } from "@milaboratories/ts-helpers";
+
+/**
+ * Renders the template graph into pl resources, caching by cache key.
+ *
+ * Differs from the v3 renderer in one way that matters: a v4 pack addresses
+ * sub-templates by content hash, and that hash already covers the whole
+ * subtree. So a template's cache key can fold in its children's hashes
+ * directly instead of re-deriving them by walking the subtree.
+ *
+ * Under v3 that walk ran on every `createResourceCached` call, including
+ * cache hits, and it walked the *expanded* tree. On a real block
+ * (sequence-embeddings 1.4.1: 39 distinct templates, 11,672 expanded nodes)
+ * it visited 35,920 nodes and made 2.8M `hash.update` calls to produce 39
+ * resources. Here it is one visit per distinct node.
+ */
+export function createTemplateV4Tree(tx: PlTransaction, pack: CompiledTemplateV4): AnyRef {
+  const resourceCache = new Map<string, AnyResourceRef>();
+  const context: RenderContext = {
+    hashToSource: pack.hashToSource,
+    pack,
+    visiting: new Set<TemplateNodeV4>(),
+  };
+
+  const createResourceCached = <T>(
+    resource: T,
+    renderer: Renderer<T>,
+    ctx: RenderContext,
+  ): AnyResourceRef => {
+    const key: Hash = createHash("sha256");
+    renderer.updateCacheKey(resource, key, ctx);
+
+    const rKey = key.digest("hex");
+
+    if (!resourceCache.has(rKey)) {
+      const rId = renderer.render(resource, tx, createResourceCached, ctx);
+      resourceCache.set(rKey, rId);
+    }
+
+    return resourceCache.get(rKey)!;
+  };
+
+  return createResourceCached(resolveTemplate(pack, pack.template), TemplateRenderer, context);
+}
+
+/** Everything a renderer needs to resolve a reference: sources by hash, and
+ *  template nodes by hash. Bundled so renderers keep a single context
+ *  parameter rather than growing one per lookup table. */
+interface RenderContext {
+  hashToSource: Record<string, string>;
+  pack: CompiledTemplateV4;
+  /** Nodes on the current path, so a reference cycle is reported instead of
+   *  recursing until the stack runs out. */
+  visiting: Set<TemplateNodeV4>;
+}
+
+type Renderer<T> = {
+  /** Updates the cache key by adding all info of the artifact. */
+  updateCacheKey: CacheKey<T>;
+  /** Create resources for all dependencies recursively and then for this artifact. */
+  render: (resource: T, tx: PlTransaction, creator: Creator, ctx: RenderContext) => AnyResourceRef;
+};
+type CacheKey<T> = (resource: T, key: Hash, ctx: RenderContext) => void;
+type Creator = <T>(resource: T, renderer: Renderer<T>, ctx: RenderContext) => AnyResourceRef;
+
+const LibRenderer: Renderer<TemplateLibDataV3> = {
+  updateCacheKey(resource, hash, _ctx) {
+    // sourceHash is already the sha256 of this source (the hashToSource key), so hash it
+    // directly instead of streaming the full source through sha256 again.
+    hash
+      .update(PlTemplateLibV1.type.name)
+      .update(PlTemplateLibV1.type.version)
+      .update(resource.name)
+      .update(resource.version)
+      .update(resource.sourceHash);
+  },
+  render(resource, tx, _creator, ctx) {
+    return tx.createValue(
+      PlTemplateLibV1.type,
+      JSON.stringify(
+        PlTemplateLibV1.fromV3Data(
+          resource,
+          getSourceCode(resource.name, ctx.hashToSource, resource.sourceHash),
+        ).data,
+      ),
+    );
+  },
+};
+
+const WasmRenderer: Renderer<TemplateWasmDataV3> = {
+  updateCacheKey(resource, hash, _ctx) {
+    hash
+      .update(PlWasmV1.type.name)
+      .update(PlWasmV1.type.version)
+      .update(resource.name)
+      .update(resource.version)
+      .update(resource.sourceHash);
+  },
+  render(resource, tx, _creator, ctx) {
+    return tx.createValue(
+      PlWasmV1.type,
+      JSON.stringify(
+        PlWasmV1.fromV3Data(
+          resource,
+          getSourceCode(resource.name, ctx.hashToSource, resource.sourceHash),
+        ).data,
+      ),
+    );
+  },
+};
+
+const SoftwareInfoRenderer: Renderer<TemplateSoftwareDataV3> = {
+  updateCacheKey(resource, hash, _ctx) {
+    hash
+      .update(PlTemplateSoftwareV1.type.name)
+      .update(PlTemplateSoftwareV1.type.version)
+      .update(resource.name)
+      .update(resource.version)
+      .update(resource.sourceHash);
+  },
+  render(resource, tx, _creator, ctx) {
+    const sw = PlTemplateSoftwareV1.fromV3Data(
+      resource,
+      getSourceCode(resource.name, ctx.hashToSource, resource.sourceHash),
+    );
+    const ref = tx.createStruct(PlTemplateSoftwareV1.type, sw.data);
+    tx.setKValue(ref, PlTemplateSoftwareV1.metaNameKey, JSON.stringify(sw.name));
+    tx.lock(ref);
+    return ref;
+  },
+};
+
+const TemplateRenderer: Renderer<TemplateNodeV4> = {
+  updateCacheKey(resource, hash, ctx) {
+    hash
+      .update(PlTemplateV1.type.name)
+      .update(PlTemplateV1.type.version)
+      .update(resource.hashOverride ?? "no-override")
+      .update(resource.name)
+      .update(resource.version)
+      .update(resource.sourceHash);
+
+    const srt = <T>(entries: [string, T][]): [string, T][] => {
+      entries.sort((a, b) => (a[0] === b[0] ? 0 : a[0] < b[0] ? -1 : 1));
+      return entries;
+    };
+
+    for (const [libId, lib] of srt(Object.entries(resource.libs ?? {}))) {
+      hash.update("lib:" + libId);
+      LibRenderer.updateCacheKey(lib, hash, ctx);
+    }
+    for (const [swId, sw] of srt(Object.entries(resource.software ?? {}))) {
+      hash.update("soft:" + swId);
+      SoftwareInfoRenderer.updateCacheKey(sw, hash, ctx);
+    }
+    for (const [swId, sw] of srt(Object.entries(resource.assets ?? {}))) {
+      hash.update("asset:" + swId);
+      SoftwareInfoRenderer.updateCacheKey(sw, hash, ctx);
+    }
+    // The child's content hash covers its entire subtree, so folding the hash
+    // in is equivalent to recursing into it — at one update instead of a walk.
+    for (const [tplId, tplHash] of srt(Object.entries(resource.templates ?? {}))) {
+      hash.update("tpl:" + tplId).update(tplHash);
+    }
+    for (const [wasmId, wasm] of srt(Object.entries(resource.wasm ?? {}))) {
+      hash.update("wasm:" + wasmId);
+      WasmRenderer.updateCacheKey(wasm, hash, ctx);
+    }
+  },
+  render(resource, tx, _creator, ctx) {
+    const tplRef = tx.createStruct(
+      PlTemplateV1.type,
+      JSON.stringify(
+        PlTemplateV1.fromV3Data(
+          resource,
+          getSourceCode(resource.name, ctx.hashToSource, resource.sourceHash),
+        ).data,
+      ),
+    );
+    // Render libraries
+    for (const [libId, lib] of Object.entries(resource.libs ?? {})) {
+      const fld = PlTemplateV1.libField(tplRef, libId);
+      tx.createField(fld, "Input");
+      tx.setField(fld, _creator(lib, LibRenderer, ctx));
+    }
+
+    // Render software and assets
+    for (const [swId, sw] of Object.entries(resource.software ?? {})) {
+      const fld = PlTemplateV1.swField(tplRef, swId);
+      tx.createField(fld, "Input");
+      tx.setField(fld, _creator(sw, SoftwareInfoRenderer, ctx));
+    }
+    for (const [swId, sw] of Object.entries(resource.assets ?? {})) {
+      const fld = PlTemplateV1.swField(tplRef, swId);
+      tx.createField(fld, "Input");
+      tx.setField(fld, _creator(sw, SoftwareInfoRenderer, ctx));
+    }
+
+    // Render dependency templates
+    ctx.visiting.add(resource);
+    for (const [depTplId, depTplHash] of Object.entries(resource.templates ?? {})) {
+      const child = resolveTemplate(ctx.pack, depTplHash);
+      if (ctx.visiting.has(child)) throw templateCycleError(child);
+      const fld = PlTemplateV1.tplField(tplRef, depTplId);
+      tx.createField(fld, "Input");
+      tx.setField(fld, _creator(child, TemplateRenderer, ctx));
+    }
+    ctx.visiting.delete(resource);
+
+    // Render wasm dependencies. The field name (alias) feeds straight into
+    // the backend's TengoTemplateV1.wasm map and becomes the lookup key in
+    // RuntimeV1.deps.Wasm consumed by plapi.loadWasm.
+    for (const [wasmId, wasm] of Object.entries(resource.wasm ?? {})) {
+      const fld = PlTemplateV1.wasmField(tplRef, wasmId);
+      tx.createField(fld, "Input");
+      tx.setField(fld, _creator(wasm, WasmRenderer, ctx));
+    }
+
+    tx.lock(tplRef);
+
+    if (!resource.hashOverride) return tplRef;
+
+    // Override template hash with proxy resource, when hash override is configured for template
+    const overrideRef = tx.createStruct(
+      PlTemplateOverrideV1.type,
+      JSON.stringify(PlTemplateOverrideV1.fromV3Data(resource)),
+    );
+    const fld = PlTemplateOverrideV1.tplField(overrideRef);
+    tx.createField(fld, "Service");
+    tx.setField(fld, tplRef);
+    tx.lock(overrideRef);
+    return overrideRef;
+  },
+};
+
+/**
+ * Gets a source code of the artifact by its source hash.
+ * the source hash was calculated and stored by tengo compiler
+ * and is different from the hash we're using for caching here.
+ */
+function getSourceCode(name: string, sources: Record<string, string>, sourceHash: string): string {
+  return notEmpty(
+    sources[sourceHash],
+    `trying to get "${name}" source: sources map doesn't contain source hash ${sourceHash}`,
+  );
+}

--- a/lib/node/pl-middle-layer/src/mutator/template/template_cache.test.ts
+++ b/lib/node/pl-middle-layer/src/mutator/template/template_cache.test.ts
@@ -26,7 +26,76 @@ import {
   TemplateCacheType,
 } from "./template_cache";
 import { parseTemplate } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV4, TemplateNodeV4 } from "@milaboratories/pl-model-backend";
 import type { BlockPackSpecPrepared } from "../../model";
+
+describe("v4 graph walking", () => {
+  // The compiler cannot emit a cycle — a node's hash covers its children's
+  // hashes, so closing one would need a hash preimage. Only a corrupt pack
+  // reaches a reader with one, and readers walk the graph recursively.
+  test("a reference cycle is reported, not recursed into", () => {
+    const a: TemplateNodeV4 = {
+      name: "@t/pkg:a",
+      version: "1.0.0",
+      sourceHash: "src",
+      libs: {},
+      templates: { b: "hash-b" },
+      software: {},
+      assets: {},
+    };
+    const b: TemplateNodeV4 = { ...a, name: "@t/pkg:b", templates: { a: "hash-a" } };
+    const pack: CompiledTemplateV4 = {
+      type: "pl.tengo-template.v4",
+      hashToSource: { src: "source" },
+      hashToTemplate: { "hash-a": a, "hash-b": b },
+      template: "hash-a",
+    };
+
+    expect(() => flattenTemplateTree(pack)).toThrow(/cycle/);
+  });
+
+  // Guards the reason v4 exists: a node reachable by many paths must be
+  // walked once. Without the memo this still produced correct output via the
+  // `seen` set, so only a visit count catches a regression.
+  test("a shared node is emitted once however many paths reach it", () => {
+    const leaf: TemplateNodeV4 = {
+      name: "@t/pkg:leaf",
+      version: "1.0.0",
+      sourceHash: "leaf",
+      libs: {},
+      templates: {},
+      software: {},
+      assets: {},
+    };
+    const mid = (name: string): TemplateNodeV4 => ({
+      ...leaf,
+      name,
+      sourceHash: name,
+      templates: { leaf: "h-leaf" },
+    });
+    const root: TemplateNodeV4 = {
+      ...leaf,
+      name: "@t/pkg:root",
+      sourceHash: "root",
+      templates: { one: "h-1", two: "h-2" },
+    };
+    const pack: CompiledTemplateV4 = {
+      type: "pl.tengo-template.v4",
+      hashToSource: { leaf: "s", "@t/pkg:m1": "s", "@t/pkg:m2": "s", root: "s" },
+      hashToTemplate: {
+        "h-leaf": leaf,
+        "h-1": mid("@t/pkg:m1"),
+        "h-2": mid("@t/pkg:m2"),
+        "h-root": root,
+      },
+      template: "h-root",
+    };
+
+    const nodes = flattenTemplateTree(pack);
+    expect(nodes.filter((n) => n.childHashes.length === 0)).toHaveLength(1);
+    expect(nodes).toHaveLength(4);
+  });
+});
 
 function createTestCacheInTx(pl: Parameters<Parameters<typeof TestHelpers.withTempRoot>[0]>[0]) {
   return pl.withWriteTx("createTestCache", async (tx) => {
@@ -41,7 +110,7 @@ function createTestCacheInTx(pl: Parameters<Parameters<typeof TestHelpers.withTe
 
 describe("flattenTemplateTree", () => {
   test("produces nodes in topological order for V2 template", () => {
-    const data = parseTemplate(ExplicitTemplateEnterNumbers);
+    const data = parseTemplate(ExplicitTemplateEnterNumbers, "gzip");
     const nodes = flattenTemplateTree(data);
     expect(nodes.length).toBeGreaterThan(0);
 
@@ -60,15 +129,15 @@ describe("flattenTemplateTree", () => {
   });
 
   test("deterministic hashes for same content", () => {
-    const data = parseTemplate(ExplicitTemplateEnterNumbers);
+    const data = parseTemplate(ExplicitTemplateEnterNumbers, "gzip");
     const nodes1 = flattenTemplateTree(data);
     const nodes2 = flattenTemplateTree(data);
     expect(nodes1.map((n) => n.hash)).toStrictEqual(nodes2.map((n) => n.hash));
   });
 
   test("different templates produce different root hashes", () => {
-    const dataEnter = parseTemplate(ExplicitTemplateEnterNumbers);
-    const dataSum = parseTemplate(ExplicitTemplateSumNumbers);
+    const dataEnter = parseTemplate(ExplicitTemplateEnterNumbers, "gzip");
+    const dataSum = parseTemplate(ExplicitTemplateSumNumbers, "gzip");
     const nodesEnter = flattenTemplateTree(dataEnter);
     const nodesSum = flattenTemplateTree(dataSum);
     expect(nodesEnter[nodesEnter.length - 1].hash).not.toBe(nodesSum[nodesSum.length - 1].hash);
@@ -187,7 +256,7 @@ describe("cacheBlockPackTemplate", () => {
         type: "prepared",
         template: {
           type: "prepared",
-          data: parseTemplate(ExplicitTemplateEnterNumbers),
+          data: parseTemplate(ExplicitTemplateEnterNumbers, "gzip"),
         },
         config: { renderingMode: "Heavy" } as any,
         frontend: { type: "url", url: "http://test" },
@@ -268,8 +337,8 @@ describe("shared library dedup", () => {
       const testCache = await createTestCacheInTx(pl);
 
       // Flatten both templates and find common hashes (shared libs)
-      const nodesEnter = flattenTemplateTree(parseTemplate(ExplicitTemplateEnterNumbers));
-      const nodesSum = flattenTemplateTree(parseTemplate(ExplicitTemplateSumNumbers));
+      const nodesEnter = flattenTemplateTree(parseTemplate(ExplicitTemplateEnterNumbers, "gzip"));
+      const nodesSum = flattenTemplateTree(parseTemplate(ExplicitTemplateSumNumbers, "gzip"));
       const enterHashes = new Set(nodesEnter.map((n) => n.hash));
       const sumHashes = new Set(nodesSum.map((n) => n.hash));
       const sharedHashes = [...enterHashes].filter((h) => sumHashes.has(h));
@@ -299,7 +368,7 @@ describe("GC", () => {
       // Cache enter-numbers template (~37 entries)
       await loadTemplateCached(pl, TplSpecEnterExplicit, { cacheResourceId: testCache });
 
-      const enterNodes = flattenTemplateTree(parseTemplate(ExplicitTemplateEnterNumbers));
+      const enterNodes = flattenTemplateTree(parseTemplate(ExplicitTemplateEnterNumbers, "gzip"));
       const allHashes = enterNodes.map((n) => n.hash);
       const halfLen = Math.floor(allHashes.length / 2);
 
@@ -339,7 +408,7 @@ describe("GC", () => {
       // Cache a template (~37 entries)
       await loadTemplateCached(pl, TplSpecEnterExplicit, { cacheResourceId: testCache });
 
-      const enterNodes = flattenTemplateTree(parseTemplate(ExplicitTemplateEnterNumbers));
+      const enterNodes = flattenTemplateTree(parseTemplate(ExplicitTemplateEnterNumbers, "gzip"));
 
       // Run GC with high max — nothing should be evicted
       const evicted = await runGc(pl, testCache, 100);

--- a/lib/node/pl-middle-layer/src/mutator/template/template_cache.ts
+++ b/lib/node/pl-middle-layer/src/mutator/template/template_cache.ts
@@ -19,18 +19,24 @@ import {
   PlTemplateSoftwareV1,
   PlTemplateV1,
   PlWasmV1,
+  resolveTemplate,
+  rootTemplate,
+  templateCycleError,
 } from "@milaboratories/pl-model-backend";
 import type {
+  AnyCompiledTemplate,
   CompiledTemplateV3,
+  CompiledTemplateV4,
   TemplateData,
   TemplateDataV3,
   TemplateLibData,
   TemplateLibDataV3,
+  TemplateNodeV4,
   TemplateSoftwareData,
   TemplateSoftwareDataV3,
   TemplateWasmDataV3,
 } from "@milaboratories/pl-model-backend";
-import { notEmpty } from "@milaboratories/ts-helpers";
+import { assertNever, notEmpty } from "@milaboratories/ts-helpers";
 import type { BlockPackSpecPrepared } from "../../model";
 import type { TemplateSpecPrepared } from "../../model/template_spec";
 import { getDebugFlags } from "../../debug";
@@ -275,10 +281,33 @@ function flattenV2Tree(data: TemplateData): CacheableNode[] {
   return nodes;
 }
 
-function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
+/** A node in either post-v2 format. The two differ only in the shape of
+ *  `templates`, which this walker reaches through a callback. */
+type AnyTemplateNode = TemplateDataV3 | TemplateNodeV4;
+
+/**
+ * Shared flattener for v3 and v4 packs.
+ *
+ * `subTemplates` hides the one real difference between the formats: v3 nests
+ * child nodes inline, v4 stores hash references into `hashToTemplate`.
+ *
+ * Memoization is by node object identity, which is what makes v4 cheap. A v4
+ * pack stores each distinct node once, so `resolveTemplate` hands back the
+ * same object for every reference to it and each node is processed once. A v3
+ * pack has a separate object per occurrence, so the memo never hits and
+ * behaviour is unchanged from before.
+ */
+function flattenNodeGraph(
+  sources: Record<string, string>,
+  root: AnyTemplateNode,
+  subTemplates: (tpl: AnyTemplateNode) => [string, AnyTemplateNode][],
+): CacheableNode[] {
   const nodes: CacheableNode[] = [];
   const seen = new Set<string>();
-  const sources = data.hashToSource;
+  const processed = new Map<AnyTemplateNode, string>();
+  /** Nodes on the current path, so a reference cycle is reported instead of
+   *  recursing until the stack runs out. */
+  const visiting = new Set<AnyTemplateNode>();
 
   function processLib(lib: TemplateLibDataV3): string {
     const hash = hashLibV3(lib);
@@ -341,7 +370,12 @@ function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
     return hash;
   }
 
-  function processTemplate(tpl: TemplateDataV3): string {
+  function processTemplate(tpl: AnyTemplateNode): string {
+    const memoized = processed.get(tpl);
+    if (memoized !== undefined) return memoized;
+    if (visiting.has(tpl)) throw templateCycleError(tpl as TemplateNodeV4);
+    visiting.add(tpl);
+
     // Defensive: a template can carry no embedded version at runtime even
     // though the type says `string` — the compiler writes `packageJson.version`
     // unchecked, so a template built from a package with no `version` field
@@ -354,27 +388,27 @@ function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
     const childHashes: string[] = [];
     const children: { fieldName: string; hash: string }[] = [];
 
-    for (const [libId, lib] of Object.entries(tpl.libs ?? {})) {
+    for (const [libId, lib] of Object.entries<TemplateLibDataV3>(tpl.libs ?? {})) {
       const h = processLib(lib);
       childHashes.push(h);
       children.push({ fieldName: `${PlTemplateV1.libPrefix}/${libId}`, hash: h });
     }
-    for (const [swId, sw] of Object.entries(tpl.software ?? {})) {
+    for (const [swId, sw] of Object.entries<TemplateSoftwareDataV3>(tpl.software ?? {})) {
       const h = processSoftware(sw);
       childHashes.push(h);
       children.push({ fieldName: `${PlTemplateV1.softPrefix}/${swId}`, hash: h });
     }
-    for (const [swId, sw] of Object.entries(tpl.assets ?? {})) {
+    for (const [swId, sw] of Object.entries<TemplateSoftwareDataV3>(tpl.assets ?? {})) {
       const h = processSoftware(sw);
       childHashes.push(h);
       children.push({ fieldName: `${PlTemplateV1.softPrefix}/${swId}`, hash: h });
     }
-    for (const [tplId, sub] of Object.entries(tpl.templates ?? {})) {
+    for (const [tplId, sub] of subTemplates(tpl)) {
       const h = processTemplate(sub);
       childHashes.push(h);
       children.push({ fieldName: `${PlTemplateV1.tplPrefix}/${tplId}`, hash: h });
     }
-    for (const [wasmId, wasm] of Object.entries(tpl.wasm ?? {})) {
+    for (const [wasmId, wasm] of Object.entries<TemplateWasmDataV3>(tpl.wasm ?? {})) {
       const h = processWasm(wasm);
       childHashes.push(h);
       children.push({ fieldName: `${PlTemplateV1.wasmPrefix}/${wasmId}`, hash: h });
@@ -393,6 +427,8 @@ function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
       h.update("child:" + child.fieldName + ":" + child.hash);
     }
     const hash = h.digest("hex");
+    visiting.delete(tpl);
+    processed.set(tpl, hash);
 
     if (seen.has(hash)) return hash;
     seen.add(hash);
@@ -429,16 +465,35 @@ function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
     return hash;
   }
 
-  processTemplate(data.template);
+  processTemplate(root);
   return nodes;
 }
 
+function flattenV3Tree(data: CompiledTemplateV3): CacheableNode[] {
+  return flattenNodeGraph(data.hashToSource, data.template, (tpl) =>
+    Object.entries(tpl.templates as Record<string, TemplateDataV3>),
+  );
+}
+
+function flattenV4Tree(data: CompiledTemplateV4): CacheableNode[] {
+  return flattenNodeGraph(data.hashToSource, rootTemplate(data), (tpl) =>
+    Object.entries(tpl.templates as Record<string, string>).map(
+      ([alias, hash]): [string, TemplateNodeV4] => [alias, resolveTemplate(data, hash)],
+    ),
+  );
+}
+
 /** Flatten template tree into a topologically ordered list of cacheable nodes (leaves first). */
-export function flattenTemplateTree(data: TemplateData | CompiledTemplateV3): CacheableNode[] {
-  if (data.type === "pl.tengo-template.v2") {
-    return flattenV2Tree(data);
-  } else {
-    return flattenV3Tree(data);
+export function flattenTemplateTree(data: AnyCompiledTemplate): CacheableNode[] {
+  switch (data.type) {
+    case "pl.tengo-template.v2":
+      return flattenV2Tree(data);
+    case "pl.tengo-template.v3":
+      return flattenV3Tree(data);
+    case "pl.tengo-template.v4":
+      return flattenV4Tree(data);
+    default:
+      return assertNever(data);
   }
 }
 
@@ -706,10 +761,10 @@ export async function loadTemplateCached(
 
   try {
     // Parse to data if needed
-    let tplData: TemplateData | CompiledTemplateV3;
+    let tplData: AnyCompiledTemplate;
     switch (spec.type) {
       case "explicit":
-        tplData = parseTemplate(spec.content);
+        tplData = parseTemplate(spec.content, spec.codec);
         break;
       case "prepared":
         tplData = spec.data;

--- a/lib/node/pl-middle-layer/src/mutator/template/template_loading.ts
+++ b/lib/node/pl-middle-layer/src/mutator/template/template_loading.ts
@@ -7,6 +7,7 @@ import type {
   TemplateSpecPrepared,
 } from "../../model/template_spec";
 import { assertNever } from "@milaboratories/ts-helpers";
+import { templateCodecForPath } from "@milaboratories/pl-model-backend";
 import { loadTemplateFromExplicitDirect, loadTemplateFromPrepared } from "./direct_template_loader";
 
 //
@@ -32,6 +33,7 @@ export async function prepareTemplateSpec(tpl: TemplateSpecAny): Promise<Templat
       return {
         type: "explicit",
         content: await fs.promises.readFile(tpl.path),
+        codec: templateCodecForPath(tpl.path),
       };
     case "from-registry":
     case "explicit":

--- a/lib/node/pl-middle-layer/src/test/known_templates.ts
+++ b/lib/node/pl-middle-layer/src/test/known_templates.ts
@@ -1,9 +1,11 @@
 import type { TemplateSpecPrepared } from "../model/template_spec";
 import { ExplicitTemplateEnterNumbers, ExplicitTemplateSumNumbers } from "./explicit_templates";
 
+// Base64 snapshots of packs published to the v1 registry, so gzip.
 export const TplSpecEnterExplicit: TemplateSpecPrepared = {
   type: "explicit",
   content: ExplicitTemplateEnterNumbers,
+  codec: "gzip",
 };
 
 export const TplSpecEnterFromRegistry: TemplateSpecPrepared = {
@@ -15,6 +17,7 @@ export const TplSpecEnterFromRegistry: TemplateSpecPrepared = {
 export const TplSpecSumExplicit: TemplateSpecPrepared = {
   type: "explicit",
   content: ExplicitTemplateSumNumbers,
+  codec: "gzip",
 };
 
 export const TplSpecSumFromRegistry: TemplateSpecPrepared = {

--- a/lib/node/pl-middle-layer/src/worker/workerApi.ts
+++ b/lib/node/pl-middle-layer/src/worker/workerApi.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/require-await */
 import { parseTemplate } from "@milaboratories/pl-model-backend";
+import type { TemplateCodec } from "@milaboratories/pl-model-backend";
 
 /**
  * Add there all heavy synchronous operations that can be moved to the worker thread.
  */
 export const workerApi = {
-  parseTemplate: async (payload: Uint8Array) => {
+  parseTemplate: async (payload: Uint8Array, codec: TemplateCodec) => {
     const t1 = performance.now();
-    const result = parseTemplate(payload);
+    const result = parseTemplate(payload, codec);
     const t2 = performance.now();
     const dt = t2 - t1;
     if (dt > 100) console.warn(`parseTemplate in worker took ${dt}ms`);

--- a/sdk/test/src/test-template.ts
+++ b/sdk/test/src/test-template.ts
@@ -117,7 +117,7 @@ export class TplTestHelpers {
       typeof template === "string"
         ? await prepareTemplateSpec({
             type: "from-file",
-            path: `./dist/tengo/tpl/${template}.plj.gz`,
+            path: `./dist/tengo/tpl/${template}.plj.zst`,
           })
         : await prepareTemplateSpec(template);
     const { resultMapRid } = await this.pl.withWriteTx("TemplateRender", async (tx) => {

--- a/tests/drivers-ml-blocks-integration/src/template-cache-v3.test.ts
+++ b/tests/drivers-ml-blocks-integration/src/template-cache-v3.test.ts
@@ -13,18 +13,53 @@ import {
   loadTemplateCached,
   TemplateCacheType,
 } from "@milaboratories/pl-middle-layer";
-import { parseTemplate } from "@milaboratories/pl-model-backend";
+import { parseTemplate, TemplatePackSuffix } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV3 } from "@milaboratories/pl-model-backend";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
-// Resolve V3 template content from the block package's built output
+// Resolve template content from the block package's built output
 // (BlockPointer.packUrl is a file: URL — convert to a path at this edge).
-const v3WorkflowPath = path.join(fileURLToPath(BlockPointer.packUrl), "main.plj.gz");
+// tengo-builder emits v4, so this is a v4 pack; the v3 flatten path is
+// covered separately below by a synthetic pack, because no build in this
+// repo produces v3 any more.
+const v3WorkflowPath = path.join(fileURLToPath(BlockPointer.packUrl), `main${TemplatePackSuffix}`);
 const V3TemplateContent = fs.existsSync(v3WorkflowPath)
   ? fs.readFileSync(v3WorkflowPath)
   : undefined;
+
+/** Minimal v3 pack: a root with one lib and one sub-template. */
+const syntheticV3: CompiledTemplateV3 = {
+  type: "pl.tengo-template.v3",
+  hashToSource: {
+    "root-src": "root source",
+    "child-src": "child source",
+    "lib-src": "lib source",
+  },
+  template: {
+    name: "@t/pkg:root",
+    version: "1.0.0",
+    sourceHash: "root-src",
+    libs: {
+      "@t/pkg:lib": { name: "@t/pkg:lib", version: "1.0.0", sourceHash: "lib-src" },
+    },
+    software: {},
+    assets: {},
+    templates: {
+      "@t/pkg:child": {
+        name: "@t/pkg:child",
+        version: "1.0.0",
+        sourceHash: "child-src",
+        libs: {},
+        software: {},
+        assets: {},
+        templates: {},
+      },
+    },
+  },
+};
 
 function createTestCacheInTx(pl: Parameters<Parameters<typeof TestHelpers.withTempRoot>[0]>[0]) {
   return pl.withWriteTx("createTestCache", async (tx) => {
@@ -36,27 +71,32 @@ function createTestCacheInTx(pl: Parameters<Parameters<typeof TestHelpers.withTe
   });
 }
 
-describe("V3 template cache", () => {
-  test.skipIf(!V3TemplateContent)("flattenTemplateTree produces topological order for V3", () => {
-    const data = parseTemplate(V3TemplateContent!);
-    expect(data.type).toBe("pl.tengo-template.v3");
-    const nodes = flattenTemplateTree(data);
-    expect(nodes.length).toBeGreaterThan(0);
-
-    const seenHashes = new Set<string>();
-    for (const node of nodes) {
-      for (const ch of node.childHashes) {
-        expect(seenHashes.has(ch)).toBe(true);
-      }
-      seenHashes.add(node.hash);
+function expectTopologicalOrder(nodes: ReturnType<typeof flattenTemplateTree>) {
+  expect(nodes.length).toBeGreaterThan(0);
+  const seenHashes = new Set<string>();
+  for (const node of nodes) {
+    for (const ch of node.childHashes) {
+      expect(seenHashes.has(ch)).toBe(true);
     }
+    seenHashes.add(node.hash);
+  }
+}
+
+describe("V3 template cache", () => {
+  test("flattenTemplateTree produces topological order for V3", () => {
+    expectTopologicalOrder(flattenTemplateTree(syntheticV3));
   });
 
-  test.skipIf(!V3TemplateContent)("V3 hashes are deterministic", () => {
-    const data = parseTemplate(V3TemplateContent!);
-    const nodes1 = flattenTemplateTree(data);
-    const nodes2 = flattenTemplateTree(data);
+  test("V3 hashes are deterministic", () => {
+    const nodes1 = flattenTemplateTree(syntheticV3);
+    const nodes2 = flattenTemplateTree(syntheticV3);
     expect(nodes1.map((n) => n.hash)).toStrictEqual(nodes2.map((n) => n.hash));
+  });
+
+  test.skipIf(!V3TemplateContent)("flattenTemplateTree handles the built pack", () => {
+    const data = parseTemplate(V3TemplateContent!, "zstd");
+    expect(data.type).toBe("pl.tengo-template.v4");
+    expectTopologicalOrder(flattenTemplateTree(data));
   });
 
   test.skipIf(!V3TemplateContent)(
@@ -64,7 +104,11 @@ describe("V3 template cache", () => {
     async () => {
       await TestHelpers.withTempRoot(async (pl) => {
         const testCache = await createTestCacheInTx(pl);
-        const v3Spec = { type: "explicit" as const, content: V3TemplateContent! };
+        const v3Spec = {
+          type: "explicit" as const,
+          content: V3TemplateContent!,
+          codec: "zstd" as const,
+        };
 
         const id1 = await loadTemplateCached(pl, v3Spec, { cacheResourceId: testCache });
         const id2 = await loadTemplateCached(pl, v3Spec, { cacheResourceId: testCache });
@@ -79,7 +123,11 @@ describe("V3 template cache", () => {
     async () => {
       await TestHelpers.withTempRoot(async (pl) => {
         const testCache = await createTestCacheInTx(pl);
-        const v3Spec = { type: "explicit" as const, content: V3TemplateContent! };
+        const v3Spec = {
+          type: "explicit" as const,
+          content: V3TemplateContent!,
+          codec: "zstd" as const,
+        };
 
         // Cached path
         const cachedId = await loadTemplateCached(pl, v3Spec, { cacheResourceId: testCache });

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -5,6 +5,7 @@
 // `workspace:*` devDeps, and the built `dist/` + `block-pack/` carry everything
 // the loader needs.
 
+import { TemplatePackSuffix } from "@milaboratories/pl-model-backend";
 import {
   ensureField,
   ensureScript,
@@ -66,7 +67,7 @@ function prepublishScript(npmOrg: string, isSdkInternal: boolean): string {
 export function blockComponents(ctx: RunContext): Record<string, string> {
   const components: Record<string, string> = {};
   for (const m of findModules(ctx, "workflow"))
-    components.workflow = `${m.name}/dist/tengo/tpl/main.plj.gz`;
+    components.workflow = `${m.name}/dist/tengo/tpl/main${TemplatePackSuffix}`;
   for (const m of findModules(ctx, "model")) components.model = `${m.name}/dist/model.json`;
   for (const m of findModules(ctx, "ui")) components.ui = `${m.name}/dist`;
   return components;

--- a/tools/block-tools/src/v2/build_dist.ts
+++ b/tools/block-tools/src/v2/build_dist.ts
@@ -3,21 +3,27 @@ import type {
   ManifestFileInfo,
 } from "@milaboratories/pl-model-middle-layer";
 import { BlockPackManifest, BlockPackManifestFile } from "@milaboratories/pl-model-middle-layer";
-import type { CompiledTemplateV3 } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV3, CompiledTemplateV4 } from "@milaboratories/pl-model-backend";
 import type { BlockPackDescriptionAbsolute } from "./model";
 import { consolidateBlockPackDescription } from "./model";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { gunzipSync } from "node:zlib";
+import { decompressTemplate, templateCodecForPath } from "@milaboratories/pl-model-backend";
 import { calculateSha256 } from "../util";
 
 /**
  * Returns the capability tokens the workflow's compiled template declares
- * it needs (via `TemplateDataV3.requiredCapabilities`, populated by
- * tengo-builder at compile time). Returns `undefined` for v2 packs, for
- * malformed packs, or when the template carries no requirements — fail-
- * safe so the worst case is "block installs anywhere", the pre-WASM
- * status quo.
+ * it needs (via `requiredCapabilities`, populated by tengo-builder at
+ * compile time).
+ *
+ * Handles both v4 and v3, because a block can be packed with a workflow
+ * built by an older tengo-builder. Reading only v4 would silently drop the
+ * requirement and let a WASM block install on a backend without the
+ * runtime.
+ *
+ * Returns `undefined` for v2 packs, for malformed packs, or when the
+ * template carries no requirements — fail-safe so the worst case is "block
+ * installs anywhere", the pre-WASM status quo.
  */
 async function workflowRequiredCapabilities(
   descriptionRelative: BlockPackDescriptionManifest,
@@ -30,15 +36,21 @@ async function workflowRequiredCapabilities(
 
   let parsed: unknown;
   try {
-    const json = gunzipSync(bytes).toString("utf-8");
+    const json = decompressTemplate(bytes, templateCodecForPath(main.path)).toString("utf-8");
     parsed = JSON.parse(json);
   } catch {
     return undefined;
   }
 
-  const pack = parsed as Partial<CompiledTemplateV3>;
-  if (pack.type !== "pl.tengo-template.v3" || !pack.template) return undefined;
-  return pack.template.requiredCapabilities;
+  const pack = parsed as Partial<CompiledTemplateV3> | Partial<CompiledTemplateV4>;
+  if (pack.type === "pl.tengo-template.v4") {
+    if (!pack.template) return undefined;
+    return pack.hashToTemplate?.[pack.template]?.requiredCapabilities;
+  }
+  if (pack.type === "pl.tengo-template.v3") {
+    return pack.template?.requiredCapabilities;
+  }
+  return undefined;
 }
 
 export async function buildBlockPackDist(

--- a/tools/tengo-builder/package.json
+++ b/tools/tengo-builder/package.json
@@ -41,6 +41,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.15.0"
   }
 }

--- a/tools/tengo-builder/src/commands/build.ts
+++ b/tools/tengo-builder/src/commands/build.ts
@@ -63,13 +63,13 @@ function generateTsBinding(compiledDist: TemplatesAndLibs) {
   const recordsCjs = compiledDist.templates
     .map(
       (tpl) =>
-        `  '${tpl.fullName.id}': { type: 'from-file', path: require.resolve('./tengo/tpl/${tpl.fullName.id}.plj.gz') }`,
+        `  '${tpl.fullName.id}': { type: 'from-file', path: require.resolve('./tengo/tpl/${tpl.fullName.id}.plj.zst') }`,
     )
     .join(",\n");
   const recordsMjs = compiledDist.templates
     .map(
       (tpl) =>
-        `  '${tpl.fullName.id}': { type: 'from-file', path: resolve(import.meta.dirname, './tengo/tpl/${tpl.fullName.id}.plj.gz') }`,
+        `  '${tpl.fullName.id}': { type: 'from-file', path: resolve(import.meta.dirname, './tengo/tpl/${tpl.fullName.id}.plj.zst') }`,
     )
     .join(",\n");
   cjs += recordsCjs;

--- a/tools/tengo-builder/src/compiler/compiler.test.ts
+++ b/tools/tengo-builder/src/compiler/compiler.test.ts
@@ -6,7 +6,12 @@ import { createLogger } from "./util";
 import { test, expect, describe, it } from "vitest";
 import { MiLogger } from "@milaboratories/ts-helpers";
 import type { FullArtifactName, TypedArtifactName } from "./package";
-import { TemplateDataV3, TemplateLibDataV3 } from "@milaboratories/pl-model-backend";
+import { rootTemplate, templateNodeHash } from "@milaboratories/pl-model-backend";
+import type {
+  CompiledTemplateV4,
+  TemplateLibDataV3,
+  TemplateNodeV4,
+} from "@milaboratories/pl-model-backend";
 
 function parseSrc(logger: MiLogger, src: ta.TestArtifactSource[]): ArtifactSource[] {
   return src.map((tp) => {
@@ -23,7 +28,7 @@ test("compile package 1", () => {
 
   expect(compiled.templates[0]).toMatchObject({
     data: {
-      type: "pl.tengo-template.v3",
+      type: "pl.tengo-template.v4",
       hashToSource: {
         "2e0d81deae0220df5901292911fd96065be96bc2187debb24bd869b47e1caa77": `
 lib := import("package1:other-lib-1")
@@ -34,20 +39,21 @@ export {
 }
 `,
       },
-      template: {
-        name: "package1:template-3",
+    },
+  });
+
+  expect(rootTemplate(compiled.templates[0].data)).toMatchObject({
+    name: "package1:template-3",
+    version: "1.2.3",
+    sourceHash: "2e0d81deae0220df5901292911fd96065be96bc2187debb24bd869b47e1caa77",
+    templates: {},
+    software: {},
+    assets: {},
+    libs: {
+      "package1:other-lib-1": {
+        name: "package1:other-lib-1",
         version: "1.2.3",
-        sourceHash: "2e0d81deae0220df5901292911fd96065be96bc2187debb24bd869b47e1caa77",
-        templates: {},
-        software: {},
-        assets: {},
-        libs: {
-          "package1:other-lib-1": {
-            name: "package1:other-lib-1",
-            version: "1.2.3",
-            sourceHash: "3f850fa4c5f6a8a3017fa883fc03fc2dee159f65e2dbb9c6cd0c6dff0aae6419",
-          },
-        },
+        sourceHash: "3f850fa4c5f6a8a3017fa883fc03fc2dee159f65e2dbb9c6cd0c6dff0aae6419",
       },
     },
   });
@@ -89,7 +95,7 @@ test.skip("compile main source set", () => {
   expect(tpl1).toBeDefined();
 
   // checking that transient library dependency was resolved
-  expect(tpl1.data.template.templates).toHaveProperty("package1:template-3");
+  expect(rootTemplate(tpl1.data).templates).toHaveProperty("package1:template-3");
 });
 
 test("compile template with hash override", () => {
@@ -103,10 +109,12 @@ test("compile template with hash override", () => {
   expect(tpl3).toBeDefined();
 
   // checking that transient library dependency was resolved
-  expect(tpl3.data.template.hashOverride).toEqual(
+  expect(rootTemplate(tpl3.data).hashOverride).toEqual(
     "CE0F6EDF-D97C-44E7-B16B-D661D4C799C1".toLowerCase(),
   );
-  expect(tpl3.data.template.libs[artifactNameToString(ta.testLocalLib3.fullName)]).toBeDefined();
+  expect(
+    rootTemplate(tpl3.data).libs[artifactNameToString(ta.testLocalLib3.fullName)],
+  ).toBeDefined();
 });
 
 test("wrong hash override value throws error", () => {
@@ -132,16 +140,29 @@ const genArtifactSource = (
 
 const genTemplateData = (
   name: FullArtifactName,
-  templates: TemplateDataV3[],
+  templates: TemplateNodeV4[],
   libs: TemplateLibDataV3[],
-) => ({
+): TemplateNodeV4 => ({
   name: genArtifactName(name),
   version: name.version,
   sourceHash: genHash(name.id),
-  templates: Object.fromEntries(templates.map((t) => [t.name, t])),
+  templates: Object.fromEntries(templates.map((t) => [t.name, templateNodeHash(t)])),
   libs: Object.fromEntries(libs.map((l) => [l.name, l])),
   software: {},
   assets: {},
+});
+
+/** Assembles the expected pack around a root node. `nodes` lists every node in
+ *  the graph, root included — each keyed by its own content hash. */
+const genPack = (
+  hashToSource: Record<string, string>,
+  root: TemplateNodeV4,
+  ...nodes: TemplateNodeV4[]
+): CompiledTemplateV4 => ({
+  type: "pl.tengo-template.v4",
+  hashToSource,
+  hashToTemplate: Object.fromEntries([root, ...nodes].map((n) => [templateNodeHash(n), n])),
+  template: templateNodeHash(root),
 });
 
 const genLibData = (name: FullArtifactName) => ({
@@ -199,18 +220,13 @@ describe("TengoTemplateCompiler.compileAndAdd", () => {
             compileMode: "dist",
             fullName: ta.testLocalTpl2Name,
             source: ta.testLocalTpl2Src,
-            data: {
-              type: "pl.tengo-template.v3",
-              hashToSource: {
+            data: genPack(
+              {
                 [genHash(ta.testLocalLib1Name.id)]: ta.testLocalLib1Src,
                 [genHash(ta.testLocalTpl2Name.id)]: ta.testLocalTpl2Src,
               },
-              template: genTemplateData(
-                ta.testLocalTpl2Name,
-                [],
-                [genLibData(ta.testLocalLib1Name)],
-              ),
-            },
+              genTemplateData(ta.testLocalTpl2Name, [], [genLibData(ta.testLocalLib1Name)]),
+            ),
           },
         ],
         software: [],
@@ -230,30 +246,27 @@ describe("TengoTemplateCompiler.compileAndAdd", () => {
             compileMode: "dist",
             fullName: ta.testLocalTpl2Name,
             source: ta.testLocalTpl2Src,
-            data: {
-              type: "pl.tengo-template.v3",
-              hashToSource: {
-                [genHash(ta.testLocalTpl2Name.id)]: ta.testLocalTpl2Src,
-              },
-              template: genTemplateData(ta.testLocalTpl2Name, [], []),
-            },
+            data: genPack(
+              { [genHash(ta.testLocalTpl2Name.id)]: ta.testLocalTpl2Src },
+              genTemplateData(ta.testLocalTpl2Name, [], []),
+            ),
           },
           {
             compileMode: "dist",
             fullName: ta.testLocalTpl1Name,
             source: ta.testLocalTpl1Src,
-            data: {
-              type: "pl.tengo-template.v3",
-              hashToSource: {
+            data: genPack(
+              {
                 [genHash(ta.testLocalTpl1Name.id)]: ta.testLocalTpl1Src,
                 [genHash(ta.testLocalTpl2Name.id)]: ta.testLocalTpl2Src,
               },
-              template: genTemplateData(
+              genTemplateData(
                 ta.testLocalTpl1Name,
                 [genTemplateData(ta.testLocalTpl2Name, [], [])],
                 [],
               ),
-            },
+              genTemplateData(ta.testLocalTpl2Name, [], []),
+            ),
           },
         ],
         software: [],
@@ -274,36 +287,31 @@ describe("TengoTemplateCompiler.compileAndAdd", () => {
             compileMode: "dist",
             fullName: ta.testLocalTpl2Name,
             source: ta.testLocalTpl2Src,
-            data: {
-              type: "pl.tengo-template.v3",
-              hashToSource: {
+            data: genPack(
+              {
                 [genHash(ta.testLocalTpl2Name.id)]: ta.testLocalTpl2Src,
                 [genHash(ta.testLocalLib3Name.id)]: ta.testLocalLib3Src,
               },
-              template: genTemplateData(
-                ta.testLocalTpl2Name,
-                [],
-                [genLibData(ta.testLocalLib3Name)],
-              ),
-            },
+              genTemplateData(ta.testLocalTpl2Name, [], [genLibData(ta.testLocalLib3Name)]),
+            ),
           },
           {
             compileMode: "dist",
             fullName: ta.testLocalTpl1Name,
             source: ta.testLocalTpl1Src,
-            data: {
-              type: "pl.tengo-template.v3",
-              hashToSource: {
+            data: genPack(
+              {
                 [genHash(ta.testLocalTpl1Name.id)]: ta.testLocalTpl1Src,
                 [genHash(ta.testLocalTpl2Name.id)]: ta.testLocalTpl2Src,
                 [genHash(ta.testLocalLib3Name.id)]: ta.testLocalLib3Src,
               },
-              template: genTemplateData(
+              genTemplateData(
                 ta.testLocalTpl1Name,
                 [genTemplateData(ta.testLocalTpl2Name, [], [genLibData(ta.testLocalLib3Name)])],
                 [],
               ),
-            },
+              genTemplateData(ta.testLocalTpl2Name, [], [genLibData(ta.testLocalLib3Name)]),
+            ),
           },
         ],
         software: [],
@@ -365,7 +373,7 @@ describe("TengoTemplateCompiler requiredCapabilities propagation", () => {
       new ArtifactSource("dist", tplName, "tpl-hash", "tpl-src", "tpl-file", [wasmName], []),
     ]);
 
-    expect(result.templates[0].data.template.requiredCapabilities).toEqual(["wasm:v1"]);
+    expect(rootTemplate(result.templates[0].data).requiredCapabilities).toEqual(["wasm:v1"]);
   });
 
   it("unions child template requiredCapabilities into the parent", () => {
@@ -405,7 +413,7 @@ describe("TengoTemplateCompiler requiredCapabilities propagation", () => {
 
     const result = compiler.compileAndAdd([childSrc, parentSrc]);
     const parent = result.templates.find((t) => t.fullName.id === "parent")!;
-    expect(parent.data.template.requiredCapabilities).toEqual(["wasm:v1"]);
+    expect(rootTemplate(parent.data).requiredCapabilities).toEqual(["wasm:v1"]);
   });
 
   it("leaves requiredCapabilities undefined when no capability is needed", () => {
@@ -421,6 +429,6 @@ describe("TengoTemplateCompiler requiredCapabilities propagation", () => {
       new ArtifactSource("dist", tplName, "plain-hash", "plain-src", "plain-file", [], []),
     ]);
 
-    expect(result.templates[0].data.template.requiredCapabilities).toBeUndefined();
+    expect(rootTemplate(result.templates[0].data).requiredCapabilities).toBeUndefined();
   });
 });

--- a/tools/tengo-builder/src/compiler/compiler.ts
+++ b/tools/tengo-builder/src/compiler/compiler.ts
@@ -15,14 +15,26 @@ import { assertNever } from "./util";
 import { applyLibraryCompilerOptions, applyTemplateCompilerOptions } from "./compileroptions";
 import type {
   BackendCapability,
-  CompiledTemplateV3,
-  TemplateDataV3,
+  CompiledTemplateV4,
+  TemplateNodeV4,
 } from "@milaboratories/pl-model-backend";
+import { rootTemplate, templateNodeHash } from "@milaboratories/pl-model-backend";
+
+/**
+ * A pack under construction. Identical to {@link CompiledTemplateV4} except
+ * that `template` is the node itself, because the node is still being
+ * populated and its content hash is not known until it is complete.
+ */
+interface WorkingPack {
+  hashToSource: Record<string, string>;
+  hashToTemplate: Record<string, TemplateNodeV4>;
+  template: TemplateNodeV4;
+}
 
 /** Add a capability token to a template's `requiredCapabilities` list,
  * skipping duplicates. Initializes the array lazily so the field stays
  * absent for templates that need nothing. */
-function addRequiredCapability(template: TemplateDataV3, capability: BackendCapability): void {
+function addRequiredCapability(template: TemplateNodeV4, capability: BackendCapability): void {
   template.requiredCapabilities = template.requiredCapabilities ?? [];
   if (!template.requiredCapabilities.includes(capability)) {
     template.requiredCapabilities.push(capability);
@@ -50,7 +62,7 @@ export class TengoTemplateCompiler {
   /** Recursively add dependencies to the template. */
   private populateTemplateDataFromDependencies(
     fullName: FullArtifactName,
-    data: CompiledTemplateV3,
+    data: WorkingPack,
     deps: TypedArtifactName[],
     trace: string[],
   ) {
@@ -125,10 +137,15 @@ export class TengoTemplateCompiler {
             continue;
 
           const tpl = this.getTemplateOrError(dep);
+          // Reference the sub-template by its content hash instead of nesting
+          // it. The child is already sealed, so its hash covers its whole
+          // subtree and a node shared by many parents is stored once.
           data.template.templates[artifactNameToString(dep)] = tpl.data.template;
-          data.hashToSource[tpl.data.template.sourceHash] = tpl.source;
 
-          // add all the sources of transitivedependencies to the resulted hashToSource
+          // add all the nodes and sources of transitive dependencies to the result
+          for (const [hash, node] of Object.entries(tpl.data.hashToTemplate)) {
+            data.hashToTemplate[hash] = node;
+          }
           for (const [hash, src] of Object.entries(tpl.data.hashToSource)) {
             data.hashToSource[hash] = src;
           }
@@ -136,7 +153,7 @@ export class TengoTemplateCompiler {
           // Union the sub-template's compile-time-computed capability
           // requirements into ours, so the top template carries the full
           // transitive set without consumers having to walk the tree.
-          for (const cap of tpl.data.template.requiredCapabilities ?? []) {
+          for (const cap of rootTemplate(tpl.data).requiredCapabilities ?? []) {
             addRequiredCapability(data.template, cap);
           }
 
@@ -154,15 +171,15 @@ export class TengoTemplateCompiler {
   }
 
   /** This method assumes that all dependencies are already added to the compiler's context */
-  private compileAndAddTemplate(tplSrc: ArtifactSource): CompiledTemplateV3 {
+  private compileAndAddTemplate(tplSrc: ArtifactSource): CompiledTemplateV4 {
     if (tplSrc.fullName.type !== "template") throw new Error("unexpected source type");
 
     // creating template with unpopulated dependencies
-    const tplData: CompiledTemplateV3 = {
-      type: "pl.tengo-template.v3",
+    const tplData: WorkingPack = {
       hashToSource: {
         [tplSrc.sourceHash]: tplSrc.src,
       },
+      hashToTemplate: {},
       template: {
         ...formatArtefactNameAndVersion(tplSrc.fullName),
         templates: {},
@@ -178,7 +195,17 @@ export class TengoTemplateCompiler {
     // collecting dependencies in output format
     this.populateTemplateDataFromDependencies(tplSrc.fullName, tplData, tplSrc.dependencies, []);
 
-    return tplData;
+    // Seal the node: it is complete, so its content hash is stable and becomes
+    // its key. Nothing mutates it after this point — parents only read it.
+    const nodeHash = templateNodeHash(tplData.template);
+    tplData.hashToTemplate[nodeHash] = tplData.template;
+
+    return {
+      type: "pl.tengo-template.v4",
+      hashToSource: tplData.hashToSource,
+      hashToTemplate: tplData.hashToTemplate,
+      template: nodeHash,
+    };
   }
 
   addLib(lib: ArtifactSource) {

--- a/tools/tengo-builder/src/compiler/compileroptions.ts
+++ b/tools/tengo-builder/src/compiler/compileroptions.ts
@@ -1,8 +1,15 @@
-import type { TemplateDataV3, TemplateLibDataV3 } from "@milaboratories/pl-model-backend";
+import type {
+  TemplateDataV3,
+  TemplateLibDataV3,
+  TemplateNodeV4,
+} from "@milaboratories/pl-model-backend";
 import type { CompilerOption } from "./package";
 import * as util from "./util";
 
-export function applyTemplateCompilerOptions(opts: CompilerOption[], tpl: TemplateDataV3) {
+export function applyTemplateCompilerOptions(
+  opts: CompilerOption[],
+  tpl: TemplateDataV3 | TemplateNodeV4,
+) {
   for (const opt of opts) {
     switch (opt.name) {
       case "hash_override": {

--- a/tools/tengo-builder/src/compiler/main.ts
+++ b/tools/tengo-builder/src/compiler/main.ts
@@ -13,7 +13,7 @@ import { ArtifactSource, parseSourceFile } from "./source";
 import { newTemplateFromContent, templateToSource } from "./template";
 import type winston from "winston";
 import { tryResolve, tryResolveOrError } from "@milaboratories/resolve-helper";
-import { serializeTemplate } from "@milaboratories/pl-model-backend";
+import { serializeTemplate, TemplatePackSuffix } from "@milaboratories/pl-model-backend";
 import {
   assertTemplatePackSize,
   assertWasmFileSize,
@@ -53,7 +53,7 @@ interface PackageJson {
   devDependencies: Record<string, string>;
 }
 
-const compiledTplSuffix = ".plj.gz";
+const compiledTplSuffix = TemplatePackSuffix;
 const compiledLibSuffix = ".lib.tengo";
 const compiledSoftwareSuffix = ".sw.json";
 const compiledAssetSuffix = ".as.json";

--- a/tools/tengo-builder/src/compiler/pack_limits.test.ts
+++ b/tools/tengo-builder/src/compiler/pack_limits.test.ts
@@ -1,4 +1,4 @@
-import type { CompiledTemplateV3 } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV4 } from "@milaboratories/pl-model-backend";
 import { describe, expect, it } from "vitest";
 
 import type { FullArtifactName } from "./package";
@@ -93,59 +93,64 @@ describe("collectWasmContributions", () => {
 
   it("reports direct WASM dependencies with stored byte size derived from base64 length", () => {
     const base64 = base64OfLength(400); // 400 base64 chars → 300 binary bytes
-    const tpl: CompiledTemplateV3 = {
-      type: "pl.tengo-template.v3",
+    const tpl: CompiledTemplateV4 = {
+      type: "pl.tengo-template.v4",
       hashToSource: { "hash-a": base64 },
-      template: {
-        name: "@t/pkg:main",
-        version: "1.0.0",
-        sourceHash: "tpl-hash",
-        libs: {},
-        templates: {},
-        software: {},
-        assets: {},
-        wasm: {
-          "@w/wasm:a": { name: "@w/wasm:a", version: "1.0.0", sourceHash: "hash-a" },
+      hashToTemplate: {
+        root: {
+          name: "@t/pkg:main",
+          version: "1.0.0",
+          sourceHash: "tpl-hash",
+          libs: {},
+          templates: {},
+          software: {},
+          assets: {},
+          wasm: {
+            "@w/wasm:a": { name: "@w/wasm:a", version: "1.0.0", sourceHash: "hash-a" },
+          },
         },
       },
+      template: "root",
     };
     const got = collectWasmContributions(tpl);
     expect(got).toEqual([{ name: "@w/wasm:a", storedBytes: 300 }]);
   });
 
-  it("recurses into sub-templates and deduplicates by artefact name", () => {
+  it("covers sub-templates and deduplicates by artefact name", () => {
     const base64a = base64OfLength(800); // 600 binary bytes
     const base64b = base64OfLength(400); // 300 binary bytes
-    const tpl: CompiledTemplateV3 = {
-      type: "pl.tengo-template.v3",
+    const tpl: CompiledTemplateV4 = {
+      type: "pl.tengo-template.v4",
       hashToSource: { "hash-a": base64a, "hash-b": base64b },
-      template: {
-        name: "@t/pkg:root",
-        version: "1.0.0",
-        sourceHash: "root-hash",
-        libs: {},
-        software: {},
-        assets: {},
-        wasm: {
-          "@w/wasm:a": { name: "@w/wasm:a", version: "1.0.0", sourceHash: "hash-a" },
+      hashToTemplate: {
+        root: {
+          name: "@t/pkg:root",
+          version: "1.0.0",
+          sourceHash: "root-hash",
+          libs: {},
+          software: {},
+          assets: {},
+          wasm: {
+            "@w/wasm:a": { name: "@w/wasm:a", version: "1.0.0", sourceHash: "hash-a" },
+          },
+          templates: { "@t/pkg:child": "child" },
         },
-        templates: {
-          "@t/pkg:child": {
-            name: "@t/pkg:child",
-            version: "1.0.0",
-            sourceHash: "child-hash",
-            libs: {},
-            templates: {},
-            software: {},
-            assets: {},
-            wasm: {
-              // duplicate of the parent's WASM — must not be counted twice
-              "@w/wasm:a": { name: "@w/wasm:a", version: "1.0.0", sourceHash: "hash-a" },
-              "@w/wasm:b": { name: "@w/wasm:b", version: "1.0.0", sourceHash: "hash-b" },
-            },
+        child: {
+          name: "@t/pkg:child",
+          version: "1.0.0",
+          sourceHash: "child-hash",
+          libs: {},
+          templates: {},
+          software: {},
+          assets: {},
+          wasm: {
+            // duplicate of the parent's WASM — must not be counted twice
+            "@w/wasm:a": { name: "@w/wasm:a", version: "1.0.0", sourceHash: "hash-a" },
+            "@w/wasm:b": { name: "@w/wasm:b", version: "1.0.0", sourceHash: "hash-b" },
           },
         },
       },
+      template: "root",
     };
     const got = collectWasmContributions(tpl).sort((a, b) => a.name.localeCompare(b.name));
     expect(got).toEqual([
@@ -154,19 +159,22 @@ describe("collectWasmContributions", () => {
     ]);
   });
 
-  it("returns an empty list when the template tree contains no WASM", () => {
-    const tpl: CompiledTemplateV3 = {
-      type: "pl.tengo-template.v3",
+  it("returns an empty list when the template graph contains no WASM", () => {
+    const tpl: CompiledTemplateV4 = {
+      type: "pl.tengo-template.v4",
       hashToSource: {},
-      template: {
-        name: "@t/pkg:main",
-        version: "1.0.0",
-        sourceHash: "tpl-hash",
-        libs: {},
-        templates: {},
-        software: {},
-        assets: {},
+      hashToTemplate: {
+        root: {
+          name: "@t/pkg:main",
+          version: "1.0.0",
+          sourceHash: "tpl-hash",
+          libs: {},
+          templates: {},
+          software: {},
+          assets: {},
+        },
       },
+      template: "root",
     };
     expect(collectWasmContributions(tpl)).toEqual([]);
   });

--- a/tools/tengo-builder/src/compiler/pack_limits.ts
+++ b/tools/tengo-builder/src/compiler/pack_limits.ts
@@ -1,4 +1,4 @@
-import type { CompiledTemplateV3, TemplateDataV3 } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV4 } from "@milaboratories/pl-model-backend";
 
 import type { FullArtifactName } from "./package";
 import { fullNameToString } from "./package";
@@ -67,16 +67,18 @@ export interface WasmContribution {
 }
 
 /**
- * Walks a compiled template tree and reports every WASM artefact embedded
- * directly or transitively. Used only by the too-large-pack error message —
- * never on the success path. Deduplicates by artefact name (sub-templates can
- * import the same WASM via different aliases and we want to attribute weight
- * only once).
+ * Reports every WASM artefact embedded in a pack, directly or transitively.
+ * Used only by the too-large-pack error message — never on the success path.
+ * Deduplicates by artefact name (sub-templates can import the same WASM via
+ * different aliases and we want to attribute weight only once).
+ *
+ * `hashToTemplate` already holds every node in the graph exactly once, so this
+ * is a flat scan; there is no tree to walk and no need to track visited nodes.
  */
-export function collectWasmContributions(tpl: CompiledTemplateV3): WasmContribution[] {
+export function collectWasmContributions(tpl: CompiledTemplateV4): WasmContribution[] {
   const seen = new Map<string, WasmContribution>();
-  function walk(t: TemplateDataV3) {
-    for (const [name, ref] of Object.entries(t.wasm ?? {})) {
+  for (const node of Object.values(tpl.hashToTemplate)) {
+    for (const [name, ref] of Object.entries(node.wasm ?? {})) {
       if (seen.has(name)) continue;
       const base64 = tpl.hashToSource[ref.sourceHash];
       // base64 encodes 3 binary bytes per 4 chars; the off-by-padding is at
@@ -84,9 +86,7 @@ export function collectWasmContributions(tpl: CompiledTemplateV3): WasmContribut
       const storedBytes = base64 != null ? Math.floor((base64.length * 3) / 4) : 0;
       seen.set(name, { name, storedBytes });
     }
-    for (const sub of Object.values(t.templates ?? {})) walk(sub);
   }
-  walk(tpl.template);
   return [...seen.values()];
 }
 

--- a/tools/tengo-builder/src/compiler/template.test.ts
+++ b/tools/tengo-builder/src/compiler/template.test.ts
@@ -1,5 +1,7 @@
 import { newTemplateFromContent, newTemplateFromData } from "./template";
 import { formatArtefactNameAndVersion, FullArtifactName } from "./package";
+import { templateNodeHash } from "@milaboratories/pl-model-backend";
+import type { TemplateNodeV4 } from "@milaboratories/pl-model-backend";
 import { test, expect } from "vitest";
 
 test("template serialization / deserialization", () => {
@@ -9,43 +11,54 @@ test("template serialization / deserialization", () => {
     id: "the-template",
     version: "1.2.3",
   };
+
+  const child: TemplateNodeV4 = {
+    name: "@milaboratory/some-package:the-template-1",
+    version: "1.2.3",
+    libs: {
+      "@milaboratory/some-package:the-library:1.2.4": {
+        name: "@milaboratory/some-package:the-library",
+        version: "1.2.4",
+        sourceHash: "asdasd2",
+      },
+    },
+    templates: {},
+    software: {},
+    assets: {},
+    sourceHash: "src 1...",
+  };
+  const childHash = templateNodeHash(child);
+
+  const root: TemplateNodeV4 = {
+    sourceHash: "asdasd3",
+    ...formatArtefactNameAndVersion(name),
+    libs: {
+      asdasd: {
+        name: "@milaboratory/some-package:the-library",
+        version: "1.2.3",
+        sourceHash: "asdasd",
+      },
+    },
+    templates: {
+      asdasd2: childHash,
+    },
+    software: {},
+    assets: {},
+  };
+  const rootHash = templateNodeHash(root);
+
   const template1 = newTemplateFromData("dist", name, {
-    type: "pl.tengo-template.v3",
+    type: "pl.tengo-template.v4",
     hashToSource: {
       asdasd: "src1...",
       asdasd2: "src2...",
       asdasd3: "src3...",
     },
-    template: {
-      sourceHash: "asdasd3",
-      ...formatArtefactNameAndVersion(name),
-      libs: {
-        asdasd: {
-          name: "@milaboratory/some-package:the-library",
-          version: "1.2.3",
-          sourceHash: "asdasd",
-        },
-      },
-      templates: {
-        asdasd2: {
-          name: "@milaboratory/some-package:the-template-1",
-          version: "1.2.3",
-          libs: {
-            "@milaboratory/some-package:the-library:1.2.4": {
-              name: "@milaboratory/some-package:the-library",
-              version: "1.2.4",
-              sourceHash: "asdasd2",
-            },
-          },
-          templates: {},
-          software: {},
-          assets: {},
-          sourceHash: "src 1...",
-        },
-      },
-      software: {},
-      assets: {},
+    hashToTemplate: {
+      [childHash]: child,
+      [rootHash]: root,
     },
+    template: rootHash,
   });
 
   const template2 = newTemplateFromContent(
@@ -54,12 +67,104 @@ test("template serialization / deserialization", () => {
     template1.content,
   );
 
-  console.log(
-    "Size: raw",
-    JSON.stringify(template1.data).length,
-    "compressed",
-    template1.content.byteLength,
-  );
-
   expect(template2.data).toStrictEqual(template1.data);
+});
+
+test("a node referenced twice is stored once", () => {
+  const shared: TemplateNodeV4 = {
+    name: "@milaboratory/some-package:shared",
+    version: "1.0.0",
+    sourceHash: "shared-src",
+    libs: {},
+    templates: {},
+    software: {},
+    assets: {},
+  };
+  const sharedHash = templateNodeHash(shared);
+
+  const name: FullArtifactName = {
+    type: "template",
+    pkg: "@milaboratory/some-package",
+    id: "the-template",
+    version: "1.2.3",
+  };
+  const root: TemplateNodeV4 = {
+    ...formatArtefactNameAndVersion(name),
+    sourceHash: "root-src",
+    libs: {},
+    // Two aliases, one node — the case v3 serialised twice.
+    templates: { first: sharedHash, second: sharedHash },
+    software: {},
+    assets: {},
+  };
+
+  const template = newTemplateFromData("dist", name, {
+    type: "pl.tengo-template.v4",
+    hashToSource: { "root-src": "root source", "shared-src": "shared source" },
+    hashToTemplate: { [sharedHash]: shared, [templateNodeHash(root)]: root },
+    template: templateNodeHash(root),
+  });
+
+  expect(Object.keys(template.data.hashToTemplate)).toHaveLength(2);
+  expect(template.data.hashToTemplate[sharedHash]).toBe(shared);
+});
+
+test("identical nodes reached by different aliases collapse to one hash", () => {
+  const make = (): TemplateNodeV4 => ({
+    name: "@milaboratory/some-package:leaf",
+    version: "1.0.0",
+    sourceHash: "leaf-src",
+    libs: {},
+    templates: {},
+    software: {},
+    assets: {},
+  });
+
+  // Distinct objects, identical content.
+  expect(templateNodeHash(make())).toBe(templateNodeHash(make()));
+});
+
+test("hashOverride changes a node's identity", () => {
+  const base: TemplateNodeV4 = {
+    name: "@milaboratory/some-package:leaf",
+    version: "1.0.0",
+    sourceHash: "leaf-src",
+    libs: {},
+    templates: {},
+    software: {},
+    assets: {},
+  };
+  const overridden: TemplateNodeV4 = {
+    ...base,
+    hashOverride: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+  };
+
+  expect(templateNodeHash(base)).not.toBe(templateNodeHash(overridden));
+});
+
+test("a node's hash covers its children", () => {
+  const childA: TemplateNodeV4 = {
+    name: "@milaboratory/some-package:child",
+    version: "1.0.0",
+    sourceHash: "child-src-a",
+    libs: {},
+    templates: {},
+    software: {},
+    assets: {},
+  };
+  const childB: TemplateNodeV4 = { ...childA, sourceHash: "child-src-b" };
+
+  const parent = (childHash: string): TemplateNodeV4 => ({
+    name: "@milaboratory/some-package:parent",
+    version: "1.0.0",
+    sourceHash: "parent-src",
+    libs: {},
+    templates: { only: childHash },
+    software: {},
+    assets: {},
+  });
+
+  expect(templateNodeHash(parent(templateNodeHash(childA)))).not.toBe(
+    templateNodeHash(parent(templateNodeHash(childB))),
+  );
 });

--- a/tools/tengo-builder/src/compiler/template.ts
+++ b/tools/tengo-builder/src/compiler/template.ts
@@ -1,7 +1,7 @@
 import type { CompileMode, FullArtifactName, FullArtifactNameWithoutType } from "./package";
 import { fullNameWithoutTypeToString, parseArtefactNameAndVersion } from "./package";
-import type { CompiledTemplateV3 } from "@milaboratories/pl-model-backend";
-import { parseTemplate, serializeTemplate } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV4 } from "@milaboratories/pl-model-backend";
+import { parseTemplate, rootTemplate, serializeTemplate } from "@milaboratories/pl-model-backend";
 
 /** Just a holder for template data, compilation options, full name and source code.
  * It mimics ArtifactSource interface.
@@ -10,13 +10,13 @@ export type TemplateWithSource = {
   readonly compileMode: CompileMode;
   readonly fullName: FullArtifactName;
   readonly source: string;
-  readonly data: CompiledTemplateV3;
+  readonly data: CompiledTemplateV4;
 };
 
 export function newTemplateWithSource(
   compileMode: CompileMode,
   fullName: FullArtifactName,
-  data: CompiledTemplateV3,
+  data: CompiledTemplateV4,
   source: string,
 ): TemplateWithSource {
   validateTemplateName(fullName, data);
@@ -32,14 +32,14 @@ export function newTemplateWithSource(
 export type Template = {
   readonly compileMode: CompileMode;
   readonly fullName: FullArtifactName;
-  readonly data: CompiledTemplateV3;
+  readonly data: CompiledTemplateV4;
   readonly content: Uint8Array;
 };
 
 export function newTemplateFromData(
   compileMode: CompileMode,
   fullName: FullArtifactName,
-  data: CompiledTemplateV3,
+  data: CompiledTemplateV4,
 ): Template {
   validateTemplateName(fullName, data);
   return {
@@ -55,9 +55,10 @@ export function newTemplateFromContent(
   fullName: FullArtifactName,
   content: Uint8Array,
 ): Template {
-  const data = parseTemplate(content);
-  if (data.type !== "pl.tengo-template.v3") {
-    throw new Error("malformed v3 template");
+  // Only ever called on packs this builder just wrote.
+  const data = parseTemplate(content, "zstd");
+  if (data.type !== "pl.tengo-template.v4") {
+    throw new Error("malformed v4 template");
   }
 
   validateTemplateName(fullName, data);
@@ -74,11 +75,11 @@ export function templateToSource(tpl: Template): TemplateWithSource {
     compileMode: tpl.compileMode,
     fullName: tpl.fullName,
     data: tpl.data,
-    source: tpl.data.hashToSource[tpl.data.template.sourceHash],
+    source: tpl.data.hashToSource[rootTemplate(tpl.data).sourceHash],
   };
 }
-function validateTemplateName(fullName: FullArtifactName, data: CompiledTemplateV3) {
-  const nameFromData: FullArtifactNameWithoutType = parseArtefactNameAndVersion(data.template);
+function validateTemplateName(fullName: FullArtifactName, data: CompiledTemplateV4) {
+  const nameFromData: FullArtifactNameWithoutType = parseArtefactNameAndVersion(rootTemplate(data));
 
   if (
     nameFromData.pkg !== fullName.pkg ||

--- a/tools/tengo-builder/src/shared/dump.ts
+++ b/tools/tengo-builder/src/shared/dump.ts
@@ -2,7 +2,7 @@ import type winston from "winston";
 import { getPackageInfo, newCompiler, compile, parseSources } from "../compiler/main";
 import type { ArtifactType } from "../compiler/package";
 import { typedArtifactNameToString } from "../compiler/package";
-import type { TemplateDataV3 } from "@milaboratories/pl-model-backend";
+import type { CompiledTemplateV4 } from "@milaboratories/pl-model-backend";
 
 export function dumpArtifacts(
   logger: winston.Logger,
@@ -149,8 +149,8 @@ export function dumpSoftware(logger: winston.Logger, stream: NodeJS.WritableStre
   const hashes = new Set<string>();
   const sourceMap = new Map<string, string>();
   for (const tpl of compiled.templates) {
-    Object.entries(tpl.data.hashToSource).forEach(([hash, src]) => sourceMap.set(hash, src));
-    getTemplateSoftware(tpl.data.template).forEach((hash) => hashes.add(hash));
+    for (const [hash, src] of Object.entries(tpl.data.hashToSource)) sourceMap.set(hash, src);
+    for (const hash of getTemplateSoftware(tpl.data)) hashes.add(hash);
   }
 
   for (const hash of hashes) {
@@ -170,14 +170,15 @@ export function dumpSoftware(logger: winston.Logger, stream: NodeJS.WritableStre
   }
 }
 
-function getTemplateSoftware(tpl: TemplateDataV3): Set<string> {
+/** `hashToTemplate` holds every node in the graph once, so a flat scan covers
+ *  the whole transitive closure without recursion. */
+function getTemplateSoftware(pack: CompiledTemplateV4): Set<string> {
   const hashes = new Set<string>();
-  for (const sw of Object.values(tpl.software)) {
-    hashes.add(sw.sourceHash);
-  }
-  for (const subTpl of Object.values(tpl.templates)) {
-    getTemplateSoftware(subTpl).forEach((hash) => hashes.add(hash));
+  for (const node of Object.values(pack.hashToTemplate)) {
+    for (const sw of Object.values(node.software)) {
+      hashes.add(sw.sourceHash);
+    }
   }
 
-  return new Set(hashes);
+  return hashes;
 }


### PR DESCRIPTION
## Problem

A block's compiled workflow (`main.plj.gz`) decompresses to far more JSON than
it has content. The published
`@platforma-open/milaboratories.sequence-embeddings@1.4.1` is 821,733 bytes
gzipped and **30,517,238 bytes decompressed**. Only 2.6 % of that is source
code.

`CompiledTemplateV3.hashToSource` deduplicates source *text*, but
`TemplateDataV3.templates` is `Record<string, TemplateDataV3>` — a nested inline
tree. Every reference to a sub-template embeds a full copy of its entire
subtree, so a shared node deep in the graph is written once per path that
reaches it:

```
distinct templates:        39
materialised nodes:    11,672
max depth:                 13

5,836 x ll.get-field
1,804 x workdir.save
1,804 x exec.delayed-compute-allocation.impl
```

87 % of the whole file (26.6 MB) is repeated `libs` metadata records —
`{name, version, sourceHash}` triples re-serialised at every one of those
11,672 nodes. 139,467 reference records point at 139 unique sources.

The compiler already holds a DAG in memory; only the serialised form expands it.

gzip hides this on the wire — duplication this regular compresses 37:1 — so the
existing size guard, which measures gzipped bytes, saw 821 KB against a 3.4 MiB
cap and passed.

## Change

`pl.tengo-template.v4` adds `hashToTemplate`, keyed by a node's content hash;
`templates` holds hash references. Same approach `hashToSource` already used for
source text, applied to the nodes.

Keyed on content rather than `sourceHash` because `hashOverride` exists to give
two templates with the same source distinct identities. Safe because children
are compiled first (topological order) and never mutated once attached — the
compiler only reads them, and `addRequiredCapability` mutates the parent.

## Results

`@platforma-open/milaboratories.sequence-embeddings@1.4.1`:

| | v3 | v4 |
|---|---|---|
| gzipped | 802 KiB | **176 KiB** (4.55x) |
| decompressed | 29.10 MiB | **1.01 MiB** (28.9x) |
| gunzip + `JSON.parse` | 93.3 ms | **3.2 ms** |
| retained heap | 93.1 MiB | **3.1 MiB** |

Across `@platforma-sdk/workflow-tengo`'s own 45 packs, decompressed size drops
from 41.65 MiB to 12.55 MiB.

Both graph walkers get cheaper too:

- `createTemplateV3Tree`'s `updateCacheKey` recursed over the expanded subtree
  on every `createResourceCached` call, including cache hits. For the block
  above that was 35,920 node visits and 2.8M `hash.update` calls to produce 39
  resources. A v4 child's hash already covers its subtree, so the cache key
  folds it in directly and the walk is gone.
- `flattenTemplateTree` memoises by node identity. A v4 pack stores each
  distinct node once, so `resolveTemplate` returns the same object for every
  reference and each node is processed once. A v3 pack has a separate object per
  occurrence, so the memo never hits and behaviour is unchanged.

## Verification

Built `@platforma-sdk/workflow-tengo` 6.8.2 locally under v4 and compared every
pack against the same version published on npm, expanding the v4 result back to
the v3 shape. It canonicalizes byte-identically for 34 of 45 templates. The
other 11 differ in exactly one artifact — `software-ptabler:main`'s `.sw.json` —
and their template graph shape (names, versions, aliases, nesting) is identical.
ptabler is a `workspace:*` dep whose local source has moved past the published
2.1.8 snapshot, so that drift is unrelated.

**0 graph-shape differences. 0 differences outside software descriptors.**

## Compatibility

- **`tengo-builder` now emits v4.** A pack built with this version cannot be
  read by a middle layer older than this release, because the middle layer
  parses `main.plj.gz` itself. This is the rollout constraint to plan around.
- **The backend is unaffected.** Every block path in `block_pack.ts`, including
  `from-registry-v1` and `from-registry-v2`, fetches the pack into
  pl-middle-layer and rewrites it to `{type: "explicit", content}`.
  `loadTemplateFromExplicitDirect` then builds the `TengoTemplateV1` resource
  tree in TypeScript. The backend only ever sees that tree, which is unchanged.
  (`TengoTemplatePack` and `TengoTemplatePackConvert` are declared in
  `template_loading.ts` and referenced by no code path.)
- **v2 and v3 stay readable.** `pl-middle-layer` and `block-tools` read all
  three, so already-published blocks keep working — including their
  `requiredCapabilities` install gate. `required_capabilities.test.ts` guards
  that specifically: reading only v4 would report "no requirements" for every
  pre-v4 block and let a WASM block install on a backend without the runtime.
- `parseTemplate` can now return `CompiledTemplateV4`; the new
  `AnyCompiledTemplate` union covers all three. Exhaustive switches over the
  result need a v4 arm.

## Cycle guard

Readers reject `templates` reference cycles instead of recursing into them. v3
could not express a cycle — it nested children inline, so one would have been an
infinite document — and v4's hash references make it representable.

This is hardening against a corrupt pack, not a live bug: a node's hash covers
its children's hashes, so the compiler would need a hash preimage to emit a
cycle. But readers walk the graph recursively and we do not verify hashes on
read, so the failure mode was a stack overflow rather than a diagnosable error.

## Follow-up, not in this PR

Switching the codec from gzip to zstd takes the same pack from 176 KiB to
128 KiB and halves decompress time. The clean way is a new extension —
`.plj.zst` — which makes the codec self-describing and gives compatibility for
free, since existing files keep their `.plj.gz` name.

Worth stating plainly so it does not get mistaken for a substitute: zstd on the
**unmodified v3** pack reaches 134 KiB, which looks like it solves the problem
and does not. Load time improves 1.1x and heap not at all, because the cost is
`JSON.parse` of 29 MiB, which no codec touches.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces template-pack v4, replacing recursively embedded template nodes with content-hash references into a flat node map while retaining v2/v3 reader compatibility. The previously reported cyclic-reference failure is fixed by tracking the active traversal path in both v4 loading paths.

- Adds `CompiledTemplateV4` and `TemplateNodeV4`, plus hash, root-resolution, reference-resolution, and cycle-error helpers.
- Updates Tengo compilation to emit deduplicated v4 packs.
- Adds v4 support to direct and cached middle-layer template loading, capability extraction, block packaging, serialization, and diagnostics.
- Preserves v2/v3 loading and capability handling for existing packs.
- Adds coverage for cycles, shared nodes, deterministic hashes, capability propagation, and pack-size behavior.
- Important touched terms:
  - **Template pack** — the compressed serialized Tengo workflow consumed by the middle layer; this PR changes newly compiled packs from v3 to v4.
  - **`CompiledTemplateV4`** — the new top-level pack type; it stores source text in `hashToSource`, nodes in `hashToTemplate`, and the root as a hash reference.
  - **`TemplateNodeV4`** — one template graph node containing artifacts, metadata, capability requirements, and child-template hash references instead of nested child objects.
  - **`hashToTemplate`** — the new content-hash-to-node map; it stores each distinct node once and preserves DAG sharing.
  - **`templateNodeHash`** — the canonical SHA-256 identity of a completed node; child hashes make the identity cover the complete subtree.
  - **`AnyCompiledTemplate`** — the shared union of v2, v3, and v4 pack types; consumers now switch exhaustively across all readable formats.
  - **Template cache** — the middle-layer path that flattens packs into topologically ordered cacheable resources; v4 traversal memoizes shared node objects and rejects active-path cycles.
  - **`requiredCapabilities`** — backend feature tokens propagated to the root template and block manifest; readers now retrieve them from either the v3 root object or the v4 root-map entry.
  - **Cycle guard** — active-path tracking using `visiting`; the direct loader and cache flattener now reject cyclic v4 references with a diagnostic error rather than exhausting the stack.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/model/backend/src/template_data_v4.ts | Defines the flat v4 pack and node contracts, canonical node hashing, reference resolution, and cycle diagnostics. |
| tools/tengo-builder/src/compiler/compiler.ts | Changes the compiler to seal completed nodes by content hash and emit deduplicated v4 node maps. |
| lib/node/pl-middle-layer/src/mutator/template/direct_template_loader_v4.ts | Renders v4 references into backend resources and now correctly rejects references to nodes active on the current traversal path. |
| lib/node/pl-middle-layer/src/mutator/template/template_cache.ts | Adds v4 graph flattening with identity memoization, topological output, and active-path cycle detection while preserving v2/v3 handling. |
| tools/block-tools/src/v2/build_dist.ts | Extends block-manifest capability extraction to resolve capability declarations from v4 root nodes while retaining v3 compatibility. |
| lib/model/backend/src/serde.ts | Extends the public parsed-template union and discriminator handling to include v4 packs. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Tengo source and dependencies] --> B[tengo-builder]
  B --> C[CompiledTemplateV4]
  C --> D[hashToSource]
  C --> E[hashToTemplate]
  C --> F[Root node hash]
  F --> E
  E -->|Child hash references| E
  C --> G[pl-middle-layer]
  G --> H{Loading path}
  H --> I[Direct resource renderer]
  H --> J[Cached graph flattener]
  I --> K[Active-path cycle guard]
  J --> K
  K --> L[TengoTemplateV1 resource graph]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Template pack v4: flat template node map"](https://github.com/milaboratory/platforma/commit/e08ddc4e3c312815c3e4df524d91c6b4842b8b84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52520586)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [pl-middle-layer](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-middle-layer.md)
- Knowledge Base — [Block model](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-model.md)
- Knowledge Base — [Block Build Tooling](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-build-tooling.md)
</details>

<!-- /greptile_comment -->