### PR TITLE
fix(pl-middle-layer): re-render production when a block's render failed outright

### DIFF
--- a/.changeset/run-rerenders-failed-production.md
+++ b/.changeset/run-rerenders-failed-production.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/pl-middle-layer": patch
+---
+
+Make Run re-render a block whose production failed outright.
+
+The Run button is enabled whenever a block's production carries an error, but the mutator recognised only one of the two shapes such a failure takes. `productionHasErrors` read the field's `status`, which is derived from the resource the field points at — so it saw a value resource that exists and carries an error, and missed a field whose own error slot is filled and that therefore has no value resource at all. In that second shape `renderProduction` found nothing to re-render for the block and committed an empty transaction: the button was live, the click was accepted, and the block never re-ran.
+
+Field-level errors are now carried through `ProjectMutator.load` alongside the value reference and counted by `productionHasErrors`, so both shapes reach `requireProductionRendering` and the enable condition the desktop uses for the button once again matches the condition the mutator renders on.

--- a/lib/node/pl-middle-layer/src/mutator/project.ts
+++ b/lib/node/pl-middle-layer/src/mutator/project.ts
@@ -103,6 +103,17 @@ interface BlockFieldState {
   ref?: AnyRef;
   status?: FieldStatus;
   value?: Uint8Array;
+  /**
+   * True when the project field's own error slot is filled, i.e. the render failed outright
+   * and left no value resource behind. Distinct from `status === "Error"`, which describes a
+   * value resource that exists but carries an error.
+   */
+  fieldError?: boolean;
+}
+
+/** Either failure shape a production field can be in: no value resource, or an errored one. */
+function hasError(state: BlockFieldState | undefined): boolean {
+  return state?.fieldError === true || state?.status === "Error";
 }
 
 type BlockFieldStates = Partial<Record<ProjectField["fieldName"], BlockFieldState>>;
@@ -258,11 +269,19 @@ class BlockInfo {
     return this.fields.prodCtx !== undefined;
   }
 
+  /**
+   * True if the rendered production failed, in either shape {@link hasError} covers.
+   *
+   * Must stay in step with the `outputError` the desktop derives in
+   * `middle_layer/project_overview.ts`, because that flag is what enables the Run button.
+   * Any failure counted there but not here leaves Run enabled yet inert: `renderProduction`
+   * finds nothing to re-render and commits an empty transaction.
+   */
   get productionHasErrors(): boolean {
     return (
-      this.fields.prodUiCtx?.status === "Error" ||
-      this.fields.prodOutput?.status === "Error" ||
-      this.fields.prodCtx?.status === "Error"
+      hasError(this.fields.prodUiCtx) ||
+      hasError(this.fields.prodOutput) ||
+      hasError(this.fields.prodCtx)
     );
   }
 
@@ -1809,9 +1828,12 @@ export class ProjectMutator {
         blockInfoStates.set(projectField.blockId, info);
       }
 
+      // `f.error` is carried separately from `f.value`: a field that errored has no value
+      // resource to read a status off, so this is the only trace the failure leaves here.
+      const fieldError = isNotNullSignedResourceId(f.error);
       info.fields[projectField.fieldName] = isNullSignedResourceId(f.value)
-        ? { modCount: 0 }
-        : { modCount: 0, ref: f.value };
+        ? { modCount: 0, fieldError }
+        : { modCount: 0, ref: f.value, fieldError };
     }
 
     //


### PR DESCRIPTION
## Problem

Press **Run** on a block whose production failed and nothing happens. The click is accepted — the desktop logs `Task: run-block | Success: true` in ~300ms — and the block never re-runs. No error, no feedback, no state change.

Reproduced against a real project: a block sitting at `calculationStatus: "Done"`, `stale: false`, `outputErrors: true`, `canRun: true`, with 4 of 8 outputs failed. Seven consecutive Run dispatches, seven successes, zero render activity.

## Cause

Two places decide whether a block's production "has errors", and they disagree.

**The button-enable rule** — `middle_layer/project_overview.ts:117-121` — is a 4-way disjunction:

```
result.error !== undefined || ctx.error !== undefined ||
result.value?.getError() !== undefined || ctx.value?.getError() !== undefined
```

**The actually-render rule** — `mutator/project.ts` `productionHasErrors` — read only the field `status`, and that status is derived at hydration from `getResourceData(f.value).error`. So it covered the last two disjuncts and missed the first two.

The gap is in hydration. `FieldData` (`pl-client/src/core/types.ts:126-135`) carries `value` **and** `error`, but `ProjectMutator.load` read only `value`. A field whose own error slot is filled has a *null* value, so it was stored as a bare `{ modCount: 0 }` — no ref, no status, no trace the failure ever happened.

Downstream: `productionRendered` is true (the field state object exists), `productionStale` is false (args unchanged), `productionHasErrors` is false — so `requireProductionRendering` is false, `renderProduction` selects nothing, and the transaction commits empty.

## Fix

- `BlockFieldState` gains `fieldError`, set from `f.error` during hydration — **in both branches**, since an errored field takes the branch that has no ref.
- `hasError()` folds the two failure shapes into one predicate.
- `productionHasErrors` applies it to `prodCtx`, `prodOutput`, `prodUiCtx`.

`requireProductionRendering` is the only consumer, and it is reached only from the explicit user action `Project.runBlock`, so the blast radius is one code path.

## Verification

- `tsc --noEmit` — exit 0
- `formatter:check` — clean
- `linter:check` — 0 warnings, 0 errors
- Consumer audit — `requireProductionRendering` is the sole reader

**Not runtime-tested.** `pl-middle-layer`'s suite is integration-only (`TestHelpers.withTempRoot` needs a live `pl`), and there is no fixture block pack that fails production, so a test needs both a backend and a new fixture. Happy to add it if wanted.

That the observed block takes the newly-covered shape follows by elimination rather than by reading its resource: the two disjuncts the mutator already saw map onto `status === "Error"`, which must be false or Run would have re-rendered — so the true disjunct is one of the two that were dropped.

## Follow-ups (not in this PR)

- A `force` path for `runBlock`, so an explicit Run never depends on a staleness predicate being right.
- `get_project_overview` in `pl-mcp-server` drops `outputsError`/`exportsError`, so output error text is unreadable headlessly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves field-level production errors while hydrating project mutation state, allowing an explicit Run action to rerender production that failed before creating a value resource.

- Adds `BlockFieldState.fieldError`, which records whether the project field’s own error slot is populated.
- Adds `hasError()`, which unifies field-level failures with errors carried by an existing value resource.
- Updates `productionHasErrors` to use the unified predicate for production context, output, and UI context fields.
- Adds a patch changeset for `@milaboratories/pl-middle-layer`.
- Important touched terms:
  - **`BlockFieldState`** — the mutator’s hydrated state for a block project field; it now retains a `fieldError` flag alongside its reference, resource status, and value.
  - **`fieldError`** — indicates that a project field’s own error slot is populated, including outright render failures that leave no value resource; newly captured from `FieldData.error`.
  - **`FieldStatus`** — describes the state of an existing value resource, including `"Error"`; unchanged, but now complemented by `fieldError`.
  - **`hasError()`** — the new common predicate for the two production failure representations: a field-level error or an errored value resource.
  - **`productionHasErrors`** — determines whether failed production requires rendering again; changed to apply `hasError()` to `prodCtx`, `prodOutput`, and `prodUiCtx`.
  - **Production rendering** — the durable execution path for a block; explicit Run can now select production whose field failed before producing a value resource.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the newly retained field-error state consistently feeding the existing explicit production-rerender path.

The change preserves an error signal previously discarded during hydration and combines it with the existing value-resource error state without changing public interfaces or introducing a demonstrated incorrect execution path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/mutator/project.ts | Preserves field-level errors during hydration and includes them in the production rerender predicate; no actionable defect was identified. |
| .changeset/run-rerenders-failed-production.md | Adds an accurate patch release note describing the newly handled production-failure representation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[ProjectMutator loads production fields] --> B{Field has its own error?}
  B -- Yes --> C[fieldError = true]
  B -- No --> D[fieldError = false]
  C --> E[hasError]
  D --> E
  F{Value resource status is Error?} --> E
  E --> G{productionHasErrors}
  G -- Yes --> H[requireProductionRendering]
  H --> I[Explicit Run rerenders production]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["\[MILAB-XXXX\]: fix: re-render production ..."](https://github.com/milaboratory/platforma/commit/cbe94c7ccc60f260c54c3ddb20b31d010253b9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54360187)</sub>

**Context used:**

- Knowledge Base — [pl-middle-layer](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-middle-layer.md)

<!-- /greptile_comment -->