### PR TITLE
MILAB-5933: honour an explicit request-timeout in test configs

### DIFF
--- a/lib/node/pl-client/src/test/test_config.ts
+++ b/lib/node/pl-client/src/test/test_config.ts
@@ -62,10 +62,16 @@ export function getTestConfig(): TestConfig {
 /** Default request timeout for tests (ms) */
 export const TEST_REQUEST_TIMEOUT = 500;
 
-/** Returns PlClientConfig with reduced timeout for tests */
+/** Returns PlClientConfig with reduced timeout for tests, unless the address sets its own */
 export function plAddressToTestConfig(address: string): PlClientConfig {
   const plConf = plAddressToConfig(address);
-  plConf.defaultRequestTimeout = TEST_REQUEST_TIMEOUT;
+  // An explicit request-timeout in the address wins over TEST_REQUEST_TIMEOUT. In the k8s e2e
+  // deploy the client dials a cluster service DNS name, and the first call on a cold channel must
+  // finish name resolution and get a load-balancer pick before it is even sent; 500ms does not
+  // cover that, so whichever test happened to open the cold channel died with DEADLINE_EXCEEDED
+  // ("Waiting for LB pick") against a healthy backend. Addresses that carry no request-timeout
+  // keep the short default, so local runs still fail fast.
+  if (!/[?&]request-timeout=/.test(address)) plConf.defaultRequestTimeout = TEST_REQUEST_TIMEOUT;
   return plConf;
 }
 


### PR DESCRIPTION
plAddressToTestConfig parsed the address and then overwrote `defaultRequestTimeout` with a flat 500ms, so the `request-timeout=3000` the pl e2e job puts in `PL_ADDRESS` never took effect.

Invisible against localhost, fatal against the k8s service DNS name: a cold gRPC channel cannot resolve and get an LB pick inside 500ms, so whichever test opened it failed with `Deadline exceeded after 0.498s ... Waiting for LB pick` against a healthy backend. Addresses without `request-timeout` keep the short default.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves an explicitly parsed `request-timeout` when creating test client configuration while retaining the short 500ms default for addresses without that parameter.

- Updates `plAddressToTestConfig` so an address-level timeout takes precedence over `TEST_REQUEST_TIMEOUT`.
- Documents why Kubernetes cold-channel setup requires a longer explicit deadline.
- **`PlClientConfig`**: The parsed client connection configuration; its `defaultRequestTimeout` is no longer unconditionally overwritten by the test helper.
- **`plAddressToTestConfig`**: The test configuration adapter; it now applies the 500ms test timeout only when the address does not specify `request-timeout`.
- **`request-timeout`**: An address query parameter defining the default request deadline; explicit values such as 3000ms are now honored in tests.
- **`TEST_REQUEST_TIMEOUT`**: The 500ms fail-fast default for tests; it remains active for addresses without an explicit timeout.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intended explicit Kubernetes request timeout now preserved and no actionable regression established.

The changed helper continues applying the 500ms test default when no timeout parameter is present and retains the parsed numeric timeout for the supported CI address form.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/test/test_config.ts | Correctly gives an explicit address-level request timeout precedence over the short test default without changing ordinary local test behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-5933: honour an explicit request-t..."](https://github.com/milaboratory/platforma/commit/8579f5271beb8a41d63c4eafdd4eb8a287a292f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54360319)</sub>

**Context used:**

- Knowledge Base — [pl-client](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/pl-client.md)

<!-- /greptile_comment -->