### PR TITLE
Batch processing: fix maxBatches for partitioned data

### DIFF
--- a/.changeset/batch-maxbatches-partitioned.md
+++ b/.changeset/batch-maxbatches-partitioned.md
@@ -1,5 +1,5 @@
 ---
-'@platforma-sdk/workflow-tengo': minor
+'@platforma-sdk/workflow-tengo': patch
 ---
 
 pframes.processColumn batch mode: make `batch.maxBatches` actually bind, and stop dropping rows on the `passContent: true` path.

--- a/.changeset/batch-maxbatches-partitioned.md
+++ b/.changeset/batch-maxbatches-partitioned.md
@@ -1,0 +1,13 @@
+---
+'@platforma-sdk/workflow-tengo': minor
+---
+
+pframes.processColumn batch mode: make `batch.maxBatches` actually bind, and stop dropping rows on the `passContent: true` path.
+
+The cap was decided in the orchestrator from `recordsInGroup`, which returns an exact row count only for inline `PColumnData/Json`. For `JsonPartitioned` / `ParquetPartitioned` it returns the *partition* count (and partitions/2 for `BinaryPartitioned`), so a single-partition column of 500k rows reported 1 record. The inflation gate `totalBatches > maxBatches` then never fired and the cap silently did nothing — precisely for the large, partitioned inputs that need it. Observed in the sequence-embeddings block: 553789 sequences with `maxBatches: 50` produced ~185 batches of 3000.
+
+The cap is now enforced per isolation scope inside `:pframes.process-pcolumn-batch-split`, which has the true row count. Each scope receives its share of the global budget (`maxBatches / isolationScopeCount`) and inflates batch size deterministically, so batch boundaries stay reproducible and per-batch dedup is preserved. The orchestrator's estimate remains only as a floor on batch size.
+
+This also fixes silent data loss with `batch.passContent: true` on partitioned input: that path took the undercounted `batchCount` verbatim and the slice loop clamps `endLine` without ever extending `batchCount`, so every row past the first batch was dropped. It now recomputes the count from the real data like the `passContent: false` path.
+
+Blocks relying on `maxBatches` will see different (larger, fewer) batches than before — that is the fix. Batch boundaries change, so previously cached per-batch results are invalidated once.

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo
@@ -37,6 +37,11 @@ self.body(func(inputs) {
 
 	batchCount := params.batchCount
 	batchSize := params.batchSize
+	// This scope's share of batch.maxBatches. 0 / absent means uncapped.
+	scopeMaxBatches := params.scopeMaxBatches
+	if is_undefined(scopeMaxBatches) {
+		scopeMaxBatches = 0
+	}
 	eph := params.eph
 	outputs := params.outputs
 	formatExt := params.formatExt
@@ -127,14 +132,19 @@ self.body(func(inputs) {
 		}
 	}
 
-	// passContent=false: orchestrator emitted one joined file + a tiny count
-	// content. Read the count to compute the true batchCount (orchestrator's
-	// `params.batchCount` is a partition-count upper-bound and may underestimate
-	// row count for parquet/json-partitioned data), then re-slice via an
-	// internal pt run. The joined file is materialized but never read into
-	// Tengo memory — it flows through pt as an input frame.
-	batchFileRefs := undefined
-	if !passContent {
+	// True row count for this scope.
+	//
+	// `params.batchCount` cannot be trusted: the orchestrator derives it from
+	// `recordsInGroup`, which returns the number of PARTITIONS (not rows) for
+	// JsonPartitioned / ParquetPartitioned inputs and partitions/2 for
+	// BinaryPartitioned — only inline PColumnData/Json yields an exact count.
+	// For a single-partition column of 500k rows the upper bound is 1, so both
+	// the orchestrator's batch count and its maxBatches decision are wrong by
+	// orders of magnitude. Recompute from the real count in both modes.
+	actualRecords := 0
+	if passContent {
+		actualRecords = len(dataLines)
+	} else {
 		ll.assert(!is_undefined(inputs.joinedFile),
 			"passContent=false but joinedFile input is missing")
 		ll.assert(!is_undefined(inputs.countContent),
@@ -145,7 +155,6 @@ self.body(func(inputs) {
 			countText = string(countText)
 		}
 		countLines := text.split(text.trim_space(countText), "\n")
-		actualRecords := 0
 		if len(countLines) >= 2 {
 			lastFields := text.split(countLines[len(countLines) - 1], "\t")
 			parsed := json.decode(text.trim_space(lastFields[len(lastFields) - 1]))
@@ -153,11 +162,28 @@ self.body(func(inputs) {
 				actualRecords = parsed
 			}
 		}
-		batchCount = (actualRecords + batchSize - 1) / batchSize
-		if batchCount == 0 {
-			batchCount = 1
-		}
+	}
 
+	// Enforce this scope's share of batch.maxBatches. The orchestrator's
+	// pre-estimate runs before any row count exists and silently does nothing
+	// whenever its upper bound undercounts, so this is where the cap actually
+	// binds. Inflation is deterministic — same rows produce the same count, the
+	// same size and the same boundaries — so per-batch dedup across reruns is
+	// preserved.
+	batchCount = (actualRecords + batchSize - 1) / batchSize
+	if scopeMaxBatches > 0 && batchCount > scopeMaxBatches && actualRecords > 0 {
+		batchSize = (actualRecords + scopeMaxBatches - 1) / scopeMaxBatches
+		batchCount = (actualRecords + batchSize - 1) / batchSize
+	}
+	if batchCount == 0 {
+		batchCount = 1
+	}
+
+	// passContent=false: re-slice the joined file via an internal pt run. The
+	// file is materialized but never read into Tengo memory — it flows through
+	// pt as an input frame.
+	batchFileRefs := undefined
+	if !passContent {
 		sliceWf := pt.workflow()
 		sliceDf := sliceWf.frame(inputs.joinedFile, { xsvType: formatExt })
 		batchFileNames := []

--- a/sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo
+++ b/sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo
@@ -150,15 +150,33 @@ self.body(func(inputs) {
 	// maxBatches — inflating batch size can't help when each scope has ≤1
 	// batch. Otherwise estimate total batch count from per-scope upper-bound
 	// record counts (inner: min across primaries; full: sum across primaries)
-	// and inflate batch size deterministically when the estimate exceeds
-	// maxBatches. Same upper-bound convention as the per-scope loop below, so
-	// the limit consistently bounds the resulting batch count.
+	// and inflate batch size when the estimate exceeds maxBatches.
+	//
+	// This estimate is only a FLOOR on the batch size, never the enforcement
+	// point: the upper bound counts partitions rather than rows for every
+	// partitioned input type (see recordsInGroup), so for such columns it
+	// undercounts drastically and this step does nothing at all. The cap is
+	// actually applied per scope inside :pframes.process-pcolumn-batch-split,
+	// which has the true row count. `scopeMaxBatches` below is that scope's
+	// share of the global budget.
 	isolationScopeCount := len(allIsolationKeys)
 	ll.assert(isolationScopeCount <= maxBatches,
 		"batch mode: isolation scope count (%v) exceeds batch.maxBatches (%v). "+
 			"A high-diversity axis is being treated as an isolation axis. "+
 			"Move it into batch.keyColumns, or raise batch.maxBatches if the high count is intentional.",
 		isolationScopeCount, maxBatches)
+
+	// Per-scope share of the global cap, handed to each split render. Split
+	// evenly: the true per-scope row counts are unknown here (that is the whole
+	// problem), so a proportional split is not available. The assert above
+	// guarantees this floors to ≥1, and scopeCount * (maxBatches / scopeCount)
+	// <= maxBatches keeps the global bound. Tradeoff: with very unevenly sized
+	// scopes a large scope is held to an equal share, so its batches come out
+	// coarser than a global optimum would allow.
+	scopeMaxBatches := maxBatches / isolationScopeCount
+	if scopeMaxBatches < 1 {
+		scopeMaxBatches = 1
+	}
 
 	_scopeUpperBound := func(sIsolationKey) {
 		if primaryJoin == "inner" {
@@ -346,6 +364,7 @@ self.body(func(inputs) {
 			params: smart.createJsonResource({
 				batchCount: batchCount,
 				batchSize: effectiveBatchSize,
+				scopeMaxBatches: scopeMaxBatches,
 				passContent: passContent,
 				formatExt: formatExt,
 				eph: eph,

--- a/tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo
@@ -5,7 +5,11 @@ self := import("@platforma-sdk/workflow-tengo:tpl")
 ll := import("@platforma-sdk/workflow-tengo:ll")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 times := import("times")
+
+hwSoftware := assets.importSoftware("@platforma-open/milaboratories.software-test-utils:hello-world")
 
 bodyTplContent := assets.importTemplate(":pframes.proc_batch_body")
 bodyTplBlob := assets.importTemplate(":pframes.proc_batch_body_blob")
@@ -13,6 +17,9 @@ bodyTplResourceMap := assets.importTemplate(":pframes.proc_batch_body_resource_m
 bodyTplNdjson := assets.importTemplate(":pframes.proc_batch_body_ndjson")
 bodyTplExtraAxis := assets.importTemplate(":pframes.proc_batch_body_extra_axis")
 bodyTplExtraAxisBlob := assets.importTemplate(":pframes.proc_batch_body_extra_axis_blob")
+bodyTplBatchTag := assets.importTemplate(":pframes.proc_batch_body_batch_tag")
+bodyTplBatchTagBlob := assets.importTemplate(":pframes.proc_batch_body_batch_tag_blob")
+bodyTplBatchTagBlobTsv := assets.importTemplate(":pframes.proc_batch_body_batch_tag_blob_tsv")
 
 self.awaitState("InputsLocked")
 self.awaitState("params", "ResourceReady")
@@ -25,6 +32,9 @@ self.body(func(inputs) {
 	// - params.bodyMode == "ndjson"      → body parses NDJSON content via pt, writes parquet
 	// - params.bodyMode == "extraAxis"     → body emits a new "half" axis column (passContent=true)
 	// - params.bodyMode == "extraAxisBlob" → body appends a "tag" axis via pt (passContent=false)
+	// - params.bodyMode == "batchTag"      → body tags each row with its batch's first key
+	// - params.bodyMode == "batchTagBlob"  → same tag via pt on a parquet Blob (passContent=false)
+	// - params.bodyMode == "batchTagBlobTsv" → same tag via pt on a tsv Blob (passContent=false)
 	// - params.batch.passContent=false     → body treats __value__ as a Blob file ref
 	// - default                            → body reads __value__ as a content string
 	bodyTpl := bodyTplContent
@@ -36,8 +46,43 @@ self.body(func(inputs) {
 		bodyTpl = bodyTplExtraAxis
 	} else if params.bodyMode == "extraAxisBlob" {
 		bodyTpl = bodyTplExtraAxisBlob
+	} else if params.bodyMode == "batchTag" {
+		bodyTpl = bodyTplBatchTag
+	} else if params.bodyMode == "batchTagBlob" {
+		bodyTpl = bodyTplBatchTagBlob
+	} else if params.bodyMode == "batchTagBlobTsv" {
+		bodyTpl = bodyTplBatchTagBlobTsv
 	} else if !is_undefined(params.batch.passContent) && !params.batch.passContent {
 		bodyTpl = bodyTplBlob
+	}
+
+	// Tests can pass `partitionedTsv` to get a genuinely single-partition
+	// PColumnData/JsonPartitioned primary — the shape real block inputs have —
+	// instead of an inline PColumnData/Json. This matters because
+	// recordsInGroup() is exact only for inline Json; for partitioned columns it
+	// returns the partition count, which is what made batch.maxBatches a no-op.
+	// Written as a file and imported with partitionKeyLength=0 so the whole
+	// column lands in a single "[]" partition.
+	partitionedData := undefined
+	if !is_undefined(params.partitionedTsv) {
+		importRun := exec.builder().
+			cpu(1).ram("50Mi").
+			software(hwSoftware).
+			arg("a").
+			writeFile("in.tsv", params.partitionedTsv).
+			saveFile("in.tsv").
+			run()
+
+		imported := xsv.importFile(importRun.getFile("in.tsv"), "tsv", {
+			axes: [{ column: "key", spec: { name: "key", type: "String" } }],
+			columns: [{ column: "heavyChain", spec: { valueType: "String", name: "heavyChain" } }],
+			storageFormat: "Json",
+			partitionKeyLength: 0
+		}, { dataOnly: true })
+
+		// dataOnly=true makes importFile return the pframe resource itself rather
+		// than a map of columns, so reach the column through its input field.
+		partitionedData = imported.getFutureInputField("heavyChain")
 	}
 
 	primaryEntries := []
@@ -57,6 +102,11 @@ self.body(func(inputs) {
 					spec: entry.filterSpec,
 					data: inputs[entry.filterDataInputName]
 				}
+			}
+		} else if !is_undefined(partitionedData) {
+			src = {
+				spec: entry.spec,
+				data: partitionedData
 			}
 		} else {
 			src = {

--- a/tests/workflow-tengo/src/pframes/proc_batch_body_batch_tag.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch_body_batch_tag.tpl.tengo
@@ -1,0 +1,70 @@
+// proc_batch_body_batch_tag — body template that makes the batch decomposition
+// observable from the merged output.
+//
+// Receives batch TSV content as __value__ (string) with columns "key" (batch-key
+// axis) + "heavyChain" (value). For every input row it emits one output row
+// carrying the batch's *fingerprint* — the first key of the batch it belongs to —
+// as the "batchTag" value column.
+//
+// Batches are sorted by the batch-key axes and sliced contiguously, so the first
+// key is a stable per-batch identifier: every row of a batch carries the same
+// tag, distinct tags across the merged output equal the number of batches that
+// actually ran, and the tag values themselves are the batch boundaries. Merging
+// otherwise erases the decomposition, which is why the batch.maxBatches
+// inflation test needs this body.
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+ll := import("@platforma-sdk/workflow-tengo:ll")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
+
+text := import("text")
+
+hwSoftware := assets.importSoftware("@platforma-open/milaboratories.software-test-utils:hello-world")
+
+self.defineOutputs(
+	"tsv"
+)
+
+self.body(func(inputs) {
+	batchContent := inputs[pConstants.VALUE_FIELD_NAME]
+
+	if !is_string(batchContent) {
+		ll.panic("expected string batch content, got: %v", batchContent)
+	}
+
+	lines := text.split(batchContent, "\n")
+	for len(lines) > 0 && lines[len(lines) - 1] == "" {
+		lines = lines[:len(lines) - 1]
+	}
+
+	// Input header is "key\theavyChain"; the first data row's key tags the batch.
+	// An empty batch (possible when the orchestrator's record count is an upper
+	// bound) emits a header-only file and therefore no tagged rows at all.
+	tag := ""
+	if len(lines) > 1 {
+		firstFields := text.split(lines[1], "\t")
+		tag = firstFields[0]
+	}
+
+	outLines := ["key\tbatchTag"]
+	for i := 1; i < len(lines); i++ {
+		fields := text.split(lines[i], "\t")
+		outLines = append(outLines, fields[0] + "\t" + tag)
+	}
+	outContent := text.join(outLines, "\n") + "\n"
+
+	// hello-world is an identity run; the transformed file is written directly.
+	run := exec.builder().
+		cpu(1).ram("50Mi").
+		software(hwSoftware).
+		arg("a").
+		writeFile("batch.tsv", outContent).
+		saveFile("batch.tsv").
+		run()
+
+	return {
+		tsv: run.getFile("batch.tsv")
+	}
+})

--- a/tests/workflow-tengo/src/pframes/proc_batch_body_batch_tag_blob.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch_body_batch_tag_blob.tpl.tengo
@@ -1,0 +1,61 @@
+// proc_batch_body_batch_tag_blob — passContent=false counterpart of
+// proc_batch_body_batch_tag, on the all-parquet path.
+//
+// Receives __value__ as a Blob parquet batch file (batch.format="parquet", which
+// requires passContent=false), so the batch fingerprint cannot be computed in
+// Tengo — it is derived with pt instead: min("key") over a constant window,
+// which broadcasts the batch's smallest key onto every row of that batch.
+// Batches are sliced contiguously from a batch-key sort, so the smallest key is
+// the batch's first key and therefore a stable per-batch identifier.
+//
+// This covers the pt re-slicing route in :pframes.process-pcolumn-batch-split,
+// which recomputes batchCount from the *actual* record count rather than the
+// orchestrator's upper bound — a different maxBatches code path than the
+// passContent=true body.
+//
+// Emits the identical tagged table twice: "out.parquet" feeds the
+// xsvType="parquet" output under test, and "out.tsv" feeds a twin tsv output.
+// The twin exists because xsvType="parquet" forces storageFormat="Parquet"
+// (asserted in pframes.xsv-import-file), and the tests have no parquet reader —
+// so the parquet column can only be checked structurally. Both outputs come out
+// of the same body invocations, so the tsv twin reports exactly the batch
+// decomposition the parquet output received.
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+ll := import("@platforma-sdk/workflow-tengo:ll")
+smart := import("@platforma-sdk/workflow-tengo:smart")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
+
+self.defineOutputs(
+	"pq",
+	"tsv"
+)
+
+self.body(func(inputs) {
+	batchFile := inputs[pConstants.VALUE_FIELD_NAME]
+
+	if !smart.isReference(batchFile) {
+		ll.panic("expected __value__ to be a file reference (passContent=false), got: %v", batchFile)
+	}
+
+	// Batch file columns: "key" (batch-key axis) + "heavyChain" (value).
+	wf := pt.workflow()
+	df := wf.frame(batchFile, { xsvType: "parquet" })
+
+	// A constant partition makes the window span the whole batch — pt's min()
+	// requires .over() to define a window, and there is no whole-frame form.
+	df = df.withColumns(pt.lit(1).alias("__all"))
+	df = df.withColumns(pt.col("key").min().over("__all").alias("batchTag"))
+
+	tagged := df.select(pt.col("key"), pt.col("batchTag"))
+	tagged.save("out.parquet", { format: "parquet" })
+	tagged.save("out.tsv", { format: "tsv" })
+
+	res := wf.run()
+
+	return {
+		pq: res.getFile("out.parquet"),
+		tsv: res.getFile("out.tsv")
+	}
+})

--- a/tests/workflow-tengo/src/pframes/proc_batch_body_batch_tag_blob_tsv.tpl.tengo
+++ b/tests/workflow-tengo/src/pframes/proc_batch_body_batch_tag_blob_tsv.tpl.tengo
@@ -1,0 +1,42 @@
+// proc_batch_body_batch_tag_blob_tsv — tsv counterpart of
+// proc_batch_body_batch_tag_blob, for the format="tsv" + passContent=false
+// combination that real blocks use (e.g. sequence-embeddings).
+//
+// Receives __value__ as a Blob tsv batch file and tags every row with its
+// batch's fingerprint — min("key") over a constant window, i.e. the batch's
+// smallest key. Batches are sliced contiguously from a batch-key sort, so that
+// is the batch's first key and a stable per-batch identifier: distinct tags in
+// the merged output equal the number of batches that actually ran.
+//
+// Emits tsv so the output can use storageFormat="Json" and stay readable in
+// tests (xsvType="parquet" would force Parquet storage, which has no reader
+// here).
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+ll := import("@platforma-sdk/workflow-tengo:ll")
+smart := import("@platforma-sdk/workflow-tengo:smart")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
+
+self.defineOutputs(
+	"tsv"
+)
+
+self.body(func(inputs) {
+	batchFile := inputs[pConstants.VALUE_FIELD_NAME]
+
+	if !smart.isReference(batchFile) {
+		ll.panic("expected __value__ to be a file reference (passContent=false), got: %v", batchFile)
+	}
+
+	wf := pt.workflow()
+	df := wf.frame(batchFile, { xsvType: "tsv" })
+	df = df.withColumns(pt.lit(1).alias("__all"))
+	df = df.withColumns(pt.col("key").min().over("__all").alias("batchTag"))
+	df.select(pt.col("key"), pt.col("batchTag")).save("out.tsv", { format: "tsv" })
+	res := wf.run()
+
+	return {
+		tsv: res.getFile("out.tsv")
+	}
+})

--- a/tests/workflow-tengo/src/pframes/proc_batch_filter.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_filter.test.ts
@@ -1,5 +1,5 @@
 import type { PUniversalColumnSpec } from "@milaboratories/pl-middle-layer";
-import { eTplTest } from "./extended_tpl_test";
+import { assertResource, eTplTest } from "./extended_tpl_test";
 import { getLongTestTimeout } from "@milaboratories/test-helpers";
 import { vi } from "vitest";
 import {
@@ -125,5 +125,147 @@ eTplTest.concurrent(
     for (const expected of expectedKeys) {
       expect(hcContent).toHaveProperty(`["${expected}"]`);
     }
+  },
+);
+
+// Xsv output for the batchTag body: the batch-key axis "key" plus a "batchTag"
+// value column carrying the first key of the batch each row came from.
+const xsvSettingsBatchTag = {
+  batchKeyColumns: ["key"],
+  columns: [
+    { column: "batchTag", id: "batchTag", spec: { valueType: "String", name: "batchTag" } },
+  ],
+  storageFormat: "Json",
+} as const;
+
+// Same column, Parquet storage — xsvType="parquet" rejects Json storage
+// (pframes.xsv-import-file). Used for the parquet output of the blob-path test.
+const xsvSettingsBatchTagParquet = {
+  ...xsvSettingsBatchTag,
+  storageFormat: "Parquet",
+} as const;
+
+eTplTest.concurrent(
+  "batch mode: maxBatches step 4 — inflated batch count and boundaries are observable",
+  async ({ helper, expect, stHelper }) => {
+    // Companion to the test above, which can only see that no records were lost:
+    // it passes even if maxBatches is ignored entirely, because merging erases
+    // the batch decomposition. Here the body tags every row with its batch's
+    // first key, so the decomposition is readable from the merged output.
+    //
+    // 12 records at size=1 would be 12 batches. maxBatches=3 forces
+    // effectiveBatchSize = ceil(12/3) = 4, and slicing is contiguous over the
+    // batch-key sort, so exactly 3 batches must run: k00-k03 / k04-k07 / k08-k11.
+    const records: Record<string, string> = {};
+    for (let i = 0; i < 12; i++) {
+      records[`["k${i.toString().padStart(2, "0")}"]`] = `SEQ${i}`;
+    }
+
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "batchTag",
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data1", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsBatchTag }],
+        batch: {
+          size: 1,
+          keyColumns: ["key"],
+          format: "tsv",
+          passContent: true,
+          maxBatches: 3,
+        },
+      }),
+      data1: createJsonData(tx, 1, records),
+    }));
+
+    const tags = readJsonPartition(theResult.inputs["tsv.batchTag.data"]);
+    expect(Object.keys(tags)).toHaveLength(12);
+
+    // Group keys by their batch tag → the batch decomposition that actually ran.
+    const batches = new Map<string, string[]>();
+    for (const [rawKey, tag] of Object.entries(tags)) {
+      const key = (JSON.parse(rawKey) as string[])[0];
+      const members = batches.get(tag as string);
+      if (members) members.push(key);
+      else batches.set(tag as string, [key]);
+    }
+    for (const members of batches.values()) members.sort();
+
+    // The assertion the losslessness test cannot make: the cap was applied.
+    // Ignoring maxBatches yields 12 batches here, not 3.
+    expect(batches.size).toEqual(3);
+
+    // Boundaries are the deterministic contiguous runs of the inflated size —
+    // this is the property that keeps dedup safe across reruns.
+    expect([...batches.keys()].sort()).toEqual(["k00", "k04", "k08"]);
+    expect(batches.get("k00")).toEqual(["k00", "k01", "k02", "k03"]);
+    expect(batches.get("k04")).toEqual(["k04", "k05", "k06", "k07"]);
+    expect(batches.get("k08")).toEqual(["k08", "k09", "k10", "k11"]);
+  },
+);
+
+eTplTest.concurrent(
+  "batch mode: maxBatches inflation on the parquet blob path (passContent=false)",
+  async ({ helper, expect, stHelper }) => {
+    // Same measurement as the test above, on the other splitting path. With
+    // passContent=false the orchestrator hands the body one joined file plus a
+    // row count, and the split template recomputes batchCount from that *actual*
+    // count (process-pcolumn-batch-split.tpl.tengo:156) instead of reusing the
+    // orchestrator's partition-count upper bound — so the inflated batch size
+    // reaches a genuinely different code path than the passContent=true test.
+    //
+    // format="parquet" requires passContent=false, and the body emits parquet for
+    // an xsvType="parquet" Xsv output: parquet in, parquet out. That output can
+    // only be checked structurally — xsvType="parquet" forces
+    // storageFormat="Parquet" and these tests have no parquet reader — so the
+    // body emits the same table as tsv too, and the twin tsv output carries the
+    // batch decomposition in readable form. Same body invocations, same batches.
+    const records: Record<string, string> = {};
+    for (let i = 0; i < 12; i++) {
+      records[`["k${i.toString().padStart(2, "0")}"]`] = `SEQ${i}`;
+    }
+
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "batchTagBlob",
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "data1", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [
+          { type: "Xsv", name: "pq", xsvType: "parquet", settings: xsvSettingsBatchTagParquet },
+          { type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsBatchTag },
+        ],
+        batch: {
+          size: 1,
+          keyColumns: ["key"],
+          format: "parquet",
+          passContent: false,
+          maxBatches: 3,
+        },
+      }),
+      data1: createJsonData(tx, 1, records),
+    }));
+
+    // The parquet output imported end-to-end (slice → parquet → merge → import).
+    const pqData = theResult.inputs["pq.batchTag.data"];
+    assertResource(pqData);
+    expect(pqData.resourceType.name).toContain("Parquet");
+
+    const tags = readJsonPartition(theResult.inputs["tsv.batchTag.data"]);
+    expect(Object.keys(tags)).toHaveLength(12);
+
+    const batches = new Map<string, string[]>();
+    for (const [rawKey, tag] of Object.entries(tags)) {
+      const key = (JSON.parse(rawKey) as string[])[0];
+      const members = batches.get(tag as string);
+      if (members) members.push(key);
+      else batches.set(tag as string, [key]);
+    }
+    for (const members of batches.values()) members.sort();
+
+    expect(batches.size).toEqual(3);
+    expect([...batches.keys()].sort()).toEqual(["k00", "k04", "k08"]);
+    expect(batches.get("k00")).toEqual(["k00", "k01", "k02", "k03"]);
+    expect(batches.get("k04")).toEqual(["k04", "k05", "k06", "k07"]);
+    expect(batches.get("k08")).toEqual(["k08", "k09", "k10", "k11"]);
   },
 );

--- a/tests/workflow-tengo/src/pframes/proc_batch_max_batches.test.ts
+++ b/tests/workflow-tengo/src/pframes/proc_batch_max_batches.test.ts
@@ -1,0 +1,121 @@
+import { eTplTest } from "./extended_tpl_test";
+import { getLongTestTimeout } from "@milaboratories/test-helpers";
+import { vi } from "vitest";
+import { jsonParams, readJsonPartition, runBatch, singleAxisSpec } from "./proc_batch_common";
+
+vi.setConfig({ testTimeout: getLongTestTimeout(60_000) });
+
+// batch.maxBatches on PARTITIONED input.
+//
+// The orchestrator estimates batch count with recordsInGroup(), which is exact
+// only for inline PColumnData/Json — for JsonPartitioned / ParquetPartitioned it
+// returns the PARTITION count and for BinaryPartitioned partitions/2. A
+// single-partition column therefore reports 1 record no matter how many rows it
+// holds, the inflation gate `totalBatches > maxBatches` never fires, and the cap
+// silently does nothing. That is the shape every real block input has, so the
+// cap used to be a no-op exactly when it was needed (sequence-embeddings:
+// 553789 sequences, maxBatches 50, got ~185 batches of 3000).
+//
+// `partitionedTsv` makes the harness build a real single-partition
+// JsonPartitioned primary (write tsv -> xsv.importFile with
+// partitionKeyLength=0) instead of an inline column.
+const PARTITIONED_TSV = (() => {
+  const lines = ["key\theavyChain"];
+  for (let i = 0; i < 12; i++) lines.push(`k${i.toString().padStart(2, "0")}\tSEQ${i}`);
+  return lines.join("\n") + "\n";
+})();
+
+// 12 rows, size=1, maxBatches=3, one isolation scope => scopeMaxBatches=3,
+// inflated size ceil(12/3)=4, contiguous over the batch-key sort.
+const EXPECTED_BATCHES: Record<string, string[]> = {
+  k00: ["k00", "k01", "k02", "k03"],
+  k04: ["k04", "k05", "k06", "k07"],
+  k08: ["k08", "k09", "k10", "k11"],
+};
+
+const xsvSettingsBatchTag = {
+  batchKeyColumns: ["key"],
+  columns: [
+    { column: "batchTag", id: "batchTag", spec: { valueType: "String", name: "batchTag" } },
+  ],
+  storageFormat: "Json",
+} as const;
+
+/** Groups keys by their batch tag — the decomposition that actually ran. */
+function batchesFrom(tags: Record<string, unknown>): Map<string, string[]> {
+  const batches = new Map<string, string[]>();
+  for (const [rawKey, tag] of Object.entries(tags)) {
+    const key = (JSON.parse(rawKey) as string[])[0];
+    const members = batches.get(tag as string);
+    if (members) members.push(key);
+    else batches.set(tag as string, [key]);
+  }
+  for (const members of batches.values()) members.sort();
+  return batches;
+}
+
+eTplTest.concurrent(
+  "batch mode: maxBatches caps batch count on partitioned input (passContent=false)",
+  async ({ helper, expect, stHelper }) => {
+    // The sequence-embeddings configuration: format="tsv", passContent=false.
+    // Before the fix this produced 12 batches of 1 — the cap was computed
+    // against a partition count of 1, so it never engaged.
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "batchTagBlobTsv",
+        partitionedTsv: PARTITIONED_TSV,
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "unused", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsBatchTag }],
+        batch: {
+          size: 1,
+          keyColumns: ["key"],
+          format: "tsv",
+          passContent: false,
+          maxBatches: 3,
+        },
+      }),
+    }));
+
+    const tags = readJsonPartition(theResult.inputs["tsv.batchTag.data"]);
+    expect(Object.keys(tags)).toHaveLength(12);
+
+    const batches = batchesFrom(tags);
+    expect(batches.size).toEqual(3);
+    expect(Object.fromEntries(batches)).toEqual(EXPECTED_BATCHES);
+  },
+);
+
+eTplTest.concurrent(
+  "batch mode: maxBatches caps batch count on partitioned input (passContent=true)",
+  async ({ helper, expect, stHelper }) => {
+    // The passContent=true path never recomputed batchCount at all, so it took
+    // the undercounted value straight from the orchestrator: 1 batch of 1 row,
+    // with the remaining 11 rows silently dropped (the slice loop clamps
+    // endLine but never extends batchCount). Asserting all 12 keys survive is
+    // the data-loss regression guard; the batch grouping is the cap check.
+    const theResult = await runBatch(helper, stHelper, (tx) => ({
+      params: jsonParams(tx, {
+        bodyMode: "batchTag",
+        partitionedTsv: PARTITIONED_TSV,
+        primaryEntries: [{ spec: singleAxisSpec, dataInputName: "unused", header: "heavyChain" }],
+        primaryJoin: "full",
+        outputs: [{ type: "Xsv", name: "tsv", xsvType: "tsv", settings: xsvSettingsBatchTag }],
+        batch: {
+          size: 1,
+          keyColumns: ["key"],
+          format: "tsv",
+          passContent: true,
+          maxBatches: 3,
+        },
+      }),
+    }));
+
+    const tags = readJsonPartition(theResult.inputs["tsv.batchTag.data"]);
+    expect(Object.keys(tags)).toHaveLength(12);
+
+    const batches = batchesFrom(tags);
+    expect(batches.size).toEqual(3);
+    expect(Object.fromEntries(batches)).toEqual(EXPECTED_BATCHES);
+  },
+);


### PR DESCRIPTION
MILAB-6799 
Previous version incorrectly estimate total data size for partitioned data and this lead to wrong maxBatches calculation. This PR fixes the issue

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes batch-count enforcement and row preservation for partitioned PColumn data by moving the authoritative calculation into the split template, where the true per-scope row count is available.

- Recomputes `batchCount` from actual records for both `passContent` modes, preventing partition-count estimates from dropping rows or bypassing the cap.
- Divides the global `maxBatches` budget among isolation scopes and deterministically inflates each scope’s batch size.
- Adds integration fixtures and coverage for inline and partitioned data across content, TSV-blob, and Parquet-blob paths.
- **PColumn** — a typed Platforma data column whose records may be stored inline or in partitions; partitioned PColumns now use their actual row count during splitting.
- **Batch** — a contiguous subset of sorted PColumn rows processed by one body invocation; its size may now be inflated to honor the configured cap.
- **`maxBatches`** — the soft upper bound on the total number of batch invocations; enforcement moves from an unreliable partition-based estimate to per-scope true counts.
- **Isolation scope** — a group of records processed independently according to isolation axes; each scope now receives an equal integer share of the global batch budget.
- **`passContent`** — selects whether batch data is supplied directly as content or as a file reference; both paths now recompute batch counts from authoritative data.
- **`actualRecords`** — the true number of rows in one isolation scope; newly used to derive batch count and effective batch size.
- **`scopeMaxBatches`** — the newly introduced per-isolation-scope share of `maxBatches`, passed from the orchestrator to the split template.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed batch-count paths preserving rows and enforcing the configured global cap.

The authoritative row count is now obtained inside each split scope, cap allocation remains globally bounded, and focused tests cover partitioned inputs along both direct-content and file-reference paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/workflow-tengo/src/pframes/process-pcolumn-batch.tpl.tengo | Allocates the global batch cap across isolation scopes and passes the resulting per-scope budget to split renders. |
| sdk/workflow-tengo/src/pframes/process-pcolumn-batch-split.tpl.tengo | Recomputes batch counts from authoritative per-scope row counts and inflates batch size when necessary. |
| tests/workflow-tengo/src/pframes/proc_batch.tpl.tengo | Extends the integration harness with genuine partitioned inputs and batch-boundary-observing body modes. |
| tests/workflow-tengo/src/pframes/proc_batch_filter.test.ts | Adds observable cap and deterministic-boundary coverage for direct-content and Parquet blob paths. |
| tests/workflow-tengo/src/pframes/proc_batch_max_batches.test.ts | Adds focused regressions proving losslessness and maxBatches enforcement for partitioned TSV inputs in both passContent modes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Partitioned or inline PColumn] --> B[Orchestrator groups isolation scopes]
  B --> C[Assign equal scopeMaxBatches budget]
  C --> D[Split template obtains actualRecords]
  D --> E{Computed batches exceed scope budget?}
  E -- Yes --> F[Inflate batchSize deterministically]
  E -- No --> G[Keep effective batchSize]
  F --> H[Slice and invoke batch body]
  G --> H
  H --> I[Merge batch outputs]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix max batch count for partitioned data"](https://github.com/milaboratory/platforma/commit/b309bd31de2e7a05e660008a2c1fae5e58959bfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54366116)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [workflow-tengo: the block workflow authoring SDK](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/workflow-tengo.md)

<!-- /greptile_comment -->