### PR TITLE
fix: keep the default table sorting alive past the first grid state save

### DIFF
--- a/.changeset/pl-data-table-default-sorting.md
+++ b/.changeset/pl-data-table-default-sorting.md
@@ -1,0 +1,23 @@
+---
+"@platforma-sdk/ui-vue": patch
+---
+
+Keep the default `sorting` passed to `createPlDataTableV3` alive
+
+`resolveSorting` falls back to the block's default sorting only while the
+persisted user sorting is `null` — `[]` means "the user cleared the sorting"
+and deliberately suppresses the default. The grid state never produced that
+`null`: AG Grid omits `sort` from its state while nothing is sorted, and
+`convertAgSortingToPTableSorting` turned the absent state into `[]`.
+
+`onStateUpdated` fires as soon as the grid initialises, so the first persisted
+state entry stamped `sorting: []` and the block's default sorting was dropped
+from that moment on — the sorted column stayed in the table, just unsorted.
+
+The absent sort state now converts to `null`, and `normalizeSort` (next to the
+existing `normalizeColumnVisibility`, which solves the same problem for hidden
+columns) turns it into an explicit `{ sortModel: [] }` only once the grid has
+reported an explicit sort model before — so clearing the sorting by hand still
+suppresses the default. Existing projects recover on the next render without a
+state migration: their stored `gridState.sort` is absent, which now reads as
+"untouched".

--- a/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
+++ b/sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue
@@ -129,7 +129,7 @@ const { gridApi, gridOptions } = useGrid({
 let isReloading = false;
 gridOptions.value.onGridPreDestroyed = (event) => {
   if (!isReloading) {
-    gridOptions.value.initialState = gridState.value = normalizeColumnVisibility(
+    gridOptions.value.initialState = gridState.value = normalizeGridState(
       makePartialState(event.api.getState()),
       gridState.value,
       event.api,
@@ -142,7 +142,7 @@ gridOptions.value.onRowDoubleClicked = (event) => {
   if (event.data && event.data.axesKey) emit("rowDoubleClicked", event.data.axesKey);
 };
 gridOptions.value.onStateUpdated = (event) => {
-  const partialState = normalizeColumnVisibility(
+  const partialState = normalizeGridState(
     makePartialState(event.state),
     gridState.value,
     event.api,
@@ -213,6 +213,42 @@ function makePartialState(state: GridState): PlDataTableGridStateCore {
   };
 }
 
+// AG Grid omits parts of its state that carry no information — columnVisibility
+// when every column is visible, sort when nothing is sorted. The model needs
+// "no state yet" (fall back to the block's defaults) to stay distinguishable
+// from "user explicitly cleared it" (store []), so both are normalized against
+// the previous state before the state is persisted.
+function normalizeGridState(
+  partialState: PlDataTableGridStateCore,
+  prevState: PlDataTableGridStateCore,
+  api: GridApi<PlAgDataTableV2Row>,
+  columnsMeta: PlDataTableColumnsMeta | undefined,
+): PlDataTableGridStateCore {
+  return normalizeSort(
+    normalizeColumnVisibility(partialState, prevState, api, columnsMeta),
+    prevState,
+  );
+}
+
+// AG Grid returns sort: undefined when no column is sorted. Left as-is that
+// erases the block's default sorting the moment any unrelated grid state is
+// persisted, so the undefined is only turned into an explicit empty sort model
+// once the user has actually sorted something before.
+function normalizeSort(
+  partialState: PlDataTableGridStateCore,
+  prevState: PlDataTableGridStateCore,
+): PlDataTableGridStateCore {
+  if (partialState.sort !== undefined) return partialState;
+
+  if (prevState.sort !== undefined) {
+    // Had an explicit sort model before → user cleared the sorting → store [].
+    return { ...partialState, sort: { sortModel: [] } };
+  }
+
+  // Never sorted → leave undefined so the model applies its default sorting.
+  return partialState;
+}
+
 // AG Grid returns columnVisibility: undefined when all columns are visible.
 // We need to distinguish "no state yet" (use isColumnOptional defaults) from
 // "user explicitly showed all columns" (store []). This function normalizes
@@ -264,11 +300,14 @@ function getDefaultHiddenColIds(
     .map((col) => col.getColId() as PlTableColumnIdJson);
 }
 
-// Normalize columnVisibility for comparison: undefined and { hiddenColIds: [] } are equivalent.
+// Normalize for comparison: an absent and an empty columnVisibility / sort mean
+// the same thing to AG Grid, and must not count as a state change to reload on.
 function stateForReloadCompare(state: PlDataTableGridStateCore): PlDataTableGridStateCore {
   const cv = state.columnVisibility;
   const normalizedCv = !cv || cv.hiddenColIds.length === 0 ? undefined : state.columnVisibility;
-  return { ...state, columnVisibility: normalizedCv };
+  const sort = state.sort;
+  const normalizedSort = !sort || sort.sortModel.length === 0 ? undefined : sort;
+  return { ...state, columnVisibility: normalizedCv, sort: normalizedSort };
 }
 
 // Reload AgGrid when new state arrives from server

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.test.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
+import { computed } from "vue";
+
+// The module pulls in uikit for `computedCached`; stub it so the test does not
+// drag the whole component library (and its DOM-time side effects) in.
+vi.mock("@milaboratories/uikit", () => ({
+  computedCached: computed,
+}));
+
+const { convertAgSortingToPTableSorting } = await import("./table-state-v2");
+
+describe("convertAgSortingToPTableSorting", () => {
+  it("reports an absent sort state as untouched, so the model keeps its default sorting", () => {
+    expect(convertAgSortingToPTableSorting(undefined)).toBeNull();
+  });
+
+  it("reports an empty sort model as explicitly cleared, which suppresses the default", () => {
+    expect(convertAgSortingToPTableSorting({ sortModel: [] })).toEqual([]);
+  });
+
+  it("converts a sort model, taking NA/absent as least values only when ascending", () => {
+    const column = { type: "column", id: "colId" };
+    const colId = JSON.stringify(column) as never;
+    expect(
+      convertAgSortingToPTableSorting({
+        sortModel: [
+          { colId, sort: "asc" },
+          { colId, sort: "desc" },
+        ],
+      }),
+    ).toEqual([
+      { column, ascending: true, naAndAbsentAreLeastValues: true },
+      { column, ascending: false, naAndAbsentAreLeastValues: false },
+    ]);
+  });
+});

--- a/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
+++ b/sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts
@@ -413,14 +413,23 @@ function convertPartitionFiltersToFilterSpec(
   });
 }
 
-function convertAgSortingToPTableSorting(state: PlDataTableGridStateCore["sort"]): PTableSorting[] {
-  return (
-    state?.sortModel.map((item) => ({
-      column: parseJson<PTableColumnId>(item.colId),
-      ascending: item.sort === "asc",
-      naAndAbsentAreLeastValues: item.sort === "asc",
-    })) ?? []
-  );
+/**
+ * AG Grid omits `sort` from its state while nothing is sorted, so the absent
+ * state must stay distinguishable from an explicitly emptied sort model: the
+ * model falls back to the block's default sorting on `null` only, and treats
+ * `[]` as "user cleared the sorting" (see `resolveSorting` in
+ * `createPlDataTableV3`). `normalizeSort` in `PlAgDataTableV2.vue` turns the
+ * absent state into `{ sortModel: [] }` once an explicit one has been seen.
+ */
+export function convertAgSortingToPTableSorting(
+  state: PlDataTableGridStateCore["sort"],
+): PTableSorting[] | null {
+  if (isNil(state)) return null;
+  return state.sortModel.map((item) => ({
+    column: parseJson<PTableColumnId>(item.colId),
+    ascending: item.sort === "asc",
+    naAndAbsentAreLeastValues: item.sort === "asc",
+  }));
 }
 
 function getHiddenColIds(


### PR DESCRIPTION
## The problem

The default sorting a block passes to `createPlDataTableV3({ sorting })` applies on the first render and then silently disappears: the sorted column stays in the table, the rows just stop being sorted.

`resolveSorting` (`sdk/model/.../createPlDataTableV3.ts`) reads the persisted user sorting three ways:

- `null` — the user never touched sorting → apply the block's default;
- `[]` — the user explicitly cleared the sorting → suppress the default.

The grid state never produced that `null`. AG Grid omits `sort` from its state while nothing is sorted, and `convertAgSortingToPTableSorting` turned the absent state into `[]`. `onStateUpdated` fires as the grid initialises, so the first entry written to `stateCache` already stamped `sorting: []` and the block's default was gone from that moment on.

Before `@platforma-sdk/model@1.80.0` `resolveSorting` used `isEmpty` instead of `isNil`, so `[]` still fell through to the default and the bug stayed hidden. Going back to `isEmpty` is not the fix — it breaks clearing the sorting by hand.

## The change

- `convertAgSortingToPTableSorting` returns `null` for an absent sort state, and `[]` only for a genuinely empty `sortModel`.
- `normalizeSort` in `PlAgDataTableV2.vue` promotes the absent state to an explicit `{ sortModel: [] }` only once the grid has reported an explicit sort model before — so clearing the sorting by hand still suppresses the default. This is the same treatment the neighbouring `normalizeColumnVisibility` already gives hidden columns; both are now applied through `normalizeGridState`.
- `stateForReloadCompare` treats an empty `sortModel` as equivalent to an absent one, so the promoted `{ sortModel: [] }` does not read as a state change and trigger a grid reload.

## Compatibility

Existing projects recover on the next render without a state migration: their stored `gridState.sort` is absent, which now reads as "untouched".

## Verification

- `pnpm --filter @platforma-sdk/ui-vue run types:check` — no errors in the changed files (the 18 errors elsewhere reproduce on a clean tree).
- `formatter:check`, `linter:check` — clean.
- New unit test `table-state-v2.test.ts` covering the three converter states, plus the package's existing node suites — green. `PlDatasetSelector.jsdomtest.ts` fails on a clean tree too in this environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves a block’s default table sorting until the user explicitly changes or clears sorting, while retaining the distinction between untouched and intentionally empty state.

- **Default sorting** — the block-provided ordering used when no user sorting preference exists; it now survives initial grid-state persistence.
- **Grid sort state** — AG Grid’s optional `sort` object; an omitted object now remains distinguishable from an explicit empty `sortModel`.
- **User sorting** — persisted table ordering selected by the user; `null` means untouched, while `[]` means explicitly cleared.
- **normalizeSort** — the new transition normalizer that promotes an omitted sort to an explicit empty model only after an explicit sorting state previously existed.
- **stateForReloadCompare** — the reload comparison representation; it now treats absent and empty AG Grid sort models as operationally equivalent.
- Adds converter tests for absent, empty, ascending, and descending sort representations.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking concern that its central sort-state transition logic is not directly covered by tests.

The nullable converter matches the receiving schema and model fallback semantics, and AG Grid initialization ordering contradicts the suspected sort-erasure path; only focused regression coverage for normalizeSort remains advisable.

**Files Needing Attention:** sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue; sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.test.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue | Adds transition-aware sort normalization and reload-comparison normalization; the behavior is coherent but lacks direct transition tests. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.ts | Converts absent AG Grid sort state to the nullable untouched representation expected by the table-state schema and model resolver. |
| sdk/ui-vue/src/components/PlAgDataTable/sources/table-state-v2.test.ts | Covers all converter representations but not the new normalizeSort state machine. |
| .changeset/pl-data-table-default-sorting.md | Accurately documents the absent-versus-empty sorting-state fix and compatibility behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[AG Grid state update] --> B{sort present?}
  B -- Yes --> C[Persist explicit sortModel]
  B -- No --> D{Previous sort present?}
  D -- No --> E[Keep sort absent]
  D -- Yes --> F[Persist empty sortModel]
  E --> G[Converter returns null]
  F --> H[Converter returns empty array]
  C --> I[Converter returns user sorting]
  G --> J[Use block default sorting]
  H --> K[Suppress block default]
  I --> L[Use user sorting]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231787%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1787&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asdk%2Fui-vue%2Fsrc%2Fcomponents%2FPlAgDataTable%2FPlAgDataTableV2.vue%3A237-250%0A**Test%20sort-state%20transitions**%0A%0A%60normalizeSort%60%20now%20carries%20the%20central%20three-state%20contract%2C%20but%20the%20added%20tests%20cover%20only%20the%20converter.%20Directly%20test%20that%20untouched%20sorting%20stays%20absent%2C%20explicit%20sorting%20is%20preserved%2C%20and%20clearing%20a%20previous%20sort%20produces%20an%20empty%20model%3B%20otherwise%20a%20regression%20can%20discard%20the%20block%20default%20or%20restore%20it%20after%20the%20user%20clears%20sorting%20without%20failing%20this%20test%20suite.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1787&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
sdk/ui-vue/src/components/PlAgDataTable/PlAgDataTableV2.vue:237-250
**Test sort-state transitions**

`normalizeSort` now carries the central three-state contract, but the added tests cover only the converter. Directly test that untouched sorting stays absent, explicit sorting is preserved, and clearing a previous sort produces an empty model; otherwise a regression can discard the block default or restore it after the user clears sorting without failing this test suite.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep the default table sorting aliv..."](https://github.com/milaboratory/platforma/commit/5070b323c05e54341fe7fb041245b1ce1bea5974) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54441246)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [UI Vue SDK and Component Library](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/ui-vue-sdk.md)

<!-- /greptile_comment -->