### PR TITLE
fix(structurer): init produces a working block

### DIFF
--- a/.changeset/fix-structure-init-installable.md
+++ b/.changeset/fix-structure-init-installable.md
@@ -1,0 +1,7 @@
+---
+'@platforma-sdk/block-tools': patch
+---
+
+Fix `structure init` so a fresh block installs, passes `pnpm run upgrade-sdk`, packs, and releases at 1.0.0. The catalog now carries `typescript` and `@platforma-sdk/block-kind`, the seeded model no longer declares an unused parameter, every module carries a version (`pnpm pack` cannot resolve a `workspace:*` dep without one), and the root gets a `.changeset/` — the config `changeset version` needs, plus an empty changeset so the first release publishes 1.0.0 instead of 1.0.1.
+
+The generated CI workflows now run Node 22, matching the toolchain. A `structure refresh` moves an existing block off Node 20, because the workflow files are engine-owned.

--- a/.changeset/fix-structure-init-installable.md
+++ b/.changeset/fix-structure-init-installable.md
@@ -2,6 +2,6 @@
 '@platforma-sdk/block-tools': patch
 ---
 
-Fix `structure init` so a fresh block installs, passes `pnpm run upgrade-sdk`, packs, and releases at 1.0.0. The catalog now carries `typescript` and `@platforma-sdk/block-kind`, the seeded model no longer declares an unused parameter, every module carries a version (`pnpm pack` cannot resolve a `workspace:*` dep without one), and the root gets a `.changeset/` — the config `changeset version` needs, plus an empty changeset so the first release publishes 1.0.0 instead of 1.0.1.
+Fix `structure init` so a fresh block installs, passes `pnpm run upgrade-sdk`, packs, and releases at 1.0.0. The catalog now carries `typescript` and `@platforma-sdk/block-kind`, the seeded model no longer declares an unused parameter, every module carries a version (`pnpm pack` cannot resolve a `workspace:*` dep without one) — backfilled by a `structure refresh` too, so a block scaffolded earlier stops failing `do-pack`, and the root gets a `.changeset/` — the config `changeset version` needs, plus an empty changeset so the first release publishes 1.0.0 instead of 1.0.1.
 
 The generated CI workflows now run Node 22, matching the toolchain. A `structure refresh` moves an existing block off Node 20, because the workflow files are engine-owned.

--- a/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
+++ b/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
@@ -202,6 +202,45 @@ describe("facade: sibling package privacy", () => {
   });
 });
 
+describe("facade: sibling versions on refresh", () => {
+  // A block scaffolded before the initials seeded `version` carries versionless
+  // sibling manifests. `refresh` never re-runs an initial for a file that
+  // exists, so the bodies have to backfill the field themselves — otherwise
+  // `do-pack` dies on ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL rewriting the
+  // facade's `workspace:*` deps.
+  test("a refresh backfills `version` on versionless siblings", () => {
+    const { fs, ctx } = simulateInit({ vars: VARS });
+    const scopes = ["kind", "model", "ui", "workflow", "test"];
+    for (const scope of scopes) {
+      const p = JSON.parse(fs.read(`${scope}/package.json`));
+      delete p.version;
+      fs.write(`${scope}/package.json`, `${JSON.stringify(p, null, 2)}\n`);
+    }
+
+    const refreshCtx: RunContext = { ...ctx, dryRun: false };
+    expect(() => engineRun(STRUCTURE, fs, refreshCtx, { templates: TEMPLATES })).not.toThrow();
+
+    for (const scope of scopes) {
+      const p = JSON.parse(fs.read(`${scope}/package.json`));
+      expect(p.version, `${scope} must be versioned after refresh`).toBe(INITIAL_MODULE_VERSION);
+      // `version` sits right after `name` — the canonical order the formatter
+      // enforces; a backfill appended at the end would fail `oxfmt --check`.
+      expect(Object.keys(p).indexOf("version")).toBe(1);
+    }
+  });
+
+  test("a refresh leaves an existing sibling `version` alone (changesets owns it)", () => {
+    const { fs, ctx } = simulateInit({ vars: VARS });
+    const bumped = JSON.parse(fs.read("model/package.json"));
+    bumped.version = "3.4.5";
+    fs.write("model/package.json", `${JSON.stringify(bumped, null, 2)}\n`);
+
+    engineRun(STRUCTURE, fs, { ...ctx, dryRun: false }, { templates: TEMPLATES });
+
+    expect(JSON.parse(fs.read("model/package.json")).version).toBe("3.4.5");
+  });
+});
+
 describe("facade: legacy shim cleanup on refresh", () => {
   test("a refresh removes a pre-existing block/index.js + index.d.ts, then is idempotent", () => {
     const { fs, ctx } = simulateInit({ vars: VARS });

--- a/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
+++ b/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
@@ -9,6 +9,7 @@ import { classifyOne, type WorkspacePackage } from "../engine/discovery";
 import { STRUCTURE } from "../structure-definition";
 import { run as engineRun } from "../engine/runner";
 import { defaultTemplateProvider, simulateInit } from "../engine/testing";
+import { INITIAL_MODULE_VERSION } from "../rules/shared/initial-version";
 
 const TEMPLATES = defaultTemplateProvider();
 
@@ -166,12 +167,37 @@ describe("facade: `prepublishOnly` publish target branches on isSdkInternal", ()
 });
 
 describe("facade: sibling package privacy", () => {
-  test("model / ui / workflow / test are `private` with no `version`", () => {
+  // Private but versioned. `pnpm pack` in the facade has to rewrite each
+  // `workspace:*` devDep to a concrete range, so a versionless sibling fails
+  // `do-pack` with ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL. The kind needs
+  // one for a second reason: its own src imports `version` from its
+  // package.json.
+  test("kind / model / ui / workflow / test are `private` and versioned", () => {
     const { fs } = simulateInit({ vars: VARS });
-    for (const scope of ["model", "ui", "workflow", "test"]) {
+    for (const scope of ["kind", "model", "ui", "workflow", "test"]) {
       const p = JSON.parse(fs.read(`${scope}/package.json`));
       expect(p.private, `${scope} must be private`).toBe(true);
-      expect("version" in p, `${scope} must not carry a version`).toBe(false);
+      expect(p.version, `${scope} must carry a version`).toBe(INITIAL_MODULE_VERSION);
+    }
+  });
+
+  test("every `workspace:*` dep of the facade resolves to a versioned package", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    const facade = JSON.parse(fs.read("block/package.json"));
+    const byName = new Map<string, string | undefined>();
+    for (const scope of ["kind", "model", "ui", "workflow", "test"]) {
+      const p = JSON.parse(fs.read(`${scope}/package.json`));
+      byName.set(p.name, p.version);
+    }
+
+    const workspaceDeps = Object.entries({
+      ...facade.dependencies,
+      ...facade.devDependencies,
+    }).filter(([, spec]) => String(spec).startsWith("workspace:"));
+    expect(workspaceDeps.length).toBeGreaterThan(0);
+
+    for (const [name] of workspaceDeps) {
+      expect(byName.get(name), `${name} is a workspace dep with no version`).toBeDefined();
     }
   });
 });

--- a/tools/block-tools/src/structure/__tests__/init-catalog-completeness.test.ts
+++ b/tools/block-tools/src/structure/__tests__/init-catalog-completeness.test.ts
@@ -1,0 +1,86 @@
+// One `"x": "catalog:"` with no `x` catalog key fails the whole `pnpm install`
+// with ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC. The dep sets live in
+// `rules/*-package-json.ts` and the catalog in `rules/root-pnpm-workspace.ts`;
+// nothing else ties the two together.
+
+import { describe, test, expect } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { simulateInit } from "../engine/testing";
+import { MemoryFileSystem } from "../engine/fs/memory";
+import { SDK_CATALOG_PACKAGES, DERIVED_CATALOG_PINS } from "../rules/root-pnpm-workspace";
+import type { BlockVars } from "../engine/api";
+
+const DEP_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+const BASE_VARS: BlockVars = {
+  facadeName: "@platforma-open/test-org.demo",
+  baseName: "test-org.demo",
+  npmOrg: "@platforma-open",
+  orgScope: "test-org",
+  shortName: "demo",
+};
+
+// Distinct mock versions, so a wrong-name lookup cannot pass by accident.
+const registryLookup = (name: string): string | undefined =>
+  SDK_CATALOG_PACKAGES.includes(name) ? "9.9.9" : undefined;
+const derivedPinLookup = (entry: string): string | undefined =>
+  DERIVED_CATALOG_PINS.some((pin) => pin.entry === entry) ? "8.8.8" : undefined;
+
+/** `path → catalog-referencing dep names`, over every package.json written. */
+function catalogReferences(fs: MemoryFileSystem): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const path of fs.list("")) {
+    if (!path.endsWith("package.json")) continue;
+    const manifest = JSON.parse(fs.read(path)) as Record<string, unknown>;
+    const names: string[] = [];
+    for (const section of DEP_SECTIONS) {
+      const deps = manifest[section];
+      if (typeof deps !== "object" || deps === null) continue;
+      for (const [name, spec] of Object.entries(deps as Record<string, string>)) {
+        if (spec === "catalog:") names.push(name);
+      }
+    }
+    if (names.length > 0) out.set(path, names);
+  }
+  return out;
+}
+
+function catalogOf(fs: MemoryFileSystem): Record<string, string> {
+  const parsed = parseYaml(fs.read("pnpm-workspace.yaml")) as {
+    catalog?: Record<string, string>;
+  };
+  return parsed.catalog ?? {};
+}
+
+describe("init output is installable: every `catalog:` dep has a catalog entry", () => {
+  for (const [shape, vars] of [
+    ["without software", BASE_VARS],
+    ["with software", { ...BASE_VARS, softwarePlatform: "python" }],
+  ] as const) {
+    test(`a block ${shape}`, () => {
+      const { fs } = simulateInit({ vars, registryLookup, derivedPinLookup });
+      const catalog = catalogOf(fs);
+      const references = catalogReferences(fs);
+
+      // Guard the guard: a walk that finds nothing would pass vacuously.
+      expect(references.size).toBeGreaterThan(0);
+
+      for (const [path, names] of references) {
+        for (const name of names) {
+          expect(
+            catalog[name],
+            `${path} declares "${name}": "catalog:", but pnpm-workspace.yaml has no ` +
+              `'${name}' catalog entry — pnpm install fails with ` +
+              `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC. Add it to ` +
+              `SDK_CATALOG_PACKAGES or INFRA_CATALOG_FLOOR in rules/root-pnpm-workspace.ts.`,
+          ).toBeDefined();
+        }
+      }
+    });
+  }
+});

--- a/tools/block-tools/src/structure/__tests__/init-lint-clean.test.ts
+++ b/tools/block-tools/src/structure/__tests__/init-lint-clean.test.ts
@@ -1,0 +1,84 @@
+// `ts-builder format` runs oxlint with `--deny-warnings`, so one unused
+// parameter in a seeded file fails `pnpm fmt` — the last step of `upgrade-sdk`.
+
+import { describe, test, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { simulateInit } from "../engine/testing";
+import type { BlockVars } from "../engine/api";
+
+const VARS: BlockVars = {
+  facadeName: "@platforma-open/test-org.demo",
+  baseName: "test-org.demo",
+  npmOrg: "@platforma-open",
+  orgScope: "test-org",
+  shortName: "demo",
+};
+
+function resolveTsBuilderConfig(configFile: string): string {
+  return fileURLToPath(import.meta.resolve(`@milaboratories/ts-builder/configs/${configFile}`));
+}
+
+/** ts-builder pins its own oxlint, so block-tools' PATH copy is a different
+ *  version. */
+function resolveOxlintBinary(): string | undefined {
+  const configsDir = path.dirname(resolveTsBuilderConfig("oxlint-base.json"));
+  const binary = path.resolve(configsDir, "..", "..", "node_modules", ".bin", "oxlint");
+  return existsSync(binary) ? binary : undefined;
+}
+
+/** The scopes whose `fmt` script lints. */
+const LINTED_SCOPES = ["kind", "model", "test", "ui"];
+
+describe("init output is lint-clean (oxlint --deny-warnings)", () => {
+  const oxlint = resolveOxlintBinary();
+
+  test.runIf(oxlint)("every seeded source passes its scope's oxlint config", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    const root = mkdtempSync(path.join(tmpdir(), "init-lint-clean-"));
+
+    for (const scope of LINTED_SCOPES) {
+      const configPath = `${scope}/.oxlintrc.json`;
+      expect(fs.exists(configPath), `${scope} must carry an .oxlintrc.json`).toBe(true);
+
+      // The generated `extends` are relative to an installed node_modules.
+      const config = JSON.parse(fs.read(configPath)) as { extends?: string[] };
+      const extendsAbsolute = (config.extends ?? []).map((entry) =>
+        resolveTsBuilderConfig(path.basename(entry)),
+      );
+      expect(
+        extendsAbsolute.length,
+        `${scope}/.oxlintrc.json must extend a config`,
+      ).toBeGreaterThan(0);
+
+      mkdirSync(path.join(root, scope), { recursive: true });
+      writeFileSync(
+        path.join(root, scope, ".oxlintrc.json"),
+        JSON.stringify({ ...config, extends: extendsAbsolute }),
+      );
+      for (const file of fs.list(`${scope}/src`)) {
+        const target = path.join(root, file);
+        mkdirSync(path.dirname(target), { recursive: true });
+        writeFileSync(target, fs.read(file));
+      }
+
+      const result = spawnSync(
+        oxlint!,
+        ["--config", path.join(root, scope, ".oxlintrc.json"), "--deny-warnings", "src"],
+        { cwd: path.join(root, scope), encoding: "utf-8" },
+      );
+      expect(
+        result.status,
+        `seeded ${scope}/src is not lint-clean, so \`pnpm run fmt\` (and with it ` +
+          `\`pnpm run upgrade-sdk\`) fails on a fresh block:\n${result.stdout}\n${result.stderr}`,
+      ).toBe(0);
+    }
+  });
+
+  if (!oxlint) {
+    test.skip("oxlint binary unavailable — skipping lint-clean guard", () => {});
+  }
+});

--- a/tools/block-tools/src/structure/__tests__/model-package-json.snapshot.test.ts
+++ b/tools/block-tools/src/structure/__tests__/model-package-json.snapshot.test.ts
@@ -9,6 +9,7 @@ import type { BlockVars } from "../engine/api";
 
 const EXPECTED_MODEL_PACKAGE_JSON = `{
   "name": "@platforma-open/test-org.demo.model",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "dist/index.cjs",

--- a/tools/block-tools/src/structure/__tests__/root-changeset-config.test.ts
+++ b/tools/block-tools/src/structure/__tests__/root-changeset-config.test.ts
@@ -1,0 +1,94 @@
+// CI runs `pnpm run version-packages` on every PR, so a block with no
+// `.changeset/config.json` fails its first CI run.
+
+import { describe, test, expect } from "vitest";
+import { simulateInit, defaultTemplateProvider } from "../engine/testing";
+import { run as engineRun } from "../engine/runner";
+import { discoverRunContext } from "../engine/discovery-fs";
+import { STRUCTURE } from "../structure-definition";
+import { MemoryFileSystem } from "../engine/fs/memory";
+import type { BlockVars } from "../engine/api";
+
+const VARS: BlockVars = {
+  facadeName: "@platforma-open/test-org.demo",
+  baseName: "test-org.demo",
+  npmOrg: "@platforma-open",
+  orgScope: "test-org",
+  shortName: "demo",
+};
+
+const PATH = ".changeset/config.json";
+
+function refresh(fs: MemoryFileSystem, isSdkInternal = false) {
+  return engineRun(STRUCTURE, fs, discoverRunContext({ fs, isSdkInternal }), {
+    templates: defaultTemplateProvider(),
+    rediscover: () => discoverRunContext({ fs, isSdkInternal, dryRun: true }),
+  });
+}
+
+describe("root .changeset/config.json", () => {
+  test("init writes the config CI needs", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    const config = JSON.parse(fs.read(PATH));
+    expect(config.changelog).toBe("@changesets/cli/changelog");
+    expect(config.commit).toBe(false);
+    expect(config.access).toBe("restricted");
+    expect(config.baseBranch).toBe("main");
+    expect(config.updateInternalDependencies).toBe("patch");
+  });
+
+  test("refresh creates it for a block that predates the rule", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    fs.delete(".changeset");
+    expect(fs.exists(PATH)).toBe(false);
+
+    refresh(fs);
+    expect(JSON.parse(fs.read(PATH)).baseBranch).toBe("main");
+  });
+
+  test("refresh keeps author-owned lists and re-asserts the CI fields", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    const authored = {
+      ...JSON.parse(fs.read(PATH)),
+      $schema: "https://unpkg.com/@changesets/config@3.0.2/schema.json",
+      ignore: ["@platforma-open/test-org.demo.ui"],
+      access: "public",
+      "//privatePackages": "a note the author added",
+    };
+    fs.write(PATH, JSON.stringify(authored, null, 2));
+
+    refresh(fs);
+    const after = JSON.parse(fs.read(PATH));
+    expect(after.ignore).toEqual(["@platforma-open/test-org.demo.ui"]);
+    expect(after.$schema).toBe("https://unpkg.com/@changesets/config@3.0.2/schema.json");
+    expect(after["//privatePackages"]).toBe("a note the author added");
+    expect(after.access).toBe("restricted");
+  });
+
+  test("sdk-internal blocks get no config — the monorepo owns it", () => {
+    const { fs } = simulateInit({ vars: VARS, isSdkInternal: true });
+    expect(fs.exists(PATH)).toBe(false);
+  });
+});
+
+describe("root .changeset/scaffold.md", () => {
+  const SEED = ".changeset/scaffold.md";
+
+  // An empty changeset names no package, so `changeset version` consumes it
+  // without bumping. That is what keeps the first RELEASED facade version at
+  // 1.0.0 instead of 1.0.1, and it passes CI's require-package-path-bump gate.
+  test("init seeds an empty changeset — no package named", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    const body = fs.read(SEED);
+    expect(body.startsWith("---\n---\n")).toBe(true);
+    expect(body).not.toContain(VARS.facadeName);
+  });
+
+  test("refresh does not resurrect it once a release consumed it", () => {
+    const { fs } = simulateInit({ vars: VARS });
+    fs.delete(SEED);
+
+    refresh(fs);
+    expect(fs.exists(SEED)).toBe(false);
+  });
+});

--- a/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
+++ b/tools/block-tools/src/structure/__tests__/root-ci-workflows.test.ts
@@ -37,6 +37,9 @@ describe("root CI workflows (fixed, generated)", () => {
     // Shared constants.
     expect(build).toContain("team-id: 'ciplopen'");
     expect(build).toContain("test: true");
+    // Both workflows track the toolchain's node major (mise pins 22).
+    expect(build).toContain("node-version: '22.x'");
+    expect(fs.read(MARK_STABLE)).toContain("node-version: '22.x'");
     // Opt-in gate: the published `block` package must be bumped on PRs.
     expect(build).toContain("require-package-path-bump: true");
     // No bare `build` script exists (root-package-json removes it), so both

--- a/tools/block-tools/src/structure/engine/testing.ts
+++ b/tools/block-tools/src/structure/engine/testing.ts
@@ -45,6 +45,9 @@ export type SimulateInitInput = {
    *  Absent → the SDK catalog keeps its seed versions (no bump), matching
    *  an offline scaffold; tests that assert init writes latest pass a mock. */
   registryLookup?: (packageName: string) => string | undefined;
+  /** Sync lookup for the derived catalog pins. Absent → those entries are
+   *  left out of the catalog; the real `init` always passes one. */
+  derivedPinLookup?: (catalogEntry: string) => string | undefined;
 };
 
 export type SimulatedInit = {
@@ -84,6 +87,7 @@ export function simulateInit(input: SimulateInitInput): SimulatedInit {
     templates,
     initMode: true,
     registryLookup: input.registryLookup,
+    derivedPinLookup: input.derivedPinLookup,
   });
 
   // Re-discover from the written FS — the returned ctx is what `check`

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -18,6 +18,7 @@ import {
 } from "../engine/api";
 import { findModules, scopeDepMaps } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 
 /** Per-org publish coordinates: the S3 upload bucket and the public registry
  *  serve URL the facade's `prepublishOnly` script passes to `block-tools
@@ -177,7 +178,7 @@ export function blockPackageJsonInitial(ctx: RunContext): Record<string, unknown
   assertBlockFieldsFilled(block);
   return {
     name: `${v.facadeName}.block`,
-    version: "1.0.0",
+    version: INITIAL_MODULE_VERSION,
     // Facade is ESM: rolldown-plugin-dts requires it, and the BlockPointer's
     // `import.meta.url` path math needs it.
     type: "module",

--- a/tools/block-tools/src/structure/rules/kind-package-json.ts
+++ b/tools/block-tools/src/structure/rules/kind-package-json.ts
@@ -29,7 +29,7 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
-import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
+import { ensureModuleVersion, INITIAL_MODULE_VERSION } from "./shared/initial-version";
 
 const KIND_EXPORTS = {
   ".": {
@@ -83,7 +83,9 @@ export function kindPackageJsonInitial(ctx: RunContext): Record<string, unknown>
 export function kindPackageJsonRules(): void {
   // Controlled sibling — workspace-only, never published to npm. `private: true`
   // makes npm refuse to publish it; the `version` is kept (changesets-owned) and
-  // is what the kind's on-wire `{name}@{version}` reference is baked from.
+  // is what the kind's on-wire `{name}@{version}` reference is baked from — only
+  // backfilled when the manifest predates the seeded field.
+  ensureModuleVersion();
   ensureField("private", true);
 
   ensureField("type", "module");

--- a/tools/block-tools/src/structure/rules/kind-package-json.ts
+++ b/tools/block-tools/src/structure/rules/kind-package-json.ts
@@ -29,6 +29,7 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 
 const KIND_EXPORTS = {
   ".": {
@@ -44,6 +45,7 @@ export function kindPackageJsonInitial(ctx: RunContext): Record<string, unknown>
   const v = ctx.blockVars;
   return {
     name: `${v.facadeName}.kind`,
+    version: INITIAL_MODULE_VERSION,
     private: true,
     type: "module",
     // `main` is the CommonJS entry (require fallback), `module` the ESM one —

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -28,7 +28,7 @@ import {
 } from "../engine/api";
 import { scopeDepMaps } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
-import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
+import { ensureModuleVersion, INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
@@ -79,7 +79,9 @@ export function modelPackageJsonInitial(ctx: RunContext): Record<string, unknown
 export function modelPackageJsonRules(): void {
   // Controlled sibling — workspace-only, never published. `private: true` makes
   // npm refuse to publish it; the `version` is kept (changesets-owned) so the
-  // packed template's lib carries a version.
+  // packed template's lib carries a version, and backfilled when the manifest
+  // predates the seeded field.
+  ensureModuleVersion();
   ensureField("private", true);
 
   ensureField("type", "module");

--- a/tools/block-tools/src/structure/rules/model-package-json.ts
+++ b/tools/block-tools/src/structure/rules/model-package-json.ts
@@ -28,6 +28,7 @@ import {
 } from "../engine/api";
 import { scopeDepMaps } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
@@ -35,6 +36,7 @@ export function modelPackageJsonInitial(ctx: RunContext): Record<string, unknown
   const v = ctx.blockVars;
   return {
     name: `${v.facadeName}.model`,
+    version: INITIAL_MODULE_VERSION,
     private: true,
     type: "module",
     // The block-model build emits both index.cjs and index.js. `main` is

--- a/tools/block-tools/src/structure/rules/root-changeset-config.ts
+++ b/tools/block-tools/src/structure/rules/root-changeset-config.ts
@@ -1,0 +1,61 @@
+// Root `.changeset/config.json`. CI runs `pnpm run version-packages`
+// (`changeset version`) on every PR and sets `require-package-path-bump`, so a
+// block without this file fails its first CI run with "There is no .changeset
+// folder".
+//
+// Managed, not fixed: `$schema` is whatever `changeset init` last wrote (seven
+// versions are in use across the blocks) and `fixed`/`linked`/`ignore` are
+// author-owned lists. Only the fields CI depends on are re-asserted.
+
+import { ensureField, enforceFieldOrder } from "../engine/api";
+
+/** Seeded so the scaffold's own PR passes the `require-package-path-bump` gate
+ *  without bumping: `changeset version` consumes it and leaves the facade at
+ *  `INITIAL_MODULE_VERSION`, so the first version a user sees is 1.0.0 rather
+ *  than 1.0.1. Seeded (not managed) — a refresh must never resurrect it once
+ *  the first release has consumed it. */
+export const EMPTY_CHANGESET_SEED = `---
+---
+
+Initial release.
+`;
+
+const CHANGELOG = "@changesets/cli/changelog";
+const ACCESS = "restricted";
+const BASE_BRANCH = "main";
+const UPDATE_INTERNAL_DEPENDENCIES = "patch";
+
+const FIELD_ORDER = [
+  "$schema",
+  "changelog",
+  "commit",
+  "fixed",
+  "linked",
+  "access",
+  "baseBranch",
+  "updateInternalDependencies",
+  "ignore",
+];
+
+export function rootChangesetConfigInitial(): Record<string, unknown> {
+  return {
+    $schema: "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+    changelog: CHANGELOG,
+    commit: false,
+    fixed: [],
+    linked: [],
+    access: ACCESS,
+    baseBranch: BASE_BRANCH,
+    updateInternalDependencies: UPDATE_INTERNAL_DEPENDENCIES,
+    ignore: [],
+  };
+}
+
+export function rootChangesetConfigRules(): void {
+  ensureField("changelog", CHANGELOG);
+  ensureField("commit", false);
+  ensureField("access", ACCESS);
+  ensureField("baseBranch", BASE_BRANCH);
+  ensureField("updateInternalDependencies", UPDATE_INTERNAL_DEPENDENCIES);
+  enforceFieldOrder(FIELD_ORDER);
+}

--- a/tools/block-tools/src/structure/rules/root-package-json.ts
+++ b/tools/block-tools/src/structure/rules/root-package-json.ts
@@ -15,6 +15,7 @@ import {
   enforceFieldOrder,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 
 // `variant=all` builds every variant the software declares — docker-vs-binary is not a per-script
 // choice. `no-software` builds placeholder software for validators.
@@ -42,7 +43,7 @@ export function rootPackageJsonInitial(): Record<string, unknown> {
   // No `name`: the root is never published. Body rules re-assert
   // (removeField("name")) as a drift-corrector.
   return {
-    version: "1.0.0",
+    version: INITIAL_MODULE_VERSION,
     private: true,
     scripts: {
       fmt: "turbo run fmt",

--- a/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
+++ b/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
@@ -30,6 +30,7 @@ export const SDK_CATALOG_PACKAGES: readonly string[] = [
   "@platforma-sdk/ui-vue",
   "@platforma-sdk/workflow-tengo",
   "@platforma-sdk/test",
+  "@platforma-sdk/block-kind",
   "@platforma-sdk/block-tools",
   "@platforma-sdk/tengo-builder",
   "@platforma-sdk/package-builder",
@@ -63,6 +64,7 @@ export const INFRA_CATALOG_FLOOR: Record<string, string> = {
   shx: "~0.4.0",
   "@changesets/cli": "~2.29.8",
   vitest: "~4.0.18",
+  typescript: "~5.9.3",
 };
 
 /** Catalog entries whose exact version is DERIVED from the version another

--- a/tools/block-tools/src/structure/rules/root.ts
+++ b/tools/block-tools/src/structure/rules/root.ts
@@ -3,11 +3,16 @@
 // skip this whole scope: the parent monorepo owns root files. Hence the
 // `when(({ ctx }) => !ctx.isSdkInternal, ...)` wrapper.
 
-import { scope, when, fixed, managed, file, generate } from "../engine/api";
+import { scope, when, fixed, managed, seed, file, text, generate } from "../engine/api";
 import { rootPackageJsonInitial, rootPackageJsonRules } from "./root-package-json";
 import { rootTurboJsonInitial, rootTurboJsonRules } from "./root-turbo-json";
 import { rootPnpmWorkspaceInitial, rootPnpmWorkspaceRules } from "./root-pnpm-workspace";
 import { rootGitignoreRules } from "./root-gitignore";
+import {
+  rootChangesetConfigInitial,
+  rootChangesetConfigRules,
+  EMPTY_CHANGESET_SEED,
+} from "./root-changeset-config";
 
 export function rootRules(): void {
   scope("root", () => {
@@ -42,6 +47,15 @@ export function rootRules(): void {
         managed(".gitignore", file("root/.gitignore"), () => {
           rootGitignoreRules();
         });
+
+        managed(
+          ".changeset/config.json",
+          generate(() => rootChangesetConfigInitial()),
+          () => {
+            rootChangesetConfigRules();
+          },
+        );
+        seed(".changeset/scaffold.md", text(EMPTY_CHANGESET_SEED));
       },
     );
   });

--- a/tools/block-tools/src/structure/rules/shared/initial-version.ts
+++ b/tools/block-tools/src/structure/rules/shared/initial-version.ts
@@ -1,4 +1,17 @@
+import { transformAt } from "../../engine/api";
+
 /** Seeded at init for every module. `pnpm pack` rewrites the facade's
  *  `workspace:*` devDeps to concrete ranges, so a versionless sibling breaks
  *  `do-pack`. Changesets owns the field afterwards. */
 export const INITIAL_MODULE_VERSION = "1.0.0";
+
+/** Backfill `version` on a sibling that has none — a block scaffolded before
+ *  the initials seeded the field keeps its versionless manifests through a
+ *  `structure refresh`, and `do-pack` then dies resolving the facade's
+ *  `workspace:*` deps. Never touches an existing value: past init the field
+ *  belongs to changesets. */
+export function ensureModuleVersion(): void {
+  transformAt<unknown>("version", (current) =>
+    typeof current === "string" && current.length > 0 ? current : INITIAL_MODULE_VERSION,
+  );
+}

--- a/tools/block-tools/src/structure/rules/shared/initial-version.ts
+++ b/tools/block-tools/src/structure/rules/shared/initial-version.ts
@@ -1,0 +1,4 @@
+/** Seeded at init for every module. `pnpm pack` rewrites the facade's
+ *  `workspace:*` devDeps to concrete ranges, so a versionless sibling breaks
+ *  `do-pack`. Changesets owns the field afterwards. */
+export const INITIAL_MODULE_VERSION = "1.0.0";

--- a/tools/block-tools/src/structure/rules/software-package-json.ts
+++ b/tools/block-tools/src/structure/rules/software-package-json.ts
@@ -20,7 +20,7 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
-import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
+import { ensureModuleVersion, INITIAL_MODULE_VERSION } from "./shared/initial-version";
 
 // The software-build build/pack commands, shared by the generator and the reconciler. block-tools
 // bundles the build engine, so these are the only build-tool commands a software-build block runs.
@@ -81,6 +81,10 @@ export function softwarePackageJsonRules(): void {
   // but never pushes it — the block then 404s pulling it at runtime. Strip it
   // so a `structure refresh` heals any block that has it.
   removeField("private");
+
+  // A software package publishes, so it must carry a `version`; backfilled when
+  // the manifest predates the seeded field, then owned by changesets.
+  ensureModuleVersion();
 
   ensureField("type", "module");
   ensureField("files", ["./dist/**/*"]);

--- a/tools/block-tools/src/structure/rules/software-package-json.ts
+++ b/tools/block-tools/src/structure/rules/software-package-json.ts
@@ -20,6 +20,7 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 
 // The software-build build/pack commands, shared by the generator and the reconciler. block-tools
 // bundles the build engine, so these are the only build-tool commands a software-build block runs.
@@ -56,6 +57,7 @@ export function softwarePackageJsonInitial(ctx: RunContext): Record<string, unkn
 
   return {
     name: `${v.facadeName}.software`,
+    version: INITIAL_MODULE_VERSION,
     type: "module",
     description: "Block Software",
     files: ["./dist/**/*"],

--- a/tools/block-tools/src/structure/rules/test-package-json.ts
+++ b/tools/block-tools/src/structure/rules/test-package-json.ts
@@ -13,12 +13,14 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
 export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
   const v = ctx.blockVars;
   return {
     name: `${v.facadeName}.test`,
+    version: INITIAL_MODULE_VERSION,
     private: true,
     type: "module",
     scripts: {

--- a/tools/block-tools/src/structure/rules/test-package-json.ts
+++ b/tools/block-tools/src/structure/rules/test-package-json.ts
@@ -13,7 +13,7 @@ import {
   type RunContext,
 } from "../engine/api";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
-import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
+import { ensureModuleVersion, INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
 export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
@@ -44,7 +44,9 @@ export function testPackageJsonInitial(ctx: RunContext): Record<string, unknown>
 export function testPackageJsonRules(): void {
   // Controlled sibling — workspace-only, never published. (The initial already
   // seeds `private: true`; the body re-asserts it. The `version` is kept —
-  // changesets-owned — so the packed template's lib carries a version.)
+  // changesets-owned — so the packed template's lib carries a version, and
+  // backfilled when the manifest predates the seeded field.)
+  ensureModuleVersion();
   ensureField("private", true);
 
   ensureField("type", "module");

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -25,6 +25,7 @@ import {
 } from "../engine/api";
 import { scopeDepMap } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
@@ -32,6 +33,7 @@ export function uiPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
   const v = ctx.blockVars;
   return {
     name: `${v.facadeName}.ui`,
+    version: INITIAL_MODULE_VERSION,
     private: true,
     type: "module",
     scripts: {

--- a/tools/block-tools/src/structure/rules/ui-package-json.ts
+++ b/tools/block-tools/src/structure/rules/ui-package-json.ts
@@ -25,7 +25,7 @@ import {
 } from "../engine/api";
 import { scopeDepMap } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
-import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
+import { ensureModuleVersion, INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
@@ -63,7 +63,9 @@ export function uiPackageJsonInitial(ctx: RunContext): Record<string, unknown> {
 
 export function uiPackageJsonRules(): void {
   // Controlled sibling — workspace-only, never published, but kept versioned
-  // (changesets-owned) so the packed template's lib carries a version.
+  // (changesets-owned) so the packed template's lib carries a version —
+  // backfilled when the manifest predates the seeded field.
+  ensureModuleVersion();
   ensureField("private", true);
 
   ensureField("type", "module");

--- a/tools/block-tools/src/structure/rules/workflow-package-json.ts
+++ b/tools/block-tools/src/structure/rules/workflow-package-json.ts
@@ -18,7 +18,7 @@ import {
 } from "../engine/api";
 import { scopeDepMaps } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
-import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
+import { ensureModuleVersion, INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
@@ -57,7 +57,9 @@ export function workflowPackageJsonInitial(ctx: RunContext): Record<string, unkn
 
 export function workflowPackageJsonRules(): void {
   // Controlled sibling — workspace-only, never published, but kept versioned
-  // (changesets-owned) so the packed template's lib carries a version.
+  // (changesets-owned) so the packed template's lib carries a version —
+  // backfilled when the manifest predates the seeded field.
+  ensureModuleVersion();
   ensureField("private", true);
 
   ensureField("type", "module");

--- a/tools/block-tools/src/structure/rules/workflow-package-json.ts
+++ b/tools/block-tools/src/structure/rules/workflow-package-json.ts
@@ -18,6 +18,7 @@ import {
 } from "../engine/api";
 import { scopeDepMaps } from "../engine/ctx";
 import { canonicalPackageJsonOrder } from "./shared/key-order";
+import { INITIAL_MODULE_VERSION } from "./shared/initial-version";
 import { COLOCATED_TEST_GLOB } from "./shared/colocated-tests";
 import { removeRetiredToolchainDeps } from "./shared/retired-deps";
 
@@ -25,6 +26,7 @@ export function workflowPackageJsonInitial(ctx: RunContext): Record<string, unkn
   const v = ctx.blockVars;
   return {
     name: `${v.facadeName}.workflow`,
+    version: INITIAL_MODULE_VERSION,
     private: true,
     type: "module",
     scripts: {

--- a/tools/block-tools/src/structure/templates/text/model/src/index.tpl.ts
+++ b/tools/block-tools/src/structure/templates/text/model/src/index.tpl.ts
@@ -11,7 +11,7 @@ const dataModel = new DataModelBuilder({ kind })
 
 export const platforma = BlockModelV3.create({ dataModel, kind })
   .args(() => ({}))
-  .templateParams((data) => ({}))
+  .templateParams(() => ({}))
   .sections(() => [{ type: "link", href: "/", label: "Main" }])
   .done();
 

--- a/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml
@@ -24,7 +24,7 @@ jobs:
     with:
       app-name: '${appName}'
       app-name-slug: '${appNameSlug}'
-      node-version: '20.x'
+      node-version: '22.x'
       gha-runner-label: hz-ubuntu-dind
       build-script-name: 'build:dev-local'
       build-before-publish-script-name: 'build:release'

--- a/tools/block-tools/src/structure/templates/text/workflows/mark-stable.tpl.yaml
+++ b/tools/block-tools/src/structure/templates/text/workflows/mark-stable.tpl.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4
     with:
       app-name: '${appName}'
-      node-version: '20.x'
+      node-version: '22.x'
       npmrc-config: |
         {
           "registries": {


### PR DESCRIPTION
A block from `structure init` cannot install. The facade declares `typescript` as a `catalog:` dependency. The kind declares `@platforma-sdk/block-kind`. The generated catalog has neither key, so pnpm stops the install. Add both keys.

The seeded model declares an unused `data` parameter. oxlint runs with `--deny-warnings`, so `pnpm fmt` fails. `upgrade-sdk` ends on `pnpm fmt`. Remove the parameter.

Give every module a version. `pnpm pack` rewrites each `workspace:*` dependency of the facade to a concrete range. It fails when a sibling has no version. The kind also needs one because its own source imports `version` from its package.json.

Add a root `.changeset/` folder. CI runs `changeset version` on every pull request, so a block without the config fails its first CI run. An empty changeset ships beside the config. It satisfies the `require-package-path-bump` gate without a bump, so the first release publishes 1.0.0.

Run Node 22 in the generated CI workflows. The engine owns those files, so a `structure refresh` also moves an existing block off Node 20.

Add tests for each case: catalog completeness, lint-clean seeds, workspace-dependency versions, the changeset config, and the node version.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes freshly initialized block repositories installable, lint-clean, packageable, and compatible with the current CI/release setup. The versioning repair is incomplete for existing blocks processed through `structure refresh`.

- Adds missing pnpm catalog entries for TypeScript and the block-kind SDK.
- Seeds package versions, Changesets configuration, and an empty initial changeset.
- Removes an unused model callback parameter and updates generated workflows to Node 22.
- Adds regression coverage for generated catalogs, linting, versions, Changesets, and workflows.
- **Important touched terms:**
  - **Structure init** — creates a new canonical block repository; it now generates complete catalogs, versioned modules, and Changesets files.
  - **Structure refresh** — reconciles an existing block with engine-owned rules; this PR refreshes workflows and creates missing Changesets files, but does not add versions to existing manifests.
  - **Facade** — the publishable block package that depends on sibling workspace modules; its pack operation now expects every sibling to carry a version.
  - **Catalog** — pnpm’s centralized dependency-version map; it gains `typescript` and `@platforma-sdk/block-kind`.
  - **Changeset** — release metadata consumed by Changesets and CI gates; initialization now seeds configuration and an empty first-PR waiver.
  - **Initial module version** — the shared `1.0.0` seed added to newly generated module manifests.
  - **Engine-owned workflow** — generated CI configuration rewritten by refresh; its Node runtime moves from 20 to 22.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until structure refresh also repairs existing versionless sibling manifests, otherwise upgraded blocks can still fail during packing.

Fresh initialization receives the required versions, but existing managed package manifests bypass initial generators and none of their reconciliation bodies adds the missing field.

**Files Needing Attention:** tools/block-tools/src/structure/rules/kind-package-json.ts and the corresponding model, software, test, UI, and workflow package rules
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/rules/kind-package-json.ts | Seeds the kind package version on creation, but its reconciliation body does not repair an existing versionless manifest. |
| tools/block-tools/src/structure/rules/root-changeset-config.ts | Adds managed Changesets configuration and a correctly formatted empty changeset seed compatible with the reusable CI gate. |
| tools/block-tools/src/structure/rules/root-pnpm-workspace.ts | Adds the two catalog entries needed by generated package manifests. |
| tools/block-tools/src/structure/rules/root.ts | Registers managed Changesets configuration and one-time scaffold seeding for standalone blocks. |
| tools/block-tools/src/structure/templates/text/workflows/build.tpl.yaml | Moves generated build CI to Node 22 while retaining the existing reusable-workflow contract. |
| tools/block-tools/src/structure/__tests__/facade-end-state.test.ts | Covers versioned fresh initialization but misses refresh of pre-existing versionless manifests. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  I[structure init] --> G[Generate package manifests]
  G --> V[Seed module versions at 1.0.0]
  G --> C[Generate complete pnpm catalog]
  G --> CS[Seed Changesets config and empty changeset]
  G --> W[Generate Node 22 workflows]
  R[structure refresh] --> E{Manifest already exists?}
  E -->|No| V
  E -->|Yes| B[Run reconciliation body only]
  B --> M[Missing version remains]
  M --> P[pnpm pack fails resolving workspace dependency]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231788%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1788&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Fblock-tools%2Fsrc%2Fstructure%2Frules%2Fkind-package-json.ts%3A48%0A**Refresh%20leaves%20siblings%20versionless**%0A%0AWhen%20%60structure%20refresh%60%20processes%20a%20block%20created%20before%20this%20change%2C%20the%20existing%20sibling%20manifests%20bypass%20%60kindPackageJsonInitial%60%20and%20the%20other%20initial%20generators%2C%20while%20their%20reconciliation%20bodies%20do%20not%20add%20%60version%60.%20The%20siblings%20remain%20versionless%2C%20causing%20facade%20packing%20to%20fail%20with%20%60ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL%60%20when%20pnpm%20resolves%20the%20%60workspace%3A*%60%20dependencies.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1788&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/block-tools/src/structure/rules/kind-package-json.ts:48
**Refresh leaves siblings versionless**

When `structure refresh` processes a block created before this change, the existing sibling manifests bypass `kindPackageJsonInitial` and the other initial generators, while their reconciliation bodies do not add `version`. The siblings remain versionless, causing facade packing to fail with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` when pnpm resolves the `workspace:*` dependencies.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(structurer): init produces a working..."](https://github.com/milaboratory/platforma/commit/9d67cc43af075d54d8a1e6009487712dc6860da0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54738570)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Block Build Tooling](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-build-tooling.md)

<!-- /greptile_comment -->