### PR TITLE
fix: put block-kind in the SDK catalog membership list

### DIFF
--- a/.changeset/block-kind-catalog-membership.md
+++ b/.changeset/block-kind-catalog-membership.md
@@ -1,0 +1,12 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Add `@platforma-sdk/block-kind` to the SDK catalog membership list.
+
+The kind rule requires the dependency as `sdk:`, which resolves to `catalog:` for a
+standalone block, but `block-kind` was absent from `SDK_CATALOG_PACKAGES` — the only
+list the catalog machinery reads. Nothing seeded the key on `init`, and
+`structure refresh --update-deps-only` had no registry lookup for it, so the version
+was never resolved or bumped. Blocks migrated to structure v2 carried a hand-written
+pin instead, which broke `pnpm install` once that release left the registry.

--- a/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
+++ b/tools/block-tools/src/structure/rules/root-pnpm-workspace.ts
@@ -31,6 +31,7 @@ export const SDK_CATALOG_PACKAGES: readonly string[] = [
   "@platforma-sdk/workflow-tengo",
   "@platforma-sdk/test",
   "@platforma-sdk/block-tools",
+  "@platforma-sdk/block-kind",
   "@platforma-sdk/tengo-builder",
   "@platforma-sdk/package-builder",
   "@milaboratories/ts-builder",


### PR DESCRIPTION
## Problem

`blocks/samples-and-data` could not install: `ERR_PNPM_NO_MATCHING_VERSION No matching version found for @platforma-sdk/block-kind@1.0.0` — and `npm run upgrade-sdk`, whose whole job is to move the catalog forward, left that entry at `1.0.0` while bumping everything around it.

The cause is a hole in the catalog machinery, not a stale pin.

`kind-package-json.ts` requires the dependency as `sdk:`, which resolves to `catalog:` for a standalone block, so every kind module references the catalog key `@platforma-sdk/block-kind`. But the package was missing from `SDK_CATALOG_PACKAGES` — the single list both halves of the version model read:

- `rootPnpmWorkspaceInitial` seeds init placeholders only for members → the key is never created on `init`.
- `buildRegistryLookup` prefetches npm latest only for members, and `rootCatalogBumpRules` calls `ensureCatalogLatest` only for members → `structure refresh --update-deps-only` has nothing to resolve for it and leaves the entry untouched, forever.

So blocks migrated to structure v2 carried a hand-written pin that no rule owned. `samples-and-data` sat on `block-kind@1.0.0`; once that release left the registry (only `1.1.0` is published now), `pnpm install` failed on an unresolvable version, and `upgrade-sdk` could not repair it because the bump skipped exactly the entry that was stale. Every v2-migrated block is exposed to the same failure.

Note the invariant at `root-pnpm-workspace.ts:49` checks the opposite direction — that each *member* matches a bump pattern. There is no check that each `catalog:` a rule *requires* has a version owner, which is why this went unnoticed.

## Change

One line: `@platforma-sdk/block-kind` joins `SDK_CATALOG_PACKAGES`, next to `block-tools`. `init` now seeds the key with the placeholder the bump overwrites, and `--update-deps-only` resolves it to npm latest like every other SDK family.

## Testing

The catalog tests are list-driven (`init-catalog-resolution`, `seed-disjointness`, `root-catalog-bump`), so init resolution, the no-pin-on-refresh guarantee and seed disjointness now cover the new entry with no test edits. `vitest run src/structure` in `tools/block-tools`: 49 files, 256 tests, all pass.

Blocks already holding a dead pin still need one `pnpm-workspace.yaml` bump by hand (or an `upgrade-sdk` run once this ships, which will now rewrite the entry).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `@platforma-sdk/block-kind` to the centralized SDK catalog membership so block initialization and dependency upgrades resolve its current registry version. It also adds a patch changeset for `@platforma-sdk/block-tools`.

- **`SDK_CATALOG_PACKAGES`** — the authoritative set of SDK package names managed through generated pnpm catalogs; this change adds `@platforma-sdk/block-kind`.
- **SDK catalog** — the pnpm dependency-version map shared by generated block packages; initialization now seeds the new member and update-deps refreshes its version.
- **`sdk:` dependency** — a structure-rule dependency marker resolved to `catalog:` for standalone blocks; `block-kind` now has the catalog ownership needed by that resolution.
- **Catalog initialization placeholder** — the intentionally invalid temporary version generated before registry resolution; it is now created for `block-kind` and overwritten with npm latest.
- **Catalog bump rule** — the update path that resolves managed SDK members to registry versions; it now includes `block-kind` through the shared membership list.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new catalog member flowing through the existing initialization and update machinery.

The added package matches the existing SDK bump pattern, is consumed by the same list-driven resolution paths as other SDK packages, and introduces no accepted functional or security failure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/rules/root-pnpm-workspace.ts | Adds `@platforma-sdk/block-kind` to the list that drives catalog seeding, registry lookup, and dependency-version updates; the existing bump-pattern invariant and list-driven tests apply to it. |
| .changeset/block-kind-catalog-membership.md | Correctly records a patch release for `@platforma-sdk/block-tools` and explains the catalog-membership repair. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[SDK_CATALOG_PACKAGES] -->|now includes block-kind| B[Initialize catalog placeholder]
  A --> C[Prefetch npm latest]
  B --> D[Catalog bump rules]
  C --> D
  D --> E[pnpm-workspace.yaml block-kind version]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: put block-kind in the SDK catalog m..."](https://github.com/milaboratory/platforma/commit/3280c4e31fd4caf3c7270f4677633dc0793952a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54740739)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Block Build Tooling](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-build-tooling.md)

<!-- /greptile_comment -->