### PR TITLE
fix(block-tools): keep the mark-stable script on the block facade

### DIFF
--- a/.changeset/keep-mark-stable-script-on-facade.md
+++ b/.changeset/keep-mark-stable-script-on-facade.md
@@ -1,0 +1,17 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+Stop stripping the `mark-stable` script from the block facade on `structure refresh`.
+
+The facade rule carried an unconditional `removeScript("mark-stable")`, classifying the
+script as pre-facade boilerplate. It is not boilerplate: the engine-generated
+`.github/workflows/mark-stable.yaml` calls the reusable
+`milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4`, which does
+`cd block && pnpm run mark-stable`. Blocks migrated to the new layout lost the script and
+their "Mark Platforma Block as Stable" workflow fails with
+`ERR_PNPM_NO_SCRIPT  Missing script: mark-stable`.
+
+This also restores what A-0013 specifies: the engine overwrites the canonical
+`build`/`check`/`prepublishOnly`/`do-pack` scripts and leaves block-specific scripts
+beyond that set alone.

--- a/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
+++ b/tools/block-tools/src/structure/__tests__/facade-end-state.test.ts
@@ -1,7 +1,7 @@
 // Facade end-state coverage — the slim `block/` the structurer emits and
 // enforces: block-scope detection by the top-level `block` field, the four-file
 // `src/` surface + facade `tsconfig.json`, the slim publishable `package.json`,
-// sibling privacy, and legacy-shim cleanup.
+// sibling privacy, legacy-shim cleanup, and author-script preservation.
 
 import { describe, test, expect } from "vitest";
 import type { BlockVars, RunContext } from "../engine/api";
@@ -173,6 +173,26 @@ describe("facade: sibling package privacy", () => {
       expect(p.private, `${scope} must be private`).toBe(true);
       expect("version" in p, `${scope} must not carry a version`).toBe(false);
     }
+  });
+});
+
+describe("facade: author scripts beyond the canonical set survive a refresh", () => {
+  test("a pre-existing `mark-stable` script is preserved", () => {
+    const { fs, ctx } = simulateInit({ vars: VARS });
+    const MARK_STABLE =
+      "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'";
+
+    // `.github/workflows/mark-stable.yaml` (engine-generated) runs
+    // `cd block && pnpm run mark-stable`, so the facade must keep the script.
+    const before = JSON.parse(fs.read("block/package.json"));
+    before.scripts["mark-stable"] = MARK_STABLE;
+    fs.write("block/package.json", `${JSON.stringify(before, null, 2)}\n`);
+
+    const refreshCtx: RunContext = { ...ctx, dryRun: false };
+    expect(() => engineRun(STRUCTURE, fs, refreshCtx, { templates: TEMPLATES })).not.toThrow();
+
+    const after = JSON.parse(fs.read("block/package.json"));
+    expect(after.scripts["mark-stable"]).toBe(MARK_STABLE);
   });
 });
 

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -11,7 +11,6 @@ import {
   ensureDevDep,
   ensureWorkspaceScopeDevDeps,
   requireField,
-  removeScript,
   enforceAlphabeticalOrder,
   enforceFieldOrder,
   type RunContext,
@@ -220,7 +219,10 @@ export function blockPackageJsonRules(ctx: RunContext): void {
 
   const scripts = blockScripts(v.npmOrg, ctx.isSdkInternal);
   for (const [name, command] of Object.entries(scripts)) ensureScript(name, command);
-  removeScript("mark-stable");
+  // Scripts beyond the canonical set are block-author territory — left as-is.
+  // `mark-stable` in particular is invoked by the engine-generated
+  // `.github/workflows/mark-stable.yaml` (which does `cd block && pnpm run
+  // mark-stable`), so stripping it broke that workflow.
 
   // Slim invariant: the facade carries ZERO runtime dependencies. The siblings
   // and the SDK build/publish deps are all devDeps, so `dependencies` ends


### PR DESCRIPTION
## Problem

Blocks migrated to the new project template fail their `Mark Platforma Block as Stable` workflow:

```
ERR_PNPM_NO_SCRIPT  Missing script: mark-stable
```

Example: [clonotype-browser run](https://github.com/platforma-open/clonotype-browser/actions/runs/32249553321/job/96057442294).

The facade rule carried an unconditional `removeScript("mark-stable")` (`tools/block-tools/src/structure/rules/block-package-json.ts`), introduced in `6ff3423b2` with the rationale *"Legacy script from the pre-facade boilerplate — gone in the slim facade"* (comment later dropped in `9b62f2cab`).

It is not boilerplate. The engine itself generates `.github/workflows/mark-stable.yaml` (`rules/root-ci.ts:47`) from `templates/text/workflows/mark-stable.tpl.yaml`, which calls the reusable `milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4` — and that workflow does `cd "${BLOCK_PATH}"` (default `block`) followed by `pnpm run mark-stable`. So the structurer generates a workflow and then removes the script that workflow needs.

The root `"mark-stable": "turbo run mark-stable"` is not a substitute: CI never invokes it, and no package implements the turbo task declared in `rules/root-turbo-json.ts:49`.

The removal also contradicts the spec. A-0013 (facade `package.json`) defines the canonical scripts as `build` / `check` / `prepublishOnly` / `do-pack` and states: *"Block-specific scripts beyond the canonical four — engine leaves them."* `mark-stable` is not mentioned anywhere in the facade project docs — no atom, no decision, no open question.

## Change

- Drop `removeScript("mark-stable")` from the facade rule (and the now-unused import).
- Add a refresh test asserting a pre-existing `mark-stable` survives `structure refresh`. Verified it fails on the current code and passes with the fix.

`pnpm run check` and all 257 structurer tests pass.

## Out of scope

- Restoring the script in the blocks that already lost it. Affected today: `clonotype-browser`, `clonotype-clustering`, `mixcr-clonotyping`, `mixcr-scfv-clonotyping`, `rarefaction`, `samples-and-data`, `antibody-tcr-lead-selection`. This PR only stops the engine from removing it again; each block needs the line back. First one: platforma-open/clonotype-browser#45.
- Whether `mark-stable` should be engine-*ensured* on the facade (so refresh repairs those blocks automatically), or whether the whole mark-stable path should be retired now that `block-tools publish` adds the package to the stable channel unless `--unstable` is passed. Both are real options and need a decision + an atom; neither belongs in a regression fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stops `structure refresh` from deleting a block facade’s pre-existing `mark-stable` script and adds regression coverage for preservation.

- **Block facade** — the slim `block/` package representing the publishable block entry point; refresh now leaves its noncanonical author-defined scripts unchanged.
- **`mark-stable` script** — a package script invoked by the generated stable-release workflow; this PR preserves an existing script but deliberately does not create or restore one.
- **Canonical scripts** — `build`, `check`, `prepublishOnly`, and `do-pack`, whose commands remain managed by the structurer.
- **Structure refresh** — the rule-engine operation that reconciles an existing block repository with the canonical layout; the new test verifies it no longer removes `mark-stable`.
- **Mark-stable workflow** — generated CI that delegates to the reusable GitHub workflow and runs the facade script from `block/`; its contract is unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed behavior.

The rule now preserves the workflow-required facade script without changing canonical-script enforcement, and the regression test exercises the affected refresh path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/rules/block-package-json.ts | Removes the targeted deletion of `mark-stable`, allowing noncanonical author scripts to survive package reconciliation. |
| tools/block-tools/src/structure/__tests__/facade-end-state.test.ts | Adds focused refresh coverage proving that an existing `mark-stable` command is preserved exactly. |
| .changeset/keep-mark-stable-script-on-facade.md | Accurately documents the workflow failure, preservation fix, and patch-level release impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(block-tools): keep the mark-stable s..."](https://github.com/milaboratory/platforma/commit/976be34cc762bbd4f8cd13760dde15e1c28c6238) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54768377)</sub>

**Context used:**

- Knowledge Base — [Block Build Tooling](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/block-build-tooling.md)

<!-- /greptile_comment -->