### PR TITLE
MILAB-1505: pin the canonical id exposed to clients

### DIFF
--- a/.changeset/pl-client-canonical-id-regression-test.md
+++ b/.changeset/pl-client-canonical-id-regression-test.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Add a regression test that pins the canonical id a committed pure resource exposes to clients

--- a/.changeset/pl-client-canonical-id-regression-test.md
+++ b/.changeset/pl-client-canonical-id-regression-test.md
@@ -1,5 +1,5 @@
 ---
-"@milaboratories/pl-client": patch
+"@milaboratories/pl-client": minor
 ---
 
-Add a regression test that pins the canonical id a committed pure resource exposes to clients
+Expose the canonical id of a resource through `PlTransaction.getResourceCanonicalId()`, and pin with a regression test that a committed pure resource reports a non-empty one

--- a/lib/node/pl-client/src/core/canonical_id.test.ts
+++ b/lib/node/pl-client/src/core/canonical_id.test.ts
@@ -1,67 +1,7 @@
-import { getTestLLClient, withTempRoot } from "../test/test_config";
+import { withTempRoot } from "../test/test_config";
 import { StructTestResource, ValueTestResource } from "../helpers/pl";
 import { field } from "./transaction";
-import type { SignedResourceId } from "./types";
-import { parseSignedResourceId } from "./types";
-import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
-import { notEmpty } from "@milaboratories/ts-helpers";
 import { test, expect } from "vitest";
-
-/**
- * Reads the canonical id the server exposes for each resource, in one read-only
- * transaction of its own.
- *
- * The request goes through the low-level client because the high-level
- * {@link PlTransaction.getResourceData} drops the `canonicalId` field of the
- * wire message. The canonical id here is exactly what any API client sees.
- */
-async function readExposedCanonicalIds(ids: SignedResourceId[]): Promise<Uint8Array[]> {
-  // The suite-wide default request timeout is deliberately short (500 ms); this
-  // read runs while the rest of the suite loads the same server, so it gets a
-  // timeout of its own to stay stable.
-  const client = await getTestLLClient({ defaultRequestTimeout: 10_000 });
-  try {
-    const tx = client.createTx(false);
-    try {
-      await tx.send(
-        {
-          oneofKind: "txOpen",
-          txOpen: {
-            name: "readExposedCanonicalIds",
-            writable: TxAPI_Open_Request_WritableTx.NOT_WRITABLE,
-            enableFormattedErrors: false,
-          },
-        },
-        false,
-      );
-
-      const canonicalIds: Uint8Array[] = [];
-      for (const id of ids) {
-        const { globalId, signature } = parseSignedResourceId(id);
-        const response = await tx.send(
-          {
-            oneofKind: "resourceGet",
-            resourceGet: {
-              resourceId: globalId,
-              resourceSignature: signature,
-              loadFields: false,
-              showSoftDeletes: false,
-            },
-          },
-          false,
-        );
-        canonicalIds.push(notEmpty(response.resourceGet.resource).canonicalId);
-      }
-
-      return canonicalIds;
-    } finally {
-      await tx.complete();
-      await tx.await();
-    }
-  } finally {
-    await client.close();
-  }
-}
 
 /**
  * Every pure resource must expose a non-empty canonical id to clients once its
@@ -83,7 +23,10 @@ async function readExposedCanonicalIds(ids: SignedResourceId[]): Promise<Uint8Ar
  * (platform/core/coretest/value_resource_canonical_id_test.go).
  *
  * The read happens in a separate transaction on purpose: the subject is what a
- * client observes after the commit, not what the writing transaction sees.
+ * client observes after the commit, not what the writing transaction sees. It
+ * stays on the same client, because resource signatures are bound to the
+ * session that minted them and a user-role client may not replay them
+ * elsewhere.
  */
 test("pure resources expose a canonical id to clients after commit", async () => {
   await withTempRoot(async (pl) => {
@@ -107,20 +50,23 @@ test("pure resources expose a canonical id to clients after commit", async () =>
       { sync: true },
     );
 
-    // Confirm the resources are what this test claims they are, then check the
-    // canonical id of each one.
-    const [valueData, structData] = await pl.withReadTx("checkResourceKinds", async (tx) => {
-      return await Promise.all([
-        tx.getResourceData(valueId, false),
-        tx.getResourceData(structId, false),
-      ]);
-    });
+    const { valueData, structData, valueCid, structCid } = await pl.withReadTx(
+      "readCanonicalIds",
+      async (tx) => {
+        // Confirm the resources are what this test claims they are, then read
+        // the canonical id the server exposes for each one.
+        return {
+          valueData: await tx.getResourceData(valueId, false),
+          structData: await tx.getResourceData(structId, false),
+          valueCid: await tx.getResourceCanonicalId(valueId),
+          structCid: await tx.getResourceCanonicalId(structId),
+        };
+      },
+    );
 
     expect(valueData.kind).toEqual("Value");
     expect(structData.kind).toEqual("Structural");
     expect(structData.final).toBe(true);
-
-    const [valueCid, structCid] = await readExposedCanonicalIds([valueId, structId]);
 
     expect(
       valueCid.length,

--- a/lib/node/pl-client/src/core/canonical_id.test.ts
+++ b/lib/node/pl-client/src/core/canonical_id.test.ts
@@ -1,0 +1,134 @@
+import { getTestLLClient, withTempRoot } from "../test/test_config";
+import { StructTestResource, ValueTestResource } from "../helpers/pl";
+import { field } from "./transaction";
+import type { SignedResourceId } from "./types";
+import { parseSignedResourceId } from "./types";
+import { TxAPI_Open_Request_WritableTx } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
+import { notEmpty } from "@milaboratories/ts-helpers";
+import { test, expect } from "vitest";
+
+/**
+ * Reads the canonical id the server exposes for each resource, in one read-only
+ * transaction of its own.
+ *
+ * The request goes through the low-level client because the high-level
+ * {@link PlTransaction.getResourceData} drops the `canonicalId` field of the
+ * wire message. The canonical id here is exactly what any API client sees.
+ */
+async function readExposedCanonicalIds(ids: SignedResourceId[]): Promise<Uint8Array[]> {
+  // The suite-wide default request timeout is deliberately short (500 ms); this
+  // read runs while the rest of the suite loads the same server, so it gets a
+  // timeout of its own to stay stable.
+  const client = await getTestLLClient({ defaultRequestTimeout: 10_000 });
+  try {
+    const tx = client.createTx(false);
+    try {
+      await tx.send(
+        {
+          oneofKind: "txOpen",
+          txOpen: {
+            name: "readExposedCanonicalIds",
+            writable: TxAPI_Open_Request_WritableTx.NOT_WRITABLE,
+            enableFormattedErrors: false,
+          },
+        },
+        false,
+      );
+
+      const canonicalIds: Uint8Array[] = [];
+      for (const id of ids) {
+        const { globalId, signature } = parseSignedResourceId(id);
+        const response = await tx.send(
+          {
+            oneofKind: "resourceGet",
+            resourceGet: {
+              resourceId: globalId,
+              resourceSignature: signature,
+              loadFields: false,
+              showSoftDeletes: false,
+            },
+          },
+          false,
+        );
+        canonicalIds.push(notEmpty(response.resourceGet.resource).canonicalId);
+      }
+
+      return canonicalIds;
+    } finally {
+      await tx.complete();
+      await tx.await();
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Every pure resource must expose a non-empty canonical id to clients once its
+ * creating transaction is committed.
+ *
+ * Regression test. The canonical id the server puts on the wire comes from a
+ * single field that only deduplication used to write. Deduplication needs all
+ * inputs final, which never happens for a resource that has no input fields at
+ * all — value and singleton resources. Both therefore reported an empty
+ * canonical id to every client forever, with no state they could reach to fix
+ * it. The defect shipped twice and was found by hand during release
+ * validation, so the check lives here, in a package that both monorepo suites
+ * of the backend CI run on every pull request.
+ *
+ * Singleton resources have the same shape and had the same defect, but the
+ * backend limits their creation to access-controller clients, so a normal API
+ * client cannot build one. The value resource below covers the same code path;
+ * the singleton case is covered by the backend unit test
+ * (platform/core/coretest/value_resource_canonical_id_test.go).
+ *
+ * The read happens in a separate transaction on purpose: the subject is what a
+ * client observes after the commit, not what the writing transaction sees.
+ */
+test("pure resources expose a canonical id to clients after commit", async () => {
+  await withTempRoot(async (pl) => {
+    const [valueId, structId] = await pl.withWriteTx(
+      "createPureResources",
+      async (tx) => {
+        const value = tx.createValue(ValueTestResource, Buffer.from("canonical id test value"));
+        // A structural resource with no fields reaches its final state as soon
+        // as both of its field sets are locked.
+        const struct = tx.createStruct(StructTestResource);
+        tx.lock(struct);
+
+        // Keep both reachable from the client root, so neither is collected
+        // before the reading transaction below.
+        tx.createField(field(tx.clientRoot, "value"), "Dynamic", value);
+        tx.createField(field(tx.clientRoot, "struct"), "Dynamic", struct);
+
+        await tx.commit();
+        return [await value.globalId, await struct.globalId];
+      },
+      { sync: true },
+    );
+
+    // Confirm the resources are what this test claims they are, then check the
+    // canonical id of each one.
+    const [valueData, structData] = await pl.withReadTx("checkResourceKinds", async (tx) => {
+      return await Promise.all([
+        tx.getResourceData(valueId, false),
+        tx.getResourceData(structId, false),
+      ]);
+    });
+
+    expect(valueData.kind).toEqual("Value");
+    expect(structData.kind).toEqual("Structural");
+    expect(structData.final).toBe(true);
+
+    const [valueCid, structCid] = await readExposedCanonicalIds([valueId, structId]);
+
+    expect(
+      valueCid.length,
+      `value resource ${valueId} exposes an empty canonical id`,
+    ).toBeGreaterThan(0);
+    expect(
+      structCid.length,
+      `structural resource ${structId} exposes an empty canonical id`,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -815,6 +815,33 @@ export class PlTransaction {
   }
 
   /**
+   * Returns the canonical id the server reports for the resource, as raw bytes.
+   *
+   * The canonical id identifies a resource by its content: resources that
+   * deduplication treats as the same get the same value. The server fills it in
+   * at different moments of the resource lifecycle — at creation for resources
+   * without input fields, at deduplication for the rest.
+   *
+   * This is the only accessor for the value. {@link getResourceData} drops it,
+   * because everything that method returns keeps its value for the whole life
+   * of the resource, and the canonical id does not. Nothing here is cached:
+   * every call asks the server.
+   */
+  public getResourceCanonicalId(rId: AnyResourceRef): Promise<Uint8Array> {
+    return this.sendSingleAndParse(
+      {
+        oneofKind: "resourceGet",
+        resourceGet: {
+          ...this.toSignedResourceId(rId),
+          loadFields: false,
+          showSoftDeletes: false,
+        },
+      },
+      (r) => notEmpty(r.resourceGet.resource).canonicalId,
+    );
+  }
+
+  /**
    * Inform platform that resource will not get any new input fields.
    * This is required, when client creates resource without schema and wants
    * controller to start calculations.


### PR DESCRIPTION
## What this pins

`ResourceState.ExposedCID()` is the only canonical ID a client ever sees over the API. It returns `effectiveCID`, which used to be written only by deduplication. Deduplication waits for `AllInputsFinal`, which is never true for a resource with no input fields at all — a value or singleton resource. Every such resource therefore reported an **empty canonical ID to every client, forever**, with no state it could reach to fix itself.

The defect shipped undetected and was fixed twice: 4.3.1 special-cased the getter (`if !r.features.IO()`), 4.3.2 replaced that by setting `effectiveCID` at creation time so the getter is unconditional again. It was found by hand during release validation; nothing on the client side checked it.

## The test

`lib/node/pl-client/src/core/canonical_id.test.ts` — `pure resources expose a canonical id to clients after commit`:

1. Creates a value resource and a structural resource brought to its final state (locked, no fields), both attached to the client root.
2. Commits the transaction.
3. In a **separate** transaction, reads both resources back.
4. Requires the exposed canonical id to be non-empty for both.

The read runs in its own transaction on purpose: the subject is what a client observes after the commit, not in-transaction state. It stays on the same client, because resource signatures are bound to the session that minted them and a user-role client may not replay one from another session.

## One API addition

`PlTransaction.getResourceCanonicalId()` — the canonical id had no accessor at all. `getResourceData()` drops the field, because everything it returns keeps its value for the whole life of a resource and the canonical id does not (it appears at creation for resources without input fields, at deduplication for the rest). Not being able to see the value from a client is part of why the defect hid.

### Singleton resources are not covered here

The brief for this work also asked for a singleton resource. A normal API client cannot create one: `access_requirements.go` maps `ResourceCreateSingleton` to `misecurity.AccessControllerOnly`, and the test user gets `PermissionDenied` (`role "u" has no access to this method`). Singletons take the same code path as value resources and are covered by the backend unit test `platform/core/coretest/value_resource_canonical_id_test.go`.

## Which CI runs it

`@milaboratories/pl-client` is in both monorepo suites of the backend test workflow (`core/pl/.github/workflows/test.yaml`: `monorepo-localfs` and `monorepo-k8s-s3` both pass `--filter=@milaboratories/pl-client`), so this check now gates every backend pull request as well as this repo's own PR suite.

## Verification

Against backends built from source, with the test user in the User role (`role: "u"` in the JWT — the role CI uses, which enforces resource signatures):

| Backend | Result |
|---|---|
| `core/pl` @ `release/4.3` (`4.3.2-1-g60d616`, contains the fix) | new test **passes**; full `pl-client` suite green (101 passed, 1 skipped) on 3 consecutive runs from a cold auth-token cache |
| `core/pl` @ tag `v4.3.0` (pre-fix) | new test **fails** on the pinned assertion: `value resource 139|… exposes an empty canonical id: expected 0 to be greater than 0` |

So the test detects the regression it pins.

The first revision of this test read through a second low-level client, which broke on session-scoped resource signatures — reproduced locally from a cold token cache as the same `Unauthenticated desc = invalid resource signature` CI reported, then fixed by keeping the read on the committing client.

`pl-client` `formatter:check`, `linter:check` and `types:check` pass; the repo-wide `pnpm check` pre-push hook passed (293/293 tasks).

## Note on the generated protobuf comment

`canonicalId` in `src/proto-grpc/.../api_types.ts` carries the comment `// could be empty; it depends on the resource lifecycle state`, which is part of why the defect hid. That file is generated from the backend `.proto`, so tightening the wording belongs in `core/pl`, not here.

## Why `test / test` is red on this PR

The job runs the suite against the ECR image `pl:main`. That image is a snapshot of `core/pl` from **10 Aug 2026** (`4.2.14-266-main`, commit `2bee67977`, per the run's own `platforma-dump` artifact), while the fix merged into `pl` `main` on **18 Aug 2026** (`3922d3ad7`). The image predates the fix, so the new test correctly reports the defect it pins:

```
AssertionError: value resource 140|… exposes an empty canonical id: expected 0 to be greater than 0
```

The same test passes against backends built from `core/pl` `main` (`0ba12964e`) and `release/4.3`. `pl`'s image-building workflow has no push-to-`main` trigger (`pull_request` + `workflow_dispatch` only) and the last `main`-ref run, from 10 Aug, is still `waiting` — so nothing has refreshed `pl:main` since. This job goes green once that image is rebuilt from current `main`; it needs no change to this branch.

Note this also means every monorepo pull request is currently tested against a backend more than a week old.
