### PR TITLE
test(workflow-tengo): e2e coverage for running a command in a 10k-file workdir

### DIFF
--- a/tests/workflow-tengo/src/exec/large-workdir.test.ts
+++ b/tests/workflow-tengo/src/exec/large-workdir.test.ts
@@ -1,0 +1,35 @@
+import { Pl } from "@milaboratories/pl-middle-layer";
+import { tplTest } from "@platforma-sdk/test";
+
+/*
+ * End-to-end check for the E2BIG failure on large working directories
+ * (fixed in Platforma 4.3.2): a command must start and complete when its
+ * working directory holds more files than the old inline expected-items list
+ * could carry (~7300 entries).
+ *
+ * `exec.run.large_workdir` fills the working directory with 10000 files and
+ * runs `hello-world` in it. The software has both a binary and a docker
+ * distribution, so the same test covers the local exec runner and the k8s
+ * runner.
+ *
+ * The message carries a random suffix on purpose: an exec step with a stable
+ * CID is deduplicated by the backend, and a cached result would never start a
+ * job at all.
+ */
+tplTest.concurrent(
+  "run-in-workdir-with-10k-files",
+  async ({ helper, expect }) => {
+    const helloText = `Hello from a workdir with 10000 files (${Math.random()})`;
+
+    const result = await helper.renderTemplate(false, "exec.run.large_workdir", ["main"], (tx) => ({
+      text: tx.createValue(Pl.JsonObject, JSON.stringify(helloText)),
+    }));
+    const mainResult = result.computeOutput("main", (a) => a?.getDataAsString());
+
+    expect(await mainResult.awaitStableValue()).eq(helloText + "\n");
+  },
+  // Building 10000 workdir entries means 10000 value resources plus the map
+  // that holds them, all in one transaction. That is slow on the backend, so
+  // the default 15s test timeout is not enough.
+  300_000,
+);

--- a/tests/workflow-tengo/src/exec/run/large_workdir.tpl.tengo
+++ b/tests/workflow-tengo/src/exec/run/large_workdir.tpl.tengo
@@ -1,0 +1,49 @@
+/**
+ * Regression test for the E2BIG failure on large working directories
+ * (fixed in Platforma 4.3.2).
+ *
+ * The k8s runner used to pass the expected-workdir-item list to the job
+ * inline. Above roughly 7300 entries the argument list got larger than the
+ * kernel limit, `execve` returned E2BIG and the job failed before the
+ * container started. The list now goes to the job by path
+ * (`.pl/expected_items` inside the workdir, see
+ * `util/k8s/job_params.go: DefaultExpectedItemsFileName` in the backend).
+ *
+ * The template fills the working directory with 10000 files, which is
+ * comfortably above the ~7300 threshold, then runs a command in it. Do not
+ * lower the count below ~7300: under that number the test passes on the
+ * buggy runner too and gives no coverage. Every file holds one byte, because
+ * the item *count* is what matters here, not the payload size.
+ */
+
+self := import("@platforma-sdk/workflow-tengo:tpl")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+
+self.defineOutputs(["main"])
+
+sw := assets.importSoftware("@platforma-open/milaboratories.software-test-utils:hello-world")
+
+// Number of files to put into the working directory.
+// Keep it above the ~7300 entries that used to break `execve`.
+workdirFileCount := 10000
+
+self.body(func(inputs) {
+	builder := exec.builder().
+		cpu(1).ram("50Mi").
+		software(sw).
+		arg(inputs.text).
+		saveStdoutContent()
+
+	// `writeFile` is the cheapest way to reach the file count: it needs no
+	// blob, no upload and no signature, only a small value resource.
+	for i := 0; i < workdirFileCount; i++ {
+		builder.writeFile("filler/" + string(i) + ".txt", "x")
+	}
+
+	run := builder.run()
+
+	return {
+		main: run.getStdoutContent()
+	}
+})


### PR DESCRIPTION
## What

Adds an end-to-end test that runs a command in a working directory holding 10000 files.

- `tests/workflow-tengo/src/exec/run/large_workdir.tpl.tengo` — fills the workdir with 10000 one-byte files through `exec.builder().writeFile` in a loop, then runs `hello-world` in it and saves stdout.
- `tests/workflow-tengo/src/exec/large-workdir.test.ts` — renders the template and asserts the stdout.

## Why

Platforma 4.3.2 fixed: *"K8s jobs no longer fail to start when the working directory holds more than ~7300 files; the workdir item list is passed to the job by path"*. Before the fix the k8s runner passed the expected-workdir-item list to the job inline; above roughly 7300 entries `execve` returned `E2BIG` and the job failed **before the container started**. `ExpectedItems []string` became `ExpectedItemsFileRelativePath string`, with the list written to `.pl/expected_items` inside the workdir (`util/k8s/job_params.go`, `DefaultExpectedItemsFileName`).

The fix shipped with unit coverage only (`core/pl/util/k8s/template_test.go`, `TestTemplateWithExpectedItemsFile`). Nothing anywhere built a real large workdir and ran a command in it — the defect was found by hand during release validation. This test closes that gap.

## Choices

- **10000 files**, comfortably above the ~7300 threshold. The template carries a comment saying why, so the number is not "optimised" down later. A count under ~7300 passes on the buggy runner and is worthless for this purpose.
- **One byte per file** — the item *count* is what breaks, not the payload size.
- **`writeFile`** rather than `addFile` — no blob, no upload, no signature; just a small value resource per entry.
- **`hello-world`** (`@platforma-open/milaboratories.software-test-utils:hello-world`) because it has both a `docker` and a `binary` entrypoint (verified in `support/small-binaries/hello-world/package.json`), so the same test works under both execution modes.
- The message passed in carries a random suffix: an exec step with a stable CID is deduplicated by the backend, and a cached result would never start a job.

## Execution-mode coverage

- `monorepo-localfs` in `core/pl/.github/workflows/test.yaml` runs `--filter=@platforma-sdk/workflow-tengo-tests` with `PL_PKG_DEV=local` on the local exec runner, so this test gets **binary** coverage now.
- `monorepo-k8s-s3` currently **excludes** that filter (the external software ships no docker image, so the backend fails with `"docker is not set"`). When the filter returns, the same test gets **docker** coverage on the k8s runner. Re-adding it is still blocked on `software-anarci` and `software-conda-empty`, which that CI comment also names.

**Do not overread this.** The original defect is k8s-specific: the local_exec path has no inline-argv mechanism for the expected-item list. The localfs run is therefore *adjacent* coverage — large-workdir handling, workdir fill rules, the new `.pl` service-dir reservation — not the same defect in a second mode. The defect itself is covered only once the k8s filter is back.

## Verification

Local backend built from `core/pl` at `origin/release/4.3` (`60d61697d`, reports `4.3.2-1-g60d616`), local exec runner, `PL_PKG_DEV=local`, 8-core macOS.

- New test alone: **passes, 35.8 s** (44.9 s wall clock including vitest startup).
- Workdir content verified once with a throwaway template that ran `ls filler | wc -l` in the same workdir: output `10000`. That template is not committed (it uses `cmd("/usr/bin/env") bash`, which has no docker equivalent).
- `src/exec` suite (63 tests) with the new test: **63/63 passed, 3 m 05 s**. Baseline without the new test on the same backend: **62/62 passed, 2 m 17 s**. Under suite load the new test takes 62–101 s (it shares two vitest workers with the rest).
- Typecheck (`tsc --noEmit`) and the package's `fmt` (oxlint + oxfmt): clean, no reformatting.
- `changeset status --since=origin/main`: no packages to bump. Only `@platforma-sdk/workflow-tengo-tests` changed, which is `private: true`, and `.changeset/config.json` has `privatePackages: false` — so no changeset entry applies here.

Honest caveats:

- This 8-core laptop is marginal for the concurrent `src/exec` suite. Across five runs, timeout-flakiness hit different files each time (`writable.test.ts` twice, `formula.test.ts` once) both **with and without** the new test; one run was invalid because the local backend was killed mid-run. The two clean back-to-back runs above are the comparison that matters. The new test does add measurable load (~50 s of extra suite wall clock here); CI runners are larger (`--runner-local-cpu=12`, 24 GiB) and the suite already runs with `retry: 2`.
- **Fails-on-buggy-code is unverified.** Reproducing the original failure needs a pre-fix backend (`v4.3.0`) behind a real k8s runner; no k8s runner was available in this environment, and the local exec runner cannot exhibit the defect at all. Treat the test as pinning the fixed behaviour, not as demonstrated to have caught the bug.

No Notion ticket was supplied, and a search of the workspace found no clear match for this defect, so the branch carries no ticket ID.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds end-to-end regression coverage that creates a 10,000-file Tengo execution workdir and verifies that `hello-world` starts and returns the expected stdout. The randomized input prevents backend deduplication from satisfying the test without launching a new execution.

- Adds a Tengo fixture that writes 10,000 one-byte files through `exec.builder().writeFile`.
- Adds a concurrent Vitest case with a five-minute timeout for the resource-heavy render.
- Verifies command execution using software that supports local binary and Kubernetes Docker modes.
- **Important touched terms:**
  - **Large working directory** — An execution workdir containing many staged entries; the new fixture creates 10,000 files, above the historical failure threshold.
  - **E2BIG** — The operating-system error returned when an `execve` argument or environment payload is too large; the test pins successful execution beyond the former inline-list limit.
  - **Tengo template** — A workflow script rendered into Platforma backend resources; this PR adds `exec.run.large_workdir` to construct and execute the large-workdir scenario.
  - **Expected-workdir-item list** — Metadata describing files expected in a managed workdir; the regression scenario exercises the path-based handling that replaced inline transmission.
  - **`writeFile`** — An exec-builder operation that stages value-resource content as a workdir file; the fixture invokes it 10,000 times with one-byte values.
  - **`hello-world`** — The test software executed in the populated workdir; its stdout proves that the command started and completed.
  - **CID deduplication** — Backend reuse of an execution with identical inputs; the randomized message changes the execution identity so each test run starts fresh work.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness or security issues identified in the added regression coverage.

The new test and fixture consistently construct the intended large-workdir condition, force a fresh backend execution, and validate successful command completion through stdout.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/workflow-tengo/src/exec/large-workdir.test.ts | Adds a randomized, extended-timeout integration test that renders the large-workdir fixture and verifies command stdout. |
| tests/workflow-tengo/src/exec/run/large_workdir.tpl.tengo | Adds a Tengo fixture that stages 10,000 files and runs the cross-mode hello-world software in the resulting workdir. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Vitest creates randomized message] --> R[Render exec.run.large_workdir]
  R --> W[Stage 10,000 one-byte files]
  W --> E[Run hello-world in managed workdir]
  E --> S[Save stdout]
  S --> A[Assert message and newline]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(workflow-tengo): run a command in a..."](https://github.com/milaboratory/platforma/commit/b4b30ac65ca3507d83960b29e68c73b6f0569438) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54899791)</sub>

**Context used:**

- Knowledge Base — [workflow-tengo: the block workflow authoring SDK](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/workflow-tengo.md)

<!-- /greptile_comment -->