### PR TITLE
MILAB-6690: align PlElementListItem head icons to top

### DIFF
--- a/.changeset/element-list-item-icons-top.md
+++ b/.changeset/element-list-item-icons-top.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/uikit": patch
+---
+
+PlElementListItem: wrap drag handle and chevron into a single container aligned to the top of the head, so icons stay on the first title line with multiline titles

--- a/lib/ui/uikit/src/components/PlElementList/PlElementListItem.vue
+++ b/lib/ui/uikit/src/components/PlElementList/PlElementListItem.vue
@@ -69,18 +69,20 @@ const emit = defineEmits<{
         ]"
         @click="isExpandable && emit('expand', props.item, props.index)"
       >
-        <div
-          v-if="props.showDragHandle"
-          :class="[$style.action, $style.draggable, { [$style.disable]: !props.isDraggable }]"
-          :data-draggable="props.isDraggable"
-        >
-          <PlIcon16 name="drag-dots" />
+        <div v-if="props.showDragHandle || isExpandable" :class="$style.headIcons">
+          <div
+            v-if="props.showDragHandle"
+            :class="[$style.action, $style.draggable, { [$style.disable]: !props.isDraggable }]"
+            :data-draggable="props.isDraggable"
+          >
+            <PlIcon16 name="drag-dots" />
+          </div>
+          <PlIcon16
+            v-if="isExpandable"
+            :class="[$style.contentChevron, { [$style.opened]: props.isExpanded }]"
+            name="chevron-down"
+          />
         </div>
-        <PlIcon16
-          v-if="isExpandable"
-          :class="[$style.contentChevron, { [$style.opened]: props.isExpanded }]"
-          name="chevron-down"
-        />
 
         <div :class="$style.title">
           <slot name="title" :item="props.item" :index="props.index" />
@@ -192,6 +194,14 @@ const emit = defineEmits<{
   min-height: 40px;
   border-radius: var(--border-radius) var(--border-radius) 0 0;
   background: var(--head-background);
+}
+
+.headIcons {
+  display: flex;
+  align-items: center;
+  align-self: flex-start;
+  height: 24px;
+  flex: 0 0 auto;
 }
 
 .contentChevron {


### PR DESCRIPTION
Wrap the drag handle and the expand chevron of `PlElementListItem` into a single `.headIcons` container and align it to the top of the head row (`align-self: flex-start`, fixed `24px` height).

Previously both icons were direct children of the vertically-centered head, so with a multiline title they drifted to the vertical middle. Now they stay on the first line of the title.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `PlElementListItem` so its drag handle and expansion chevron remain aligned with the top of the head row for multiline titles, and records the UIKit patch release.
- **PlElementListItem** — a UIKit list-row component supporting titles, expandable content, drag handles, and row actions. Its leading icons are now grouped inside a top-aligned `headIcons` container.
- **headIcons** — the new flex container around the drag handle and expansion chevron. It has a fixed 24px height and opts out of vertical centering with `align-self: flex-start`.
- **Drag handle** — the `drag-dots` control used to initiate sortable interaction. Its selector and `data-draggable` contract remain unchanged inside the new container.
- **Expansion chevron** — the icon indicating collapsed or expanded content. Its rotation and expansion behavior remain unchanged while its layout ancestry changes.
- **Changeset** — release metadata consumed by the monorepo publishing workflow. It declares a patch release for `@milaboratories/uikit`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the change is presentational and preserves existing drag, expansion, and event contracts.

The new wrapper keeps the sortable handle attribute and expansion behavior on the same elements, while its dimensions accommodate the existing 24px action and 16px chevron without clipping.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/ui/uikit/src/components/PlElementList/PlElementListItem.vue | Groups the existing leading icons in a 24px top-aligned flex container without changing their selectors, events, or conditional rendering. |
| .changeset/element-list-item-icons-top.md | Correctly records the user-visible layout adjustment as a UIKit patch release. |

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6690: align PlElementListItem head..."](https://github.com/milaboratory/platforma/commit/fdca27404cb37860ebf9aee8fd3774d630ae4be7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56189306)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->