### PR TITLE
chore: emit .vue.d.ts again in browser-lib builds

### DIFF
--- a/.changeset/vue-dts-processor.md
+++ b/.changeset/vue-dts-processor.md
@@ -1,0 +1,9 @@
+---
+"@milaboratories/ts-builder": patch
+"@platforma-sdk/ui-vue": patch
+"@milaboratories/uikit": patch
+---
+
+Restore emission of `*.vue.d.ts` declarations in browser-lib builds.
+
+vite-plugin-dts 5 auto-detects whether to run its Vue program processor, but its detector only scans two directory levels below the package root. Our SFCs live deeper (`src/components/**`), so it fell back to the plain TypeScript processor and silently emitted no `*.vue.d.ts` — while `dist/lib.d.ts` still re-exported those `.vue` specifiers, breaking any consumer that resolves them (e.g. block model facade builds). ts-builder now picks the processor itself.

--- a/etc/blocks/ui-examples/ui/src/pages/PlAdvancedFilterPage.vue
+++ b/etc/blocks/ui-examples/ui/src/pages/PlAdvancedFilterPage.vue
@@ -99,33 +99,6 @@ async function getSuggestOptions({
   }
   return (uniqueValuesByColumnOrAxisId[key] || []).filter((v) => v.label.includes(searchStr));
 }
-async function getSuggestModel({
-  columnId,
-  searchStr,
-  axisIdx,
-}: {
-  columnId: PlAdvancedFilterColumnId;
-  searchStr: string;
-  axisIdx?: number;
-}) {
-  const key = columnIdKey(columnId);
-  if (axisIdx !== undefined) {
-    const axisValues = uniqueValuesByAxisIdx[key]?.[axisIdx];
-    return (
-      axisValues.find((v) => v.value === searchStr) || {
-        value: searchStr,
-        label: `Label of ${searchStr}`,
-      }
-    );
-  }
-  const columnValues = uniqueValuesByColumnOrAxisId[key];
-  return (
-    columnValues.find((v) => v.value === searchStr) || {
-      value: searchStr,
-      label: `Label of ${searchStr}`,
-    }
-  );
-}
 
 const errorState: PlAdvancedFilter = {
   id: Math.random(),
@@ -232,6 +205,10 @@ const filterStates = ref<Record<string, PlAdvancedFilter>>({
 });
 
 const selectedSavedFilters = ref<keyof typeof filterStates.value>("normalState");
+
+function updateFilters(filters: PlAdvancedFilter) {
+  filterStates.value = { ...filterStates.value, [selectedSavedFilters.value]: filters };
+}
 const filterStatesOptions = [
   { value: "normalState", label: "Normal state" },
   { value: "errorState", label: "State with errors" },
@@ -271,11 +248,11 @@ watch(
       </div>
       <div :key="selectedSavedFilters" :class="$style.rightColumn">
         <PlAdvancedFilterComponent
-          v-model:filters="filterStates[selectedSavedFilters] as PlAdvancedFilter"
-          :items="options"
+          :filters="filterStates[selectedSavedFilters]"
+          :on-update-filters="updateFilters"
+          :options="options"
           :enable-dnd="enableDnd"
           :get-suggest-options="getSuggestOptions"
-          :get-suggest-model="getSuggestModel"
         />
       </div>
     </div>

--- a/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
+++ b/sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue
@@ -54,8 +54,6 @@ const props = withDefaults(
     isRemovable: () => true,
     isDraggable: () => true,
 
-    getSuggestModel: undefined,
-
     enableDnd: false,
     enableAddGroupButton: false,
     enableToggling: false,

--- a/tools/ts-builder/src/configs/utils/createViteLibConfig.ts
+++ b/tools/ts-builder/src/configs/utils/createViteLibConfig.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "node:fs";
+import { globSync } from "node:fs";
 import type { ConfigEnv, UserConfig } from "vite";
 import { mergeConfig } from "vite";
 import dts from "vite-plugin-dts";
@@ -25,7 +25,7 @@ export function createViteLibConfig(configEnv: ConfigEnv): UserConfig {
             // live deeper (src/components/**), so the detector misses them, falls back to
             // the plain TS processor and silently emits no *.vue.d.ts — while lib.d.ts
             // still re-exports those .vue specifiers. Decide it ourselves.
-            processor: hasVueFiles("src") ? "vue" : "ts",
+            processor: globSync("src/**/*.vue").length > 0 ? "vue" : "ts",
             compilerOptions: {
               declaration: true,
               declarationMap: true,
@@ -63,14 +63,4 @@ export function createViteLibConfig(configEnv: ConfigEnv): UserConfig {
       },
     },
   } satisfies UserConfig);
-}
-
-// Internals
-
-function hasVueFiles(dir: string): boolean {
-  try {
-    return readdirSync(dir, { recursive: true }).some((entry) => String(entry).endsWith(".vue"));
-  } catch {
-    return false;
-  }
 }

--- a/tools/ts-builder/src/configs/utils/createViteLibConfig.ts
+++ b/tools/ts-builder/src/configs/utils/createViteLibConfig.ts
@@ -1,5 +1,4 @@
 import { readdirSync } from "node:fs";
-import { join } from "node:path";
 import type { ConfigEnv, UserConfig } from "vite";
 import { mergeConfig } from "vite";
 import dts from "vite-plugin-dts";
@@ -26,7 +25,7 @@ export function createViteLibConfig(configEnv: ConfigEnv): UserConfig {
             // live deeper (src/components/**), so the detector misses them, falls back to
             // the plain TS processor and silently emits no *.vue.d.ts — while lib.d.ts
             // still re-exports those .vue specifiers. Decide it ourselves.
-            processor: containsVueFiles("src") ? "vue" : "ts",
+            processor: hasVueFiles("src") ? "vue" : "ts",
             compilerOptions: {
               declaration: true,
               declarationMap: true,
@@ -68,18 +67,10 @@ export function createViteLibConfig(configEnv: ConfigEnv): UserConfig {
 
 // Internals
 
-function containsVueFiles(dir: string): boolean {
-  let entries;
+function hasVueFiles(dir: string): boolean {
   try {
-    entries = readdirSync(dir, { withFileTypes: true });
+    return readdirSync(dir, { recursive: true }).some((entry) => String(entry).endsWith(".vue"));
   } catch {
     return false;
   }
-
-  for (const entry of entries) {
-    if (entry.isFile() && entry.name.endsWith(".vue")) return true;
-    if (entry.isDirectory() && containsVueFiles(join(dir, entry.name))) return true;
-  }
-
-  return false;
 }

--- a/tools/ts-builder/src/configs/utils/createViteLibConfig.ts
+++ b/tools/ts-builder/src/configs/utils/createViteLibConfig.ts
@@ -1,3 +1,5 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import type { ConfigEnv, UserConfig } from "vite";
 import { mergeConfig } from "vite";
 import dts from "vite-plugin-dts";
@@ -19,6 +21,12 @@ export function createViteLibConfig(configEnv: ConfigEnv): UserConfig {
       : [
           libInjectCss(),
           dts({
+            // vite-plugin-dts >= 5 picks its program processor automatically, but its
+            // detector only scans two directory levels below the package root. Our SFCs
+            // live deeper (src/components/**), so the detector misses them, falls back to
+            // the plain TS processor and silently emits no *.vue.d.ts — while lib.d.ts
+            // still re-exports those .vue specifiers. Decide it ourselves.
+            processor: containsVueFiles("src") ? "vue" : "ts",
             compilerOptions: {
               declaration: true,
               declarationMap: true,
@@ -56,4 +64,22 @@ export function createViteLibConfig(configEnv: ConfigEnv): UserConfig {
       },
     },
   } satisfies UserConfig);
+}
+
+// Internals
+
+function containsVueFiles(dir: string): boolean {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith(".vue")) return true;
+    if (entry.isDirectory() && containsVueFiles(join(dir, entry.name))) return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Problem

`@platforma-sdk/ui-vue@1.83.1` stopped publishing `dist/components/**/*.vue.d.ts` while `dist/lib.d.ts` kept re-exporting four `.vue` specifiers. Any consumer that resolves those types fails — e.g. a block model's slim facade build, which inlines every type in the model's public surface and reaches `ui-vue` through `graph-maker/dist/forms`. Blocks are currently pinning `1.83.0` to work around it.

Every version from `1.79.20` through `1.83.0` shipped the declarations; `1.83.1` is the first build produced after the TypeScript 7 migration (#1764).

## Cause

The TS7 migration bumped `vite-plugin-dts` from `^4.5.3` to `^5.0.3`. v5 auto-detects whether to run its Vue program processor, but the detector (`unplugin-dts`) only scans two directory levels below the package root. Our SFCs live in `src/components/**`, `.vue` appears in neither the entry, the `include` globs, nor the tsconfig, so detection returned false, the plain TypeScript processor ran, and no `*.vue.d.ts` was emitted. There is no warning on that path — it only warns when `processor: "ts"` is set explicitly.

`@milaboratories/uikit` (117 SFCs) is affected identically.

## Fix

`ts-builder` picks the processor itself, from a recursive scan of `src`.

## Fallout

Restoring the declarations un-`any`-ed `PlAdvancedFilterComponent` in `etc/blocks/ui-examples` and surfaced a demo page that had drifted from the component: it bound `v-model:filters` (the component takes an `onUpdateFilters` callback prop), passed `:items` instead of `:options`, and passed `:get-suggest-model` — a prop removed in #1301, whose dead `withDefaults` entry was still sitting in the component. All fixed in the second commit.

## Verification

- `sdk/ui-vue`: 39 `*.vue.d.ts` emitted (was 0); all 4 `.vue` re-exports in `dist/lib.d.ts` now resolve.
- `lib/ui/uikit`: 109 `*.vue.d.ts` emitted.
- `lib/other/biowasm-tools` (no SFCs): unchanged, builds via the TS processor.
- `pnpm check`: 293/293 tasks green.

Once this releases, blocks can drop the `@platforma-sdk/ui-vue: 1.83.0` pin.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores Vue declaration emission in browser-library builds and updates the advanced-filter example to conform to its typed component contract.

- Adds recursive `.vue` source detection so `vite-plugin-dts` uses its Vue processor for packages containing SFCs.
- Corrects the `PlAdvancedFilterComponent` example to pass `filters`, `options`, and `onUpdateFilters`, and removes an obsolete prop default.
- Adds patch changesets for `@milaboratories/ts-builder`, `@platforma-sdk/ui-vue`, and `@milaboratories/uikit`.
- **Browser library** — a reusable browser-targeted package built through Vite; its declaration build now explicitly selects a processor based on source contents.
- **Vue Single-File Component (SFC)** — a `.vue` file combining component template, logic, and styling; recursive detection now identifies SFCs nested anywhere under `src`.
- **Vue declaration (`*.vue.d.ts`)** — TypeScript metadata describing an emitted Vue component; these files are emitted again so downstream `.vue` type exports resolve.
- **`vite-plugin-dts` processor** — the declaration-generation implementation, either Vue-aware or plain TypeScript; `ts-builder` now selects `"vue"` for SFC packages and `"ts"` otherwise.
- **`PlAdvancedFilter`** — the typed state representing an advanced filter tree; the example now replaces the selected state through the component’s callback contract.
- **`onUpdateFilters`** — the callback prop through which `PlAdvancedFilterComponent` returns updated filter state; it replaces the example’s unsupported `v-model:filters` binding.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

Current browser-library build entry points run from package roots, the processor selection matches the source layout, and the example’s filter updates conform to the component’s synchronous callback contract.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/ts-builder/src/configs/utils/createViteLibConfig.ts | Recursively detects Vue SFCs under the package source directory and explicitly selects the appropriate declaration processor. |
| etc/blocks/ui-examples/ui/src/pages/PlAdvancedFilterPage.vue | Aligns the example with the current advanced-filter props and immutable update-callback contract. |
| sdk/ui-vue/src/components/PlAdvancedFilter/PlAdvancedFilter.vue | Removes a stale default for a prop that is no longer part of the component interface. |
| .changeset/vue-dts-processor.md | Records patch releases for the shared builder and both browser libraries affected by restored Vue declarations. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Source[src directory] --> Scan{Contains .vue files?}
  Scan -->|Yes| Vue[Vue declaration processor]
  Scan -->|No| TS[TypeScript declaration processor]
  Vue --> VueDTS[Emit JavaScript and *.vue.d.ts]
  TS --> TSDTS[Emit JavaScript and TypeScript declarations]
  VueDTS --> Package[Published browser library]
  TSDTS --> Package
  Package --> Consumer[Downstream type resolution]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix PlAdvancedFilter usage unmask..."](https://github.com/milaboratory/platforma/commit/949d0fcd6256f07fd68495df8a918e17b7cb23f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57541111)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Build and package tools](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/build-and-package-tools.md)
- Knowledge Base — [Developer toolchain and delivery](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/developer-toolchain.md)
- Knowledge Base — [User interface components](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/ui-components.md)
- Knowledge Base — [UIKit component system](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/uikit.md)
</details>


<!-- /greptile_comment -->