### PR TITLE
MILAB-6670: pl-client — list every login method and forward the picked id

### DIFF
--- a/.changeset/pl-client-login-methods.md
+++ b/.changeset/pl-client-login-methods.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-client": minor
+---
+
+Added `loginMethods()`, which returns every login method the backend advertises — of every kind, SSO and basic alike — each keeping its own id, description and kind. `beginSSOLogin`, `loginSSO` and `login` now accept an optional method id to route the login to a specific advertised method; omitting it keeps today's first-match behavior. `ssoConfig()` and `supportedAuthSchemes` are deprecated in favor of `loginMethods()` but remain available with their existing shape.

--- a/lib/node/pl-client/.oxfmtrc.json
+++ b/lib/node/pl-client/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "extends": ["node_modules/@milaboratories/ts-builder/configs/oxfmt.json"],
-  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md", "src/proto-grpc/**"]
+  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md", "src/proto-grpc/**", "proto/**"]
 }

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -1776,8 +1776,13 @@ message AuthAPI {
       // instance. Unique across the entire server.
       string id = 6;
 
-      // description is the human-readable label in case we'd like to render it in UI.
+      // description is the long-form human-readable text a client may render
+      // alongside the title, for example in a tooltip or under the button.
       string description = 7;
+
+      // title is the short human-readable label a client renders for this
+      // method, for example on the sign-in button. Always set.
+      string title = 9;
 
       oneof method {
         BasicAuthMethod basic = 4;
@@ -1789,7 +1794,7 @@ message AuthAPI {
       reserved 2; // string name - replaced by id + description
       reserved 3; // map<string, string> info
 
-      // next free: 8;
+      // next free: 10;
     }
   }
 

--- a/lib/node/pl-client/proto/plapi/plapiproto/api.proto
+++ b/lib/node/pl-client/proto/plapi/plapiproto/api.proto
@@ -608,6 +608,23 @@ message TxAPI {
 
     message Response {
       Tx tx = 1;
+
+      // The token to store and send back as changed_since_token on any later Tree
+      // request. Everything the token denotes has finished committing, and it is
+      // sampled as this transaction opens, so a write that had not committed by
+      // then sits above it while one that had is visible to this transaction's
+      // reads. One token per transaction, however many tree reads it issues.
+      //
+      // Absent on a WRITABLE open, which is issued no token: the walk would see
+      // that transaction's own uncommitted writes (see changed_since_token).
+      //
+      // Store it only after a whole tree response has been applied successfully. A
+      // client that keeps it after a partial apply will never be sent the
+      // resources it dropped. Clear it on tree rebuild, on a root-set change, and
+      // whenever the seed array is invalidated - the server no longer refuses a
+      // token presented against a differently shaped request, so that is the
+      // client's to enforce.
+      bytes next_since_token = 2;
     }
   }
   message Commit {
@@ -961,7 +978,35 @@ message ResourceAPI {
       // are included with deleted_time populated.
       bool show_soft_deletes = 9;
 
-      // next free: 10;
+      // An opaque continuation token, taken verbatim from a previous response's
+      // next_since_token. The server returns bodies only for resources that
+      // changed after the point this token denotes; every other visited resource
+      // gets a body-less frame with resource_unchanged set. Empty or absent (the
+      // default) requests the full tree.
+      //
+      // Clients must not parse, construct or compare this value: its encoding is
+      // server-private and may change without a wire version bump. Store the
+      // token only after applying a whole response successfully.
+      //
+      // A token the server cannot use is answered with the full tree, never with
+      // an error, so it is always safe to send back whatever was last received.
+      // The server detects and ignores a token that does not fit the request it
+      // arrives on - the token is bound to the traversal-shaping parameters
+      // (resource_id, seeds, max_depth, include_kv, show_soft_deletes,
+      // field_filter, traverse_stop_rules), so changing any of them costs one
+      // full tree instead of silently reporting never-sent resources as held.
+      //
+      // Ignored on a WRITABLE transaction, which also receives no
+      // next_since_token: the walk sees that transaction's uncommitted writes, so
+      // delta skipping there could pin a body describing state that never
+      // committed. Poll from a read-only transaction.
+      //
+      // Servers advertise support via "treeChangedSince:v1" in
+      // MaintenanceAPI.Ping.Response.capabilities; old servers ignore this field
+      // and always send the full tree.
+      bytes changed_since_token = 10;
+
+      // next free: 11;
     }
 
     // A single entry point for multi-root tree traversal.
@@ -1049,8 +1094,9 @@ message ResourceAPI {
     // Multi-message
     message Response {
       // Full resource payload. Absent on stop-marker frames (when the server
-      // advertises `treeStopMarker:v1` and traverse_was_stopped is true).
-      // Always populated on normal frames.
+      // advertises `treeStopMarker:v1` and traverse_was_stopped is true) and on
+      // unchanged frames (when resource_unchanged is true). Populated on every
+      // other frame.
       optional Resource resource = 1;
 
       // Populated only when include_kv=true in the request.
@@ -1067,10 +1113,27 @@ message ResourceAPI {
       // are zero/empty.
       bool traverse_was_stopped = 3;
 
-      // Populated only on stop-marker frames (resource is unset).
-      // Zero / empty on normal frames; use resource.resource_id instead.
+      // Populated on frames where resource is unset - stop-marker and unchanged
+      // frames. Zero / empty on frames carrying a resource; use
+      // resource.resource_id instead.
       uint64 resource_id = 4;
       bytes resource_signature = 5;
+
+      // True on a body-less frame emitted for a resource the client already holds:
+      // resource is unset, and resource_id and resource_signature carry the
+      // identity instead. The client keeps everything it holds for that resource,
+      // fields and kv alike, and the traversal still descends into it - an
+      // unchanged parent routinely has changed children.
+      //
+      // Orthogonal to traverse_was_stopped; a frame may set both.
+      //
+      // A resource may appear twice in one response: an unchanged frame, then a
+      // body frame later in the same response. The later frame supersedes the
+      // earlier one, so apply frames in arrival order and treat an unchanged
+      // frame for an unknown resource as benign rather than fatal.
+      bool resource_unchanged = 6;
+
+      // next free: 7;
     }
   }
 
@@ -1735,7 +1798,9 @@ message AuthAPI {
   // before redirecting to the IdP. The current stub implementation forgets the
   // nonce immediately and does not validate it on Login.
   message BeginSSOLogin {
-    message Request {}
+    message Request {
+      optional string idp = 1;
+    }
 
     message PublicPKCE {
       string nonce = 1; // server-issued one-time value
@@ -1790,6 +1855,7 @@ message AuthAPI {
     message BasicCredentials {
       string login = 1;
       string password = 2;
+      optional string idp = 3;
     }
 
     // TokenCredentials accepts any opaque bearer-style string: a controller
@@ -1802,6 +1868,7 @@ message AuthAPI {
     // endpoint after the desktop completes a PKCE exchange.
     message SSOCredentials {
       bytes token_response = 1;
+      optional string idp = 2;
     }
 
     message Request {
@@ -1968,10 +2035,22 @@ message AuthAPI {
   }
 
   message User {
-    // login is the stable identifier of the user — the grant target and the
-    // GetUserRoot key. Further fields (e.g. first name, last name, email) may
-    // be added later without breaking compatibility.
+    // login is the user's provider-facing login identifier and the value clients
+    // pass as a grant target / impersonation subject. It is the only identity a
+    // client needs: the backend resolves it to an internal id that is never
+    // exposed over the API.
     string login = 1;
+    // display_name is the user's human-readable name, mapped from the provider on
+    // login. May be empty for migrated users who have not logged in since upgrade.
+    string display_name = 2;
+    // email is the user's email, mapped from the provider on login. May be empty
+    // when the provider does not supply it or the mapping is disabled.
+    string email = 3;
+    // attributes carries the remaining provider-mapped attributes the client
+    // configured (e.g. full_name, external_id, custom fields), keyed by attribute
+    // name. The default attributes (login, display_name, email) are promoted to
+    // their own fields above and are not repeated here.
+    map<string, string> attributes = 4;
   }
 
   message ListUsers {

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -862,7 +862,9 @@ components:
              desktop, which performs the token exchange as a confidential client.
     AuthAPI_BeginSSOLogin_Request:
       type: object
-      properties: {}
+      properties:
+        idp:
+          type: string
     AuthAPI_BeginSSOLogin_Response:
       type: object
       properties:
@@ -1007,6 +1009,8 @@ components:
           type: string
         password:
           type: string
+        idp:
+          type: string
     AuthAPI_Login_Request:
       type: object
       properties:
@@ -1039,6 +1043,8 @@ components:
         tokenResponse:
           type: string
           format: bytes
+        idp:
+          type: string
       description: |-
         SSOCredentials carries the raw JSON body returned by the IdP's /token
          endpoint after the desktop completes a PKCE exchange.

--- a/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
+++ b/lib/node/pl-client/proto/plapi/plapiproto/openapi.yaml
@@ -3,1777 +3,1784 @@
 
 openapi: 3.0.3
 info:
-  title: Platform API
-  version: 1.0.0
+    title: Platform API
+    version: 1.0.0
 paths:
-  /v1/auth/grant-access:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GrantAccess
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GrantAccess_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GrantAccess_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/jwt-token:
-    post:
-      tags:
-        - Platform
-      description: |-
-        Deprecated: Use Login for session creation and role transitions,
-         and RefreshToken for token renewal. Backends implementing this API always return
-         codes.Unimplemented. Kept here so clients can still call old backends.
-      operationId: Platform_GetJWTToken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GetJWTToken_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GetJWTToken_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/login:
-    post:
-      tags:
-        - Platform
-      description: |-
-        Login authenticates with the given credentials and returns a new Platforma JWT.
-         Every Login call creates a new session. Use RefreshToken to renew an existing one.
-         This method is public: no Authorization header is required.
-      operationId: Platform_Login
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_Login_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_Login_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/methods:
-    get:
-      tags:
-        - Platform
-      description: Authentication
-      operationId: Platform_AuthMethods
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_ListMethods_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/mint-signature:
-    post:
-      tags:
-        - Platform
-      description: |-
-        MintSignature creates a resource signature bound to a target session.
-         Controllers use it during workflow bootstrap to pre-sign resources
-         so the workflow can access them under its own isolated session.
-      operationId: Platform_MintSignature
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_MintSignature_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_MintSignature_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/refresh:
-    post:
-      tags:
-        - Platform
-      description: |-
-        RefreshToken accepts a valid Platforma JWT and re-issues it with the same
-         session ID and role. Only the token expiration may be changed.
-         Workflow-scoped tokens cannot be refreshed; call Login instead.
-         This method is public: no Authorization header is required.
-      operationId: Platform_RefreshToken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_RefreshToken_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_RefreshToken_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/revoke-access:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_RevokeAccess
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_RevokeAccess_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_RevokeAccess_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/session-info:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetSessionInfo
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GetSessionInfo_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GetSessionInfo_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/sso/begin-login:
-    post:
-      tags:
-        - Platform
-      description: |-
-        BeginSSOLogin returns a fresh one-time nonce that the desktop must place
-         into the OIDC auth-request before redirecting to the IdP. Used by the SSO
-         login flow. This method is public: no Authorization header is required.
-      operationId: Platform_BeginSSOLogin
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/auth/user-root:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetUserRoot
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthAPI_GetUserRoot_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthAPI_GetUserRoot_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/aliases-and-urls:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_WriteControllerAliasesAndUrls
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-    delete:
-      tags:
-        - Platform
-      operationId: Platform_RemoveControllerAliasesAndUrls
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/attach-subscription:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerAttachSubscription
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_AttachSubscription_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_AttachSubscription_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/create:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerCreate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Create_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Create_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/deregister:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerDeregister
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Deregister_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Deregister_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/exists:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerExists
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Exists_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Exists_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/features:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerSetFeatures
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_SetFeatures_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_SetFeatures_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-    delete:
-      tags:
-        - Platform
-      operationId: Platform_ControllerClearFeatures
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_ClearFeatures_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_ClearFeatures_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/get:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerGet
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Get_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Get_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/notifications:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetControllerNotifications
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_GetNotifications_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_GetNotifications_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/register:
-    post:
-      tags:
-        - Platform
-      description: Controllers
-      operationId: Platform_ControllerRegister
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Register_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Register_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/update:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ControllerUpdate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_Update_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_Update_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/controller/url:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_GetControllerUrl
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ControllerAPI_GetUrl_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ControllerAPI_GetUrl_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/license:
-    get:
-      tags:
-        - Platform
-      operationId: Platform_License
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MaintenanceAPI_License_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lease/create:
-    post:
-      tags:
-        - Platform
-      description: |-
-        LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
-         Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
-         To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
-      operationId: Platform_LeaseResource
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_Lease_Create_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_Lease_Create_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lease/release:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_ReleaseLease
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_Lease_Release_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_Lease_Release_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lease/update:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_UpdateLease
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_Lease_Update_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_Lease_Update_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/locks/lock/create:
-    post:
-      tags:
-        - Platform
-      description: |-
-        LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
-           - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
-           - list resource's fields, take fields with names set in request
-           - get resolved values of listed fields (IDs of 'ON' resources).
-           - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
+    /v1/auth/grant-access:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GrantAccess
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GrantAccess_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GrantAccess_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/jwt-token:
+        post:
+            tags:
+                - Platform
+            description: |-
+                Deprecated: Use Login for session creation and role transitions,
+                 and RefreshToken for token renewal. Backends implementing this API always return
+                 codes.Unimplemented. Kept here so clients can still call old backends.
+            operationId: Platform_GetJWTToken
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GetJWTToken_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GetJWTToken_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/login:
+        post:
+            tags:
+                - Platform
+            description: |-
+                Login authenticates with the given credentials and returns a new Platforma JWT.
+                 Every Login call creates a new session. Use RefreshToken to renew an existing one.
+                 This method is public: no Authorization header is required.
+            operationId: Platform_Login
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_Login_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_Login_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/methods:
+        get:
+            tags:
+                - Platform
+            description: Authentication
+            operationId: Platform_AuthMethods
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_ListMethods_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/mint-signature:
+        post:
+            tags:
+                - Platform
+            description: |-
+                MintSignature creates a resource signature bound to a target session.
+                 Controllers use it during workflow bootstrap to pre-sign resources
+                 so the workflow can access them under its own isolated session.
+            operationId: Platform_MintSignature
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_MintSignature_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_MintSignature_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/refresh:
+        post:
+            tags:
+                - Platform
+            description: |-
+                RefreshToken accepts a valid Platforma JWT and re-issues it with the same
+                 session ID and role. Only the token expiration may be changed.
+                 Workflow-scoped tokens cannot be refreshed; call Login instead.
+                 This method is public: no Authorization header is required.
+            operationId: Platform_RefreshToken
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_RefreshToken_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_RefreshToken_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/revoke-access:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_RevokeAccess
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_RevokeAccess_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_RevokeAccess_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/session-info:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetSessionInfo
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GetSessionInfo_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GetSessionInfo_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/sso/begin-login:
+        post:
+            tags:
+                - Platform
+            description: |-
+                BeginSSOLogin returns a fresh one-time nonce that the desktop must place
+                 into the OIDC auth-request before redirecting to the IdP. Used by the SSO
+                 login flow. This method is public: no Authorization header is required.
+            operationId: Platform_BeginSSOLogin
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/auth/user-root:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetUserRoot
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AuthAPI_GetUserRoot_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AuthAPI_GetUserRoot_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/aliases-and-urls:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_WriteControllerAliasesAndUrls
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_WriteAliasesAndUrls_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Platform
+            operationId: Platform_RemoveControllerAliasesAndUrls
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_RemoveAliasesAndUrls_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/attach-subscription:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerAttachSubscription
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_AttachSubscription_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_AttachSubscription_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/create:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerCreate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Create_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Create_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/deregister:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerDeregister
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Deregister_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Deregister_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/exists:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerExists
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Exists_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Exists_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/features:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerSetFeatures
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_SetFeatures_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_SetFeatures_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+        delete:
+            tags:
+                - Platform
+            operationId: Platform_ControllerClearFeatures
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_ClearFeatures_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_ClearFeatures_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/get:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerGet
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Get_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Get_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/notifications:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetControllerNotifications
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_GetNotifications_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_GetNotifications_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/register:
+        post:
+            tags:
+                - Platform
+            description: Controllers
+            operationId: Platform_ControllerRegister
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Register_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Register_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/update:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ControllerUpdate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_Update_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_Update_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/controller/url:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_GetControllerUrl
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ControllerAPI_GetUrl_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ControllerAPI_GetUrl_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/license:
+        get:
+            tags:
+                - Platform
+            operationId: Platform_License
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MaintenanceAPI_License_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lease/create:
+        post:
+            tags:
+                - Platform
+            description: |-
+                LeaseResource creates a lease for a resource. A lease is a temporary lock that needs periodic renewal to stay valid.
+                 Leases are a separate mechanism from locks: leases are focused on 'clients', while locks are focused on 'resources'.
+                 To keep the lease active, the client needs the lease ID that is generated when a lease is created and used for lease updates.
+            operationId: Platform_LeaseResource
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_Lease_Create_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_Lease_Create_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lease/release:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_ReleaseLease
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_Lease_Release_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_Lease_Release_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lease/update:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_UpdateLease
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_Lease_Update_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_Lease_Update_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/locks/lock/create:
+        post:
+            tags:
+                - Platform
+            description: |-
+                LockFieldValues gets the resource and obtains a lock on all resolved values of listed fields:
+                   - get the resource that will take the lock ('FOR' resource) (lock cannot be obtained 'FOR' or 'ON' deleted resource)
+                   - list resource's fields, take fields with names set in request
+                   - get resolved values of listed fields (IDs of 'ON' resources).
+                   - acquire lock on all 'ON' resources, marking 'FOR' resource as an owner.
 
-         Lock logic constraints:
-           - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
-             succeeds, while the other fails with an error (no long waiting)
-           - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
-             the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
-           - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
-             being lockable. An attempt to lock a resource that has not become original will fail.
-           - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
-      operationId: Platform_LockFieldValues
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/notifications/get:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_NotificationsGet
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/NotificationAPI_Get_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NotificationAPI_Get_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/ping:
-    get:
-      tags:
-        - Platform
-      description: Various service requests
-      operationId: Platform_Ping
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MaintenanceAPI_Ping_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/resource-types:
-    get:
-      tags:
-        - Platform
-      description: Other stuff
-      operationId: Platform_ListResourceTypes
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MiscAPI_ListResourceTypes_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/subscription/attach-filter:
-    post:
-      tags:
-        - Platform
-      description: Subscriptions
-      operationId: Platform_SubscriptionAttachFilter
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SubscriptionAPI_AttachFilter_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionAPI_AttachFilter_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/subscription/detach-filter:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_SubscriptionDetachFilter
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SubscriptionAPI_DetachFilter_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionAPI_DetachFilter_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
-  /v1/tx-sync:
-    post:
-      tags:
-        - Platform
-      operationId: Platform_TxSync
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TxAPI_Sync_Request"
-        required: true
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TxAPI_Sync_Response"
-        default:
-          description: Default error response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Status"
+                 Lock logic constraints:
+                   - Locking is optimistic: if two processes try to obtain a lock on the same resource, one of them
+                     succeeds, while the other fails with an error (no long waiting)
+                   - Only resolved reference can be locked: to obtain a lock for a particular field's value, the backend needs to know
+                     the resource ID this field points to. Unless all listed field references are resolved to a final ID, the lock will fail.
+                   - Only an original resource can be locked: if a resource is 'pure' (supports deduplication), it has to pass deduplication before
+                     being lockable. An attempt to lock a resource that has not become original will fail.
+                   - Locking is a one-way operation: it cannot be 'released' or 'revoked'.
+            operationId: Platform_LockFieldValues
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/notifications/get:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_NotificationsGet
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/NotificationAPI_Get_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/NotificationAPI_Get_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/ping:
+        get:
+            tags:
+                - Platform
+            description: Various service requests
+            operationId: Platform_Ping
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MaintenanceAPI_Ping_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/resource-types:
+        get:
+            tags:
+                - Platform
+            description: Other stuff
+            operationId: Platform_ListResourceTypes
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MiscAPI_ListResourceTypes_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/subscription/attach-filter:
+        post:
+            tags:
+                - Platform
+            description: Subscriptions
+            operationId: Platform_SubscriptionAttachFilter
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SubscriptionAPI_AttachFilter_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SubscriptionAPI_AttachFilter_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/subscription/detach-filter:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_SubscriptionDetachFilter
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SubscriptionAPI_DetachFilter_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SubscriptionAPI_DetachFilter_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
+    /v1/tx-sync:
+        post:
+            tags:
+                - Platform
+            operationId: Platform_TxSync
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TxAPI_Sync_Request'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/TxAPI_Sync_Response'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Status'
 components:
-  schemas:
-    AuthAPI_BeginSSOLogin_PublicPKCE:
-      type: object
-      properties:
-        nonce:
-          type: string
-        expiresAt:
-          type: string
-          format: date-time
-        clientSecret:
-          type: string
-          description: |-
-            Confidential-client secret for the IdP token exchange; absent for public clients.
-             Rationale: Google's OIDC does not support public clients — it requires a
-             client_secret at the token endpoint even for the PKCE auth-code flow. That is a
-             gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
-             leaving the server. So the backend holds the secret and forwards it here to the
-             desktop, which performs the token exchange as a confidential client.
-    AuthAPI_BeginSSOLogin_Request:
-      type: object
-      properties:
-        idp:
-          type: string
-    AuthAPI_BeginSSOLogin_Response:
-      type: object
-      properties:
-        publicPkce:
-          $ref: "#/components/schemas/AuthAPI_BeginSSOLogin_PublicPKCE"
-    AuthAPI_GetJWTToken_Request:
-      type: object
-      properties:
-        expiration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        requestedRole:
-          type: integer
-          format: enum
-    AuthAPI_GetJWTToken_Response:
-      type: object
-      properties:
-        token:
-          type: string
-        sessionId:
-          type: string
-          description: Session info fields
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_GetSessionInfo_Request:
-      type: object
-      properties: {}
-    AuthAPI_GetSessionInfo_Response:
-      type: object
-      properties:
-        sessionId:
-          type: string
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_GetUserRoot_Request:
-      type: object
-      properties:
-        login:
-          type: string
-        createIfNotExists:
-          type: boolean
-    AuthAPI_GetUserRoot_Response:
-      type: object
-      properties:
-        userRoot:
-          $ref: "#/components/schemas/AuthAPI_UserRoot"
-    AuthAPI_GrantAccess_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        targetUser:
-          type: string
-        permissions:
-          $ref: "#/components/schemas/AuthAPI_Grant_Permissions"
-        grantType:
-          type: integer
-          format: enum
-    AuthAPI_GrantAccess_Response:
-      type: object
-      properties: {}
-    AuthAPI_Grant_Permissions:
-      type: object
-      properties:
-        writable:
-          type: boolean
-      description: Permissions describes access level for a grant.
-    AuthAPI_ListMethods_BasicAuthMethod:
-      type: object
-      properties: {}
-    AuthAPI_ListMethods_MethodInfo:
-      type: object
-      properties:
-        id:
-          type: string
-          description: |-
-            id is the stable, machine-readable identifier of the login method
-             instance. Unique across the entire server.
-        description:
-          type: string
-          description: description is the human-readable label in case we'd like to render it in UI.
-        basic:
-          $ref: "#/components/schemas/AuthAPI_ListMethods_BasicAuthMethod"
-        token:
-          $ref: "#/components/schemas/AuthAPI_ListMethods_TokenAuthMethod"
-        sso:
-          $ref: "#/components/schemas/AuthAPI_ListMethods_SSOAuthMethod"
-    AuthAPI_ListMethods_Response:
-      type: object
-      properties:
-        methods:
-          type: array
-          items:
-            $ref: "#/components/schemas/AuthAPI_ListMethods_MethodInfo"
-    AuthAPI_ListMethods_SSOAuthMethod:
-      type: object
-      properties:
-        issuer:
-          type: string
-        clientId:
-          type: string
-        scopes:
-          type: string
-        resource:
-          type: string
-        prompt:
-          type: string
-        redirectPorts:
-          type: array
-          items:
-            type: integer
-            format: uint32
-        subjectTokenSource:
-          type: string
-        userIdClaim:
-          type: string
-        groupsClaim:
-          type: string
-        flowType:
-          type: integer
-          format: enum
-        accessType:
-          type: string
-      description: |-
-        SSOAuthMethod advertises an external IdP-based login flow. The desktop
-         app uses the contents to drive the PKCE exchange locally, then hands the
-         resulting IdP token-response back via Login.SSOCredentials.
-    AuthAPI_ListMethods_TokenAuthMethod:
-      type: object
-      properties: {}
-    AuthAPI_Login_BasicCredentials:
-      type: object
-      properties:
-        login:
-          type: string
-        password:
-          type: string
-        idp:
-          type: string
-    AuthAPI_Login_Request:
-      type: object
-      properties:
-        basic:
-          $ref: "#/components/schemas/AuthAPI_Login_BasicCredentials"
-        token:
-          $ref: "#/components/schemas/AuthAPI_Login_TokenCredentials"
-        sso:
-          $ref: "#/components/schemas/AuthAPI_Login_SSOCredentials"
-        expiration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        requestedRole:
-          type: integer
-          format: enum
-    AuthAPI_Login_Response:
-      type: object
-      properties:
-        token:
-          type: string
-        sessionId:
-          type: string
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_Login_SSOCredentials:
-      type: object
-      properties:
-        tokenResponse:
-          type: string
-          format: bytes
-        idp:
-          type: string
-      description: |-
-        SSOCredentials carries the raw JSON body returned by the IdP's /token
-         endpoint after the desktop completes a PKCE exchange.
-    AuthAPI_Login_TokenCredentials:
-      type: object
-      properties:
-        token:
-          type: string
-          format: bytes
-      description: |-
-        TokenCredentials accepts any opaque bearer-style string: a controller
-         pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
-    AuthAPI_MintSignature_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        targetSid:
-          type: string
-          format: bytes
-        color:
-          $ref: "#/components/schemas/Color"
-    AuthAPI_MintSignature_Response:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-    AuthAPI_RefreshToken_Request:
-      type: object
-      properties:
-        token:
-          type: string
-        expiration:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-    AuthAPI_RefreshToken_Response:
-      type: object
-      properties:
-        token:
-          type: string
-        sessionId:
-          type: string
-          format: bytes
-        role:
-          type: integer
-          format: enum
-    AuthAPI_RevokeAccess_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        targetUser:
-          type: string
-    AuthAPI_RevokeAccess_Response:
-      type: object
-      properties: {}
-    AuthAPI_UserRoot:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-    Color:
-      type: object
-      properties:
-        root:
-          type: string
-        permissions:
-          type: integer
-          format: uint32
-    Controller:
-      type: object
-      properties:
-        type:
-          type: string
-        id:
-          type: string
-        subscriptionID:
-          type: string
-    ControllerAPI_AttachSubscription_Request:
-      type: object
-      properties:
-        controllerId:
-          type: string
-        subscriptionId:
-          type: string
-    ControllerAPI_AttachSubscription_Response:
-      type: object
-      properties: {}
-    ControllerAPI_ClearFeatures_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_ClearFeatures_Response:
-      type: object
-      properties: {}
-    ControllerAPI_Create_Request:
-      type: object
-      properties:
-        id:
-          type: string
-        controllerType:
-          type: string
-    ControllerAPI_Create_Response:
-      type: object
-      properties:
-        controllerId:
-          type: string
-    ControllerAPI_Deregister_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_Deregister_Response:
-      type: object
-      properties: {}
-    ControllerAPI_Exists_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_Exists_Response:
-      type: object
-      properties:
-        exists:
-          type: boolean
-    ControllerAPI_GetNotifications_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        maxNotifications:
-          type: integer
-          format: uint32
-    ControllerAPI_GetNotifications_Response:
-      type: object
-      properties:
-        notifications:
-          type: array
-          items:
-            $ref: "#/components/schemas/Notification"
-    ControllerAPI_GetUrl_Request:
-      type: object
-      properties:
-        controllerAlias:
-          type: string
-        resourceId:
-          type: string
-    ControllerAPI_GetUrl_Response:
-      type: object
-      properties:
-        controllerUrl:
-          type: string
-    ControllerAPI_Get_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_Get_Response:
-      type: object
-      properties:
-        controller:
-          $ref: "#/components/schemas/Controller"
-    ControllerAPI_Register_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        filters:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/NotificationFilter"
-        resourceSchemas:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceSchema"
-    ControllerAPI_Register_Response:
-      type: object
-      properties:
-        controllerId:
-          type: string
-        subscriptionId:
-          type: string
-    ControllerAPI_RemoveAliasesAndUrls_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-    ControllerAPI_RemoveAliasesAndUrls_Response:
-      type: object
-      properties: {}
-    ControllerAPI_SetFeatures_Request:
-      type: object
-      properties:
-        features:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceAPIFeature"
-    ControllerAPI_SetFeatures_Response:
-      type: object
-      properties: {}
-    ControllerAPI_Update_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        filters:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/NotificationFilter"
-        resourceSchemas:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceSchema"
-    ControllerAPI_Update_Response:
-      type: object
-      properties: {}
-    ControllerAPI_WriteAliasesAndUrls_Request:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        aliasesToUrls:
-          type: object
-          additionalProperties:
-            type: string
-    ControllerAPI_WriteAliasesAndUrls_Response:
-      type: object
-      properties: {}
-    Field:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: "#/components/schemas/FieldRef"
-          description: field ID is always combination of parent resource ID and field name
-        type:
-          type: integer
-          format: enum
-        features:
-          $ref: "#/components/schemas/Resource_Features"
-        value:
-          type: string
-          description: |-
-            _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
-             If a field refers to another field, it will get
-             a value only when this chain of references ends up with a direct resource
-             reference. At that moment, all fields in the chain will get their values
-             resolved and will start to refer to the same resource directly.
-        valueSignature:
-          type: string
-          description: |-
-            Signature for value resource ID, inheriting the parent resource's color.
-             Populated server-side when the parent resource has a known color in the current TX.
-          format: bytes
-        valueStatus:
-          type: integer
-          description: Whether the value is empty, assigned, or finally resolved.
-          format: enum
-        valueIsFinal:
-          type: boolean
-          description: If the value is in its final state (ready, duplicate or error)
-        error:
-          type: string
-          description: |-
-            Error resource ID, if any.
-             Is intended to report problems _from_ the platform to the client.
-        errorSignature:
-          type: string
-          description: Signature for error resource ID, inheriting the parent resource's color.
-          format: bytes
-    FieldRef:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        fieldName:
-          type: string
-    FieldSchema:
-      type: object
-      properties:
-        type:
-          type: integer
-          format: enum
-        name:
-          type: string
-    GoogleProtobufAny:
-      type: object
-      properties:
-        "@type":
-          type: string
-          description: The type of the serialized message.
-      additionalProperties: true
-      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
-    LocksAPI_Lease_Create_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        timeout:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        name:
-          type: string
-    LocksAPI_Lease_Create_Response:
-      type: object
-      properties:
-        leaseId:
-          type: string
-          format: bytes
-    LocksAPI_Lease_Release_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        leaseId:
-          type: string
-          format: bytes
-    LocksAPI_Lease_Release_Response:
-      type: object
-      properties: {}
-    LocksAPI_Lease_Update_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        resourceSignature:
-          type: string
-          format: bytes
-        leaseId:
-          type: string
-          format: bytes
-        timeout:
-          pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
-          type: string
-        name:
-          type: string
-    LocksAPI_Lease_Update_Response:
-      type: object
-      properties: {}
-    LocksAPI_LockFieldValues_Create_Request:
-      type: object
-      properties:
-        resourceId:
-          type: string
-        lockReferencesOf:
-          type: array
-          items:
-            type: string
-        comment:
-          type: string
-    LocksAPI_LockFieldValues_Create_Response:
-      type: object
-      properties:
-        acquired:
-          type: boolean
-          description: |-
-            true when lock was acquired (new, or already owned by the owner)
-             Client MUST pay attention to this flag, as it shows if lock was successful.
-        conflictingLocks:
-          type: array
-          items:
-            $ref: "#/components/schemas/LocksAPI_LockFieldValues_Create_Response_LockInfo"
-          description: |-
-            Info about why lock was not acquired.
-             Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
-             The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
-        conflictsListTruncated:
-          type: boolean
-    LocksAPI_LockFieldValues_Create_Response_LockInfo:
-      type: object
-      properties:
-        targetId:
-          type: string
-        fieldName:
-          type: string
-        lockedBy:
-          type: string
-        lockedAt:
-          type: string
-          format: date-time
-        comment:
-          type: string
-    MaintenanceAPI_License_Response:
-      type: object
-      properties:
-        status:
-          type: integer
-          format: int32
-        isOk:
-          type: boolean
-        responseBody:
-          type: string
-          description: Raw response body as it was received from the license server.
-          format: bytes
-    MaintenanceAPI_Ping_Response:
-      type: object
-      properties:
-        coreVersion:
-          type: string
-        coreFullVersion:
-          type: string
-        compression:
-          type: integer
-          format: enum
-        instanceId:
-          type: string
-          description: |-
-            instanceID is a unique ID that changes when we reset DB state.
-             If we reset a state and a database, but the address of the backend is still the same,
-             without instanceID we are not sure if it's the same state or not,
-             and UI can't detect it and clear its state (e.g. caches of drivers).
-        platform:
-          type: string
-        os:
-          type: string
-        arch:
-          type: string
-        capabilities:
-          type: array
-          items:
-            type: string
-          description: |-
-            Opt-in capabilities advertised by this server instance. Two
-             client-side usage modes share this same wire field, decided
-             per-token by the client:
-               - Optimization hint. Client picks between a fast path and a
-                 fallback without probing by trial-and-error; missing tokens
-                 just cause the fallback to run (e.g. "treeFilter:v2").
-               - Install-time gate. Client refuses to install a block whose
-                 manifest declares a required capability the server doesn't
-                 advertise; missing tokens fail closed (e.g. "wasm:v1").
+    schemas:
+        AuthAPI_BeginSSOLogin_PublicPKCE:
+            type: object
+            properties:
+                nonce:
+                    type: string
+                expiresAt:
+                    type: string
+                    format: date-time
+                clientSecret:
+                    type: string
+                    description: |-
+                        Confidential-client secret for the IdP token exchange; absent for public clients.
+                         Rationale: Google's OIDC does not support public clients — it requires a
+                         client_secret at the token endpoint even for the PKCE auth-code flow. That is a
+                         gap in Google Cloud OIDC: a desktop app cannot use Google OIDC without the secret
+                         leaving the server. So the backend holds the secret and forwards it here to the
+                         desktop, which performs the token exchange as a confidential client.
+        AuthAPI_BeginSSOLogin_Request:
+            type: object
+            properties:
+                idp:
+                    type: string
+        AuthAPI_BeginSSOLogin_Response:
+            type: object
+            properties:
+                publicPkce:
+                    $ref: '#/components/schemas/AuthAPI_BeginSSOLogin_PublicPKCE'
+        AuthAPI_GetJWTToken_Request:
+            type: object
+            properties:
+                expiration:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                requestedRole:
+                    type: integer
+                    format: enum
+        AuthAPI_GetJWTToken_Response:
+            type: object
+            properties:
+                token:
+                    type: string
+                sessionId:
+                    type: string
+                    description: Session info fields
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_GetSessionInfo_Request:
+            type: object
+            properties: {}
+        AuthAPI_GetSessionInfo_Response:
+            type: object
+            properties:
+                sessionId:
+                    type: string
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_GetUserRoot_Request:
+            type: object
+            properties:
+                login:
+                    type: string
+                createIfNotExists:
+                    type: boolean
+        AuthAPI_GetUserRoot_Response:
+            type: object
+            properties:
+                userRoot:
+                    $ref: '#/components/schemas/AuthAPI_UserRoot'
+        AuthAPI_GrantAccess_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                targetUser:
+                    type: string
+                permissions:
+                    $ref: '#/components/schemas/AuthAPI_Grant_Permissions'
+                grantType:
+                    type: integer
+                    format: enum
+        AuthAPI_GrantAccess_Response:
+            type: object
+            properties: {}
+        AuthAPI_Grant_Permissions:
+            type: object
+            properties:
+                writable:
+                    type: boolean
+            description: Permissions describes access level for a grant.
+        AuthAPI_ListMethods_BasicAuthMethod:
+            type: object
+            properties: {}
+        AuthAPI_ListMethods_MethodInfo:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: |-
+                        id is the stable, machine-readable identifier of the login method
+                         instance. Unique across the entire server.
+                description:
+                    type: string
+                    description: |-
+                        description is the long-form human-readable text a client may render
+                         alongside the title, for example in a tooltip or under the button.
+                title:
+                    type: string
+                    description: |-
+                        title is the short human-readable label a client renders for this
+                         method, for example on the sign-in button. Always set.
+                basic:
+                    $ref: '#/components/schemas/AuthAPI_ListMethods_BasicAuthMethod'
+                token:
+                    $ref: '#/components/schemas/AuthAPI_ListMethods_TokenAuthMethod'
+                sso:
+                    $ref: '#/components/schemas/AuthAPI_ListMethods_SSOAuthMethod'
+        AuthAPI_ListMethods_Response:
+            type: object
+            properties:
+                methods:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AuthAPI_ListMethods_MethodInfo'
+        AuthAPI_ListMethods_SSOAuthMethod:
+            type: object
+            properties:
+                issuer:
+                    type: string
+                clientId:
+                    type: string
+                scopes:
+                    type: string
+                resource:
+                    type: string
+                prompt:
+                    type: string
+                redirectPorts:
+                    type: array
+                    items:
+                        type: integer
+                        format: uint32
+                subjectTokenSource:
+                    type: string
+                userIdClaim:
+                    type: string
+                groupsClaim:
+                    type: string
+                flowType:
+                    type: integer
+                    format: enum
+                accessType:
+                    type: string
+            description: |-
+                SSOAuthMethod advertises an external IdP-based login flow. The desktop
+                 app uses the contents to drive the PKCE exchange locally, then hands the
+                 resulting IdP token-response back via Login.SSOCredentials.
+        AuthAPI_ListMethods_TokenAuthMethod:
+            type: object
+            properties: {}
+        AuthAPI_Login_BasicCredentials:
+            type: object
+            properties:
+                login:
+                    type: string
+                password:
+                    type: string
+                idp:
+                    type: string
+        AuthAPI_Login_Request:
+            type: object
+            properties:
+                basic:
+                    $ref: '#/components/schemas/AuthAPI_Login_BasicCredentials'
+                token:
+                    $ref: '#/components/schemas/AuthAPI_Login_TokenCredentials'
+                sso:
+                    $ref: '#/components/schemas/AuthAPI_Login_SSOCredentials'
+                expiration:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                requestedRole:
+                    type: integer
+                    format: enum
+        AuthAPI_Login_Response:
+            type: object
+            properties:
+                token:
+                    type: string
+                sessionId:
+                    type: string
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_Login_SSOCredentials:
+            type: object
+            properties:
+                tokenResponse:
+                    type: string
+                    format: bytes
+                idp:
+                    type: string
+            description: |-
+                SSOCredentials carries the raw JSON body returned by the IdP's /token
+                 endpoint after the desktop completes a PKCE exchange.
+        AuthAPI_Login_TokenCredentials:
+            type: object
+            properties:
+                token:
+                    type: string
+                    format: bytes
+            description: |-
+                TokenCredentials accepts any opaque bearer-style string: a controller
+                 pre-shared secret, an existing Platforma JWT, or a future OIDC id-token.
+        AuthAPI_MintSignature_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                targetSid:
+                    type: string
+                    format: bytes
+                color:
+                    $ref: '#/components/schemas/Color'
+        AuthAPI_MintSignature_Response:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+        AuthAPI_RefreshToken_Request:
+            type: object
+            properties:
+                token:
+                    type: string
+                expiration:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+        AuthAPI_RefreshToken_Response:
+            type: object
+            properties:
+                token:
+                    type: string
+                sessionId:
+                    type: string
+                    format: bytes
+                role:
+                    type: integer
+                    format: enum
+        AuthAPI_RevokeAccess_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                targetUser:
+                    type: string
+        AuthAPI_RevokeAccess_Response:
+            type: object
+            properties: {}
+        AuthAPI_UserRoot:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+        Color:
+            type: object
+            properties:
+                root:
+                    type: string
+                permissions:
+                    type: integer
+                    format: uint32
+        Controller:
+            type: object
+            properties:
+                type:
+                    type: string
+                id:
+                    type: string
+                subscriptionID:
+                    type: string
+        ControllerAPI_AttachSubscription_Request:
+            type: object
+            properties:
+                controllerId:
+                    type: string
+                subscriptionId:
+                    type: string
+        ControllerAPI_AttachSubscription_Response:
+            type: object
+            properties: {}
+        ControllerAPI_ClearFeatures_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_ClearFeatures_Response:
+            type: object
+            properties: {}
+        ControllerAPI_Create_Request:
+            type: object
+            properties:
+                id:
+                    type: string
+                controllerType:
+                    type: string
+        ControllerAPI_Create_Response:
+            type: object
+            properties:
+                controllerId:
+                    type: string
+        ControllerAPI_Deregister_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_Deregister_Response:
+            type: object
+            properties: {}
+        ControllerAPI_Exists_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_Exists_Response:
+            type: object
+            properties:
+                exists:
+                    type: boolean
+        ControllerAPI_GetNotifications_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                maxNotifications:
+                    type: integer
+                    format: uint32
+        ControllerAPI_GetNotifications_Response:
+            type: object
+            properties:
+                notifications:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Notification'
+        ControllerAPI_GetUrl_Request:
+            type: object
+            properties:
+                controllerAlias:
+                    type: string
+                resourceId:
+                    type: string
+        ControllerAPI_GetUrl_Response:
+            type: object
+            properties:
+                controllerUrl:
+                    type: string
+        ControllerAPI_Get_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_Get_Response:
+            type: object
+            properties:
+                controller:
+                    $ref: '#/components/schemas/Controller'
+        ControllerAPI_Register_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                filters:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/NotificationFilter'
+                resourceSchemas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceSchema'
+        ControllerAPI_Register_Response:
+            type: object
+            properties:
+                controllerId:
+                    type: string
+                subscriptionId:
+                    type: string
+        ControllerAPI_RemoveAliasesAndUrls_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+        ControllerAPI_RemoveAliasesAndUrls_Response:
+            type: object
+            properties: {}
+        ControllerAPI_SetFeatures_Request:
+            type: object
+            properties:
+                features:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceAPIFeature'
+        ControllerAPI_SetFeatures_Response:
+            type: object
+            properties: {}
+        ControllerAPI_Update_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                filters:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/NotificationFilter'
+                resourceSchemas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceSchema'
+        ControllerAPI_Update_Response:
+            type: object
+            properties: {}
+        ControllerAPI_WriteAliasesAndUrls_Request:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                aliasesToUrls:
+                    type: object
+                    additionalProperties:
+                        type: string
+        ControllerAPI_WriteAliasesAndUrls_Response:
+            type: object
+            properties: {}
+        Field:
+            type: object
+            properties:
+                id:
+                    allOf:
+                        - $ref: '#/components/schemas/FieldRef'
+                    description: field ID is always combination of parent resource ID and field name
+                type:
+                    type: integer
+                    format: enum
+                features:
+                    $ref: '#/components/schemas/Resource_Features'
+                value:
+                    type: string
+                    description: |-
+                        _resolved_ value of a field or _assigned_ if the field was assigned to a resource.
+                         If a field refers to another field, it will get
+                         a value only when this chain of references ends up with a direct resource
+                         reference. At that moment, all fields in the chain will get their values
+                         resolved and will start to refer to the same resource directly.
+                valueSignature:
+                    type: string
+                    description: |-
+                        Signature for value resource ID, inheriting the parent resource's color.
+                         Populated server-side when the parent resource has a known color in the current TX.
+                    format: bytes
+                valueStatus:
+                    type: integer
+                    description: Whether the value is empty, assigned, or finally resolved.
+                    format: enum
+                valueIsFinal:
+                    type: boolean
+                    description: If the value is in its final state (ready, duplicate or error)
+                error:
+                    type: string
+                    description: |-
+                        Error resource ID, if any.
+                         Is intended to report problems _from_ the platform to the client.
+                errorSignature:
+                    type: string
+                    description: Signature for error resource ID, inheriting the parent resource's color.
+                    format: bytes
+        FieldRef:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                fieldName:
+                    type: string
+        FieldSchema:
+            type: object
+            properties:
+                type:
+                    type: integer
+                    format: enum
+                name:
+                    type: string
+        GoogleProtobufAny:
+            type: object
+            properties:
+                '@type':
+                    type: string
+                    description: The type of the serialized message.
+            additionalProperties: true
+            description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        LocksAPI_Lease_Create_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                timeout:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                name:
+                    type: string
+        LocksAPI_Lease_Create_Response:
+            type: object
+            properties:
+                leaseId:
+                    type: string
+                    format: bytes
+        LocksAPI_Lease_Release_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                leaseId:
+                    type: string
+                    format: bytes
+        LocksAPI_Lease_Release_Response:
+            type: object
+            properties: {}
+        LocksAPI_Lease_Update_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                resourceSignature:
+                    type: string
+                    format: bytes
+                leaseId:
+                    type: string
+                    format: bytes
+                timeout:
+                    pattern: ^-?(?:0|[1-9][0-9]{0,11})(?:\.[0-9]{1,9})?s$
+                    type: string
+                name:
+                    type: string
+        LocksAPI_Lease_Update_Response:
+            type: object
+            properties: {}
+        LocksAPI_LockFieldValues_Create_Request:
+            type: object
+            properties:
+                resourceId:
+                    type: string
+                lockReferencesOf:
+                    type: array
+                    items:
+                        type: string
+                comment:
+                    type: string
+        LocksAPI_LockFieldValues_Create_Response:
+            type: object
+            properties:
+                acquired:
+                    type: boolean
+                    description: |-
+                        true when lock was acquired (new, or already owned by the owner)
+                         Client MUST pay attention to this flag, as it shows if lock was successful.
+                conflictingLocks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/LocksAPI_LockFieldValues_Create_Response_LockInfo'
+                    description: |-
+                        Info about why lock was not acquired.
+                         Limited number of conflicts is reported: i.e. if lock operation failed for 20 fields, only first 10 are listed here.
+                         The number '10' is not a fixed contract for external clients. It is just 'somehow truncated'.
+                conflictsListTruncated:
+                    type: boolean
+        LocksAPI_LockFieldValues_Create_Response_LockInfo:
+            type: object
+            properties:
+                targetId:
+                    type: string
+                fieldName:
+                    type: string
+                lockedBy:
+                    type: string
+                lockedAt:
+                    type: string
+                    format: date-time
+                comment:
+                    type: string
+        MaintenanceAPI_License_Response:
+            type: object
+            properties:
+                status:
+                    type: integer
+                    format: int32
+                isOk:
+                    type: boolean
+                responseBody:
+                    type: string
+                    description: Raw response body as it was received from the license server.
+                    format: bytes
+        MaintenanceAPI_Ping_Response:
+            type: object
+            properties:
+                coreVersion:
+                    type: string
+                coreFullVersion:
+                    type: string
+                compression:
+                    type: integer
+                    format: enum
+                instanceId:
+                    type: string
+                    description: |-
+                        instanceID is a unique ID that changes when we reset DB state.
+                         If we reset a state and a database, but the address of the backend is still the same,
+                         without instanceID we are not sure if it's the same state or not,
+                         and UI can't detect it and clear its state (e.g. caches of drivers).
+                platform:
+                    type: string
+                os:
+                    type: string
+                arch:
+                    type: string
+                capabilities:
+                    type: array
+                    items:
+                        type: string
+                    description: |-
+                        Opt-in capabilities advertised by this server instance. Two
+                         client-side usage modes share this same wire field, decided
+                         per-token by the client:
+                           - Optimization hint. Client picks between a fast path and a
+                             fallback without probing by trial-and-error; missing tokens
+                             just cause the fallback to run (e.g. "treeFilter:v2").
+                           - Install-time gate. Client refuses to install a block whose
+                             manifest declares a required capability the server doesn't
+                             advertise; missing tokens fail closed (e.g. "wasm:v1").
 
-             Each entry is an opaque token "<feature>:<version>" (e.g.
-             "treeFilter:v2"). The field is unset on servers predating this
-             mechanism, which the client treats as "no optional capabilities
-             advertised" — fallback for hints, fail-closed for gates.
+                         Each entry is an opaque token "<feature>:<version>" (e.g.
+                         "treeFilter:v2"). The field is unset on servers predating this
+                         mechanism, which the client treats as "no optional capabilities
+                         advertised" — fallback for hints, fail-closed for gates.
 
-             All list see pl/platform/api/plapiserver/server_capabilities.go
-    MiscAPI_ListResourceTypes_Response:
-      type: object
-      properties:
-        types:
-          type: array
-          items:
-            $ref: "#/components/schemas/ResourceType"
-    Notification:
-      type: object
-      properties:
-        subscriptionId:
-          type: string
-        eventId:
-          type: string
-        resourceId:
-          type: string
-        resourceType:
-          $ref: "#/components/schemas/ResourceType"
-        events:
-          $ref: "#/components/schemas/Notification_Events"
-        fieldChanges:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/Notification_FieldChange"
-        payload:
-          $ref: "#/components/schemas/NotificationFilter_Payload"
-        filterName:
-          type: string
-        txSpan:
-          $ref: "#/components/schemas/SpanInfo"
-    NotificationAPI_Get_Request:
-      type: object
-      properties:
-        subscription:
-          type: string
-        maxNotifications:
-          type: integer
-          format: uint32
-    NotificationAPI_Get_Response:
-      type: object
-      properties:
-        notifications:
-          type: array
-          items:
-            $ref: "#/components/schemas/Notification"
-    NotificationFilter:
-      type: object
-      properties:
-        resourceType:
-          $ref: "#/components/schemas/ResourceType"
-        resourceId:
-          type: string
-        eventFilter:
-          $ref: "#/components/schemas/NotificationFilter_EventFilter"
-        payload:
-          $ref: "#/components/schemas/NotificationFilter_Payload"
-    NotificationFilter_EventFilter:
-      type: object
-      properties:
-        all:
-          type: boolean
-        resourceCreated:
-          type: boolean
-        resourceDeleted:
-          type: boolean
-        resourceReady:
-          type: boolean
-        resourceRecovered:
-          type: boolean
-        resourceDuplicate:
-          type: boolean
-        resourceError:
-          type: boolean
-        inputsLocked:
-          type: boolean
-          description: Field events
-        outputsLocked:
-          type: boolean
-        fieldCreated:
-          type: boolean
-        fieldGotError:
-          type: boolean
-        inputSet:
-          type: boolean
-        allInputsSet:
-          type: boolean
-        outputSet:
-          type: boolean
-        allOutputsSet:
-          type: boolean
-        genericOtwSet:
-          type: boolean
-        dynamicChanged:
-          type: boolean
-    NotificationFilter_Payload:
-      type: object
-      properties:
-        values:
-          type: object
-          additionalProperties:
-            type: string
-            format: bytes
-    Notification_Events:
-      type: object
-      properties:
-        resourceCreated:
-          type: boolean
-        resourceDeleted:
-          type: boolean
-        resourceReady:
-          type: boolean
-        resourceDuplicate:
-          type: boolean
-        resourceError:
-          type: boolean
-        inputsLocked:
-          type: boolean
-        outputsLocked:
-          type: boolean
-        fieldCreated:
-          type: boolean
-        fieldGotError:
-          type: boolean
-        inputSet:
-          type: boolean
-        allInputsSet:
-          type: boolean
-        outputSet:
-          type: boolean
-        allOutputsSet:
-          type: boolean
-        genericOtwSet:
-          type: boolean
-        dynamicChanged:
-          type: boolean
-        resourceRecovered:
-          type: boolean
-    Notification_FieldChange:
-      type: object
-      properties:
-        old:
-          $ref: "#/components/schemas/Field"
-        new:
-          $ref: "#/components/schemas/Field"
-    ResourceAPIFeature:
-      type: object
-      properties:
-        controllerType:
-          type: string
-        featureName:
-          type: string
-        resourceType:
-          $ref: "#/components/schemas/ResourceType"
-        endpoint:
-          type: string
-    ResourceSchema:
-      type: object
-      properties:
-        type:
-          $ref: "#/components/schemas/ResourceType"
-        fields:
-          type: array
-          items:
-            $ref: "#/components/schemas/FieldSchema"
-        accessFlags:
-          allOf:
-            - $ref: "#/components/schemas/ResourceSchema_AccessFlags"
-          description: Access restriction flags for non-controller roles
-        freeInputs:
-          type: boolean
-        freeOutputs:
-          type: boolean
-    ResourceSchema_AccessFlags:
-      type: object
-      properties:
-        createResource:
-          type: boolean
-          description: |-
-            Allow-list approach: default = forbidden (false)
-             Controllers set this to true allow non-controller roles (role='u', role='w')
-        readFields:
-          type: boolean
-          description: "IMPORTANT: read_fields=false with write_fields=true is a forbidden combination"
-        writeFields:
-          type: boolean
-        readKv:
-          type: boolean
-          description: "IMPORTANT: read_kv=false with write_kv=true is a forbidden combination"
-        writeKv:
-          type: boolean
-        readByFieldType:
-          type: object
-          additionalProperties:
-            type: boolean
-          description: |-
-            Per-field-type overrides (map: field_type → bool)
-             When defined for a field type, overrides resource-level flags
-        writeByFieldType:
-          type: object
-          additionalProperties:
-            type: boolean
-        setError:
-          type: boolean
-          description: |-
-            Allows non-controller roles (role='u', role='w') to set error on the resource,
-             marking it as failed and dropping it from recovery/deduplication indicies.
-    ResourceType:
-      type: object
-      properties:
-        name:
-          type: string
-        version:
-          type: string
-    Resource_Features:
-      type: object
-      properties:
-        ephemeral:
-          type: boolean
-    SpanInfo:
-      type: object
-      properties:
-        path:
-          type: string
-        carrier:
-          type: object
-          additionalProperties:
-            type: string
-    Status:
-      type: object
-      properties:
-        code:
-          type: integer
-          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-          format: int32
-        message:
-          type: string
-          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        details:
-          type: array
-          items:
-            $ref: "#/components/schemas/GoogleProtobufAny"
-          description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
-      description: "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
-    SubscriptionAPI_AttachFilter_Request:
-      type: object
-      properties:
-        subscriptionId:
-          type: string
-        filterName:
-          type: string
-        filterId:
-          type: string
-    SubscriptionAPI_AttachFilter_Response:
-      type: object
-      properties: {}
-    SubscriptionAPI_DetachFilter_Request:
-      type: object
-      properties:
-        subscriptionId:
-          type: string
-        filterName:
-          type: string
-    SubscriptionAPI_DetachFilter_Response:
-      type: object
-      properties: {}
-    TxAPI_Sync_Request:
-      type: object
-      properties:
-        txId:
-          type: string
-    TxAPI_Sync_Response:
-      type: object
-      properties: {}
+                         All list see pl/platform/api/plapiserver/server_capabilities.go
+        MiscAPI_ListResourceTypes_Response:
+            type: object
+            properties:
+                types:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ResourceType'
+        Notification:
+            type: object
+            properties:
+                subscriptionId:
+                    type: string
+                eventId:
+                    type: string
+                resourceId:
+                    type: string
+                resourceType:
+                    $ref: '#/components/schemas/ResourceType'
+                events:
+                    $ref: '#/components/schemas/Notification_Events'
+                fieldChanges:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/Notification_FieldChange'
+                payload:
+                    $ref: '#/components/schemas/NotificationFilter_Payload'
+                filterName:
+                    type: string
+                txSpan:
+                    $ref: '#/components/schemas/SpanInfo'
+        NotificationAPI_Get_Request:
+            type: object
+            properties:
+                subscription:
+                    type: string
+                maxNotifications:
+                    type: integer
+                    format: uint32
+        NotificationAPI_Get_Response:
+            type: object
+            properties:
+                notifications:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Notification'
+        NotificationFilter:
+            type: object
+            properties:
+                resourceType:
+                    $ref: '#/components/schemas/ResourceType'
+                resourceId:
+                    type: string
+                eventFilter:
+                    $ref: '#/components/schemas/NotificationFilter_EventFilter'
+                payload:
+                    $ref: '#/components/schemas/NotificationFilter_Payload'
+        NotificationFilter_EventFilter:
+            type: object
+            properties:
+                all:
+                    type: boolean
+                resourceCreated:
+                    type: boolean
+                resourceDeleted:
+                    type: boolean
+                resourceReady:
+                    type: boolean
+                resourceRecovered:
+                    type: boolean
+                resourceDuplicate:
+                    type: boolean
+                resourceError:
+                    type: boolean
+                inputsLocked:
+                    type: boolean
+                    description: Field events
+                outputsLocked:
+                    type: boolean
+                fieldCreated:
+                    type: boolean
+                fieldGotError:
+                    type: boolean
+                inputSet:
+                    type: boolean
+                allInputsSet:
+                    type: boolean
+                outputSet:
+                    type: boolean
+                allOutputsSet:
+                    type: boolean
+                genericOtwSet:
+                    type: boolean
+                dynamicChanged:
+                    type: boolean
+        NotificationFilter_Payload:
+            type: object
+            properties:
+                values:
+                    type: object
+                    additionalProperties:
+                        type: string
+                        format: bytes
+        Notification_Events:
+            type: object
+            properties:
+                resourceCreated:
+                    type: boolean
+                resourceDeleted:
+                    type: boolean
+                resourceReady:
+                    type: boolean
+                resourceDuplicate:
+                    type: boolean
+                resourceError:
+                    type: boolean
+                inputsLocked:
+                    type: boolean
+                outputsLocked:
+                    type: boolean
+                fieldCreated:
+                    type: boolean
+                fieldGotError:
+                    type: boolean
+                inputSet:
+                    type: boolean
+                allInputsSet:
+                    type: boolean
+                outputSet:
+                    type: boolean
+                allOutputsSet:
+                    type: boolean
+                genericOtwSet:
+                    type: boolean
+                dynamicChanged:
+                    type: boolean
+                resourceRecovered:
+                    type: boolean
+        Notification_FieldChange:
+            type: object
+            properties:
+                old:
+                    $ref: '#/components/schemas/Field'
+                new:
+                    $ref: '#/components/schemas/Field'
+        ResourceAPIFeature:
+            type: object
+            properties:
+                controllerType:
+                    type: string
+                featureName:
+                    type: string
+                resourceType:
+                    $ref: '#/components/schemas/ResourceType'
+                endpoint:
+                    type: string
+        ResourceSchema:
+            type: object
+            properties:
+                type:
+                    $ref: '#/components/schemas/ResourceType'
+                fields:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/FieldSchema'
+                accessFlags:
+                    allOf:
+                        - $ref: '#/components/schemas/ResourceSchema_AccessFlags'
+                    description: Access restriction flags for non-controller roles
+                freeInputs:
+                    type: boolean
+                freeOutputs:
+                    type: boolean
+        ResourceSchema_AccessFlags:
+            type: object
+            properties:
+                createResource:
+                    type: boolean
+                    description: |-
+                        Allow-list approach: default = forbidden (false)
+                         Controllers set this to true allow non-controller roles (role='u', role='w')
+                readFields:
+                    type: boolean
+                    description: 'IMPORTANT: read_fields=false with write_fields=true is a forbidden combination'
+                writeFields:
+                    type: boolean
+                readKv:
+                    type: boolean
+                    description: 'IMPORTANT: read_kv=false with write_kv=true is a forbidden combination'
+                writeKv:
+                    type: boolean
+                readByFieldType:
+                    type: object
+                    additionalProperties:
+                        type: boolean
+                    description: |-
+                        Per-field-type overrides (map: field_type → bool)
+                         When defined for a field type, overrides resource-level flags
+                writeByFieldType:
+                    type: object
+                    additionalProperties:
+                        type: boolean
+                setError:
+                    type: boolean
+                    description: |-
+                        Allows non-controller roles (role='u', role='w') to set error on the resource,
+                         marking it as failed and dropping it from recovery/deduplication indicies.
+        ResourceType:
+            type: object
+            properties:
+                name:
+                    type: string
+                version:
+                    type: string
+        Resource_Features:
+            type: object
+            properties:
+                ephemeral:
+                    type: boolean
+        SpanInfo:
+            type: object
+            properties:
+                path:
+                    type: string
+                carrier:
+                    type: object
+                    additionalProperties:
+                        type: string
+        Status:
+            type: object
+            properties:
+                code:
+                    type: integer
+                    description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+                    format: int32
+                message:
+                    type: string
+                    description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+                details:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GoogleProtobufAny'
+                    description: A list of messages that carry the error details.  There is a common set of message types for APIs to use.
+            description: 'The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).'
+        SubscriptionAPI_AttachFilter_Request:
+            type: object
+            properties:
+                subscriptionId:
+                    type: string
+                filterName:
+                    type: string
+                filterId:
+                    type: string
+        SubscriptionAPI_AttachFilter_Response:
+            type: object
+            properties: {}
+        SubscriptionAPI_DetachFilter_Request:
+            type: object
+            properties:
+                subscriptionId:
+                    type: string
+                filterName:
+                    type: string
+        SubscriptionAPI_DetachFilter_Response:
+            type: object
+            properties: {}
+        TxAPI_Sync_Request:
+            type: object
+            properties:
+                txId:
+                    type: string
+        TxAPI_Sync_Response:
+            type: object
+            properties: {}
 tags:
-  - name: Platform
+    - name: Platform

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -967,7 +967,7 @@ export class LLPlClient implements WireClientProviderFactory {
       // while protobuf-ts models it as a discriminated union. Reshape per item.
       resp = {
         methods: (wsResponse.methods ?? []).map((m): grpcTypes.AuthAPI_ListMethods_MethodInfo => {
-          const base = { id: m.id, description: m.description };
+          const base = { id: m.id, description: m.description, title: m.title };
           if (m.basic !== undefined) {
             return { ...base, method: { oneofKind: "basic", basic: m.basic } };
           }

--- a/lib/node/pl-client/src/core/ll_client.ts
+++ b/lib/node/pl-client/src/core/ll_client.ts
@@ -645,15 +645,19 @@ export class LLPlClient implements WireClientProviderFactory {
     }
   }
 
-  /** Login via username/password. Returns a fresh JWT. Backend creates a new session per call. */
+  /** Login via username/password. Returns a fresh JWT. Backend creates a new session per call.
+   * `opts.idP` names the advertised login method to route to; omitted, the backend keeps its
+   * current first-match behaviour. */
   public async loginBasic(
     user: string,
     password: string,
-    opts: { ttlSeconds?: bigint; role?: AuthAPI_Role } = {},
+    opts: { ttlSeconds?: bigint; role?: AuthAPI_Role; idP?: string } = {},
   ): Promise<string> {
     const cl = this.clientProvider.get();
     const ttl = opts.ttlSeconds ?? BigInt(this.conf.authTTLSeconds);
     const role = opts.role ?? AuthAPI_Role.UNSPECIFIED;
+    const basic =
+      opts.idP === undefined ? { login: user, password } : { login: user, password, idp: opts.idP };
 
     if (cl instanceof GrpcPlApiClient) {
       return (
@@ -661,7 +665,7 @@ export class LLPlClient implements WireClientProviderFactory {
           {
             credentials: {
               oneofKind: "basic",
-              basic: { login: user, password },
+              basic,
             },
             expiration: { seconds: ttl, nanos: 0 },
             requestedRole: role,
@@ -674,7 +678,7 @@ export class LLPlClient implements WireClientProviderFactory {
         // openapi-typescript generated all body fields as required, but Login.Request
         // has a credentials oneof — only one of `basic`/`token` is sent. Cast around it.
         body: {
-          basic: { login: user, password },
+          basic,
           expiration: `${ttl}s`,
           requestedRole: role,
         } as any,
@@ -723,16 +727,19 @@ export class LLPlClient implements WireClientProviderFactory {
   }
 
   /** Login via SSO: forwards the raw IdP /token JSON body to the backend.
-   * Backend validates signature + nonce + audience and mints a Platforma JWT. */
-  public async loginSSO(tokenResponse: Uint8Array): Promise<string> {
+   * Backend validates signature + nonce + audience and mints a Platforma JWT. `idP` names the
+   * advertised login method to route to; omitted, the backend keeps its current first-match
+   * behaviour. */
+  public async loginSSO(tokenResponse: Uint8Array, idP?: string): Promise<string> {
     const cl = this.clientProvider.get();
+    const sso = idP === undefined ? { tokenResponse } : { tokenResponse, idp: idP };
     if (cl instanceof GrpcPlApiClient) {
       return (
         await cl.login(
           {
             credentials: {
               oneofKind: "sso",
-              sso: { tokenResponse },
+              sso,
             },
           },
           { timeout: DEFAULT_LOGIN_TIMEOUT },
@@ -741,7 +748,7 @@ export class LLPlClient implements WireClientProviderFactory {
     } else {
       const resp = cl.POST("/v1/auth/login", {
         body: {
-          sso: { tokenResponse: Buffer.from(tokenResponse).toString("base64") },
+          sso: { ...sso, tokenResponse: Buffer.from(tokenResponse).toString("base64") },
         } as any,
       });
       return notEmpty((await resp).data, "REST: empty response for SSO login request").token;
@@ -750,11 +757,16 @@ export class LLPlClient implements WireClientProviderFactory {
 
   /** Request a one-time PKCE nonce + its expiry from the backend. The desktop is
    * expected to place the nonce verbatim into the OIDC auth-request before
-   * redirecting to the IdP; the backend enforces the expiry on {@link loginSSO}. */
-  public async beginSSOLogin(): Promise<{ nonce: string; expiresAt: Date; clientSecret?: string }> {
+   * redirecting to the IdP; the backend enforces the expiry on {@link loginSSO}. `idP` names the
+   * advertised login method to route to; omitted, the backend keeps its current first-match
+   * behaviour. */
+  public async beginSSOLogin(
+    idP?: string,
+  ): Promise<{ nonce: string; expiresAt: Date; clientSecret?: string }> {
     const cl = this.clientProvider.get();
+    const request = idP === undefined ? {} : { idp: idP };
     if (cl instanceof GrpcPlApiClient) {
-      const resp = (await cl.beginSSOLogin({}).response).flow;
+      const resp = (await cl.beginSSOLogin(request).response).flow;
       if (resp.oneofKind !== "publicPkce") {
         throw new Error(`beginSSOLogin: unsupported flow ${resp.oneofKind}`);
       }
@@ -766,7 +778,7 @@ export class LLPlClient implements WireClientProviderFactory {
       };
     } else {
       const wsResponse = notEmpty(
-        (await cl.POST("/v1/auth/sso/begin-login", { body: {} })).data,
+        (await cl.POST("/v1/auth/sso/begin-login", { body: request as any })).data,
         "REST: empty response for beginSSOLogin request",
       );
       const pkce = notEmpty(wsResponse.publicPkce, "REST: missing publicPkce in beginSSOLogin");

--- a/lib/node/pl-client/src/core/transaction.ts
+++ b/lib/node/pl-client/src/core/transaction.ts
@@ -1238,6 +1238,8 @@ export class PlTransaction {
         includeKv: opts?.includeKv ?? false,
         maxDepth: opts?.maxDepth,
         showSoftDeletes: false,
+        // Empty token requests the full tree — this call has no continuation to resume.
+        changedSinceToken: new Uint8Array(0),
       },
     });
 

--- a/lib/node/pl-client/src/core/unauth_client.test.ts
+++ b/lib/node/pl-client/src/core/unauth_client.test.ts
@@ -1,6 +1,6 @@
 import { UnauthenticatedPlClient } from "./unauth_client";
 import { getTestConfig, plAddressToTestConfig } from "../test/test_config";
-import { UnauthenticatedError } from "./errors";
+import { UnauthenticatedError, isUnimplementedError } from "./errors";
 import { test, expect } from "vitest";
 
 test("ping test", async () => {
@@ -29,4 +29,72 @@ test("wrong login", async () => {
   await expect(client.login(testConfig.test_user, testConfig.test_password + "A")).rejects.toThrow(
     UnauthenticatedError,
   );
+});
+
+// --- multi-method login ---
+//
+// These cases assume the backend is configured with (at least) two htpasswd
+// login methods whose config `name` values differ but which both accept the
+// same PL_TEST_USER/PL_TEST_PASSWORD credentials — the id
+// is the only thing distinguishing them.
+
+/** Runs every multi-method case against one client, gRPC or REST alike. */
+async function runMultiMethodCases(address: string) {
+  const testConfig = getTestConfig();
+  if (testConfig.test_user === undefined || testConfig.test_password === undefined) {
+    console.log("skipped");
+    return;
+  }
+  const client = await UnauthenticatedPlClient.build(plAddressToTestConfig(address));
+
+  const basicMethods = client.loginMethods().filter((m) => m.kind === "basic");
+  expect(basicMethods.length).toBeGreaterThanOrEqual(2);
+  // The driver's fixed description is the same string on every htpasswd method — only
+  // the id tells the two apart.
+  expect(basicMethods[0].description).toBe(basicMethods[1].description);
+  expect(basicMethods[0].id).not.toBe(basicMethods[1].id);
+
+  expect(client.supportedAuthSchemes.basic).toBe(true);
+
+  const secondMethod = basicMethods[1];
+  const picked = await client.login(
+    testConfig.test_user,
+    testConfig.test_password,
+    secondMethod.id,
+  );
+  expect(picked.jwtToken).not.toBe("");
+
+  const unpicked = await client.login(testConfig.test_user, testConfig.test_password);
+  expect(unpicked.jwtToken).not.toBe("");
+
+  await expect(
+    client.login(testConfig.test_user, testConfig.test_password, "no-such-method"),
+  ).rejects.toThrow();
+}
+
+// Skipped: this environment's backend cannot be configured with two htpasswd login methods.
+test.skip("loginMethods and login address two identically-described htpasswd methods by id (gRPC)", async () => {
+  const testConfig = getTestConfig();
+  await runMultiMethodCases(testConfig.address);
+});
+
+// Skipped: this environment's backend cannot be configured with two htpasswd login methods.
+test.skip("loginMethods and login address two identically-described htpasswd methods by id (REST)", async () => {
+  const testConfig = getTestConfig();
+  const separator = testConfig.address.includes("?") ? "&" : "?";
+  await runMultiMethodCases(`${testConfig.address}${separator}wire-protocol=rest`);
+});
+
+test("beginSSOLogin rejects an id no configured method carries, and reports no SSO configured when unpicked", async () => {
+  const testConfig = getTestConfig();
+  const client = await UnauthenticatedPlClient.build(plAddressToTestConfig(testConfig.address));
+
+  await expect(client.beginSSOLogin("no-such-method")).rejects.toThrow();
+
+  try {
+    await client.beginSSOLogin();
+    throw new Error("expected beginSSOLogin() to reject on a server with no SSO method configured");
+  } catch (e) {
+    expect(isUnimplementedError(e)).toBe(true);
+  }
 });

--- a/lib/node/pl-client/src/core/unauth_client.ts
+++ b/lib/node/pl-client/src/core/unauth_client.ts
@@ -178,17 +178,24 @@ export class UnauthenticatedPlClient {
 
   /** Login with username and password.
    *
-   * Routes to {@link LLPlClient.loginBasic} or {@link LLPlClient.loginWithToken} based on
-   * advertised auth methods. On legacy backends, uses GetJWTToken with Basic header.
+   * Routes to {@link LLPlClient.loginBasic} or {@link LLPlClient.loginWithToken} based on the
+   * advertised method `idP` names. On legacy backends, uses GetJWTToken with Basic header.
    *
-   * `idP` names the advertised method — basic branch only. Token and legacy branches ignore it
-   * and keep today's first-match behavior. */
+   * `idP` names the advertised method. A named basic-kind method routes to the basic branch;
+   * a named token-kind method routes to the token branch even when the backend also advertises
+   * a basic method — the token wire carries no selector, so the id itself is dropped there and
+   * only the branch choice is kept. Omitted, or naming no advertised method, falls back to
+   * today's first-match behavior: basic wins over token when both are advertised. */
   public async login(user: string, password: string, idP?: string): Promise<AuthInformation> {
     try {
       let token: string;
       if (this.ll.hasCapability("auth:v2")) {
         const schemes = this.supportedAuthSchemes;
-        if (schemes.basic) {
+        const namedKind =
+          idP === undefined ? undefined : this.loginMethods().find((m) => m.id === idP)?.kind;
+        if (namedKind === "token") {
+          token = await this.ll.loginWithToken(password);
+        } else if (schemes.basic) {
           token =
             idP === undefined
               ? await this.ll.loginBasic(user, password)

--- a/lib/node/pl-client/src/core/unauth_client.ts
+++ b/lib/node/pl-client/src/core/unauth_client.ts
@@ -18,6 +18,7 @@ export type SSOFlowType = "public_pkce";
  * may surface (`userIdClaim`, `groupsClaim`). */
 export type SSOAuthMethod = {
   id: string;
+  title: string;
   description: string;
   issuer: string;
   clientId: string;
@@ -49,11 +50,11 @@ export type SSOLoginAttempt = {
 };
 
 /** One login method the backend advertises, of any kind. Every advertised method keeps its own
- * `id`, `description` and kind. Two same-kind methods, such as two LDAP directories, are two
- * entries a caller can name apart and never collapsed into one. See {@link UnauthenticatedPlClient.loginMethods}. */
+ * `id`, `title`, `description` and kind. Two same-kind methods, such as two LDAP directories, are
+ * two entries a caller can name apart and never collapsed into one. See {@link UnauthenticatedPlClient.loginMethods}. */
 export type LoginMethod =
-  | { kind: "basic"; id: string; description: string }
-  | { kind: "token"; id: string; description: string }
+  | { kind: "basic"; id: string; title: string; description: string }
+  | { kind: "token"; id: string; title: string; description: string }
   | ({ kind: "sso" } & SSOAuthMethod);
 
 /** Primarily used for initial authentication (login) */
@@ -113,6 +114,7 @@ export class UnauthenticatedPlClient {
     if (sso.flowType !== AuthAPI_ListMethods_SSOAuthMethod_FlowType.PUBLIC_PKCE) return undefined;
     return {
       id: method.id,
+      title: method.title || method.description || method.id,
       description: method.description,
       issuer: sso.issuer,
       clientId: sso.clientId,
@@ -145,7 +147,7 @@ export class UnauthenticatedPlClient {
   }
 
   /** Every login method the backend advertises, of every kind, in advertised order, each
-   * keeping its own `id`, `description` and kind. An entry with no usable method arm, or an
+   * keeping its own `id`, `title`, `description` and kind. An entry with no usable method arm, or an
    * SSO entry whose flow no client here can drive, is dropped rather than failing the whole
    * list, which is why this accessor skips where {@link ssoConfig} throws. */
   public loginMethods(): LoginMethod[] {
@@ -157,6 +159,7 @@ export class UnauthenticatedPlClient {
           picked.push({
             kind: method.method.oneofKind,
             id: method.id,
+            title: method.title || method.description || method.id,
             description: method.description,
           });
           break;

--- a/lib/node/pl-client/src/core/unauth_client.ts
+++ b/lib/node/pl-client/src/core/unauth_client.ts
@@ -48,6 +48,14 @@ export type SSOLoginAttempt = {
   clientSecret?: string;
 };
 
+/** One login method the backend advertises, of any kind. Every advertised method keeps its own
+ * `id`, `description` and kind. Two same-kind methods, such as two LDAP directories, are two
+ * entries a caller can name apart and never collapsed into one. See {@link UnauthenticatedPlClient.loginMethods}. */
+export type LoginMethod =
+  | { kind: "basic"; id: string; description: string }
+  | { kind: "token"; id: string; description: string }
+  | ({ kind: "sso" } & SSOAuthMethod);
+
 /** Primarily used for initial authentication (login) */
 export class UnauthenticatedPlClient {
   public readonly ll: LLPlClient;
@@ -82,7 +90,9 @@ export class UnauthenticatedPlClient {
 
   /** Classifies the advertised authentication methods by credential scheme.
    * On legacy backends (no auth:v2) the typed oneof is empty; callers fall through to {@link login}
-   * which uses the legacy GetJWTToken path. SSO is surfaced via {@link ssoConfig}, not here. */
+   * which uses the legacy GetJWTToken path.
+   * @deprecated collapses every basic-kind method into one boolean; use {@link loginMethods} to
+   * see each advertised method's own id. `login()` still reads this to choose the credential path. */
   public get supportedAuthSchemes(): { basic: boolean; token: boolean } {
     const result = { basic: false, token: false };
     for (const m of this.ll.authMethodsSync.methods) {
@@ -92,8 +102,36 @@ export class UnauthenticatedPlClient {
     return result;
   }
 
+  /** Builds the {@link SSOAuthMethod} projection an advertised SSO entry carries, or `undefined`
+   * for a flow no client here can drive. Shared by {@link ssoConfig} and {@link loginMethods},
+   * which each apply their own rule for an unsupported flow. */
+  private toSSOAuthMethod(
+    method: AuthAPI_ListMethods_Response["methods"][number],
+  ): SSOAuthMethod | undefined {
+    if (method.method.oneofKind !== "sso") return undefined;
+    const sso = method.method.sso;
+    if (sso.flowType !== AuthAPI_ListMethods_SSOAuthMethod_FlowType.PUBLIC_PKCE) return undefined;
+    return {
+      id: method.id,
+      description: method.description,
+      issuer: sso.issuer,
+      clientId: sso.clientId,
+      scopes: sso.scopes,
+      resource: sso.resource,
+      prompt: sso.prompt,
+      redirectPorts: sso.redirectPorts,
+      subjectTokenSource: sso.subjectTokenSource,
+      userIdClaim: sso.userIdClaim,
+      groupsClaim: sso.groupsClaim,
+      accessType: sso.accessType || undefined,
+      flowType: "public_pkce",
+    };
+  }
+
   /** Projection of the first advertised SSO method, derived from {@link authMethodsSync}.
-   * v1: at most one SSO method per deployment, so callers do not need to discriminate. */
+   * v1: at most one SSO method per deployment, so callers do not need to discriminate.
+   * @deprecated surfaces only the first advertised SSO method; use {@link loginMethods} to see
+   * every advertised method, of every kind. */
   public ssoConfig(): SSOAuthMethod | undefined {
     for (const method of this.ll.authMethodsSync.methods) {
       if (method.method.oneofKind !== "sso") continue;
@@ -101,42 +139,57 @@ export class UnauthenticatedPlClient {
       if (sso.flowType !== AuthAPI_ListMethods_SSOAuthMethod_FlowType.PUBLIC_PKCE) {
         throw new Error(`ssoConfig: unsupported SSO flow type ${sso.flowType}`);
       }
-      return {
-        id: method.id,
-        description: method.description,
-        issuer: sso.issuer,
-        clientId: sso.clientId,
-        scopes: sso.scopes,
-        resource: sso.resource,
-        prompt: sso.prompt,
-        redirectPorts: sso.redirectPorts,
-        subjectTokenSource: sso.subjectTokenSource,
-        userIdClaim: sso.userIdClaim,
-        groupsClaim: sso.groupsClaim,
-        accessType: sso.accessType || undefined,
-        flowType: "public_pkce",
-      };
+      return this.toSSOAuthMethod(method);
     }
     return undefined;
   }
 
-  /** Login with username+password.
+  /** Every login method the backend advertises, of every kind, in advertised order, each
+   * keeping its own `id`, `description` and kind. An entry with no usable method arm, or an
+   * SSO entry whose flow no client here can drive, is dropped rather than failing the whole
+   * list, which is why this accessor skips where {@link ssoConfig} throws. */
+  public loginMethods(): LoginMethod[] {
+    const picked: LoginMethod[] = [];
+    for (const method of this.ll.authMethodsSync.methods) {
+      switch (method.method.oneofKind) {
+        case "basic":
+        case "token":
+          picked.push({
+            kind: method.method.oneofKind,
+            id: method.id,
+            description: method.description,
+          });
+          break;
+        case "sso": {
+          const sso = this.toSSOAuthMethod(method);
+          if (sso !== undefined) picked.push({ kind: "sso", ...sso });
+          break;
+        }
+        default:
+          // No arm at all — a legacy backend advertising nothing pickable.
+          break;
+      }
+    }
+    return picked;
+  }
+
+  /** Login with username and password.
    *
-   * On auth:v2 backends the client inspects the advertised AuthMethods:
-   *   - if basic auth is offered, sends {@link LLPlClient.loginBasic};
-   *   - if only token auth is offered, treats `password` as an opaque bearer token and
-   *     sends {@link LLPlClient.loginWithToken} (so deployments configured for static-token
-   *     auth still log in without the caller switching methods).
+   * Routes to {@link LLPlClient.loginBasic} or {@link LLPlClient.loginWithToken} based on
+   * advertised auth methods. On legacy backends, uses GetJWTToken with Basic header.
    *
-   * On legacy backends (no auth:v2) it falls through to GetJWTToken with the Basic header,
-   * preserving original behavior. */
-  public async login(user: string, password: string): Promise<AuthInformation> {
+   * `idP` names the advertised method — basic branch only. Token and legacy branches ignore it
+   * and keep today's first-match behavior. */
+  public async login(user: string, password: string, idP?: string): Promise<AuthInformation> {
     try {
       let token: string;
       if (this.ll.hasCapability("auth:v2")) {
         const schemes = this.supportedAuthSchemes;
         if (schemes.basic) {
-          token = await this.ll.loginBasic(user, password);
+          token =
+            idP === undefined
+              ? await this.ll.loginBasic(user, password)
+              : await this.ll.loginBasic(user, password, { idP });
         } else if (schemes.token) {
           token = await this.ll.loginWithToken(password);
         } else {
@@ -157,9 +210,12 @@ export class UnauthenticatedPlClient {
   }
 
   /** Request fresh server-issued login material. v1 only emits the public-PKCE flow;
-   * desktop MUST place the returned `nonce` verbatim into the OIDC auth-request. */
-  public async beginSSOLogin(): Promise<SSOLoginAttempt> {
-    const attempt = await this.ll.beginSSOLogin();
+   * desktop MUST place the returned `nonce` verbatim into the OIDC auth-request. `idP` names
+   * the advertised SSO method to route to; omitted, the backend keeps its current first-match
+   * behaviour. */
+  public async beginSSOLogin(idP?: string): Promise<SSOLoginAttempt> {
+    const attempt =
+      idP === undefined ? await this.ll.beginSSOLogin() : await this.ll.beginSSOLogin(idP);
     return {
       flow: "public_pkce",
       nonce: attempt.nonce,
@@ -168,10 +224,18 @@ export class UnauthenticatedPlClient {
     };
   }
 
-  /** Forward the verbatim IdP `/token` response body and receive a Platforma JWT. */
-  public async loginSSO(payload: { tokenResponse: Uint8Array }): Promise<AuthInformation> {
+  /** Forward the verbatim IdP `/token` response body and receive a Platforma JWT. `idP` names
+   * the advertised SSO method to route to; omitted, the backend keeps its current first-match
+   * behaviour. */
+  public async loginSSO(payload: {
+    tokenResponse: Uint8Array;
+    idP?: string;
+  }): Promise<AuthInformation> {
     try {
-      const jwtToken = await this.ll.loginSSO(payload.tokenResponse);
+      const jwtToken =
+        payload.idP === undefined
+          ? await this.ll.loginSSO(payload.tokenResponse)
+          : await this.ll.loginSSO(payload.tokenResponse, payload.idP);
       if (jwtToken === "") throw new Error("empty token");
       return { jwtToken };
     } catch (e: any) {

--- a/lib/node/pl-client/src/core/unauth_client_branch.test.ts
+++ b/lib/node/pl-client/src/core/unauth_client_branch.test.ts
@@ -16,9 +16,23 @@ function makeStub(opts: { hasAuthV2: boolean; scheme?: Scheme; methods?: MethodI
   const methods =
     opts.methods ??
     (scheme === "basic"
-      ? [{ id: "basic", method: { oneofKind: "basic", basic: {} } }]
+      ? [
+          {
+            id: "basic",
+            title: "basic",
+            description: "",
+            method: { oneofKind: "basic", basic: {} },
+          },
+        ]
       : scheme === "token"
-        ? [{ id: "token", method: { oneofKind: "token", token: {} } }]
+        ? [
+            {
+              id: "token",
+              title: "token",
+              description: "",
+              method: { oneofKind: "token", token: {} },
+            },
+          ]
         : []);
   const ll = {
     hasCapability: vi.fn(
@@ -80,6 +94,7 @@ test("hasCapability proxies to underlying LLPlClient", () => {
 
 function ssoMethod(overrides: {
   id: string;
+  title?: string;
   description: string;
   issuer: string;
   flowType?: AuthAPI_ListMethods_SSOAuthMethod_FlowType;
@@ -95,6 +110,7 @@ function ssoMethod(overrides: {
 }): MethodInfo {
   return {
     id: overrides.id,
+    title: overrides.title ?? overrides.id,
     description: overrides.description,
     method: {
       oneofKind: "sso",
@@ -115,12 +131,12 @@ function ssoMethod(overrides: {
   };
 }
 
-function basicMethod(id: string, description = "Basic auth"): MethodInfo {
-  return { id, description, method: { oneofKind: "basic", basic: {} } };
+function basicMethod(id: string, description = "Basic auth", title = id): MethodInfo {
+  return { id, title, description, method: { oneofKind: "basic", basic: {} } };
 }
 
-function tokenMethod(id: string, description = "Static token"): MethodInfo {
-  return { id, description, method: { oneofKind: "token", token: {} } };
+function tokenMethod(id: string, description = "Static token", title = id): MethodInfo {
+  return { id, title, description, method: { oneofKind: "token", token: {} } };
 }
 
 // --- loginMethods() ---
@@ -145,6 +161,35 @@ test("loginMethods lists every advertised method, of every kind, in advertised o
     "htpasswd-b",
     "token-a",
   ]);
+  expect(listed.map((m) => m.title)).toEqual([
+    "sso-a",
+    "sso-b",
+    "htpasswd-a",
+    "htpasswd-b",
+    "token-a",
+  ]);
+});
+
+test("loginMethods falls back to description, then id, when the backend omits title", () => {
+  const methods: MethodInfo[] = [
+    {
+      id: "no-title",
+      title: "",
+      description: "Untitled backend",
+      method: { oneofKind: "basic", basic: {} },
+    },
+    {
+      id: "no-title-no-description",
+      title: "",
+      description: "",
+      method: { oneofKind: "token", token: {} },
+    },
+  ];
+  const { client } = makeStub({ hasAuthV2: true, methods });
+
+  const listed = client.loginMethods();
+
+  expect(listed.map((m) => m.title)).toEqual(["Untitled backend", "no-title-no-description"]);
 });
 
 test("loginMethods keeps same-kind methods distinct while supportedAuthSchemes still collapses them", () => {
@@ -164,6 +209,7 @@ test("loginMethods keeps same-kind methods distinct while supportedAuthSchemes s
 test("loginMethods maps every field of an SSO projection, and drops an empty accessType", () => {
   const method = ssoMethod({
     id: "sso-1",
+    title: "Corporate SSO",
     description: "Corp SSO",
     issuer: "https://idp.example",
     clientId: "the-client-id",
@@ -183,6 +229,7 @@ test("loginMethods maps every field of an SSO projection, and drops an empty acc
   expect(entry).toEqual({
     kind: "sso",
     id: "sso-1",
+    title: "Corporate SSO",
     description: "Corp SSO",
     issuer: "https://idp.example",
     clientId: "the-client-id",
@@ -199,7 +246,12 @@ test("loginMethods maps every field of an SSO projection, and drops an empty acc
 });
 
 test("loginMethods drops an advertised method with no usable arm", () => {
-  const armless: MethodInfo = { id: "legacy", description: "", method: { oneofKind: undefined } };
+  const armless: MethodInfo = {
+    id: "legacy",
+    title: "legacy",
+    description: "",
+    method: { oneofKind: undefined },
+  };
   const { client } = makeStub({ hasAuthV2: true, methods: [armless, basicMethod("htpasswd-a")] });
 
   expect(client.loginMethods().map((m) => m.id)).toEqual(["htpasswd-a"]);
@@ -293,13 +345,19 @@ test("ssoConfig returns the first sso method and drops the rest", () => {
   });
 });
 
-test("ssoConfig carries id and description onto the returned SSOAuthMethod", () => {
-  const method = ssoMethod({ id: "sso-1", description: "Corp SSO", issuer: "https://idp.example" });
+test("ssoConfig carries id, title and description onto the returned SSOAuthMethod", () => {
+  const method = ssoMethod({
+    id: "sso-1",
+    title: "Corporate IdP",
+    description: "Corp SSO",
+    issuer: "https://idp.example",
+  });
   const { client } = makeStub({ hasAuthV2: true, methods: [method] });
 
   const sso = client.ssoConfig();
 
   expect(sso?.id).toBe("sso-1");
+  expect(sso?.title).toBe("Corporate IdP");
   expect(sso?.description).toBe("Corp SSO");
 });
 
@@ -319,8 +377,8 @@ test("ssoConfig throws when the sso method's flow type is not PUBLIC_PKCE", () =
 
 test("supportedAuthSchemes collapses a basic+token+sso method list to scheme booleans", () => {
   const methods: MethodInfo[] = [
-    { id: "basic", description: "", method: { oneofKind: "basic", basic: {} } },
-    { id: "token", description: "", method: { oneofKind: "token", token: {} } },
+    { id: "basic", title: "basic", description: "", method: { oneofKind: "basic", basic: {} } },
+    { id: "token", title: "token", description: "", method: { oneofKind: "token", token: {} } },
     ssoMethod({ id: "sso-1", description: "Corp SSO", issuer: "https://idp.example" }),
   ];
   const { client } = makeStub({ hasAuthV2: true, methods });

--- a/lib/node/pl-client/src/core/unauth_client_branch.test.ts
+++ b/lib/node/pl-client/src/core/unauth_client_branch.test.ts
@@ -1,17 +1,23 @@
 import { test, expect, vi } from "vitest";
 import { UnauthenticatedPlClient } from "./unauth_client";
 import type { BackendCapability } from "./capabilities";
+import {
+  AuthAPI_ListMethods_SSOAuthMethod_FlowType,
+  type AuthAPI_ListMethods_Response,
+} from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api";
 
 type Scheme = "basic" | "token" | "none";
+type MethodInfo = AuthAPI_ListMethods_Response["methods"][number];
 
-function makeStub(opts: { hasAuthV2: boolean; scheme?: Scheme }) {
+function makeStub(opts: { hasAuthV2: boolean; scheme?: Scheme; methods?: MethodInfo[] }) {
   const scheme = opts.scheme ?? "basic";
   const methods =
-    scheme === "basic"
+    opts.methods ??
+    (scheme === "basic"
       ? [{ id: "basic", method: { oneofKind: "basic", basic: {} } }]
       : scheme === "token"
         ? [{ id: "token", method: { oneofKind: "token", token: {} } }]
-        : [];
+        : []);
   const ll = {
     hasCapability: vi.fn(
       (capability: BackendCapability) => capability === "auth:v2" && opts.hasAuthV2,
@@ -66,4 +72,81 @@ test("hasCapability proxies to underlying LLPlClient", () => {
   expect(client.hasCapability("auth:v2")).toBe(true);
   expect(client.hasCapability("treeFilter:v2")).toBe(false);
   expect(ll.hasCapability).toHaveBeenCalledWith("auth:v2");
+});
+
+function ssoMethod(overrides: {
+  id: string;
+  description: string;
+  issuer: string;
+  flowType?: AuthAPI_ListMethods_SSOAuthMethod_FlowType;
+}): MethodInfo {
+  return {
+    id: overrides.id,
+    description: overrides.description,
+    method: {
+      oneofKind: "sso",
+      sso: {
+        issuer: overrides.issuer,
+        clientId: "client-id",
+        scopes: "openid",
+        resource: "",
+        prompt: "",
+        redirectPorts: [12345],
+        subjectTokenSource: "id_token",
+        userIdClaim: "sub",
+        groupsClaim: "",
+        flowType: overrides.flowType ?? AuthAPI_ListMethods_SSOAuthMethod_FlowType.PUBLIC_PKCE,
+        accessType: undefined,
+      },
+    },
+  };
+}
+
+test("ssoConfig returns the first sso method and drops the rest", () => {
+  const first = ssoMethod({ id: "sso-first", description: "First IdP", issuer: "https://first.example" });
+  const second = ssoMethod({ id: "sso-second", description: "Second IdP", issuer: "https://second.example" });
+  const { client } = makeStub({ hasAuthV2: true, methods: [first, second] });
+
+  const sso = client.ssoConfig();
+
+  expect(sso).toMatchObject({
+    id: "sso-first",
+    description: "First IdP",
+    issuer: "https://first.example",
+  });
+});
+
+test("ssoConfig carries id and description onto the returned SSOAuthMethod", () => {
+  const method = ssoMethod({ id: "sso-1", description: "Corp SSO", issuer: "https://idp.example" });
+  const { client } = makeStub({ hasAuthV2: true, methods: [method] });
+
+  const sso = client.ssoConfig();
+
+  expect(sso?.id).toBe("sso-1");
+  expect(sso?.description).toBe("Corp SSO");
+});
+
+test("ssoConfig throws when the sso method's flow type is not PUBLIC_PKCE", () => {
+  const method = ssoMethod({
+    id: "sso-1",
+    description: "Corp SSO",
+    issuer: "https://idp.example",
+    // 99 is not a defined FlowType value; casts an out-of-range value the
+    // proto currently has none for, to pin the guard against a future flow.
+    flowType: 99 as AuthAPI_ListMethods_SSOAuthMethod_FlowType,
+  });
+  const { client } = makeStub({ hasAuthV2: true, methods: [method] });
+
+  expect(() => client.ssoConfig()).toThrow("ssoConfig: unsupported SSO flow type");
+});
+
+test("supportedAuthSchemes collapses a basic+token+sso method list to scheme booleans", () => {
+  const methods: MethodInfo[] = [
+    { id: "basic", description: "", method: { oneofKind: "basic", basic: {} } },
+    { id: "token", description: "", method: { oneofKind: "token", token: {} } },
+    ssoMethod({ id: "sso-1", description: "Corp SSO", issuer: "https://idp.example" }),
+  ];
+  const { client } = makeStub({ hasAuthV2: true, methods });
+
+  expect(client.supportedAuthSchemes).toEqual({ basic: true, token: true });
 });

--- a/lib/node/pl-client/src/core/unauth_client_branch.test.ts
+++ b/lib/node/pl-client/src/core/unauth_client_branch.test.ts
@@ -323,6 +323,27 @@ test("login drops the picked id on the token branch", async () => {
   expect(info.jwtToken).toBe("jwt-from-loginWithToken");
 });
 
+test("login routes to loginWithToken when the picked id names a token method, even though the backend also advertises basic", async () => {
+  const { client, ll } = makeStub({
+    hasAuthV2: true,
+    methods: [
+      { id: "ldap-a", title: "ldap-a", description: "", method: { oneofKind: "basic", basic: {} } },
+      {
+        id: "htpasswd",
+        title: "htpasswd",
+        description: "",
+        method: { oneofKind: "token", token: {} },
+      },
+    ],
+  });
+
+  const info = await client.login("alice", "opaque-token", "htpasswd");
+
+  expect(ll.loginWithToken).toHaveBeenCalledWith("opaque-token");
+  expect(ll.loginBasic).not.toHaveBeenCalled();
+  expect(info.jwtToken).toBe("jwt-from-loginWithToken");
+});
+
 test("ssoConfig returns the first sso method and drops the rest", () => {
   const first = ssoMethod({
     id: "sso-first",

--- a/lib/node/pl-client/src/core/unauth_client_branch.test.ts
+++ b/lib/node/pl-client/src/core/unauth_client_branch.test.ts
@@ -1,5 +1,7 @@
 import { test, expect, vi } from "vitest";
 import { UnauthenticatedPlClient } from "./unauth_client";
+import { LLPlClient } from "./ll_client";
+import { PlatformClient as GrpcPlApiClient } from "../proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.client";
 import type { BackendCapability } from "./capabilities";
 import {
   AuthAPI_ListMethods_SSOAuthMethod_FlowType,
@@ -25,6 +27,8 @@ function makeStub(opts: { hasAuthV2: boolean; scheme?: Scheme; methods?: MethodI
     loginBasic: vi.fn().mockResolvedValue("jwt-from-loginBasic"),
     loginWithToken: vi.fn().mockResolvedValue("jwt-from-loginWithToken"),
     getJwtToken: vi.fn().mockResolvedValue("jwt-from-getJwtToken"),
+    beginSSOLogin: vi.fn().mockResolvedValue({ nonce: "nonce", expiresAt: new Date() }),
+    loginSSO: vi.fn().mockResolvedValue("jwt-from-loginSSO"),
     authMethodsSync: { methods },
     conf: { authTTLSeconds: 100 },
   };
@@ -79,6 +83,15 @@ function ssoMethod(overrides: {
   description: string;
   issuer: string;
   flowType?: AuthAPI_ListMethods_SSOAuthMethod_FlowType;
+  clientId?: string;
+  scopes?: string;
+  resource?: string;
+  prompt?: string;
+  redirectPorts?: number[];
+  subjectTokenSource?: string;
+  userIdClaim?: string;
+  groupsClaim?: string;
+  accessType?: string;
 }): MethodInfo {
   return {
     id: overrides.id,
@@ -87,24 +100,188 @@ function ssoMethod(overrides: {
       oneofKind: "sso",
       sso: {
         issuer: overrides.issuer,
-        clientId: "client-id",
-        scopes: "openid",
-        resource: "",
-        prompt: "",
-        redirectPorts: [12345],
-        subjectTokenSource: "id_token",
-        userIdClaim: "sub",
-        groupsClaim: "",
+        clientId: overrides.clientId ?? "client-id",
+        scopes: overrides.scopes ?? "openid",
+        resource: overrides.resource ?? "",
+        prompt: overrides.prompt ?? "",
+        redirectPorts: overrides.redirectPorts ?? [12345],
+        subjectTokenSource: overrides.subjectTokenSource ?? "id_token",
+        userIdClaim: overrides.userIdClaim ?? "sub",
+        groupsClaim: overrides.groupsClaim ?? "",
         flowType: overrides.flowType ?? AuthAPI_ListMethods_SSOAuthMethod_FlowType.PUBLIC_PKCE,
-        accessType: undefined,
+        accessType: overrides.accessType,
       },
     },
   };
 }
 
+function basicMethod(id: string, description = "Basic auth"): MethodInfo {
+  return { id, description, method: { oneofKind: "basic", basic: {} } };
+}
+
+function tokenMethod(id: string, description = "Static token"): MethodInfo {
+  return { id, description, method: { oneofKind: "token", token: {} } };
+}
+
+// --- loginMethods() ---
+
+test("loginMethods lists every advertised method, of every kind, in advertised order", () => {
+  const methods: MethodInfo[] = [
+    ssoMethod({ id: "sso-a", description: "First IdP", issuer: "https://first.example" }),
+    ssoMethod({ id: "sso-b", description: "Second IdP", issuer: "https://second.example" }),
+    basicMethod("htpasswd-a", "htpasswd"),
+    basicMethod("htpasswd-b", "htpasswd"),
+    tokenMethod("token-a", "static token"),
+  ];
+  const { client } = makeStub({ hasAuthV2: true, methods });
+
+  const listed = client.loginMethods();
+
+  expect(listed.map((m) => m.kind)).toEqual(["sso", "sso", "basic", "basic", "token"]);
+  expect(listed.map((m) => m.id)).toEqual([
+    "sso-a",
+    "sso-b",
+    "htpasswd-a",
+    "htpasswd-b",
+    "token-a",
+  ]);
+});
+
+test("loginMethods keeps same-kind methods distinct while supportedAuthSchemes still collapses them", () => {
+  const methods: MethodInfo[] = [
+    basicMethod("htpasswd-a", "htpasswd"),
+    basicMethod("htpasswd-b", "htpasswd"),
+    tokenMethod("token-a"),
+  ];
+  const { client } = makeStub({ hasAuthV2: true, methods });
+
+  const listed = client.loginMethods().filter((m) => m.kind === "basic");
+
+  expect(listed.map((m) => m.id)).toEqual(["htpasswd-a", "htpasswd-b"]);
+  expect(client.supportedAuthSchemes).toEqual({ basic: true, token: true });
+});
+
+test("loginMethods maps every field of an SSO projection, and drops an empty accessType", () => {
+  const method = ssoMethod({
+    id: "sso-1",
+    description: "Corp SSO",
+    issuer: "https://idp.example",
+    clientId: "the-client-id",
+    scopes: "openid profile",
+    resource: "https://api.example",
+    prompt: "consent",
+    redirectPorts: [11000, 11001],
+    subjectTokenSource: "access_token",
+    userIdClaim: "email",
+    groupsClaim: "groups",
+    accessType: "",
+  });
+  const { client } = makeStub({ hasAuthV2: true, methods: [method] });
+
+  const [entry] = client.loginMethods();
+
+  expect(entry).toEqual({
+    kind: "sso",
+    id: "sso-1",
+    description: "Corp SSO",
+    issuer: "https://idp.example",
+    clientId: "the-client-id",
+    scopes: "openid profile",
+    resource: "https://api.example",
+    prompt: "consent",
+    redirectPorts: [11000, 11001],
+    subjectTokenSource: "access_token",
+    userIdClaim: "email",
+    groupsClaim: "groups",
+    flowType: "public_pkce",
+    accessType: undefined,
+  });
+});
+
+test("loginMethods drops an advertised method with no usable arm", () => {
+  const armless: MethodInfo = { id: "legacy", description: "", method: { oneofKind: undefined } };
+  const { client } = makeStub({ hasAuthV2: true, methods: [armless, basicMethod("htpasswd-a")] });
+
+  expect(client.loginMethods().map((m) => m.id)).toEqual(["htpasswd-a"]);
+});
+
+test("loginMethods drops an SSO entry whose flow type is unsupported, keeping every other entry", () => {
+  const unsupported = ssoMethod({
+    id: "sso-legacy",
+    description: "Corp SSO",
+    issuer: "https://idp.example",
+    flowType: 99 as AuthAPI_ListMethods_SSOAuthMethod_FlowType,
+  });
+  const { client } = makeStub({
+    hasAuthV2: true,
+    methods: [unsupported, basicMethod("htpasswd-a")],
+  });
+
+  expect(client.loginMethods().map((m) => m.id)).toEqual(["htpasswd-a"]);
+});
+
+test("beginSSOLogin forwards the picked id to the low-level client", async () => {
+  const { client, ll } = makeStub({ hasAuthV2: true, scheme: "none" });
+
+  await client.beginSSOLogin("sso-a");
+
+  expect(ll.beginSSOLogin).toHaveBeenCalledWith("sso-a");
+});
+
+test("beginSSOLogin omits the argument when no id is picked", async () => {
+  const { client, ll } = makeStub({ hasAuthV2: true, scheme: "none" });
+
+  await client.beginSSOLogin();
+
+  expect(ll.beginSSOLogin).toHaveBeenCalledWith();
+});
+
+test("loginSSO carries the picked id to the low-level client alongside the token response", async () => {
+  const { client, ll } = makeStub({ hasAuthV2: true, scheme: "none" });
+  const tokenResponse = new Uint8Array([1, 2, 3]);
+
+  await client.loginSSO({ tokenResponse, idP: "sso-a" });
+
+  expect(ll.loginSSO).toHaveBeenCalledWith(tokenResponse, "sso-a");
+});
+
+test("loginSSO sends only the token response when no id is picked", async () => {
+  const { client, ll } = makeStub({ hasAuthV2: true, scheme: "none" });
+  const tokenResponse = new Uint8Array([1, 2, 3]);
+
+  await client.loginSSO({ tokenResponse });
+
+  expect(ll.loginSSO).toHaveBeenCalledWith(tokenResponse);
+});
+
+test("login forwards the picked id into loginBasic's options bag", async () => {
+  const { client, ll } = makeStub({ hasAuthV2: true, scheme: "basic" });
+
+  await client.login("alice", "pw", "htpasswd-b");
+
+  expect(ll.loginBasic).toHaveBeenCalledWith("alice", "pw", { idP: "htpasswd-b" });
+});
+
+test("login drops the picked id on the token branch", async () => {
+  const { client, ll } = makeStub({ hasAuthV2: true, scheme: "token" });
+
+  const info = await client.login("alice", "opaque-token", "some-id");
+
+  expect(ll.loginWithToken).toHaveBeenCalledWith("opaque-token");
+  expect(info.jwtToken).toBe("jwt-from-loginWithToken");
+});
+
 test("ssoConfig returns the first sso method and drops the rest", () => {
-  const first = ssoMethod({ id: "sso-first", description: "First IdP", issuer: "https://first.example" });
-  const second = ssoMethod({ id: "sso-second", description: "Second IdP", issuer: "https://second.example" });
+  const first = ssoMethod({
+    id: "sso-first",
+    description: "First IdP",
+    issuer: "https://first.example",
+  });
+  const second = ssoMethod({
+    id: "sso-second",
+    description: "Second IdP",
+    issuer: "https://second.example",
+  });
   const { client } = makeStub({ hasAuthV2: true, methods: [first, second] });
 
   const sso = client.ssoConfig();
@@ -149,4 +326,76 @@ test("supportedAuthSchemes collapses a basic+token+sso method list to scheme boo
   const { client } = makeStub({ hasAuthV2: true, methods });
 
   expect(client.supportedAuthSchemes).toEqual({ basic: true, token: true });
+});
+
+// --- LLPlClient.loginBasic carries the id on both transports ---
+
+function makeLLStub(cl: { login?: ReturnType<typeof vi.fn>; POST?: ReturnType<typeof vi.fn> }) {
+  return Object.assign(Object.create(LLPlClient.prototype) as object, {
+    clientProvider: { get: () => cl },
+    conf: { authTTLSeconds: 100 },
+  }) as LLPlClient;
+}
+
+test("loginBasic carries idP in the request body on the gRPC transport", async () => {
+  const login = vi.fn(() => ({ response: Promise.resolve({ token: "jwt" }) }));
+  const cl = Object.assign(Object.create(GrpcPlApiClient.prototype) as object, { login });
+  const ll = makeLLStub(cl);
+
+  await ll.loginBasic("alice", "pw", { idP: "htpasswd-b" });
+
+  expect(login).toHaveBeenCalledWith(
+    expect.objectContaining({
+      credentials: {
+        oneofKind: "basic",
+        basic: { login: "alice", password: "pw", idp: "htpasswd-b" },
+      },
+    }),
+    expect.anything(),
+  );
+});
+
+test("loginBasic without idP produces the same gRPC request body as today", async () => {
+  const login = vi.fn(() => ({ response: Promise.resolve({ token: "jwt" }) }));
+  const cl = Object.assign(Object.create(GrpcPlApiClient.prototype) as object, { login });
+  const ll = makeLLStub(cl);
+
+  await ll.loginBasic("alice", "pw");
+
+  expect(login).toHaveBeenCalledWith(
+    expect.objectContaining({
+      credentials: { oneofKind: "basic", basic: { login: "alice", password: "pw" } },
+    }),
+    expect.anything(),
+  );
+});
+
+test("loginBasic carries idP in the request body on the REST transport", async () => {
+  const POST = vi.fn(() => Promise.resolve({ data: { token: "jwt" } }));
+  const ll = makeLLStub({ POST });
+
+  await ll.loginBasic("alice", "pw", { idP: "htpasswd-b" });
+
+  expect(POST).toHaveBeenCalledWith(
+    "/v1/auth/login",
+    expect.objectContaining({
+      body: expect.objectContaining({
+        basic: { login: "alice", password: "pw", idp: "htpasswd-b" },
+      }),
+    }),
+  );
+});
+
+test("loginBasic without idP produces the same REST request body as today", async () => {
+  const POST = vi.fn(() => Promise.resolve({ data: { token: "jwt" } }));
+  const ll = makeLLStub({ POST });
+
+  await ll.loginBasic("alice", "pw");
+
+  expect(POST).toHaveBeenCalledWith(
+    "/v1/auth/login",
+    expect.objectContaining({
+      body: expect.objectContaining({ basic: { login: "alice", password: "pw" } }),
+    }),
+  );
 });

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -3701,11 +3701,19 @@ export interface AuthAPI_ListMethods_MethodInfo {
      */
     id: string;
     /**
-     * description is the human-readable label in case we'd like to render it in UI.
+     * description is the long-form human-readable text a client may render
+     * alongside the title, for example in a tooltip or under the button.
      *
      * @generated from protobuf field: string description = 7
      */
     description: string;
+    /**
+     * title is the short human-readable label a client renders for this
+     * method, for example on the sign-in button. Always set.
+     *
+     * @generated from protobuf field: string title = 9
+     */
+    title: string;
     /**
      * @generated from protobuf oneof: method
      */
@@ -17826,6 +17834,7 @@ class AuthAPI_ListMethods_MethodInfo$Type extends MessageType<AuthAPI_ListMethod
         super("MiLaboratories.PL.API.AuthAPI.ListMethods.MethodInfo", [
             { no: 6, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "title", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "basic", kind: "message", oneof: "method", T: () => AuthAPI_ListMethods_BasicAuthMethod },
             { no: 5, name: "token", kind: "message", oneof: "method", T: () => AuthAPI_ListMethods_TokenAuthMethod },
             { no: 8, name: "sso", kind: "message", oneof: "method", T: () => AuthAPI_ListMethods_SSOAuthMethod }
@@ -17835,6 +17844,7 @@ class AuthAPI_ListMethods_MethodInfo$Type extends MessageType<AuthAPI_ListMethod
         const message = globalThis.Object.create((this.messagePrototype!));
         message.id = "";
         message.description = "";
+        message.title = "";
         message.method = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<AuthAPI_ListMethods_MethodInfo>(this, message, value);
@@ -17850,6 +17860,9 @@ class AuthAPI_ListMethods_MethodInfo$Type extends MessageType<AuthAPI_ListMethod
                     break;
                 case /* string description */ 7:
                     message.description = reader.string();
+                    break;
+                case /* string title */ 9:
+                    message.title = reader.string();
                     break;
                 case /* MiLaboratories.PL.API.AuthAPI.ListMethods.BasicAuthMethod basic */ 4:
                     message.method = {
@@ -17896,6 +17909,9 @@ class AuthAPI_ListMethods_MethodInfo$Type extends MessageType<AuthAPI_ListMethod
         /* MiLaboratories.PL.API.AuthAPI.ListMethods.SSOAuthMethod sso = 8; */
         if (message.method.oneofKind === "sso")
             AuthAPI_ListMethods_SSOAuthMethod.internalBinaryWrite(message.method.sso, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* string title = 9; */
+        if (message.title !== "")
+            writer.tag(9, WireType.LengthDelimited).string(message.title);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
+++ b/lib/node/pl-client/src/proto-grpc/github.com/milaboratory/pl/plapi/plapiproto/api.ts
@@ -1025,6 +1025,26 @@ export interface TxAPI_Open_Response {
      * @generated from protobuf field: MiLaboratories.PL.API.Tx tx = 1
      */
     tx?: Tx;
+    /**
+     * The token to store and send back as changed_since_token on any later Tree
+     * request. Everything the token denotes has finished committing, and it is
+     * sampled as this transaction opens, so a write that had not committed by
+     * then sits above it while one that had is visible to this transaction's
+     * reads. One token per transaction, however many tree reads it issues.
+     *
+     * Absent on a WRITABLE open, which is issued no token: the walk would see
+     * that transaction's own uncommitted writes (see changed_since_token).
+     *
+     * Store it only after a whole tree response has been applied successfully. A
+     * client that keeps it after a partial apply will never be sent the
+     * resources it dropped. Clear it on tree rebuild, on a root-set change, and
+     * whenever the seed array is invalidated - the server no longer refuses a
+     * token presented against a differently shaped request, so that is the
+     * client's to enforce.
+     *
+     * @generated from protobuf field: bytes next_since_token = 2
+     */
+    nextSinceToken: Uint8Array;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.TxAPI.Commit
@@ -1826,6 +1846,37 @@ export interface ResourceAPI_Tree_Request {
      * @generated from protobuf field: bool show_soft_deletes = 9
      */
     showSoftDeletes: boolean;
+    /**
+     * An opaque continuation token, taken verbatim from a previous response's
+     * next_since_token. The server returns bodies only for resources that
+     * changed after the point this token denotes; every other visited resource
+     * gets a body-less frame with resource_unchanged set. Empty or absent (the
+     * default) requests the full tree.
+     *
+     * Clients must not parse, construct or compare this value: its encoding is
+     * server-private and may change without a wire version bump. Store the
+     * token only after applying a whole response successfully.
+     *
+     * A token the server cannot use is answered with the full tree, never with
+     * an error, so it is always safe to send back whatever was last received.
+     * The server detects and ignores a token that does not fit the request it
+     * arrives on - the token is bound to the traversal-shaping parameters
+     * (resource_id, seeds, max_depth, include_kv, show_soft_deletes,
+     * field_filter, traverse_stop_rules), so changing any of them costs one
+     * full tree instead of silently reporting never-sent resources as held.
+     *
+     * Ignored on a WRITABLE transaction, which also receives no
+     * next_since_token: the walk sees that transaction's uncommitted writes, so
+     * delta skipping there could pin a body describing state that never
+     * committed. Poll from a read-only transaction.
+     *
+     * Servers advertise support via "treeChangedSince:v1" in
+     * MaintenanceAPI.Ping.Response.capabilities; old servers ignore this field
+     * and always send the full tree.
+     *
+     * @generated from protobuf field: bytes changed_since_token = 10
+     */
+    changedSinceToken: Uint8Array;
 }
 /**
  * A single entry point for multi-root tree traversal.
@@ -2021,8 +2072,9 @@ export interface ResourceAPI_Tree_KV {
 export interface ResourceAPI_Tree_Response {
     /**
      * Full resource payload. Absent on stop-marker frames (when the server
-     * advertises `treeStopMarker:v1` and traverse_was_stopped is true).
-     * Always populated on normal frames.
+     * advertises `treeStopMarker:v1` and traverse_was_stopped is true) and on
+     * unchanged frames (when resource_unchanged is true). Populated on every
+     * other frame.
      *
      * @generated from protobuf field: optional MiLaboratories.PL.API.Resource resource = 1
      */
@@ -2048,8 +2100,9 @@ export interface ResourceAPI_Tree_Response {
      */
     traverseWasStopped: boolean;
     /**
-     * Populated only on stop-marker frames (resource is unset).
-     * Zero / empty on normal frames; use resource.resource_id instead.
+     * Populated on frames where resource is unset - stop-marker and unchanged
+     * frames. Zero / empty on frames carrying a resource; use
+     * resource.resource_id instead.
      *
      * @generated from protobuf field: uint64 resource_id = 4
      */
@@ -2058,6 +2111,23 @@ export interface ResourceAPI_Tree_Response {
      * @generated from protobuf field: bytes resource_signature = 5
      */
     resourceSignature: Uint8Array;
+    /**
+     * True on a body-less frame emitted for a resource the client already holds:
+     * resource is unset, and resource_id and resource_signature carry the
+     * identity instead. The client keeps everything it holds for that resource,
+     * fields and kv alike, and the traversal still descends into it - an
+     * unchanged parent routinely has changed children.
+     *
+     * Orthogonal to traverse_was_stopped; a frame may set both.
+     *
+     * A resource may appear twice in one response: an unchanged frame, then a
+     * body frame later in the same response. The later frame supersedes the
+     * earlier one, so apply frames in arrival order and treat an unchanged
+     * frame for an unknown resource as benign rather than fatal.
+     *
+     * @generated from protobuf field: bool resource_unchanged = 6
+     */
+    resourceUnchanged: boolean;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.ResourceAPI.TreeSize
@@ -3675,6 +3745,10 @@ export interface AuthAPI_BeginSSOLogin {
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.Request
  */
 export interface AuthAPI_BeginSSOLogin_Request {
+    /**
+     * @generated from protobuf field: optional string idp = 1
+     */
+    idp?: string;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.PublicPKCE
@@ -3773,6 +3847,10 @@ export interface AuthAPI_Login_BasicCredentials {
      * @generated from protobuf field: string password = 2
      */
     password: string;
+    /**
+     * @generated from protobuf field: optional string idp = 3
+     */
+    idp?: string;
 }
 /**
  * TokenCredentials accepts any opaque bearer-style string: a controller
@@ -3797,6 +3875,10 @@ export interface AuthAPI_Login_SSOCredentials {
      * @generated from protobuf field: bytes token_response = 1
      */
     tokenResponse: Uint8Array;
+    /**
+     * @generated from protobuf field: optional string idp = 2
+     */
+    idp?: string;
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.Login.Request
@@ -4229,13 +4311,39 @@ export interface AuthAPI_ListUserResources_SharedResource {
  */
 export interface AuthAPI_User {
     /**
-     * login is the stable identifier of the user — the grant target and the
-     * GetUserRoot key. Further fields (e.g. first name, last name, email) may
-     * be added later without breaking compatibility.
+     * login is the user's provider-facing login identifier and the value clients
+     * pass as a grant target / impersonation subject. It is the only identity a
+     * client needs: the backend resolves it to an internal id that is never
+     * exposed over the API.
      *
      * @generated from protobuf field: string login = 1
      */
     login: string;
+    /**
+     * display_name is the user's human-readable name, mapped from the provider on
+     * login. May be empty for migrated users who have not logged in since upgrade.
+     *
+     * @generated from protobuf field: string display_name = 2
+     */
+    displayName: string;
+    /**
+     * email is the user's email, mapped from the provider on login. May be empty
+     * when the provider does not supply it or the mapping is disabled.
+     *
+     * @generated from protobuf field: string email = 3
+     */
+    email: string;
+    /**
+     * attributes carries the remaining provider-mapped attributes the client
+     * configured (e.g. full_name, external_id, custom fields), keyed by attribute
+     * name. The default attributes (login, display_name, email) are promoted to
+     * their own fields above and are not repeated here.
+     *
+     * @generated from protobuf field: map<string, string> attributes = 4
+     */
+    attributes: {
+        [key: string]: string;
+    };
 }
 /**
  * @generated from protobuf message MiLaboratories.PL.API.AuthAPI.ListUsers
@@ -5998,11 +6106,13 @@ export const TxAPI_Open_Request = new TxAPI_Open_Request$Type();
 class TxAPI_Open_Response$Type extends MessageType<TxAPI_Open_Response> {
     constructor() {
         super("MiLaboratories.PL.API.TxAPI.Open.Response", [
-            { no: 1, name: "tx", kind: "message", T: () => Tx }
+            { no: 1, name: "tx", kind: "message", T: () => Tx },
+            { no: 2, name: "next_since_token", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<TxAPI_Open_Response>): TxAPI_Open_Response {
         const message = globalThis.Object.create((this.messagePrototype!));
+        message.nextSinceToken = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<TxAPI_Open_Response>(this, message, value);
         return message;
@@ -6014,6 +6124,9 @@ class TxAPI_Open_Response$Type extends MessageType<TxAPI_Open_Response> {
             switch (fieldNo) {
                 case /* MiLaboratories.PL.API.Tx tx */ 1:
                     message.tx = Tx.internalBinaryRead(reader, reader.uint32(), options, message.tx);
+                    break;
+                case /* bytes next_since_token */ 2:
+                    message.nextSinceToken = reader.bytes();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -6030,6 +6143,9 @@ class TxAPI_Open_Response$Type extends MessageType<TxAPI_Open_Response> {
         /* MiLaboratories.PL.API.Tx tx = 1; */
         if (message.tx)
             Tx.internalBinaryWrite(message.tx, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* bytes next_since_token = 2; */
+        if (message.nextSinceToken.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.nextSinceToken);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -9591,7 +9707,8 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
             { no: 6, name: "include_kv", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 7, name: "traverse_stop_rules", kind: "message", T: () => ResourceAPI_Tree_Filter },
             { no: 8, name: "seeds", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_SeedResource },
-            { no: 9, name: "show_soft_deletes", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 9, name: "show_soft_deletes", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 10, name: "changed_since_token", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<ResourceAPI_Tree_Request>): ResourceAPI_Tree_Request {
@@ -9601,6 +9718,7 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
         message.includeKv = false;
         message.seeds = [];
         message.showSoftDeletes = false;
+        message.changedSinceToken = new Uint8Array(0);
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_Tree_Request>(this, message, value);
         return message;
@@ -9633,6 +9751,9 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
                     break;
                 case /* bool show_soft_deletes */ 9:
                     message.showSoftDeletes = reader.bool();
+                    break;
+                case /* bytes changed_since_token */ 10:
+                    message.changedSinceToken = reader.bytes();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -9670,6 +9791,9 @@ class ResourceAPI_Tree_Request$Type extends MessageType<ResourceAPI_Tree_Request
         /* bool show_soft_deletes = 9; */
         if (message.showSoftDeletes !== false)
             writer.tag(9, WireType.Varint).bool(message.showSoftDeletes);
+        /* bytes changed_since_token = 10; */
+        if (message.changedSinceToken.length)
+            writer.tag(10, WireType.LengthDelimited).bytes(message.changedSinceToken);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -9930,7 +10054,8 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
             { no: 2, name: "kv", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => ResourceAPI_Tree_KV },
             { no: 3, name: "traverse_was_stopped", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 4, name: "resource_id", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 5, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+            { no: 5, name: "resource_signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 6, name: "resource_unchanged", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<ResourceAPI_Tree_Response>): ResourceAPI_Tree_Response {
@@ -9939,6 +10064,7 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         message.traverseWasStopped = false;
         message.resourceId = 0n;
         message.resourceSignature = new Uint8Array(0);
+        message.resourceUnchanged = false;
         if (value !== undefined)
             reflectionMergePartial<ResourceAPI_Tree_Response>(this, message, value);
         return message;
@@ -9962,6 +10088,9 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
                     break;
                 case /* bytes resource_signature */ 5:
                     message.resourceSignature = reader.bytes();
+                    break;
+                case /* bool resource_unchanged */ 6:
+                    message.resourceUnchanged = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -9990,6 +10119,9 @@ class ResourceAPI_Tree_Response$Type extends MessageType<ResourceAPI_Tree_Respon
         /* bytes resource_signature = 5; */
         if (message.resourceSignature.length)
             writer.tag(5, WireType.LengthDelimited).bytes(message.resourceSignature);
+        /* bool resource_unchanged = 6; */
+        if (message.resourceUnchanged !== false)
+            writer.tag(6, WireType.Varint).bool(message.resourceUnchanged);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -17815,7 +17947,9 @@ export const AuthAPI_BeginSSOLogin = new AuthAPI_BeginSSOLogin$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class AuthAPI_BeginSSOLogin_Request$Type extends MessageType<AuthAPI_BeginSSOLogin_Request> {
     constructor() {
-        super("MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.Request", []);
+        super("MiLaboratories.PL.API.AuthAPI.BeginSSOLogin.Request", [
+            { no: 1, name: "idp", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
     }
     create(value?: PartialMessage<AuthAPI_BeginSSOLogin_Request>): AuthAPI_BeginSSOLogin_Request {
         const message = globalThis.Object.create((this.messagePrototype!));
@@ -17828,6 +17962,9 @@ class AuthAPI_BeginSSOLogin_Request$Type extends MessageType<AuthAPI_BeginSSOLog
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
+                case /* optional string idp */ 1:
+                    message.idp = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -17840,6 +17977,9 @@ class AuthAPI_BeginSSOLogin_Request$Type extends MessageType<AuthAPI_BeginSSOLog
         return message;
     }
     internalBinaryWrite(message: AuthAPI_BeginSSOLogin_Request, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional string idp = 1; */
+        if (message.idp !== undefined)
+            writer.tag(1, WireType.LengthDelimited).string(message.idp);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -18158,7 +18298,8 @@ class AuthAPI_Login_BasicCredentials$Type extends MessageType<AuthAPI_Login_Basi
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.Login.BasicCredentials", [
             { no: 1, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "password", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 2, name: "password", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "idp", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_Login_BasicCredentials>): AuthAPI_Login_BasicCredentials {
@@ -18180,6 +18321,9 @@ class AuthAPI_Login_BasicCredentials$Type extends MessageType<AuthAPI_Login_Basi
                 case /* string password */ 2:
                     message.password = reader.string();
                     break;
+                case /* optional string idp */ 3:
+                    message.idp = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -18198,6 +18342,9 @@ class AuthAPI_Login_BasicCredentials$Type extends MessageType<AuthAPI_Login_Basi
         /* string password = 2; */
         if (message.password !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.password);
+        /* optional string idp = 3; */
+        if (message.idp !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.idp);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -18259,7 +18406,8 @@ export const AuthAPI_Login_TokenCredentials = new AuthAPI_Login_TokenCredentials
 class AuthAPI_Login_SSOCredentials$Type extends MessageType<AuthAPI_Login_SSOCredentials> {
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.Login.SSOCredentials", [
-            { no: 1, name: "token_response", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+            { no: 1, name: "token_response", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "idp", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_Login_SSOCredentials>): AuthAPI_Login_SSOCredentials {
@@ -18277,6 +18425,9 @@ class AuthAPI_Login_SSOCredentials$Type extends MessageType<AuthAPI_Login_SSOCre
                 case /* bytes token_response */ 1:
                     message.tokenResponse = reader.bytes();
                     break;
+                case /* optional string idp */ 2:
+                    message.idp = reader.string();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -18292,6 +18443,9 @@ class AuthAPI_Login_SSOCredentials$Type extends MessageType<AuthAPI_Login_SSOCre
         /* bytes token_response = 1; */
         if (message.tokenResponse.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.tokenResponse);
+        /* optional string idp = 2; */
+        if (message.idp !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.idp);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -19930,12 +20084,18 @@ export const AuthAPI_ListUserResources_SharedResource = new AuthAPI_ListUserReso
 class AuthAPI_User$Type extends MessageType<AuthAPI_User> {
     constructor() {
         super("MiLaboratories.PL.API.AuthAPI.User", [
-            { no: 1, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "login", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "display_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "email", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "attributes", kind: "map", K: 9 /*ScalarType.STRING*/, V: { kind: "scalar", T: 9 /*ScalarType.STRING*/ } }
         ]);
     }
     create(value?: PartialMessage<AuthAPI_User>): AuthAPI_User {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.login = "";
+        message.displayName = "";
+        message.email = "";
+        message.attributes = {};
         if (value !== undefined)
             reflectionMergePartial<AuthAPI_User>(this, message, value);
         return message;
@@ -19948,6 +20108,15 @@ class AuthAPI_User$Type extends MessageType<AuthAPI_User> {
                 case /* string login */ 1:
                     message.login = reader.string();
                     break;
+                case /* string display_name */ 2:
+                    message.displayName = reader.string();
+                    break;
+                case /* string email */ 3:
+                    message.email = reader.string();
+                    break;
+                case /* map<string, string> attributes */ 4:
+                    this.binaryReadMap4(message.attributes, reader, options);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -19959,10 +20128,35 @@ class AuthAPI_User$Type extends MessageType<AuthAPI_User> {
         }
         return message;
     }
+    private binaryReadMap4(map: AuthAPI_User["attributes"], reader: IBinaryReader, options: BinaryReadOptions): void {
+        let len = reader.uint32(), end = reader.pos + len, key: keyof AuthAPI_User["attributes"] | undefined, val: AuthAPI_User["attributes"][any] | undefined;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case 1:
+                    key = reader.string();
+                    break;
+                case 2:
+                    val = reader.string();
+                    break;
+                default: throw new globalThis.Error("unknown map entry field for MiLaboratories.PL.API.AuthAPI.User.attributes");
+            }
+        }
+        map[key ?? ""] = val ?? "";
+    }
     internalBinaryWrite(message: AuthAPI_User, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string login = 1; */
         if (message.login !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.login);
+        /* string display_name = 2; */
+        if (message.displayName !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.displayName);
+        /* string email = 3; */
+        if (message.email !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.email);
+        /* map<string, string> attributes = 4; */
+        for (let k of globalThis.Object.keys(message.attributes))
+            writer.tag(4, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.attributes[k]).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -586,7 +586,9 @@ export interface components {
        */
       clientSecret: string;
     };
-    AuthAPI_BeginSSOLogin_Request: Record<string, never>;
+    AuthAPI_BeginSSOLogin_Request: {
+      idp: string;
+    };
     AuthAPI_BeginSSOLogin_Response: {
       publicPkce: components["schemas"]["AuthAPI_BeginSSOLogin_PublicPKCE"];
     };
@@ -672,6 +674,7 @@ export interface components {
     AuthAPI_Login_BasicCredentials: {
       login: string;
       password: string;
+      idp: string;
     };
     AuthAPI_Login_Request: {
       basic: components["schemas"]["AuthAPI_Login_BasicCredentials"];
@@ -695,6 +698,7 @@ export interface components {
     AuthAPI_Login_SSOCredentials: {
       /** Format: bytes */
       tokenResponse: string;
+      idp: string;
     };
     /**
      * @description TokenCredentials accepts any opaque bearer-style string: a controller

--- a/lib/node/pl-client/src/proto-rest/plapi.ts
+++ b/lib/node/pl-client/src/proto-rest/plapi.ts
@@ -642,8 +642,10 @@ export interface components {
        *      instance. Unique across the entire server.
        */
       id: string;
-      /** @description description is the human-readable label in case we'd like to render it in UI. */
+      /** @description description is the long-form human-readable text a client may render alongside the title, for example in a tooltip or under the button. */
       description: string;
+      /** @description title is the short human-readable label a client renders for this method, for example on the sign-in button. Always set. */
+      title: string;
       basic: components["schemas"]["AuthAPI_ListMethods_BasicAuthMethod"];
       token: components["schemas"]["AuthAPI_ListMethods_TokenAuthMethod"];
       sso: components["schemas"]["AuthAPI_ListMethods_SSOAuthMethod"];


### PR DESCRIPTION
## Summary

`pl-client` gave a caller no way to offer a choice of login method. The SSO accessor returned only the first advertised SSO method, and the scheme accessor collapsed every basic-kind method to a single `basic: true` boolean, so two LDAP directories and an htpasswd file on one server were indistinguishable. No login call — SSO or password — carried any way to say which method the caller meant.

- Characterization tests pin `ssoConfig()`'s today's first-match/flow-type-guard behavior and `supportedAuthSchemes` ahead of the refactor.
- One accessor, `loginMethods()`, now returns every advertised method of every kind, each keeping the `id`, description and kind the server advertised.
- Every login call (`beginSSOLogin`, `loginSSO`, `login`) accepts that `id` and forwards it to the backend's selector field. A caller that names no method behaves exactly as before.
- `ssoConfig()` and `supportedAuthSchemes` stay, deprecated but unchanged in shape — the password login path inside this package still reads the scheme booleans to choose between basic and token credentials.

## Commits

- `pl-client: pin ssoConfig()'s first-match and flow-type guard, and supportedAuthSchemes`
- `feat(pl-client): list every login method and forward the picked id`

Part of MILAB-6670 (multiprovider login UI). A stacked branch (`uikit-split-menu-width`, not yet in this PR) adds a `PlBtnSplit` prop the desktop's picker UI needs; that will follow separately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds discovery and selection of individual authentication methods across the public client and both wire transports. It also regenerates protocol bindings containing additional user and resource-tree fields.

- **LoginMethod** — A discriminated union describing one advertised basic, token, or supported SSO method; newly added with each method's id and description preserved.
- **Method id / idP** — The selector identifying a specific advertised authenticator; newly accepted by password and SSO client entry points and serialized as the backend `idp` field.
- **SSOAuthMethod** — The client-usable public-PKCE SSO configuration; now shared by `ssoConfig()` and the new `loginMethods()` projection.
- **supportedAuthSchemes** — The legacy basic/token boolean projection; now deprecated but retained for credential-branch selection.
- **changedSinceToken / nextSinceToken** — Opaque resource-tree delta tokens added to the protocol bindings; current transaction traversal explicitly sends an empty token for a full tree.
- **resourceUnchanged** — A new body-less resource-tree response marker represented in the generated gRPC binding.
- **AuthAPI.User** — The protocol user record; expanded with display name, email, and mapped attributes.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until selecting a token method on a mixed basic/token backend is routed correctly or explicitly rejected.

The new public method list exposes token ids as selectable, while login() chooses basic authentication whenever any basic method exists and consequently sends a selected token id to the wrong credential type.

**Files Needing Attention:** lib/node/pl-client/src/core/unauth_client.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-client/src/core/unauth_client.ts | Adds method discovery and selector forwarding, but mixed basic/token advertisements can misroute a selected token method through basic authentication. |
| lib/node/pl-client/src/core/ll_client.ts | Correctly serializes optional basic and SSO method selectors over both gRPC and REST while preserving omission behavior. |
| lib/node/pl-client/proto/plapi/plapiproto/api.proto | Adds auth selector fields and unrelated generated-contract inputs for users and resource-tree deltas; token credentials still have no method selector. |
| lib/node/pl-client/src/core/transaction.ts | Supplies an empty changed-since token, retaining full-tree traversal behavior. |
| lib/node/pl-client/src/core/unauth_client_branch.test.ts | Thoroughly characterizes projections and forwarding but does not cover selecting a token method on a mixed basic/token backend. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[loginMethods returns advertised entries] --> B[Caller selects method id]
  B --> C{Selected kind}
  C -->|SSO| D[beginSSOLogin and loginSSO forward idp]
  C -->|Basic| E[login forwards idp in BasicCredentials]
  C -->|Token on mixed backend| F[Aggregate basic flag wins]
  F --> G[Token id is sent as a basic idp]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231803%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1803&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fnode%2Fpl-client%2Fsrc%2Fcore%2Funauth_client.ts%3A188-194%0A**Token%20method%20selection%20misroutes**%0A%0AWhen%20a%20backend%20advertises%20both%20basic%20and%20token%20methods%20and%20the%20caller%20selects%20a%20token%20entry%20returned%20by%20%60loginMethods%28%29%60%2C%20%60login%28%29%60%20gives%20the%20aggregate%20basic%20flag%20precedence%20and%20sends%20the%20token%20method's%20id%20inside%20basic%20credentials%2C%20causing%20the%20selected%20token%20login%20to%20be%20rejected%20or%20routed%20to%20the%20wrong%20authenticator.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1803&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/node/pl-client/src/core/unauth_client.ts:188-194
**Token method selection misroutes**

When a backend advertises both basic and token methods and the caller selects a token entry returned by `loginMethods()`, `login()` gives the aggregate basic flag precedence and sends the token method's id inside basic credentials, causing the selected token login to be rejected or routed to the wrong authenticator.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\[MILAB-6670\]: feat(pl-client): list ever..."](https://github.com/milaboratory/platforma/commit/5c588bef1c726ceaa9cd5f654a58b9d2cd13555d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59940637)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Platform client and configuration](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/platform-client-and-configuration.md)

<!-- /greptile_comment -->