### PR TITLE
Skip non-column exports when listing pool columns

### DIFF
--- a/.changeset/drop-non-column-exports-from-collection.md
+++ b/.changeset/drop-non-column-exports-from-collection.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-model-common": patch
+---
+
+Fix column enumeration so an upstream export whose spec is not a PColumn spec is skipped. A block that exports a `kind: "File"` object, such as a custom MiXCR library, no longer reaches column predicates and crashes them on a missing `axesSpec`.

--- a/lib/model/common/src/columns/accessor_traversal.test.ts
+++ b/lib/model/common/src/columns/accessor_traversal.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import type { PColumnSpec, PObjectSpec } from "../pool";
+import { ResourceTypeName } from "../resource_types";
+import { listColumnNames } from "./accessor_traversal";
+import type { AccessorLike, FieldTraversalStepLike } from "./types";
+
+class StubAccessor implements AccessorLike<StubAccessor> {
+  readonly resourceType: { readonly name: string };
+  readonly #fields: Record<string, StubAccessor>;
+  readonly #data: unknown;
+
+  constructor(typeName: string, fields: Record<string, StubAccessor> = {}, data?: unknown) {
+    this.resourceType = { name: typeName };
+    this.#fields = fields;
+    this.#data = data;
+  }
+
+  traverse(step: FieldTraversalStepLike): StubAccessor | undefined {
+    return this.#fields[step.field];
+  }
+
+  listInputFields(): string[] {
+    return Object.keys(this.#fields);
+  }
+
+  getInputsLocked(): boolean {
+    return true;
+  }
+
+  hasData(): boolean {
+    return this.#data !== undefined;
+  }
+
+  getDataAsJson<T = unknown>(): T | undefined {
+    return this.#data as T | undefined;
+  }
+}
+
+const columnSpec: PColumnSpec = { kind: "PColumn", name: "column", valueType: "Int", axesSpec: [] };
+const fileSpec: PObjectSpec = { kind: "File", name: "library" };
+
+describe("listColumnNames", () => {
+  test("skips a resolved non-column export and keeps an unresolved spec", () => {
+    const pframe = new StubAccessor(ResourceTypeName.PFrame, {
+      "column.spec": new StubAccessor("json", {}, columnSpec),
+      "column.data": new StubAccessor("json"),
+      "library.spec": new StubAccessor("json", {}, fileSpec),
+      "library.data": new StubAccessor("json"),
+      "pending.spec": new StubAccessor("json"),
+    });
+    expect(listColumnNames(pframe)).toEqual(["column", "pending"]);
+  });
+});

--- a/lib/model/common/src/columns/accessor_traversal.ts
+++ b/lib/model/common/src/columns/accessor_traversal.ts
@@ -1,4 +1,5 @@
-import { createGlobalPObjectId, createLocalPObjectId } from "../pool";
+import type { PObjectSpec } from "../pool";
+import { createGlobalPObjectId, createLocalPObjectId, isPColumnSpec } from "../pool";
 import { ResourceTypeName } from "../resource_types";
 import type { AccessorLike, LeafEntry, UpstreamBlockCtx } from "./types";
 
@@ -12,8 +13,10 @@ export const DESCEND_TYPES: ReadonlyArray<string> = [
 ];
 
 /**
- * Enumerate column names backing a PFrame accessor — derived from
- * `<name>.spec` field names, without resolving the spec resources.
+ * Enumerate column names backing a PFrame accessor, from the `<name>.spec`
+ * field names. A name whose spec has resolved to a non-column object (a
+ * `kind: "File"` export, for example) is skipped. A name whose spec has no
+ * data yet is kept, because it may still resolve to a column.
  */
 export function listColumnNames<A extends AccessorLike<A>>(
   accessor: A,
@@ -25,6 +28,10 @@ export function listColumnNames<A extends AccessorLike<A>>(
     if (!field.endsWith(".spec")) continue;
     const raw = field.slice(0, -".spec".length);
     if (!raw.startsWith(prefix)) continue;
+    const spec = accessor
+      .traverse({ field, assertFieldType: "Input", ignoreError: true })
+      ?.getDataAsJson<PObjectSpec>();
+    if (spec !== undefined && !isPColumnSpec(spec)) continue;
     out.push(raw.slice(prefix.length));
   }
   return out;


### PR DESCRIPTION
An upstream block can export a `kind: "File"` object beside its columns. MiXCR Clonotyping does this for a custom library. The result pool listed it as a column, and `isLabelColumn` in a block model read `axesSpec.length` on it and threw.

`listColumnNames` now reads each `<name>.spec` and skips a spec that has data and is not a PColumn spec. Every entries provider, on the host and in the sandbox, builds its ids from it, so a non-column export never becomes a column id. A spec with no data yet stays listed, because it may still resolve to a column.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents resolved non-column exports from entering column collections, but its new spec read can throw for unresolved sandbox resources that the implementation intends to retain.
- **PFrame:** A model container for related columns; enumeration now inspects each exported object's spec before treating its name as a frame column.
- **PColumnSpec:** The serialized schema of a Platforma column, identified by `kind: "PColumn"`; resolved specs that fail this type guard are now excluded.
- **PObjectSpec:** The broader exported-object schema that can describe columns or objects such as files; it is now the type read from each `<name>.spec`.
- **Columns provider:** The host or sandbox component that derives logical column IDs from accessors and result pools; all such providers inherit the new filtering behavior.
- **Unresolved spec:** A connected spec resource whose content is not available yet; the intended behavior is to keep it listed, but the sandbox accessor currently throws when the new code reads it.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The pending-spec crash in sandbox column enumeration should be fixed before merging.

The new unconditional JSON read reaches a real transient resource state where the sandbox accessor throws, preventing providers from enumerating columns even though unresolved specs are meant to remain visible.

**Files Needing Attention:** lib/model/common/src/columns/accessor_traversal.ts, lib/model/common/src/columns/accessor_traversal.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/model/common/src/columns/accessor_traversal.ts | Adds the correct resolved-spec type filter, but reads pending sandbox specs through an accessor method that throws when content is unavailable. |
| lib/model/common/src/columns/accessor_traversal.test.ts | Covers resolved columns, resolved files, and a stubbed unresolved spec, but the stub returns undefined rather than matching the real sandbox accessor’s throwing behavior. |
| .changeset/drop-non-column-exports-from-collection.md | Accurately describes filtering resolved non-column exports, although the claimed unresolved-spec behavior is not preserved in the sandbox implementation. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[PFrame input fields] --> B[listColumnNames]
  B --> C{Spec content available?}
  C -->|Resolved PColumn| D[Include column name]
  C -->|Resolved non-column| E[Skip export]
  C -->|Unresolved in sandbox| F[getDataAsJson throws]
  D --> G[Column provider IDs]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231804%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1804&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fmodel%2Fcommon%2Fsrc%2Fcolumns%2Faccessor_traversal.ts%3A31-33%0A**Pending%20specs%20crash%20enumeration**%0A%0AWhen%20a%20sandbox%20column%20provider%20encounters%20a%20connected%20%60%3Cname%3E.spec%60%20resource%20whose%20content%20has%20not%20been%20written%20yet%2C%20%60getDataAsJson%60%20throws%20%60Resource%20has%20no%20content.%60%2C%20aborting%20provider%20construction%20or%20result-pool%20enumeration%20instead%20of%20retaining%20the%20pending%20column.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20specAccessor%20%3D%20accessor.traverse%28%7B%0A%20%20%20%20%20%20field%2C%0A%20%20%20%20%20%20assertFieldType%3A%20%22Input%22%2C%0A%20%20%20%20%20%20ignoreError%3A%20true%2C%0A%20%20%20%20%7D%29%3B%0A%20%20%20%20const%20spec%20%3D%20specAccessor%3F.hasData%28%29%0A%20%20%20%20%20%20%3F%20specAccessor.getDataAsJson%3CPObjectSpec%3E%28%29%0A%20%20%20%20%20%20%3A%20undefined%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1804&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/model/common/src/columns/accessor_traversal.ts:31-33
**Pending specs crash enumeration**

When a sandbox column provider encounters a connected `<name>.spec` resource whose content has not been written yet, `getDataAsJson` throws `Resource has no content.`, aborting provider construction or result-pool enumeration instead of retaining the pending column.

```suggestion
    const specAccessor = accessor.traverse({
      field,
      assertFieldType: "Input",
      ignoreError: true,
    });
    const spec = specAccessor?.hasData()
      ? specAccessor.getDataAsJson<PObjectSpec>()
      : undefined;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Skip non-column exports when listing poo..."](https://github.com/milaboratory/platforma/commit/81ca489d9b2f7d02f4d3a0793bdb7a9645ae57ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59971948)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Data model and tabular data](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/data-model.md)
- Knowledge Base — [Columns, collections, and identities](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/columns-and-identities.md)

<!-- /greptile_comment -->