### PR TITLE
fix: bootstrap a missing kind package on structure refresh

### DIFF
--- a/.changeset/kind-bootstrap-on-refresh.md
+++ b/.changeset/kind-bootstrap-on-refresh.md
@@ -1,0 +1,21 @@
+---
+"@platforma-sdk/block-tools": patch
+---
+
+`structure refresh` now bootstraps a missing `kind/` package instead of failing.
+
+A block written before kinds existed has no `kind/` on disk, so DISCOVERY found no
+kind module, every kind rule fanned out over nothing, and the facade rule threw
+`declares no kind` before touching a file. The only way forward was to hand-craft
+`kind/package.json` first so discovery could see it.
+
+DISCOVERY now synthesises the kind module when the package is absent, the same way
+`init` does, so a plain refresh writes `kind/package.json`, its three configs, and
+`kind/src/index.ts`, and adds `kind` to `packages:`. The entry point moved from
+`seed` (init-only) to `scaffold` (create-if-missing in every mode) — otherwise the
+bootstrapped package would have no entry point at all. Once the file exists nothing
+touches it again: the params contract belongs to the block author.
+
+Run the block's `upgrade-sdk` rather than a bare refresh. The bootstrapped
+`kind/package.json` requires `@platforma-sdk/block-kind` as `catalog:`, and the
+catalog key is seeded by `refresh --update-deps-only`, which `upgrade-sdk` runs first.

--- a/tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts
+++ b/tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts
@@ -1,0 +1,100 @@
+// A block written before kinds existed carries no `kind/` package, so
+// DISCOVERY finds no kind module. `refresh` must BOOTSTRAP the package rather
+// than fail: DISCOVERY synthesises the module (discovery-fs.ts) and the kind
+// rules then write it. Before this, the facade rule threw
+// `declares no kind` before a single file was touched, and the only way
+// forward was to hand-craft `kind/package.json` so discovery could see it.
+
+import { describe, test, expect } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type { BlockVars } from "../engine/api";
+import { simulateInit, defaultTemplateProvider } from "../engine/testing";
+import { discoverRunContext } from "../engine/discovery-fs";
+import { run as engineRun } from "../engine/runner";
+import { STRUCTURE } from "../structure-definition";
+import type { MemoryFileSystem } from "../engine/fs/memory";
+
+const VARS: BlockVars = {
+  facadeName: "@platforma-open/test-org.demo",
+  baseName: "test-org.demo",
+  npmOrg: "@platforma-open",
+  orgScope: "test-org",
+  shortName: "demo",
+};
+
+/** A canonical block with its `kind/` package stripped back off — the shape a
+ *  pre-kind block has on disk. */
+function preKindBlock(): MemoryFileSystem {
+  const { fs } = simulateInit({ vars: VARS });
+  for (const p of Object.keys(fs.snapshot())) {
+    if (p === "kind" || p.startsWith("kind/")) fs.delete(p);
+  }
+  const ws = parseYaml(fs.read("pnpm-workspace.yaml")) as { packages: string[] };
+  ws.packages = ws.packages.filter((p) => p !== "kind");
+  fs.write("pnpm-workspace.yaml", `packages:\n${ws.packages.map((p) => `  - ${p}\n`).join("")}`);
+  return fs;
+}
+
+function refresh(fs: MemoryFileSystem) {
+  const ctx = discoverRunContext({ fs, isSdkInternal: false });
+  return engineRun(STRUCTURE, fs, ctx, { templates: defaultTemplateProvider() });
+}
+
+describe("refresh bootstraps a missing kind package", () => {
+  test("DISCOVERY synthesises the kind module", () => {
+    const ctx = discoverRunContext({ fs: preKindBlock(), isSdkInternal: false });
+    const kind = ctx.modules.filter((m) => m.scope === "kind");
+    expect(kind).toHaveLength(1);
+    expect(kind[0]).toMatchObject({
+      name: "@platforma-open/test-org.demo.kind",
+      path: "kind",
+    });
+  });
+
+  test("refresh writes the package, its configs and the params sentinel", () => {
+    const fs = preKindBlock();
+    expect(fs.exists("kind/package.json")).toBe(false);
+
+    refresh(fs);
+
+    expect(fs.exists("kind/package.json")).toBe(true);
+    expect(fs.exists("kind/tsconfig.json")).toBe(true);
+    expect(fs.exists("kind/.oxlintrc.json")).toBe(true);
+    expect(fs.exists("kind/.oxfmtrc.json")).toBe(true);
+
+    const pkg = JSON.parse(fs.read("kind/package.json")) as {
+      name: string;
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.name).toBe("@platforma-open/test-org.demo.kind");
+    expect(pkg.dependencies).toHaveProperty("@platforma-sdk/block-kind");
+
+    // The entry point is a `scaffold`, so it lands on refresh too — a `seed`
+    // would have left the package without one.
+    expect(fs.read("kind/src/index.ts")).toContain("NEEDS_BLOCK_PARAMS");
+  });
+
+  test("the bootstrapped kind joins the workspace and the model's deps", () => {
+    const fs = preKindBlock();
+    refresh(fs);
+
+    const ws = parseYaml(fs.read("pnpm-workspace.yaml")) as { packages: string[] };
+    expect(ws.packages).toContain("kind");
+
+    const model = JSON.parse(fs.read("model/package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(model.dependencies).toHaveProperty("@platforma-open/test-org.demo.kind");
+  });
+
+  test("a second refresh is a fixpoint — the sentinel is never rewritten", () => {
+    const fs = preKindBlock();
+    refresh(fs);
+    fs.write("kind/src/index.ts", "// the author's own contract\n");
+
+    const changes = refresh(fs).changes;
+
+    expect(changes).toHaveLength(0);
+    expect(fs.read("kind/src/index.ts")).toBe("// the author's own contract\n");
+  });
+});

--- a/tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts
+++ b/tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts
@@ -22,8 +22,39 @@ const VARS: BlockVars = {
   shortName: "demo",
 };
 
-/** A canonical block with its `kind/` package stripped back off — the shape a
- *  pre-kind block has on disk. */
+/** The packages `init` wires to the kind: the model depends on it, the facade
+ *  carries it as a devDependency. */
+const KIND_DEPENDENTS = ["model/package.json", "block/package.json"];
+
+type DepSections = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const DEP_SECTIONS = ["dependencies", "devDependencies", "peerDependencies"] as const;
+
+/** Every `<facade>.kind` reference the file declares, in any dep section. */
+function kindDepsOf(fs: MemoryFileSystem, path: string): string[] {
+  const pkg = JSON.parse(fs.read(path)) as DepSections;
+  return DEP_SECTIONS.flatMap((s) => Object.keys(pkg[s] ?? {})).filter((d) => d.endsWith(".kind"));
+}
+
+/** Drop every `<facade>.kind` reference from one package.json. */
+function stripKindDeps(fs: MemoryFileSystem, path: string): void {
+  const pkg = JSON.parse(fs.read(path)) as DepSections;
+  for (const section of DEP_SECTIONS) {
+    const deps = pkg[section];
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) if (name.endsWith(".kind")) delete deps[name];
+  }
+  fs.write(path, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+/** A canonical block with every trace of its kind stripped back off — the shape
+ *  a pre-kind block has on disk. The package, the workspace entry AND the
+ *  dependencies its siblings declare on it all have to go: leaving the deps
+ *  behind would make the wiring assertions below pass without a bootstrap. */
 function preKindBlock(): MemoryFileSystem {
   const { fs } = simulateInit({ vars: VARS });
   for (const p of Object.keys(fs.snapshot())) {
@@ -32,6 +63,7 @@ function preKindBlock(): MemoryFileSystem {
   const ws = parseYaml(fs.read("pnpm-workspace.yaml")) as { packages: string[] };
   ws.packages = ws.packages.filter((p) => p !== "kind");
   fs.write("pnpm-workspace.yaml", `packages:\n${ws.packages.map((p) => `  - ${p}\n`).join("")}`);
+  for (const p of KIND_DEPENDENTS) stripKindDeps(fs, p);
   return fs;
 }
 
@@ -74,17 +106,21 @@ describe("refresh bootstraps a missing kind package", () => {
     expect(fs.read("kind/src/index.ts")).toContain("NEEDS_BLOCK_PARAMS");
   });
 
-  test("the bootstrapped kind joins the workspace and the model's deps", () => {
+  test("the bootstrapped kind joins the workspace and its dependents", () => {
     const fs = preKindBlock();
+
+    // The fixture really is kind-free: nothing declares the dep yet, so the
+    // assertions after the refresh can only pass by way of the bootstrap.
+    for (const p of KIND_DEPENDENTS) expect(kindDepsOf(fs, p)).toEqual([]);
+
     refresh(fs);
 
     const ws = parseYaml(fs.read("pnpm-workspace.yaml")) as { packages: string[] };
     expect(ws.packages).toContain("kind");
 
-    const model = JSON.parse(fs.read("model/package.json")) as {
-      dependencies?: Record<string, string>;
-    };
-    expect(model.dependencies).toHaveProperty("@platforma-open/test-org.demo.kind");
+    for (const p of KIND_DEPENDENTS) {
+      expect(kindDepsOf(fs, p)).toEqual(["@platforma-open/test-org.demo.kind"]);
+    }
   });
 
   test("a second refresh is a fixpoint — the sentinel is never rewritten", () => {

--- a/tools/block-tools/src/structure/engine/discovery-fs.ts
+++ b/tools/block-tools/src/structure/engine/discovery-fs.ts
@@ -197,6 +197,19 @@ export function discoverRunContext(input: DiscoverInput): RunContext {
   const facadeName = blockMod.name.replace(/\.block$/, "");
   const blockVars = parseBlockVars(facadeName);
 
+  // A kind is a mandatory block component, but a block written before kinds
+  // existed has no `kind/` package on disk, so DISCOVERY finds no kind module
+  // and every kind rule fans out over nothing. Synthesise the module the same
+  // way `init` does (`modulesForInit`) so a plain `structure refresh`
+  // BOOTSTRAPS the package: the managed `package.json` and the fixed configs
+  // are written from their generators, `src/index.ts` lands as a scaffold, and
+  // `kind` joins `packages:` because `ensureWorkspaceModulePaths` reads
+  // `ctx.modules`. Without this a pre-kind block could only be migrated by
+  // hand-crafting the package first — `refresh` threw before touching a file.
+  if (!modules.some((m) => m.scope === "kind")) {
+    modules.push({ scope: "kind", name: `${facadeName}.kind`, path: "kind" });
+  }
+
   return createRunContext({
     isSdkInternal,
     updateDepsOnly: input.updateDepsOnly ?? false,

--- a/tools/block-tools/src/structure/rules/block-package-json.ts
+++ b/tools/block-tools/src/structure/rules/block-package-json.ts
@@ -200,8 +200,11 @@ export function blockPackageJsonRules(ctx: RunContext): void {
   const v = ctx.blockVars;
 
   // The kind is a MANDATORY block component: every block must declare exactly
-  // one sibling `kind/` package. Fail loudly otherwise — a kind-less block is
-  // invalid, and this is what surfaces the not-yet-migrated blocks.
+  // one sibling `kind/` package. DISCOVERY synthesises the module when the
+  // package is absent, so `refresh` bootstraps it instead of failing here and
+  // the zero branch is an invariant guard rather than the migration signal it
+  // once was. Two or more kinds stay a hard error — nothing can pick between
+  // them.
   const kindModules = findModules(ctx, "kind");
   if (kindModules.length !== 1) {
     throw new Error(

--- a/tools/block-tools/src/structure/rules/kind.ts
+++ b/tools/block-tools/src/structure/rules/kind.ts
@@ -1,10 +1,11 @@
 // Kind-scope rules. Static config files + managed package.json; the
-// `src/index.ts` seed is dropped by `init` and never touched again (the block
-// author owns the BlockParams contract). The seed is a deliberate non-building
-// sentinel — its BlockParams is undefined, so a scaffolded-but-unmigrated block
-// fails to typecheck until the params contract is chosen on purpose.
+// `src/index.ts` scaffold is dropped once, on whichever run first finds it
+// missing, and never touched again — the block author owns the BlockParams
+// contract. What lands is a deliberate non-building sentinel: its BlockParams
+// is undefined, so a scaffolded-but-unmigrated block fails to typecheck until
+// the params contract is chosen on purpose.
 
-import { scope, fixed, managed, seed, file, generate } from "../engine/api";
+import { scope, fixed, managed, scaffold, file, generate } from "../engine/api";
 import { kindPackageJsonInitial, kindPackageJsonRules } from "./kind-package-json";
 
 export function kindRules(): void {
@@ -16,7 +17,13 @@ export function kindRules(): void {
     // Minimal-but-real kind: identity imported from the package's own
     // package.json, plus a non-building BlockParams sentinel the block author
     // must resolve (via the migration recipe or by hand) before the block builds.
-    seed("src/index.ts", file("kind/src/index.ts"));
+    //
+    // `scaffold`, not `seed`: create-if-missing in EVERY mode, so `refresh`
+    // bootstrapping a kind for a pre-kind block deposits the sentinel too. A
+    // seed is init-only, which would have left such a block with a kind package
+    // that has no entry point. Once the file exists the engine never touches it
+    // — the params contract belongs to the block author.
+    scaffold("src/index.ts", file("kind/src/index.ts"));
 
     managed(
       "package.json",


### PR DESCRIPTION
## Problem

A block written before kinds existed carries no `kind/` package, so DISCOVERY finds no kind module, every kind rule fans out over nothing, and the facade rule throws before a single file is touched:

```
error: block '@platforma-open/milaboratories.immune-assay-data' declares no kind
       — every block must have a sibling kind/ package
```

The documented migration step says `structure refresh` creates the kind package. It never did. The only way forward was to hand-craft `kind/package.json` first, purely so discovery could see it — reported on [docs.platforma.bio#48](https://github.com/milaboratory/docs.platforma.bio/pull/48).

## Change

- **`engine/discovery-fs.ts`** — `discoverRunContext` synthesises the kind module when the package is absent, the same way `modulesForInit` does for `init`. Everything else follows: the managed `package.json` and the three fixed configs are written from their generators, and `kind` joins `packages:` because `ensureWorkspaceModulePaths` reads `ctx.modules`.
- **`rules/kind.ts`** — `src/index.ts` moves from `seed` to `scaffold`. A seed is init-only by definition, which would have left a bootstrapped kind with no entry point. `scaffold` is create-if-missing in every mode and never touches an existing file, so the params contract still belongs to the block author.
- **`rules/block-package-json.ts`** — the `declares no kind` branch stays as an invariant guard; the "declares N kinds" branch is untouched.

## Verification

End to end on a copy of `blocks/blast`, a real pre-kind block:

1. `refresh --update-deps-only` seeds the `@platforma-sdk/block-kind` catalog key.
2. A plain `refresh` bootstraps `kind/` with its configs and the params sentinel.
3. `pnpm install` resolves the `catalog:` reference.
4. A second refresh reports zero changes, and an author-edited `src/index.ts` is left alone.

Also: new tests in `src/structure/__tests__/kind-bootstrap.test.ts`, the full block-tools suite green (365 tests), `pnpm check` green across all 293 tasks, and `check-blocks` reports zero changes for all 13 `etc/blocks/*`.

## Note for migrators

Run the block's `upgrade-sdk`, not a bare `refresh`. The bootstrapped `kind/package.json` requires `@platforma-sdk/block-kind` as `catalog:`, and that catalog key is seeded by `refresh --update-deps-only`, which `upgrade-sdk` runs first.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows structure refresh to bootstrap the mandatory `kind/` package for blocks created before kinds existed. Discovery now synthesizes the missing module, and the kind entry point is treated as a create-if-missing scaffold so refresh can generate it without replacing author-owned content.

Key changes:
- Synthesizes a canonical kind module when discovery finds none.
- Generates the kind package, fixed configuration files, workspace membership, and entry-point sentinel during refresh.
- Preserves the invariant that a block resolves to exactly one kind.
- Adds a patch changeset and focused bootstrap tests, although the dependency-wiring test fixture retains pre-existing kind references.

Important touched terms:
- **Block** — a Platforma extension composed of packages such as model, workflow, UI, and kind. Older blocks without a kind can now be migrated by refresh.
- **Kind package** — the mandatory sibling package defining a block’s kind identity and `BlockParams` contract. This PR bootstraps it at `kind/` when absent.
- **Discovery** — the phase that reads package metadata and constructs the modules participating in structure rules. It now inserts a synthetic kind module when no kind is discovered.
- **Run context** — the structure engine’s representation of block variables, execution mode, and discovered modules. Its module list now includes the synthesized kind, allowing downstream rules to process it.
- **Seed** — an init-only file created once and subsequently left under author control. The kind entry point no longer uses this behavior.
- **Scaffold** — a create-if-missing file applied in init and normal refresh modes without overwriting an existing file. `kind/src/index.ts` now uses this behavior.
- **Managed file** — a file whose structured engine-owned fields are reconciled while applying package rules. The synthesized module enables management of `kind/package.json`.
- **Fixed file** — a canonical file regenerated from its template. The kind package’s TypeScript, lint, and formatting configurations are generated through fixed rules.
- **Update-dependencies mode** — the preliminary upgrade mode that updates catalog versions without applying normal structural leaves. Kind synthesis does not itself create kind files in this mode.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge; the remaining non-blocking concern is that one bootstrap test does not genuinely exercise dependency wiring from a pre-kind state.

Kind synthesis is correctly constrained by execution modes, the scaffold preserves existing author content, and no behavioral or security failure remains; only the regression fixture should be strengthened so dependency wiring cannot break unnoticed.

**Files Needing Attention:** tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/block-tools/src/structure/engine/discovery-fs.ts | Adds the synthetic canonical kind module needed for downstream refresh rules when discovery finds no existing kind. |
| tools/block-tools/src/structure/rules/kind.ts | Changes the author-owned kind entry point from init-only seed behavior to create-if-missing scaffold behavior. |
| tools/block-tools/src/structure/rules/block-package-json.ts | Documents that the zero-kind branch is now an invariant guard while preserving the exactly-one-kind validation. |
| tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts | Covers discovery, generated files, workspace membership, and idempotence, but its pre-kind fixture retains package references that make the model-dependency assertion ineffective. |
| .changeset/kind-bootstrap-on-refresh.md | Records the patch release and explains bootstrap behavior, sentinel ownership, and the required upgrade-sdk migration flow. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Discover block packages] --> B{Kind module found?}
  B -->|Yes| C[Use discovered kind]
  B -->|No| D[Synthesize canonical kind module]
  C --> E[Build run context]
  D --> E
  E --> F[Apply kind rules]
  F --> G[Manage kind/package.json]
  F --> H[Write fixed configs]
  F --> I{src/index.ts exists?}
  I -->|No| J[Create params sentinel]
  I -->|Yes| K[Preserve author content]
  E --> L[Add kind to workspace and package references]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231805%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1805&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Fblock-tools%2Fsrc%2Fstructure%2F__tests__%2Fkind-bootstrap.test.ts%3A28-39%0A**Fixture%20Retains%20Kind%20References**%0A%0AThe%20pre-kind%20fixture%20removes%20the%20%60kind%2F%60%20files%20and%20workspace%20entry%2C%20but%20it%20leaves%20the%20model%20and%20facade%20references%20created%20by%20%60simulateInit%60.%20As%20a%20result%2C%20the%20model%20dependency%20assertion%20already%20passes%20before%20%60refresh%60%2C%20so%20this%20test%20would%20not%20catch%20a%20regression%20where%20bootstrap%20fails%20to%20wire%20the%20new%20kind%20into%20dependent%20packages.%20Remove%20those%20references%20while%20building%20the%20fixture%20and%20assert%20that%20they%20are%20absent%20before%20refresh.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1805&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/block-tools/src/structure/__tests__/kind-bootstrap.test.ts:28-39
**Fixture Retains Kind References**

The pre-kind fixture removes the `kind/` files and workspace entry, but it leaves the model and facade references created by `simulateInit`. As a result, the model dependency assertion already passes before `refresh`, so this test would not catch a regression where bootstrap fails to wire the new kind into dependent packages. Remove those references while building the fixture and assert that they are absent before refresh.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bootstrap a missing kind package on..."](https://github.com/milaboratory/platforma/commit/46d96ffbc64314ee0043d1655ad6fc76acaf4ba0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60350784)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Developer toolchain and delivery](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/developer-toolchain.md)

<!-- /greptile_comment -->