### PR TITLE
chore(PlDataTable): drop "Ambiguous PObjectId" warning from column resolver

### DIFF
--- a/.changeset/quiet-resolver-collision.md
+++ b/.changeset/quiet-resolver-collision.md
@@ -1,0 +1,5 @@
+---
+"@platforma-sdk/model": patch
+---
+
+Drop the "Ambiguous PObjectId" warning from the PlDataTable column resolver. Several recipes wrapping the same underlying column is expected (e.g. one column filtered by different axis values), so the message was noise. First match still wins.

--- a/sdk/model/src/components/PlDataTable/columnResolver.test.ts
+++ b/sdk/model/src/components/PlDataTable/columnResolver.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   createLocalPObjectId,
   createColumnOverriddenId,
@@ -97,7 +97,7 @@ describe("createColumnResolver", () => {
     expect(r({ type: "column", id: other })).toBeUndefined();
   });
 
-  test("collision warns once and keeps first", () => {
+  test("collision keeps first", () => {
     const pid = createLocalPObjectId(["main", "out"], "col-1");
     const wrappedA = wrap(pid, "A");
     const wrappedB = wrap(pid, "B");
@@ -113,9 +113,7 @@ describe("createColumnResolver", () => {
       return r;
     };
 
-    const warn = vi.fn();
-    const r = createColumnResolver([makeFake(wrappedA), makeFake(wrappedB)], { warn });
-    expect(warn).toHaveBeenCalledTimes(1);
+    const r = createColumnResolver([makeFake(wrappedA), makeFake(wrappedB)]);
     const out = r({ type: "column", id: pid });
     expect(out).toEqual({ type: "column", id: wrappedA });
   });

--- a/sdk/model/src/components/PlDataTable/columnResolver.ts
+++ b/sdk/model/src/components/PlDataTable/columnResolver.ts
@@ -20,10 +20,7 @@ import type { ColumnRecipe } from "../../columns";
  */
 export type ColumnResolver = (ref: PTableColumnId) => PTableColumnId | undefined;
 
-export function createColumnResolver(
-  columns: ColumnRecipe[],
-  deps?: { warn?: (msg: string) => void },
-): ColumnResolver {
+export function createColumnResolver(columns: ColumnRecipe[]): ColumnResolver {
   const axisIds: AxisId[] = [];
   for (const c of columns) {
     for (const ax of c.getSpec().axesSpec) {
@@ -36,14 +33,7 @@ export function createColumnResolver(
   for (const c of columns) {
     byFullId.set(c.id, c);
     const pid = extractPObjectId(c.id);
-    const existing = byPObjectId.get(pid);
-    if (existing === undefined) {
-      byPObjectId.set(pid, c);
-    } else if (existing.id !== c.id) {
-      deps?.warn?.(
-        `Ambiguous PObjectId ${pid}: recipe ids ${existing.id} and ${c.id} both match — keeping first.`,
-      );
-    }
+    if (!byPObjectId.has(pid)) byPObjectId.set(pid, c);
   }
 
   return (ref: PTableColumnId): PTableColumnId | undefined => {

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts
@@ -82,10 +82,7 @@ export function createPlDataTableV2<A, U>(
 
   const fullColumns = [...columns, ...fullLabelColumns];
 
-  const resolver = createColumnResolver(
-    fullColumns.map((c) => DataColumn.fromColumn(c)),
-    { warn: ctx.logWarn.bind(ctx) },
-  );
+  const resolver = createColumnResolver(fullColumns.map((c) => DataColumn.fromColumn(c)));
 
   // -- Filtering: rewrite via resolver, throw if any reference is unresolved --
   const rawFilters = tableStateNormalized.pTableParams.filters;

--- a/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
+++ b/sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts
@@ -132,10 +132,11 @@ export function createPlDataTableV3<A, U>(
   );
   const orderByColId = evaluateRules(options.displayOptions?.ordering ?? [], allColumnsForRules);
 
-  const resolver = createColumnResolver(
-    [...primary, ...direct, ...linked.flatMap((lc) => [...collectLinkerColumns(lc), lc])],
-    { warn: ctx.logWarn.bind(ctx) },
-  );
+  const resolver = createColumnResolver([
+    ...primary,
+    ...direct,
+    ...linked.flatMap((lc) => [...collectLinkerColumns(lc), lc]),
+  ]);
 
   const remapedDefaultFilters = remapFilterColumnIds(options.filters, resolver);
   const filters = filterFilters(


### PR DESCRIPTION
## What

Removes the `Ambiguous PObjectId ...: recipe ids ... both match — keeping first.` warning emitted by `createColumnResolver`, and the now-unused `warn` hook it was the only consumer of (both call sites in `createPlDataTableV2`/`V3` updated).

## Why

Several recipes wrapping the same underlying `PObjectId` is an expected state: the same column filtered by different axis values produces distinct recipe ids over one `PObjectId`. The warning therefore fired during normal block usage and was noise in the log.

Behaviour is unchanged: the first matching recipe still wins when a bare `PObjectId` is resolved.

## Checks

- `vitest` on `columnResolver.test.ts`: 6/6 passing
- `tsc --noEmit`, `linter:check`, `formatter:check` in `sdk/model`: clean
- changeset: `@platforma-sdk/model` patch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a noisy ambiguous-physical-ID warning from the PlDataTable column resolver while preserving its existing first-match resolution behavior. It also removes the warning dependency from the V2 and V3 table constructors, updates the collision test, and adds a patch changeset.

- Resolution by full logical ID remains unchanged.
- Resolution by bare physical ID still selects the first matching recipe.
- The removed hook was internal and had no remaining consumers.

**Important touched terms**
- **`PObjectId`** — The physical identity of a stored column. Multiple logical recipes may refer to the same `PObjectId`; the resolver no longer warns when this occurs.
- **`ColumnRecipe`** — An immutable description of how to obtain a logical column view. Recipe collisions on one physical ID continue to retain the first recipe.
- **`ColumnResolver`** — A function that maps a table-column reference to a resolvable logical column reference. Its resolution behavior is unchanged.
- **`PTableColumnId`** — A table-level reference to either an axis or data column. Data-column references continue to be resolved by full logical ID first and physical ID second.
- **Logical column ID** — A column identity carrying view context such as filtering or overrides. Distinct logical IDs may legitimately wrap the same physical column.
- **Warning dependency** — The former optional `warn` callback accepted by `createColumnResolver`. It was removed together with its V2/V3 call-site wiring because collision warnings were its only use.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it removes only an internal diagnostic path while retaining and testing the existing first-match behavior.

No actionable failures remain: the resolver’s map semantics are equivalent, collision behavior remains covered, and the changed function is not part of the package’s public API.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/model/src/components/PlDataTable/columnResolver.ts | Removes collision logging and its optional dependency while preserving first-insertion resolution for shared physical IDs. |
| sdk/model/src/components/PlDataTable/columnResolver.test.ts | Removes the obsolete warning assertion while retaining coverage that collisions resolve to the first recipe. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV2.ts | Stops supplying the removed warning dependency to the internal resolver. |
| sdk/model/src/components/PlDataTable/createPlDataTable/createPlDataTableV3.ts | Stops supplying the removed warning dependency without changing the resolver’s column ordering. |
| .changeset/quiet-resolver-collision.md | Records the internal diagnostic cleanup as a model SDK patch release. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(PlDataTable): drop &quot;Ambiguous PObj..."](https://github.com/milaboratory/platforma/commit/1b1c13cfa52d974b19e53b589edec64981dd333e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61558058)</sub>

**Context used:**

- Knowledge Base — [Data model and tabular data](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/data-model.md)
- Knowledge Base — [Columns, collections, and identities](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/columns-and-identities.md)

<!-- /greptile_comment -->