### PR TITLE
MILAB-6817: carry the block's label on a template export problem

### DIFF
--- a/.changeset/template-export-problem-block-label.md
+++ b/.changeset/template-export-problem-block-label.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-middle-layer": minor
+---
+
+`TemplateExportProblem` carries `blockLabel`, the block's label from the project structure, so a UI can name the block that stops an export instead of showing its id.

--- a/lib/node/pl-middle-layer/src/model/template_export.test.ts
+++ b/lib/node/pl-middle-layer/src/model/template_export.test.ts
@@ -24,6 +24,35 @@ function providerFrom(params: Record<string, TemplateParamsResult>) {
 
 const ok = (value: unknown): TemplateParamsResult => ({ value });
 
+describe("labels", () => {
+  test("an entry and a problem both carry the block's label, not its id", () => {
+    // `simpleStructure` labels every block after its id, which cannot tell a label read from
+    // the structure apart from an id copied into the field. Distinct labels here can.
+    const structure: ProjectStructure = {
+      groups: [
+        {
+          id: "g1",
+          label: "G1",
+          blocks: [
+            { id: "b1", label: "MiXCR Clonotyping", renderingMode: "Heavy" },
+            { id: "b2", label: "Clonotype Browser", renderingMode: "Heavy" },
+          ],
+        },
+      ],
+    };
+    const walk = walkProjectForTemplateExport(structure, providerFrom({ b1: ok({}) }));
+
+    expect(walk.entries).toEqual([{ blockId: "b1", blockLabel: "MiXCR Clonotyping", params: {} }]);
+    expect(walk.problems).toEqual([
+      {
+        blockId: "b2",
+        blockLabel: "Clonotype Browser",
+        error: "Block state is unavailable, so its template params could not be derived",
+      },
+    ]);
+  });
+});
+
 describe("order", () => {
   test("entries come out in structure order — no sort, none needed", () => {
     // The structure IS the topological order: a block can only legally reference

--- a/lib/node/pl-middle-layer/src/model/template_export.test.ts
+++ b/lib/node/pl-middle-layer/src/model/template_export.test.ts
@@ -101,7 +101,7 @@ describe("collecting each block's descriptor output", () => {
       providerFrom({ mixcr: ok(params) }),
     );
 
-    expect(walk.entries).toEqual([{ blockId: "mixcr", params }]);
+    expect(walk.entries).toEqual([{ blockId: "mixcr", blockLabel: "mixcr", params }]);
   });
 
   test("a block with nothing to project yields empty params", () => {
@@ -112,7 +112,9 @@ describe("collecting each block's descriptor output", () => {
       providerFrom({ "pool-explorer": ok({}) }),
     );
 
-    expect(walk.entries).toEqual([{ blockId: "pool-explorer", params: {} }]);
+    expect(walk.entries).toEqual([
+      { blockId: "pool-explorer", blockLabel: "pool-explorer", params: {} },
+    ]);
     expect(walk.problems).toEqual([]);
   });
 });
@@ -145,7 +147,7 @@ describe("what the walk does with params", () => {
       providerFrom({ block1: ok({}) }),
     );
 
-    expect(walk.entries).toEqual([{ blockId: "block1", params: {} }]);
+    expect(walk.entries).toEqual([{ blockId: "block1", blockLabel: "block1", params: {} }]);
   });
 
   test("a wrapper's contents are never inspected, whatever they are", () => {
@@ -210,7 +212,7 @@ describe("problems", () => {
     // Every offending block is reported at once rather than aborting on the
     // first, so the user fixes them in one pass.
     expect(walk.problems).toEqual([
-      { blockId: "b", error: "templateParams() threw: not exportable yet" },
+      { blockId: "b", blockLabel: "b", error: "templateParams() threw: not exportable yet" },
     ]);
     expect(walk.entries.map((e) => e.blockId)).toEqual(["a", "c"]);
   });
@@ -228,6 +230,7 @@ describe("problems", () => {
     expect(walk.problems).toEqual([
       {
         blockId: "ghost",
+        blockLabel: "ghost",
         error: "Block state is unavailable, so its template params could not be derived",
       },
     ]);
@@ -249,7 +252,11 @@ describe("problems", () => {
 
     expect(walk.entries).toEqual([]);
     expect(walk.problems).toEqual([
-      { blockId: "odd", error: `templateParams() must return an object, got ${expected}` },
+      {
+        blockId: "odd",
+        blockLabel: "odd",
+        error: `templateParams() must return an object, got ${expected}`,
+      },
     ]);
   });
 });

--- a/lib/node/pl-middle-layer/src/model/template_export.ts
+++ b/lib/node/pl-middle-layer/src/model/template_export.ts
@@ -20,6 +20,9 @@ export type TemplateExportEntry = {
    * already stored in params need no translation.
    */
   readonly blockId: string;
+  /** The block's label from the project structure, carried so a problem found downstream can
+   *  name the block to a person. Not written to the template. */
+  readonly blockLabel: string;
   /**
    * The block's params exactly as it projected them.
    *
@@ -33,6 +36,9 @@ export type TemplateExportEntry = {
 /** Why one block could not be exported. */
 export type TemplateExportProblem = {
   readonly blockId: string;
+  /** The block's label as the project structure holds it. An id means nothing to the person who
+   *  pressed Export; this is what a UI shows. */
+  readonly blockLabel: string;
   readonly error: string;
 };
 
@@ -91,19 +97,20 @@ export function walkProjectForTemplateExport(
   const entries: TemplateExportEntry[] = [];
   const problems: TemplateExportProblem[] = [];
 
-  for (const { id } of allBlocks(structure)) {
+  for (const { id, label } of allBlocks(structure)) {
     const derived = paramsProvider(id);
 
     if (derived === undefined) {
       problems.push({
         blockId: id,
+        blockLabel: label,
         error: "Block state is unavailable, so its template params could not be derived",
       });
       continue;
     }
 
     if (derived.error !== undefined) {
-      problems.push({ blockId: id, error: derived.error });
+      problems.push({ blockId: id, blockLabel: label, error: derived.error });
       continue;
     }
 
@@ -117,12 +124,13 @@ export function walkProjectForTemplateExport(
     if (typeof params !== "object" || params === null || Array.isArray(params)) {
       problems.push({
         blockId: id,
+        blockLabel: label,
         error: `templateParams() must return an object, got ${typeName(params)}`,
       });
       continue;
     }
 
-    entries.push({ blockId: id, params: params as Record<string, unknown> });
+    entries.push({ blockId: id, blockLabel: label, params: params as Record<string, unknown> });
   }
 
   return { entries, problems };

--- a/lib/node/pl-middle-layer/src/model/template_serializer.test.ts
+++ b/lib/node/pl-middle-layer/src/model/template_serializer.test.ts
@@ -385,14 +385,16 @@ describe("assembleProjectTemplateV1", () => {
   test("carries the walk's problems through unchanged", () => {
     const { document, problems } = assembleProjectTemplateV1(
       {
-        entries: [{ blockId: "a", params: {} }],
-        problems: [{ blockId: "ghost", error: "state unavailable" }],
+        entries: [{ blockId: "a", blockLabel: "a", params: {} }],
+        problems: [{ blockId: "ghost", blockLabel: "ghost", error: "state unavailable" }],
       },
       kindPerBlock,
       () => registrySpec,
     );
 
-    expect(problems).toEqual([{ blockId: "ghost", error: "state unavailable" }]);
+    expect(problems).toEqual([
+      { blockId: "ghost", blockLabel: "ghost", error: "state unavailable" },
+    ]);
     expect(document.blocks.map((b) => b.id)).toEqual(["a"]);
   });
 });

--- a/lib/node/pl-middle-layer/src/model/template_serializer.test.ts
+++ b/lib/node/pl-middle-layer/src/model/template_serializer.test.ts
@@ -198,6 +198,27 @@ describe("problems", () => {
     expect(result.problems[0].error).toContain("declares no kind");
   });
 
+  test("a problem raised here carries the block's label from the walk", () => {
+    // Labels distinct from ids, or the assertion could not tell a label carried through from
+    // an id copied into the field.
+    const structure: ProjectStructure = {
+      groups: [
+        {
+          id: "g1",
+          label: "G1",
+          blocks: [{ id: "legacy", label: "Old Aligner", renderingMode: "Heavy" }],
+        },
+      ],
+    };
+    const result = exportOf(structure, { legacy: ok({}) }, () => undefined);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.problems).toEqual([
+      { blockId: "legacy", blockLabel: "Old Aligner", error: expect.stringContaining("no kind") },
+    ]);
+  });
+
   test("a malformed stored kind reference is a problem, not a throw", () => {
     const result = exportOf(
       simpleStructure("a"),

--- a/lib/node/pl-middle-layer/src/model/template_serializer.ts
+++ b/lib/node/pl-middle-layer/src/model/template_serializer.ts
@@ -126,6 +126,7 @@ export function assembleProjectTemplateV1(
     if (kind === undefined) {
       problems.push({
         blockId: entry.blockId,
+        blockLabel: entry.blockLabel,
         error:
           "Block declares no kind, so it cannot be written to a template: an entry's kind " +
           "carries the params contract the entry is typed against",
@@ -143,6 +144,7 @@ export function assembleProjectTemplateV1(
     } catch (e) {
       problems.push({
         blockId: entry.blockId,
+        blockLabel: entry.blockLabel,
         error: `Block's stored kind reference is malformed: ${e instanceof Error ? e.message : String(e)}`,
       });
       continue;


### PR DESCRIPTION
## Summary

\`TemplateExportProblem\` (and the walk's \`TemplateExportEntry\`) now carry \`blockLabel\`, the block's label as the project structure holds it. Nothing changes in the template document itself.

## Why

Save as Template in the desktop app reports every block that stops an export, but it can only quote each block's id, which means nothing to the person reading it. The label is already in hand during the walk, so it rides along at no extra cost.

## Consumer

Desktop PR milaboratory/platforma-desktop-app#535 will show the label once this is released.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR carries each project block's human-readable label through template-export collection and error reporting while leaving the stored template document unchanged. It also adds the release changeset and updates unit expectations.

**Important touched terms**
- **`TemplateExportEntry`** — The successful result of collecting one block's template parameters. It now includes `blockLabel` for downstream errors generated during serialization.
- **`TemplateExportProblem`** — A description of why one block prevented template export. It now includes `blockLabel` so user interfaces can identify the block by its project-facing name rather than only its ID.
- **`walkProjectForTemplateExport`** — The traversal that collects exportable block parameters and reports collection failures. It now reads each label from the project structure and attaches it to entries and problems.
- **`assembleProjectTemplateV1`** — The operation that converts collected entries into the stored template document. It now preserves the entry label in serializer-generated problems but does not write it into the document.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking test gap around distinguishing human-readable labels from block IDs.

Production code consistently propagates the project-structure label and excludes it from the stored document; the only accepted concern is that identical fixture labels and IDs leave the central behavior insufficiently protected against regression.

**Files Needing Attention:** lib/node/pl-middle-layer/src/model/template_export.test.ts and lib/node/pl-middle-layer/src/model/template_serializer.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-middle-layer/src/model/template_export.ts | Adds the required label fields and consistently obtains them from each project-structure block during export traversal. |
| lib/node/pl-middle-layer/src/model/template_serializer.ts | Preserves labels in both serializer-generated error paths without adding them to the persisted template document. |
| lib/node/pl-middle-layer/src/model/template_export.test.ts | Updates traversal expectations for the new field, but does not exercise a label that differs from its block ID. |
| lib/node/pl-middle-layer/src/model/template_serializer.test.ts | Updates pass-through expectations, while distinct-label propagation through serializer-generated problems remains untested. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Structure[Project structure block<br/>id + label] --> Walk[walkProjectForTemplateExport]
    Walk --> Entry[TemplateExportEntry<br/>blockId + blockLabel + params]
    Walk --> Problem[TemplateExportProblem<br/>blockId + blockLabel + error]
    Entry --> Serializer[assembleProjectTemplateV1]
    Serializer --> SerializerProblem[Serializer problem<br/>blockId + blockLabel + error]
    Serializer --> Document[Template document<br/>id + kind + params + location]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231810%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1810&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fnode%2Fpl-middle-layer%2Fsrc%2Fmodel%2Ftemplate_export.test.ts%3A104%0A**Labels%20Match%20IDs**%0A%0AThe%20new%20assertions%20always%20use%20a%20block%20label%20identical%20to%20its%20ID%2C%20so%20they%20would%20still%20pass%20if%20%60blockLabel%60%20were%20accidentally%20populated%20from%20%60blockId%60.%20Use%20at%20least%20one%20distinct%20label%20and%20verify%20it%20through%20both%20successful%20entries%20and%20problems%20to%20protect%20the%20human-readable%20label%20behavior%20from%20regression.%20The%20serializer%20test%20has%20the%20same%20limitation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1810&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/node/pl-middle-layer/src/model/template_export.test.ts:104
**Labels Match IDs**

The new assertions always use a block label identical to its ID, so they would still pass if `blockLabel` were accidentally populated from `blockId`. Use at least one distinct label and verify it through both successful entries and problems to protect the human-readable label behavior from regression. The serializer test has the same limitation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6817: carry the block&#39;s label on a..."](https://github.com/milaboratory/platforma/commit/d8b9666518f00a020473297696c95b745f28ddca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61600666)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Backend integration and driver contracts](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/backend-and-drivers.md)

<!-- /greptile_comment -->