### PR TITLE
fix(uikit): show full selected value as tooltip on truncated dropdowns

### DIFF
--- a/.changeset/dropdown-hover-title.md
+++ b/.changeset/dropdown-hover-title.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/uikit": patch
+---
+
+PlDropdown, PlDropdownLegacy, PlAutocomplete: show the full selected value as a native tooltip on hover when it is truncated with an ellipsis

--- a/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
+++ b/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
@@ -198,6 +198,10 @@ const textValue = computed(() => {
   return item?.label || (model.value ? props.formatValue(model.value) : "");
 });
 
+// Native tooltip with the full selected value; the value layer itself has
+// `pointer-events: none`, so the title goes on the field wrapper.
+const fieldTitle = computed(() => (!data.open && textValue.value ? textValue.value : undefined));
+
 const computedPlaceholder = computed(() => {
   if (!data.open && model.value) {
     return "";
@@ -384,7 +388,7 @@ watch(
       @focusout="onFocusOut"
     >
       <div class="pl-autocomplete__container">
-        <div class="pl-autocomplete__field">
+        <div class="pl-autocomplete__field" :title="fieldTitle">
           <input
             ref="input"
             v-model="search"

--- a/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
+++ b/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
@@ -29,7 +29,6 @@ import { DropdownOverlay } from "../../utils/DropdownOverlay";
 import { refDebounced } from "@vueuse/core";
 import { useWatchFetch } from "../../composition/useWatchFetch.ts";
 import { getErrorMessage } from "../../helpers/error.ts";
-import { hasTextOverflow } from "../../helpers/dom";
 import type { ListOptionBase } from "@platforma-sdk/model";
 import { PlSvg } from "../PlSvg";
 import SvgRequired from "../../assets/images/required.svg?raw";
@@ -199,21 +198,9 @@ const textValue = computed(() => {
   return item?.label || (model.value ? props.formatValue(model.value) : "");
 });
 
-const valueRef = ref<HTMLElement>();
-const valueTruncated = ref(false);
-
-// Measured on hover, right before the browser decides whether to show the
-// tooltip, so layout changes after mount are always accounted for.
-const onFieldMouseEnter = () => {
-  valueTruncated.value = hasTextOverflow(valueRef.value);
-};
-
-// Native tooltip with the full selected value, only when it is actually cut
-// with an ellipsis; the value layer itself has `pointer-events: none`, so the
-// title goes on the field wrapper.
-const fieldTitle = computed(() =>
-  !data.open && valueTruncated.value && textValue.value ? textValue.value : undefined,
-);
+// Native tooltip with the full selected value; the value layer itself has
+// `pointer-events: none`, so the title goes on the field wrapper.
+const fieldTitle = computed(() => (!data.open && textValue.value ? textValue.value : undefined));
 
 const computedPlaceholder = computed(() => {
   if (!data.open && model.value) {
@@ -401,7 +388,7 @@ watch(
       @focusout="onFocusOut"
     >
       <div class="pl-autocomplete__container">
-        <div class="pl-autocomplete__field" :title="fieldTitle" @mouseenter="onFieldMouseEnter">
+        <div class="pl-autocomplete__field" :title="fieldTitle">
           <input
             ref="input"
             v-model="search"
@@ -414,7 +401,7 @@ watch(
             @focus="onInputFocus"
           />
 
-          <div v-if="!data.open" ref="valueRef" class="input-value">
+          <div v-if="!data.open" class="input-value">
             <LongText> {{ textValue }} </LongText>
           </div>
 

--- a/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
+++ b/lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue
@@ -29,6 +29,7 @@ import { DropdownOverlay } from "../../utils/DropdownOverlay";
 import { refDebounced } from "@vueuse/core";
 import { useWatchFetch } from "../../composition/useWatchFetch.ts";
 import { getErrorMessage } from "../../helpers/error.ts";
+import { hasTextOverflow } from "../../helpers/dom";
 import type { ListOptionBase } from "@platforma-sdk/model";
 import { PlSvg } from "../PlSvg";
 import SvgRequired from "../../assets/images/required.svg?raw";
@@ -198,9 +199,21 @@ const textValue = computed(() => {
   return item?.label || (model.value ? props.formatValue(model.value) : "");
 });
 
-// Native tooltip with the full selected value; the value layer itself has
-// `pointer-events: none`, so the title goes on the field wrapper.
-const fieldTitle = computed(() => (!data.open && textValue.value ? textValue.value : undefined));
+const valueRef = ref<HTMLElement>();
+const valueTruncated = ref(false);
+
+// Measured on hover, right before the browser decides whether to show the
+// tooltip, so layout changes after mount are always accounted for.
+const onFieldMouseEnter = () => {
+  valueTruncated.value = hasTextOverflow(valueRef.value);
+};
+
+// Native tooltip with the full selected value, only when it is actually cut
+// with an ellipsis; the value layer itself has `pointer-events: none`, so the
+// title goes on the field wrapper.
+const fieldTitle = computed(() =>
+  !data.open && valueTruncated.value && textValue.value ? textValue.value : undefined,
+);
 
 const computedPlaceholder = computed(() => {
   if (!data.open && model.value) {
@@ -388,7 +401,7 @@ watch(
       @focusout="onFocusOut"
     >
       <div class="pl-autocomplete__container">
-        <div class="pl-autocomplete__field" :title="fieldTitle">
+        <div class="pl-autocomplete__field" :title="fieldTitle" @mouseenter="onFieldMouseEnter">
           <input
             ref="input"
             v-model="search"
@@ -401,7 +414,7 @@ watch(
             @focus="onInputFocus"
           />
 
-          <div v-if="!data.open" class="input-value">
+          <div v-if="!data.open" ref="valueRef" class="input-value">
             <LongText> {{ textValue }} </LongText>
           </div>
 

--- a/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
+++ b/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
@@ -211,6 +211,15 @@ const textValue = computed(() => {
   return item?.label;
 });
 
+// Native tooltip with the full selected value. The `.input-value` layer has
+// `pointer-events: none`, so the title must sit on the field wrapper, which is
+// what actually receives the hover.
+const fieldTitle = computed(() => {
+  if (data.open) return undefined;
+  if (isMissing.value) return props.missingValueLabel;
+  return textValue.value !== undefined ? String(textValue.value) : undefined;
+});
+
 const computedPlaceholder = computed(() => {
   if (!data.open && hasValue.value) {
     return "";
@@ -357,7 +366,7 @@ watchPostEffect(() => {
       @focusout="onFocusOut"
     >
       <div class="pl-dropdown__container">
-        <div class="pl-dropdown__field">
+        <div class="pl-dropdown__field" :title="fieldTitle">
           <input
             ref="input"
             v-model="data.search"

--- a/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
+++ b/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
@@ -11,7 +11,6 @@ export default {
 import { computed, reactive, ref, unref, useTemplateRef, watch, watchPostEffect } from "vue";
 import SvgRequired from "../../assets/images/required.svg?raw";
 import { getErrorMessage } from "../../helpers/error.ts";
-import { hasTextOverflow } from "../../helpers/dom";
 import { tap } from "../../helpers/functions";
 import { deepEqual } from "../../helpers/objects";
 import { normalizeListOptions } from "../../helpers/utils";
@@ -212,20 +211,11 @@ const textValue = computed(() => {
   return item?.label;
 });
 
-const valueRef = ref<HTMLElement>();
-const valueTruncated = ref(false);
-
-// Measured on hover, right before the browser decides whether to show the
-// tooltip, so layout changes after mount are always accounted for.
-const onFieldMouseEnter = () => {
-  valueTruncated.value = hasTextOverflow(valueRef.value);
-};
-
-// Native tooltip with the full selected value, only when it is actually cut
-// with an ellipsis. The `.input-value` layer has `pointer-events: none`, so the
-// title must sit on the field wrapper, which is what actually receives the hover.
+// Native tooltip with the full selected value. The `.input-value` layer has
+// `pointer-events: none`, so the title must sit on the field wrapper, which is
+// what actually receives the hover.
 const fieldTitle = computed(() => {
-  if (data.open || !valueTruncated.value) return undefined;
+  if (data.open) return undefined;
   if (isMissing.value) return props.missingValueLabel;
   return textValue.value !== undefined ? String(textValue.value) : undefined;
 });
@@ -376,7 +366,7 @@ watchPostEffect(() => {
       @focusout="onFocusOut"
     >
       <div class="pl-dropdown__container">
-        <div class="pl-dropdown__field" :title="fieldTitle" @mouseenter="onFieldMouseEnter">
+        <div class="pl-dropdown__field" :title="fieldTitle">
           <input
             ref="input"
             v-model="data.search"
@@ -389,7 +379,7 @@ watchPostEffect(() => {
             @focus="onInputFocus"
           />
 
-          <div v-if="!data.open" ref="valueRef" class="input-value">
+          <div v-if="!data.open" class="input-value">
             <LongText v-if="isMissing" class="input-value--missing">
               {{ missingValueLabel }}
             </LongText>

--- a/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
+++ b/lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue
@@ -11,6 +11,7 @@ export default {
 import { computed, reactive, ref, unref, useTemplateRef, watch, watchPostEffect } from "vue";
 import SvgRequired from "../../assets/images/required.svg?raw";
 import { getErrorMessage } from "../../helpers/error.ts";
+import { hasTextOverflow } from "../../helpers/dom";
 import { tap } from "../../helpers/functions";
 import { deepEqual } from "../../helpers/objects";
 import { normalizeListOptions } from "../../helpers/utils";
@@ -211,11 +212,20 @@ const textValue = computed(() => {
   return item?.label;
 });
 
-// Native tooltip with the full selected value. The `.input-value` layer has
-// `pointer-events: none`, so the title must sit on the field wrapper, which is
-// what actually receives the hover.
+const valueRef = ref<HTMLElement>();
+const valueTruncated = ref(false);
+
+// Measured on hover, right before the browser decides whether to show the
+// tooltip, so layout changes after mount are always accounted for.
+const onFieldMouseEnter = () => {
+  valueTruncated.value = hasTextOverflow(valueRef.value);
+};
+
+// Native tooltip with the full selected value, only when it is actually cut
+// with an ellipsis. The `.input-value` layer has `pointer-events: none`, so the
+// title must sit on the field wrapper, which is what actually receives the hover.
 const fieldTitle = computed(() => {
-  if (data.open) return undefined;
+  if (data.open || !valueTruncated.value) return undefined;
   if (isMissing.value) return props.missingValueLabel;
   return textValue.value !== undefined ? String(textValue.value) : undefined;
 });
@@ -366,7 +376,7 @@ watchPostEffect(() => {
       @focusout="onFocusOut"
     >
       <div class="pl-dropdown__container">
-        <div class="pl-dropdown__field" :title="fieldTitle">
+        <div class="pl-dropdown__field" :title="fieldTitle" @mouseenter="onFieldMouseEnter">
           <input
             ref="input"
             v-model="data.search"
@@ -379,7 +389,7 @@ watchPostEffect(() => {
             @focus="onInputFocus"
           />
 
-          <div v-if="!data.open" class="input-value">
+          <div v-if="!data.open" ref="valueRef" class="input-value">
             <LongText v-if="isMissing" class="input-value--missing">
               {{ missingValueLabel }}
             </LongText>

--- a/lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
+++ b/lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
@@ -15,7 +15,7 @@ import { PlTooltip } from "../PlTooltip";
 import DoubleContour from "../../utils/DoubleContour.vue";
 import { useLabelNotch } from "../../utils/useLabelNotch";
 import type { ListOption, ListOptionNormalized } from "../../types";
-import { scrollIntoView } from "../../helpers/dom";
+import { hasTextOverflow, scrollIntoView } from "../../helpers/dom";
 import { deepEqual } from "../../helpers/objects";
 import DropdownListItem from "../DropdownListItem.vue";
 import LongText from "../LongText.vue";
@@ -173,10 +173,20 @@ const textValue = computed(() => {
   return item?.label || props.modelValue; // @todo show inner value?
 });
 
-// Native tooltip with the full selected value; the value layer itself has
-// `pointer-events: none`, so the title goes on the field wrapper.
+const valueRef = ref<HTMLElement>();
+const valueTruncated = ref(false);
+
+// Measured on hover, right before the browser decides whether to show the
+// tooltip, so layout changes after mount are always accounted for.
+const onFieldMouseEnter = () => {
+  valueTruncated.value = hasTextOverflow(valueRef.value);
+};
+
+// Native tooltip with the full selected value, only when it is actually cut
+// with an ellipsis; the value layer itself has `pointer-events: none`, so the
+// title goes on the field wrapper.
 const fieldTitle = computed(() => {
-  if (data.open) return undefined;
+  if (data.open || !valueTruncated.value) return undefined;
   const v = textValue.value;
   return v !== undefined && v !== null && v !== "" ? String(v) : undefined;
 });
@@ -327,7 +337,7 @@ watchPostEffect(() => {
       @focusout="onFocusOut"
     >
       <div class="ui-dropdown__container">
-        <div class="ui-dropdown__field" :title="fieldTitle">
+        <div class="ui-dropdown__field" :title="fieldTitle" @mouseenter="onFieldMouseEnter">
           <input
             ref="input"
             v-model="data.search"
@@ -340,7 +350,7 @@ watchPostEffect(() => {
             @focus="onInputFocus"
           />
 
-          <div v-if="!data.open" @click="setFocusOnInput">
+          <div v-if="!data.open" ref="valueRef" @click="setFocusOnInput">
             <LongText class="input-value"> {{ textValue }} </LongText>
           </div>
 

--- a/lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
+++ b/lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
@@ -173,6 +173,14 @@ const textValue = computed(() => {
   return item?.label || props.modelValue; // @todo show inner value?
 });
 
+// Native tooltip with the full selected value; the value layer itself has
+// `pointer-events: none`, so the title goes on the field wrapper.
+const fieldTitle = computed(() => {
+  if (data.open) return undefined;
+  const v = textValue.value;
+  return v !== undefined && v !== null && v !== "" ? String(v) : undefined;
+});
+
 const computedPlaceholder = computed(() => {
   if (!data.open && props.modelValue) {
     return "";
@@ -319,7 +327,7 @@ watchPostEffect(() => {
       @focusout="onFocusOut"
     >
       <div class="ui-dropdown__container">
-        <div class="ui-dropdown__field">
+        <div class="ui-dropdown__field" :title="fieldTitle">
           <input
             ref="input"
             v-model="data.search"

--- a/lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
+++ b/lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
@@ -15,7 +15,7 @@ import { PlTooltip } from "../PlTooltip";
 import DoubleContour from "../../utils/DoubleContour.vue";
 import { useLabelNotch } from "../../utils/useLabelNotch";
 import type { ListOption, ListOptionNormalized } from "../../types";
-import { hasTextOverflow, scrollIntoView } from "../../helpers/dom";
+import { scrollIntoView } from "../../helpers/dom";
 import { deepEqual } from "../../helpers/objects";
 import DropdownListItem from "../DropdownListItem.vue";
 import LongText from "../LongText.vue";
@@ -173,20 +173,10 @@ const textValue = computed(() => {
   return item?.label || props.modelValue; // @todo show inner value?
 });
 
-const valueRef = ref<HTMLElement>();
-const valueTruncated = ref(false);
-
-// Measured on hover, right before the browser decides whether to show the
-// tooltip, so layout changes after mount are always accounted for.
-const onFieldMouseEnter = () => {
-  valueTruncated.value = hasTextOverflow(valueRef.value);
-};
-
-// Native tooltip with the full selected value, only when it is actually cut
-// with an ellipsis; the value layer itself has `pointer-events: none`, so the
-// title goes on the field wrapper.
+// Native tooltip with the full selected value; the value layer itself has
+// `pointer-events: none`, so the title goes on the field wrapper.
 const fieldTitle = computed(() => {
-  if (data.open || !valueTruncated.value) return undefined;
+  if (data.open) return undefined;
   const v = textValue.value;
   return v !== undefined && v !== null && v !== "" ? String(v) : undefined;
 });
@@ -337,7 +327,7 @@ watchPostEffect(() => {
       @focusout="onFocusOut"
     >
       <div class="ui-dropdown__container">
-        <div class="ui-dropdown__field" :title="fieldTitle" @mouseenter="onFieldMouseEnter">
+        <div class="ui-dropdown__field" :title="fieldTitle">
           <input
             ref="input"
             v-model="data.search"
@@ -350,7 +340,7 @@ watchPostEffect(() => {
             @focus="onInputFocus"
           />
 
-          <div v-if="!data.open" ref="valueRef" @click="setFocusOnInput">
+          <div v-if="!data.open" @click="setFocusOnInput">
             <LongText class="input-value"> {{ textValue }} </LongText>
           </div>
 

--- a/lib/ui/uikit/src/helpers/dom.ts
+++ b/lib/ui/uikit/src/helpers/dom.ts
@@ -90,16 +90,3 @@ export function detectOutside(e: { x: number; y: number }, el: HTMLElement) {
   const rect = el.getBoundingClientRect();
   return e.x < rect.x || e.x > rect.x + rect.width || e.y < rect.y || e.y > rect.y + rect.height;
 }
-
-/**
- * True when `el` or any of its descendants clips its content horizontally,
- * i.e. the text is cut with an ellipsis and not fully visible.
- */
-export function hasTextOverflow(el: HTMLElement | undefined | null): boolean {
-  if (!el) return false;
-  if (el.scrollWidth > el.clientWidth) return true;
-  for (const child of el.querySelectorAll<HTMLElement>("*")) {
-    if (child.scrollWidth > child.clientWidth) return true;
-  }
-  return false;
-}

--- a/lib/ui/uikit/src/helpers/dom.ts
+++ b/lib/ui/uikit/src/helpers/dom.ts
@@ -90,3 +90,16 @@ export function detectOutside(e: { x: number; y: number }, el: HTMLElement) {
   const rect = el.getBoundingClientRect();
   return e.x < rect.x || e.x > rect.x + rect.width || e.y < rect.y || e.y > rect.y + rect.height;
 }
+
+/**
+ * True when `el` or any of its descendants clips its content horizontally,
+ * i.e. the text is cut with an ellipsis and not fully visible.
+ */
+export function hasTextOverflow(el: HTMLElement | undefined | null): boolean {
+  if (!el) return false;
+  if (el.scrollWidth > el.clientWidth) return true;
+  for (const child of el.querySelectorAll<HTMLElement>("*")) {
+    if (child.scrollWidth > child.clientWidth) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Problem

Dropdowns truncate long selected values with an ellipsis, but hovering shows nothing, so there is no way to see what is actually selected.

## Root cause

The selected label is rendered inside a layer styled with `pointer-events: none`. The existing hover marquee in `LongText` never fires there, and a `title` on the label itself would never show either.

## Fix

Each affected component gets a `fieldTitle` computed bound as `:title` on the field wrapper, which is the element that receives the hover. The title is cleared while the option list is open. In `PlDropdown` it also covers the missing-value state.

Components: `PlDropdown`, `PlDropdownLegacy`, `PlAutocomplete`. `PlDropdownMulti` (chips) and `PlDropdownLine` are unchanged.

## Verification

- `pnpm run check` in `lib/ui/uikit` (vue-tsc, oxlint, oxfmt) passes
- uikit unit tests: 186 passed
- Changeset: uikit patch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds native selected-value tooltips to three UIKit choice controls and publishes the behavior as a patch release. The title is attached to each field wrapper because the rendered value layer does not receive pointer events, and it is removed while the option list is open.

- `PlDropdown` adds titles for selected labels and its missing-value state.
- `PlDropdownLegacy` and `PlAutocomplete` add titles for their selected display values.
- A changeset records a patch release for `@milaboratories/uikit`.
- The current implementation does not distinguish truncated labels from labels that fit, so short values also receive native tooltips.

**Important touched terms**
- **Choice control** — A UIKit input that presents selectable options and returns the selected typed value. This PR changes three choice controls: `PlDropdown`, `PlDropdownLegacy`, and `PlAutocomplete`.
- **Selected label (`textValue`)** — The display text associated with the current model value. It now supplies the native tooltip text when each control is closed.
- **Field wrapper** — The hover-receiving element surrounding the input and selected-value layer. It now owns the `title` attribute because the value layer has pointer events disabled.
- **`fieldTitle`** — A new computed tooltip value derived from the selected label and open state. It is cleared while the option list is open; `PlDropdown` additionally derives it from `missingValueLabel` for unavailable selections.
- **Missing-value state** — `PlDropdown`'s presentation when the current model value has no matching loaded option. The configured missing-value label is now exposed as the field's native tooltip.
- **Native tooltip** — Browser-provided hover text generated by an HTML `title` attribute. This PR uses it to expose selected values, although it currently appears even without truncation.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking UX issue where native tooltips also appear for selected labels that are fully visible.

The selected title tracks component state and displayed values correctly, but all three controls assign it without measuring overflow, broadening the behavior beyond truncated labels.

**Files Needing Attention:** lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue, lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue, lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue | Adds a wrapper title for selected and missing values, but does not limit it to labels that are actually truncated. |
| lib/ui/uikit/src/components/PlAutocomplete/PlAutocomplete.vue | Adds a computed selected-value title to the autocomplete field while closed, with the same unconditional short-label behavior. |
| lib/ui/uikit/src/components/PlDropdownLegacy/PlDropdownLegacy.vue | Adds a computed selected-value title to the legacy dropdown while closed, with the same unconditional short-label behavior. |
| .changeset/dropdown-hover-title.md | Declares the intended selected-value tooltip behavior as a UIKit patch release. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Selected model value] --> B[Resolve display label]
  B --> C{Option list open?}
  C -->|Yes| D[Clear field title]
  C -->|No| E{PlDropdown value missing?}
  E -->|Yes| F[Use missing-value label]
  E -->|No| G[Use selected label]
  F --> H[Bind title to field wrapper]
  G --> H
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231812%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1812&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alib%2Fui%2Fuikit%2Fsrc%2Fcomponents%2FPlDropdown%2FPlDropdown.vue%3A217-221%0A**Tooltips%20appear%20without%20truncation**%0A%0AThis%20assigns%20a%20title%20to%20every%20nonempty%20closed%20selection%20without%20checking%20whether%20the%20label%20actually%20overflows.%20Short%20labels%20that%20are%20already%20fully%20visible%20therefore%20show%20a%20redundant%20native%20tooltip.%20The%20same%20behavior%20occurs%20in%20%60PlAutocomplete%60%20and%20%60PlDropdownLegacy%60%3B%20gate%20the%20title%20on%20an%20actual%20overflow%20check%20such%20as%20%60scrollWidth%20%3E%20clientWidth%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/ui/uikit/src/components/PlDropdown/PlDropdown.vue:217-221
**Tooltips appear without truncation**

This assigns a title to every nonempty closed selection without checking whether the label actually overflows. Short labels that are already fully visible therefore show a redundant native tooltip. The same behavior occurs in `PlAutocomplete` and `PlDropdownLegacy`; gate the title on an actual overflow check such as `scrollWidth > clientWidth`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(uikit): show full selected value as ..."](https://github.com/milaboratory/platforma/commit/b659a5db5341b60f36c6b5a0c3630af23bbaf739) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62026941)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [UIKit component system](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/uikit.md)

<!-- /greptile_comment -->