### PR TITLE
perf(pl-tree): cut the cost of applying a tree update

### DIFF
--- a/.changeset/tree-apply-cost.md
+++ b/.changeset/tree-apply-cost.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-tree": patch
+---
+
+Make `PlTreeState.updateFromResourceData` 11% faster on a steady tree-sync poll and 23% faster on a first load, mainly by walking stored fields and kv entries in lockstep with the incoming ones instead of hashing every freshly decoded name.

--- a/lib/node/pl-tree/src/state.test.ts
+++ b/lib/node/pl-tree/src/state.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "vitest";
 import { Computable } from "@milaboratories/computable";
+import type { Watcher } from "@milaboratories/computable";
+import type { FieldData } from "@milaboratories/pl-client";
 import {
   createSignedResourceId,
   DefaultFinalResourceDataPredicate,
@@ -19,6 +21,15 @@ import {
 } from "./test_utils";
 
 const rid = createSignedResourceId;
+
+/** Minimal Watcher for tests that read tree state directly, outside a Computable. */
+class NoopWatcher implements Watcher {
+  isChanged = false;
+  markChanged(): void {
+    this.isChanged = true;
+  }
+}
+const w = () => new NoopWatcher();
 
 test("simple tree test 1", async () => {
   const tree = new PlTreeState(TestDynamicRootId1, DefaultFinalResourceDataPredicate);
@@ -316,4 +327,150 @@ test("exception - ready without locks 2", () => {
       },
     ]),
   ).toThrow(/ready without input or output lock/);
+});
+
+// The field and kv update loops walk the stored entries in lockstep with the incoming ones
+// and only fall back to a hash lookup once the two orders diverge. These cover the
+// divergence shapes: reordering, an insertion in the middle, a removal. A reorder that
+// changes nothing must invalidate nothing and must not disturb refCounts, which is what
+// pins the fallback: mistaking a reordered field for a new one still leaves the right field
+// set behind, but double-counts the reference and fires spurious change notifications.
+
+const rootRes = (fields: FieldData[]) => [{ ...TestDynamicRootState1, fields }];
+
+test("a pure field reorder changes nothing and invalidates nothing", () => {
+  const tree = new PlTreeState(TestDynamicRootId1, DefaultFinalResourceDataPredicate);
+  tree.updateFromResourceData(rootRes([dField("a"), dField("b"), dField("c")]));
+
+  const watcher = w();
+  const root = tree.get(watcher, TestDynamicRootId1);
+  root.listDynamicFields(watcher);
+  for (const name of ["a", "b", "c"]) root.getField(watcher, name, () => {});
+  expect(watcher.isChanged).toStrictEqual(false);
+
+  tree.updateFromResourceData(rootRes([dField("c"), dField("b"), dField("a")]));
+
+  expect(watcher.isChanged).toStrictEqual(false);
+  expect(
+    tree
+      .get(w(), TestDynamicRootId1)
+      .fields.map((f) => f.name)
+      .sort(),
+  ).toStrictEqual(["a", "b", "c"]);
+});
+
+test("field inserted mid-order, then removed, is tracked", () => {
+  const tree = new PlTreeState(TestDynamicRootId1, DefaultFinalResourceDataPredicate);
+  const names = () =>
+    tree
+      .get(w(), TestDynamicRootId1)
+      .fields.map((f) => f.name)
+      .sort();
+
+  tree.updateFromResourceData(rootRes([dField("a"), dField("c")]));
+  expect(names()).toStrictEqual(["a", "c"]);
+
+  // "b" appears between two fields that are already stored: the walk diverges at "b"
+  tree.updateFromResourceData(rootRes([dField("a"), dField("b"), dField("c")]));
+  expect(names()).toStrictEqual(["a", "b", "c"]);
+
+  // and disappears again, in a shuffled order
+  tree.updateFromResourceData(rootRes([dField("c"), dField("a")]));
+  expect(names()).toStrictEqual(["a", "c"]);
+});
+
+test("reordering fields does not inflate refCounts", () => {
+  const tree = new PlTreeState(TestDynamicRootId1, DefaultFinalResourceDataPredicate);
+  const leaf = (n: bigint) => ({
+    ...TestValueResourceState1,
+    id: rid(n),
+    data: new TextEncoder().encode(`v${n}`),
+  });
+
+  tree.updateFromResourceData([
+    {
+      ...TestDynamicRootState1,
+      fields: [dField("a", rid(1n)), dField("b", rid(2n))],
+    },
+    leaf(1n),
+    leaf(2n),
+  ]);
+
+  // reorder and repoint in one update: the two fields swap targets
+  tree.updateFromResourceData([
+    {
+      ...TestDynamicRootState1,
+      fields: [dField("b", rid(1n)), dField("a", rid(2n))],
+    },
+    leaf(1n),
+    leaf(2n),
+  ]);
+
+  const byName = new Map(tree.get(w(), TestDynamicRootId1).fields.map((f) => [f.name, f.value]));
+  expect(byName.get("a")).toStrictEqual(rid(2n));
+  expect(byName.get("b")).toStrictEqual(rid(1n));
+
+  // dropping "a" must collect leaf 2: its refCount has to be exactly 1, so a reorder that
+  // was mistaken for an insertion (and double-incremented) would leave it alive here
+  tree.updateFromResourceData(rootRes([dField("b", rid(1n))]));
+  expect(tree.get(w(), rid(1n)).getDataAsString()).toStrictEqual("v1");
+  expect(() => tree.get(w(), rid(2n))).toThrow(/not found/);
+});
+
+test("kv reordering neither invalidates watchers nor loses entries", () => {
+  const tree = new PlTreeState(TestDynamicRootId1, DefaultFinalResourceDataPredicate);
+  const kvOf = (entries: [string, string][]) => [
+    {
+      ...TestDynamicRootState1,
+      fields: [],
+      kv: entries.map(([key, value]) => ({ key, value: Buffer.from(value) })),
+    },
+  ];
+  const read = (key: string) => tree.get(w(), TestDynamicRootId1).getKeyValueString(w(), key);
+
+  tree.updateFromResourceData(
+    kvOf([
+      ["k1", "one"],
+      ["k2", "two"],
+    ]),
+  );
+  expect([read("k1"), read("k2")]).toStrictEqual(["one", "two"]);
+
+  // reversed order, same values: no watcher may fire
+  const watcher = w();
+  const root = tree.get(watcher, TestDynamicRootId1);
+  root.getKeyValue(watcher, "k1");
+  root.getKeyValue(watcher, "k2");
+  tree.updateFromResourceData(
+    kvOf([
+      ["k2", "two"],
+      ["k1", "one"],
+    ]),
+  );
+  expect(watcher.isChanged).toStrictEqual(false);
+
+  // a key inserted before the stored ones, so the walk diverges immediately
+  tree.updateFromResourceData(
+    kvOf([
+      ["k0", "zero"],
+      ["k2", "two"],
+      ["k1", "ONE"],
+    ]),
+  );
+  expect([read("k0"), read("k1"), read("k2")]).toStrictEqual(["zero", "ONE", "two"]);
+
+  // and a deletion
+  tree.updateFromResourceData(kvOf([["k1", "ONE"]]));
+  expect([read("k0"), read("k1"), read("k2")]).toStrictEqual([undefined, "ONE", undefined]);
+});
+
+test("removal of a typed field still throws after a reorder", () => {
+  const tree = new PlTreeState(TestDynamicRootId1, DefaultFinalResourceDataPredicate);
+
+  tree.updateFromResourceData(rootRes([iField("a"), iField("b"), dField("c")]));
+
+  // reordered, and the input field "b" is gone: the removal scan must still see it
+  expect(() => tree.updateFromResourceData(rootRes([dField("c"), iField("a")]))).toThrow(
+    /removal of Input field b/,
+  );
 });

--- a/lib/node/pl-tree/src/state.ts
+++ b/lib/node/pl-tree/src/state.ts
@@ -521,6 +521,45 @@ export class PlTreeState {
     let addedCount = 0;
     let firstAdded: SignedResourceId | undefined;
 
+    // Diagnostic context for unexpectedTransitionError, refreshed once per resource. It lives
+    // out here so the loop body allocates neither a closure nor a snapshot per resource on the
+    // path where nothing goes wrong. Only the mutable half of BasicResourceData needs
+    // capturing: id, kind, type and data are readonly on PlTreeResource, so they are read back
+    // from the resource when the message is built.
+    let errRd: ExtendedResourceData;
+    let errRes: PlTreeResource | undefined;
+    let errOriginalResourceId: OptionalSignedResourceId = NullSignedResourceId;
+    let errError: OptionalSignedResourceId = NullSignedResourceId;
+    let errInputsLocked = false;
+    let errOutputsLocked = false;
+    let errResourceReady = false;
+    let errFinal = false;
+    const unexpectedTransitionError = (reason: string): never => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { fields, ...rdWithoutFields } = errRd;
+      const statBeforeMutation: BasicResourceData | undefined =
+        errRes === undefined
+          ? undefined
+          : {
+              id: errRes.id,
+              kind: errRes.kind,
+              type: errRes.type,
+              data: errRes.data,
+              resourceReady: errResourceReady,
+              inputsLocked: errInputsLocked,
+              outputsLocked: errOutputsLocked,
+              error: errError,
+              originalResourceId: errOriginalResourceId,
+              final: errFinal,
+            };
+      this.invalidateTree();
+      throw new TreeStateUpdateError(
+        `Unexpected resource state transition (${reason}): ${stringifyWithResourceId(
+          rdWithoutFields,
+        )} -> ${stringifyWithResourceId(statBeforeMutation)}`,
+      );
+    };
+
     // patching / creating resources
     for (const rd of resourceData) {
       let resource = this.resources.get(rd.id);
@@ -530,20 +569,17 @@ export class PlTreeState {
       // they never change; this flag isolates value/flag-only changes from real metadata churn.
       let metadataChanged = false;
 
-      const statBeforeMutation = resource?.basicState;
-      const unexpectedTransitionError = (reason: string): never => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { fields, ...rdWithoutFields } = rd;
-        this.invalidateTree();
-        throw new TreeStateUpdateError(
-          `Unexpected resource state transition (${reason}): ${stringifyWithResourceId(
-            rdWithoutFields,
-          )} -> ${stringifyWithResourceId(statBeforeMutation)}`,
-        );
-      };
+      errRd = rd;
+      errRes = resource;
 
       if (resource !== undefined) {
         // updating existing resource
+        errOriginalResourceId = resource.originalResourceId;
+        errError = resource.error;
+        errInputsLocked = resource.inputsLocked;
+        errOutputsLocked = resource.outputsLocked;
+        errResourceReady = resource.resourceReady;
+        errFinal = resource.finalFlag;
 
         if (resource.finalState)
           unexpectedTransitionError("resource state can\t be updated after it is marked as final");

--- a/lib/node/pl-tree/src/state.ts
+++ b/lib/node/pl-tree/src/state.ts
@@ -577,9 +577,27 @@ export class PlTreeState {
           if (stat) stat.errorsAttached++;
         }
 
-        // updating fields
+        // updating fields.
+        //
+        // Fields normally arrive in the order they are already stored, so the stored ones are
+        // walked in lockstep with the incoming ones and matched by direct name comparison
+        // rather than through a fieldsMap lookup: every field name in a poll response is
+        // freshly decoded from protobuf, so V8 has no cached hash for any of them.
+        //
+        // Any divergence (reordering, an insertion, a removal) abandons the walk, and the rest
+        // of the resource resolves through fieldsMap.get, which is always correct. The walk is
+        // abandoned before any fieldsMap.set, so it never observes an insertion made through
+        // the live iterator.
+        let walk: MapIterator<PlTreeField> | undefined =
+          rd.fields.length > 0 ? resource.fieldsMap.values() : undefined;
         for (const fd of rd.fields) {
-          let field = resource.fieldsMap.get(fd.name);
+          let field: PlTreeField | undefined;
+          if (walk !== undefined) {
+            const next = walk.next();
+            if (next.done === true || next.value.name !== fd.name) walk = undefined;
+            else field = next.value;
+          }
+          if (field === undefined) field = resource.fieldsMap.get(fd.name);
 
           if (!field) {
             // new field

--- a/lib/node/pl-tree/src/state.ts
+++ b/lib/node/pl-tree/src/state.ts
@@ -513,6 +513,14 @@ export class PlTreeState {
     const incrementRefs: SignedResourceId[] = [];
     const decrementRefs: SignedResourceId[] = [];
 
+    // `resourcesAdded` is notified once, after the loop: markChanged detaches every watcher on
+    // its first call and no watcher can attach in the middle of this synchronous loop, so a
+    // single notification covers every resource added here. It also builds the marker string
+    // just once, which is worth doing because resourceIdToString on a signed id parses a
+    // BigInt and hex-decodes a Buffer.
+    let addedCount = 0;
+    let firstAdded: SignedResourceId | undefined;
+
     // patching / creating resources
     for (const rd of resourceData) {
       let resource = this.resources.get(rd.id);
@@ -832,7 +840,8 @@ export class PlTreeState {
 
         // adding the resource to the heap
         this.resources.set(resource.id, resource);
-        this.resourcesAdded.markChanged(`new resource ${resourceIdToString(resource.id)} added`);
+        if (addedCount === 0) firstAdded = resource.id;
+        addedCount++;
       }
 
       if (stat) {
@@ -848,6 +857,13 @@ export class PlTreeState {
         }
       }
     }
+
+    if (firstAdded !== undefined)
+      this.resourcesAdded.markChanged(
+        addedCount === 1
+          ? `new resource ${resourceIdToString(firstAdded)} added`
+          : `${addedCount} new resources added, first ${resourceIdToString(firstAdded)}`,
+      );
 
     // applying refCount increments
     for (const rid of incrementRefs) {

--- a/lib/node/pl-tree/src/state.ts
+++ b/lib/node/pl-tree/src/state.ts
@@ -781,11 +781,23 @@ export class PlTreeState {
           if (stat) stat.readyFlips++;
         }
 
-        // syncing kv
+        // syncing kv. Same lockstep walk as the fields above, for the same reason: kv keys
+        // arrive in a stable order and are freshly decoded strings. The walk is only set up
+        // when there is something to compare against, so a resource with no kv allocates no
+        // iterator.
+        let kvWalk: MapIterator<[string, Uint8Array]> | undefined =
+          rd.kv.length > 0 ? resource.kv.entries() : undefined;
         for (const kv of rd.kv) {
-          const current = resource.kv.get(kv.key);
+          let current: Uint8Array | undefined;
+          if (kvWalk !== undefined) {
+            const next = kvWalk.next();
+            if (next.done === true || next.value[0] !== kv.key) kvWalk = undefined;
+            else current = next.value[1];
+          }
+          if (current === undefined) current = resource.kv.get(kv.key);
           if (current === undefined) {
             resource.kv.set(kv.key, kv.value);
+            kvWalk = undefined;
             notEmpty(resource.kvChangedPerKey).markChanged(
               kv.key,
               `kv added for ${resourceIdToString(resource.id)}: ${kv.key}`,


### PR DESCRIPTION
Makes `PlTreeState.updateFromResourceData`, the apply step of a tree-sync poll, faster.

## Changes

- **`5126c71` Notify `resourcesAdded` once per update** instead of once per new resource.
  → **21% faster on a first load**, nothing on a steady poll.
- **`f3d0776` Walk stored fields in lockstep with the incoming ones**, matching by direct name
  comparison instead of a `fieldsMap` hash lookup per field — poll-response field names are
  freshly decoded, so V8 has to hash every one. → **10% faster on a steady poll.**
- **`c64783a` Same lockstep walk for KV entries.** → **2% faster on a steady poll.**
- **`d56e597` Hoist the transition-error snapshot out of the patch loop**, dropping a closure
  and a `basicState` clone per resource per update. → **4% faster on a steady poll.**

## Improvement

Per apply, at 10,000 resources with ~10 fields and 2 KV entries each:

| update contains | faster by |
|---|---|
| first load, every resource new | **23%** |
| steady poll, everything held and unchanged | **11%** |
| field added and removed on 10% of resources | **13%** |
| field value repointed on 10% of resources | **11%** |
| 2% of resources drop child refs, cascading through `collectGarbage` | **12%** |


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimizes the in-memory apply phase of tree synchronization while retaining existing field, KV, reference-count, watcher, and transition-validation behavior.

### Important touched terms
- **`PlTreeState.updateFromResourceData`** — Applies incoming resource snapshots to the local tree. It now batches resource-added notification, uses lockstep field/KV traversal, and reuses transition-error diagnostic machinery.
- **`PlTreeResource`** — The stored representation of one resource and its mutable state. Its pre-update state is now captured through scalar diagnostic variables rather than cloning `basicState` for every resource.
- **`fieldsMap`** — A name-keyed map of a resource’s fields. Incoming fields now take a direct iterator fast path while order matches, then fall back to map lookup after any divergence.
- **KV entries (`resource.kv`)** — Per-resource string keys mapped to binary values. Their synchronization now uses the same lockstep fast path, abandoning it before inserting into the map.
- **`resourcesAdded`** — The change source watched when a requested resource is absent. It is now marked once after an update rather than once for every newly created resource.
- **`unexpectedTransitionError`** — Invalidates the tree and reports an illegal resource-state transition. Its closure and immutable diagnostic setup are now allocated once per update.
- **Reference counts** — Counts that retain resources reachable through fields. New tests verify that field reordering and repointing do not inflate these counts or prevent garbage collection.
- **Watcher invalidation** — Notification that observed tree state changed. New tests ensure pure field and KV reordering does not spuriously invalidate watchers.

### Additional changes
- Adds focused regression coverage for reordered, inserted, removed, and repointed fields; KV reorder/update/deletion; typed-field removal; and reference-count integrity.
- Adds a patch changeset documenting the measured tree-apply performance improvement.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the optimized paths preserving existing observable behavior and receiving focused regression coverage.

No actionable correctness, security, or repository-rule issue remains; exact-name fallback protects divergent field and KV ordering, batched notification preserves watcher semantics, and the diagnostic snapshot matches the prior pre-mutation state.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-tree/src/state.ts | Introduces notification batching, lockstep field/KV traversal, and reusable transition-error diagnostics without changing established update semantics. |
| lib/node/pl-tree/src/state.test.ts | Adds targeted tests for order divergence, watcher stability, field lifecycle, KV synchronization, and reference-count correctness. |
| .changeset/tree-apply-cost.md | Records a patch release and summarizes the measured apply-phase performance improvement. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming resource snapshots] --> B{Stored resource exists?}
    B -- No --> C[Create resource]
    C --> D[Count newly added resource]
    B -- Yes --> E[Capture mutable pre-update state]
    E --> F[Apply metadata and state transitions]
    F --> G[Walk stored fields in lockstep]
    G --> H{Names still match?}
    H -- Yes --> I[Use iterator value directly]
    H -- No --> J[Fall back to fieldsMap lookup]
    I --> K[Apply field changes and reference deltas]
    J --> K
    K --> L[Walk KV entries in lockstep]
    L --> M{Keys still match?}
    M -- Yes --> N[Use iterator value directly]
    M -- No --> O[Fall back to KV map lookup]
    N --> P[Apply KV changes and deletions]
    O --> P
    D --> Q[After patch loop]
    P --> Q
    Q --> R[Notify resourcesAdded once]
    R --> S[Apply reference deltas and garbage collection]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(pl-tree): hoist the transition-erro..."](https://github.com/milaboratory/platforma/commit/d56e59748342c785677b2ad5f49414af983ce083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62085128)</sub>

<!-- /greptile_comment -->