### PR TITLE
fix(pl-tree): append follow-up resources without a spread

### DIFF
--- a/.changeset/tree-followup-push-spread.md
+++ b/.changeset/tree-followup-push-spread.md
@@ -1,0 +1,5 @@
+---
+"@milaboratories/pl-tree": patch
+---
+
+Fix a `RangeError: Maximum call stack size exceeded` in `loadTreeStateViaResourceTree` when a stop-marker follow-up round returns a very large number of resources, which left the synchronized tree permanently failing on every poll.

--- a/lib/node/pl-tree/src/sync.test.ts
+++ b/lib/node/pl-tree/src/sync.test.ts
@@ -476,6 +476,37 @@ test("stop-marker-unknown-triggers-followup: unknown marker fetched in follow-up
   expect(callCount).toBe(2);
 });
 
+test("stop-marker-followup-large: a very large follow-up round does not overflow the stack", async () => {
+  // Regression: result.push(...followUpResult) threw RangeError once the follow-up round
+  // exceeded the argument limit (~200k elements on Node 26).
+  const followUpSize = 300_000;
+  let callCount = 0;
+  const tx = {
+    resourceTree: () => {
+      callCount++;
+      if (callCount === 1) {
+        return (async function* () {
+          yield makeStopMarker("NG:0x1");
+        })();
+      } else {
+        return (async function* () {
+          for (let i = 0; i < followUpSize; i++) yield makeFullResource(`NG:0x${i.toString(16)}`);
+        })();
+      }
+    },
+  } as unknown as Parameters<typeof loadTreeState>[0];
+
+  const request = {
+    seedResources: ["NG:0x99"],
+    finalResources: new Set<string>(),
+  } as unknown as Parameters<typeof loadTreeState>[1];
+
+  const result = await loadTreeState(tx, request, undefined, stopMarkerCaps);
+
+  expect(result).toHaveLength(followUpSize);
+  expect(callCount).toBe(2);
+});
+
 test("legacy-backend-compat: no stop markers in stream → no follow-up call", async () => {
   // Old backends emit only full-resource frames; pendingFollowUp stays empty
   // and the follow-up loop body never executes.

--- a/lib/node/pl-tree/src/sync.ts
+++ b/lib/node/pl-tree/src/sync.ts
@@ -366,7 +366,7 @@ async function loadTreeStateViaResourceTree(
     traverseStopRules,
   });
 
-  const { result, followUpSeeds } = await processResourceTreeStream(
+  let { result, followUpSeeds } = await processResourceTreeStream(
     treeItems,
     finalResources,
     pruningFunction,
@@ -401,7 +401,8 @@ async function loadTreeStateViaResourceTree(
       pruningFunction,
       stats,
     );
-    result.push(...followUpResult);
+    // spreading fails due to exceeding stack argument size
+    result = result.concat(followUpResult);
     if (stats) {
       logger?.info?.(
         `loadTreeStateViaResourceTree: follow-up request for ${roundSeeds.length} stop-marker seeds: ${JSON.stringify(roundSeeds)}`,


### PR DESCRIPTION
Stacked on `perf/tree-apply-cost`.

`result.push(...followUpResult)` in `loadTreeStateViaResourceTree` passes every element as a separate argument and throws `RangeError: Maximum call stack size exceeded` once the array reaches roughly 200k elements on Node 26. The stop-marker follow-up fetch is deliberately unpruned, so on a large project one round can return that many resources. Because the poll loop in `SynchronizedTreeState` only rebuilds on `TreeStateUpdateError`, the failure repeated on every poll with no recovery.

- Append element by element instead of spreading.
- Regression test: a follow-up round of 300k resources. Fails with `RangeError` on the old code, passes now.
- Changeset: `@milaboratories/pl-tree` patch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents large stop-marker follow-up rounds from exceeding JavaScript’s function-argument limit. It replaces spread-based array appending with element-by-element appending, adds a 300,000-resource regression test, and records a patch release for `@milaboratories/pl-tree`.

**Important touched terms**
- **Resource tree** — The backend-provided graph of related Platforma resources used to construct synchronized local state. The loading behavior is unchanged, but large follow-up results can now be accumulated safely.
- **Stop marker** — A streamed placeholder indicating that a referenced resource requires a separate follow-up fetch. The PR makes the resulting unpruned follow-up round safe when it contains hundreds of thousands of resources.
- **Follow-up round** — An additional resource-tree request made for unresolved stop-marker seeds. Its result is now appended one element at a time instead of being expanded into arguments to `Array.prototype.push`.
- **Synchronized tree state** — The local, polling view of backend resources maintained by `pl-tree`. It no longer remains stuck in repeated polling failures when a large follow-up append would previously throw `RangeError`.
- **Spread append** — The `array.push(...items)` pattern, which passes every item as a separate function argument and can exceed the runtime argument limit. It is replaced with a `for...of` append that preserves ordering and duplicates without that limit.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and directly addresses the large follow-up failure without changing result semantics.

The new loop preserves ordering, duplicates, and returned data while removing the function-argument limit, and the regression test exercises the intended streaming follow-up path.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/node/pl-tree/src/sync.ts | Replaces argument-spread appending with behaviorally equivalent element-wise appending to avoid runtime argument limits. |
| lib/node/pl-tree/src/sync.test.ts | Adds a regression test exercising a 300,000-resource stop-marker follow-up round and confirming exactly two backend calls. |
| .changeset/tree-followup-push-spread.md | Records the large-follow-up reliability fix as a patch release for `@milaboratories/pl-tree`. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Sync as Synchronized tree
    participant Backend as Resource-tree backend
    participant Result as Local result array
    Sync->>Backend: Initial resource-tree request
    Backend-->>Sync: Stop marker
    Sync->>Backend: Unpruned follow-up request
    Backend-->>Sync: Large resource array
    loop Each follow-up resource
        Sync->>Result: push(resource)
    end
    Result-->>Sync: Complete tree-loading result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pl-tree): append follow-up resources..."](https://github.com/milaboratory/platforma/commit/6337c85ee36fc78b7e05c0db857d12b071039634) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62087041)</sub>

**Context used:**

- Knowledge Base — [Node runtime services](https://app.greptile.com/milaboratories/-/custom-context/knowledge-base/milaboratory/platforma/-/docs/node-runtime-services.md)

<!-- /greptile_comment -->