### PR TITLE
fix(blocks-deps-updater): stop the tests depending on the npm registry

### DIFF
--- a/.changeset/blocks-deps-updater-test-registry.md
+++ b/.changeset/blocks-deps-updater-test-registry.md
@@ -3,4 +3,5 @@
 ---
 
 `updatePackages` accepts an optional resolver for a package's latest version, so its tests no
-longer depend on npmjs.org being reachable and fast.
+longer depend on npmjs.org being reachable and fast. A non-retryable registry status now fails
+immediately instead of being retried twice.

--- a/.changeset/blocks-deps-updater-test-registry.md
+++ b/.changeset/blocks-deps-updater-test-registry.md
@@ -1,0 +1,6 @@
+---
+"@platforma-sdk/blocks-deps-updater": patch
+---
+
+`updatePackages` accepts an optional resolver for a package's latest version, so its tests no
+longer depend on npmjs.org being reachable and fast.

--- a/tools/blocks-deps-updater/src/updater.test.ts
+++ b/tools/blocks-deps-updater/src/updater.test.ts
@@ -5,6 +5,13 @@ import dedent from "dedent";
 import { describe, expect, it } from "vitest";
 import { updatePackages } from "./updater";
 
+/** Stand-in for the registry. A unit test asserting catalog rewriting has no business
+ * depending on npmjs.org being reachable, let alone fast. */
+const fakeLatest =
+  (versions: Record<string, string> = {}) =>
+  async (packageName: string) =>
+    versions[packageName] ?? "9.9.9";
+
 async function tmpDir(): Promise<AsyncDisposable & { path: string }> {
   // TODO: migrate to `mkdtempDisposable` after migration to Node.js 24
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), "deps-updater-test-"));
@@ -34,7 +41,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     expect(await readWorkspace(dir.path)).toBe(
       dedent`
@@ -56,7 +63,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     const result = await readWorkspace(dir.path);
     expect(result).toContain("ag-grid-enterprise: ~34.1.2");
@@ -76,7 +83,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     const result = await readWorkspace(dir.path);
     expect(result).toContain("ag-grid-enterprise");
@@ -94,7 +101,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n";
     await writeWorkspace(dir.path, content);
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     expect(await readWorkspace(dir.path)).toBe(content);
   });
@@ -110,7 +117,7 @@ describe("pinned versions enforcement", () => {
     await writeWorkspace(dir.path, content);
 
     const before = (await fs.stat(path.join(dir.path, "pnpm-workspace.yaml"))).mtimeMs;
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
     const after = (await fs.stat(path.join(dir.path, "pnpm-workspace.yaml"))).mtimeMs;
 
     expect(after).toBe(before);
@@ -127,7 +134,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n";
     await writeWorkspace(dir.path, content);
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     const result = await readWorkspace(dir.path);
     expect(result).not.toContain("ag-grid");
@@ -148,7 +155,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     const result = await readWorkspace(dir.path);
     expect(result).toContain("# workspace config");
@@ -170,7 +177,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     expect(await readWorkspace(dir.path)).toBe(
       dedent`
@@ -199,7 +206,7 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path);
+    await updatePackages(dir.path, fakeLatest());
 
     const result = await readWorkspace(dir.path);
     expect(result).toContain("~34.1.2");

--- a/tools/blocks-deps-updater/src/updater.test.ts
+++ b/tools/blocks-deps-updater/src/updater.test.ts
@@ -2,15 +2,24 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import dedent from "dedent";
-import { describe, expect, it } from "vitest";
-import { updatePackages } from "./updater";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getLatestVersion, updatePackages } from "./updater";
 
-/** Stand-in for the registry. A unit test asserting catalog rewriting has no business
- * depending on npmjs.org being reachable, let alone fast. */
-const fakeLatest =
-  (versions: Record<string, string> = {}) =>
-  async (packageName: string) =>
-    versions[packageName] ?? "9.9.9";
+/** Stand-in for the registry. Rejects any package it was not told about, so a test that should
+ * never reach the resolver fails loudly instead of quietly taking a made-up version, and
+ * records what was asked for so package selection can be asserted. */
+function fakeLatest(versions: Record<string, string> = {}) {
+  const asked: string[] = [];
+  return Object.assign(
+    async (packageName: string) => {
+      asked.push(packageName);
+      const version = versions[packageName];
+      if (version === undefined) throw new Error(`unexpected registry lookup: ${packageName}`);
+      return version;
+    },
+    { asked },
+  );
+}
 
 async function tmpDir(): Promise<AsyncDisposable & { path: string }> {
   // TODO: migrate to `mkdtempDisposable` after migration to Node.js 24
@@ -134,9 +143,13 @@ describe("pinned versions enforcement", () => {
       ` + "\n";
     await writeWorkspace(dir.path, content);
 
-    await updatePackages(dir.path, fakeLatest());
+    const registry = fakeLatest({ "@platforma-sdk/model": "1.9.0" });
+    await updatePackages(dir.path, registry);
 
     const result = await readWorkspace(dir.path);
+    expect(registry.asked).toEqual(["@platforma-sdk/model"]);
+    expect(result).toContain('"@platforma-sdk/model": 1.9.0');
+    expect(result).toContain("some-other-pkg: ^5.0.0");
     expect(result).not.toContain("ag-grid");
   });
 
@@ -206,13 +219,82 @@ describe("pinned versions enforcement", () => {
       ` + "\n",
     );
 
-    await updatePackages(dir.path, fakeLatest());
+    const registry = fakeLatest({
+      "@platforma-sdk/model": "2.1.0",
+      "@platforma-sdk/workflow-tengo": "1.6.4",
+    });
+    await updatePackages(dir.path, registry);
 
     const result = await readWorkspace(dir.path);
+    // Only the unpinned SDK entries are looked up: ag-grid is pinned and vue is not ours.
+    expect([...registry.asked].sort()).toEqual([
+      "@platforma-sdk/model",
+      "@platforma-sdk/workflow-tengo",
+    ]);
+    expect(result).toContain('"@platforma-sdk/model": 2.1.0');
+    expect(result).toContain('"@platforma-sdk/workflow-tengo": 1.6.4');
     expect(result).toContain("~34.1.2");
     expect(result).not.toContain("^34.2.0");
     expect(result).not.toContain("*ag-grid");
-    expect(result).toContain("vue");
+    expect(result).toContain("vue: ^3.5.0");
     expect(result).toContain("packages");
+  });
+});
+
+/** The default resolver, which every test above deliberately replaces. Covered here with
+ * `fetch` stubbed, so the request shape, the response parsing and the retry loop are asserted
+ * without the suite reaching npmjs.org. */
+describe("registry lookup", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** Returns the URLs requested, in order. The last response is reused if fetch is called
+   * more times than there are responses, so an unexpected retry shows up as a call count. */
+  function stubFetch(...responses: Response[]): string[] {
+    const urls: string[] = [];
+    let next = 0;
+    vi.stubGlobal("fetch", async (url: string | URL) => {
+      urls.push(String(url));
+      return responses[Math.min(next++, responses.length - 1)];
+    });
+    return urls;
+  }
+
+  const distTags = (body: unknown) => new Response(JSON.stringify(body));
+
+  it("requests the package's dist-tags and returns latest", async () => {
+    const urls = stubFetch(distTags({ latest: "3.4.5", next: "4.0.0-rc.1" }));
+
+    await expect(getLatestVersion("@platforma-sdk/model")).resolves.toBe("3.4.5");
+    expect(urls).toEqual(["https://registry.npmjs.org/-/package/@platforma-sdk/model/dist-tags"]);
+  });
+
+  it("rejects a response carrying no latest dist-tag", async () => {
+    stubFetch(distTags({ next: "4.0.0-rc.1" }));
+
+    await expect(getLatestVersion("@platforma-sdk/model")).rejects.toThrow("no 'latest' dist-tag");
+  });
+
+  it("does not retry a non-retryable status", async () => {
+    const urls = stubFetch(new Response("", { status: 404 }));
+
+    await expect(getLatestVersion("@platforma-sdk/nope")).rejects.toThrow(
+      "registry returned HTTP 404",
+    );
+    expect(urls).toHaveLength(1);
+  });
+
+  it("retries a 429 once Retry-After allows", async () => {
+    // An HTTP-date in the past parses to a zero wait, so this covers the retry loop and the
+    // Retry-After date branch without putting a real sleep back into the suite.
+    const urls = stubFetch(
+      new Response("", {
+        status: 429,
+        headers: { "retry-after": "Thu, 01 Jan 1970 00:00:00 GMT" },
+      }),
+      distTags({ latest: "1.0.1" }),
+    );
+
+    await expect(getLatestVersion("@milaboratories/helpers")).resolves.toBe("1.0.1");
+    expect(urls).toHaveLength(2);
   });
 });

--- a/tools/blocks-deps-updater/src/updater.ts
+++ b/tools/blocks-deps-updater/src/updater.ts
@@ -18,13 +18,21 @@ function parseRetryAfter(header: string | null): number | null {
   return null;
 }
 
+/** A registry answer that asking again will not improve. Distinguished so the retry loop's own
+ * catch rethrows it: as a plain Error it was thrown inside the try, swallowed there, and a 404
+ * cost three requests and two backoffs before surfacing. */
+class NonRetryableRegistryError extends Error {}
+
 async function fetchWithRetry(url: string): Promise<Response> {
   for (let attempt = 1; ; attempt++) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
       if (res.ok) return res;
       const retryable = res.status === 429 || res.status >= 500;
-      if (!retryable || attempt > RETRY_COUNT) {
+      if (!retryable) {
+        throw new NonRetryableRegistryError(`registry returned HTTP ${res.status}`);
+      }
+      if (attempt > RETRY_COUNT) {
         throw new Error(`registry returned HTTP ${res.status}`);
       }
       // Respect Retry-After header: either delay-seconds or HTTP-date (RFC 9110)
@@ -34,7 +42,7 @@ async function fetchWithRetry(url: string): Promise<Response> {
         continue;
       }
     } catch (err) {
-      if (attempt > RETRY_COUNT) throw err;
+      if (err instanceof NonRetryableRegistryError || attempt > RETRY_COUNT) throw err;
     }
     const delay = RETRY_BASE_MS * 2 ** (attempt - 1) * (0.8 + 0.4 * Math.random());
     await sleep(delay);

--- a/tools/blocks-deps-updater/src/updater.ts
+++ b/tools/blocks-deps-updater/src/updater.ts
@@ -41,6 +41,9 @@ async function fetchWithRetry(url: string): Promise<Response> {
   }
 }
 
+/** Resolves a package's `latest` dist-tag. Injectable so tests do not reach the registry. */
+export type LatestVersionResolver = (packageName: string) => Promise<string>;
+
 async function getLatestVersion(packageName: string): Promise<string> {
   const res = await fetchWithRetry(`https://registry.npmjs.org/-/package/${packageName}/dist-tags`);
 
@@ -91,7 +94,13 @@ interface Change {
   to: string;
 }
 
-export async function updatePackages(cwd?: string): Promise<void> {
+export async function updatePackages(
+  cwd?: string,
+  /** Defaults to a live registry lookup. Tests pass a stub: any catalog carrying an unpinned
+   * `@platforma-sdk/*` or `@milaboratories/*` package would otherwise fetch npmjs.org, which
+   * made them fail whenever a response outran vitest's 5s budget. */
+  resolveLatestVersion: LatestVersionResolver = getLatestVersion,
+): Promise<void> {
   const workspacePath = path.resolve(cwd ?? process.cwd(), "pnpm-workspace.yaml");
 
   let content: string;
@@ -117,7 +126,7 @@ export async function updatePackages(cwd?: string): Promise<void> {
   const pinned: Change[] = [];
 
   // Fetch latest versions for all SDK packages in parallel
-  const latestVersions = await Promise.all(sdkPackages.map((pkg) => getLatestVersion(pkg)));
+  const latestVersions = await Promise.all(sdkPackages.map((pkg) => resolveLatestVersion(pkg)));
 
   for (let i = 0; i < sdkPackages.length; i++) {
     const packageName = sdkPackages[i];

--- a/tools/blocks-deps-updater/src/updater.ts
+++ b/tools/blocks-deps-updater/src/updater.ts
@@ -44,7 +44,7 @@ async function fetchWithRetry(url: string): Promise<Response> {
 /** Resolves a package's `latest` dist-tag. Injectable so tests do not reach the registry. */
 export type LatestVersionResolver = (packageName: string) => Promise<string>;
 
-async function getLatestVersion(packageName: string): Promise<string> {
+export async function getLatestVersion(packageName: string): Promise<string> {
   const res = await fetchWithRetry(`https://registry.npmjs.org/-/package/${packageName}/dist-tags`);
 
   const tags = (await res.json()) as Record<string, string>;


### PR DESCRIPTION
`blocks-deps-updater`'s tests hit the real npm registry, so they fail in CI whenever a response is slow.

## Cause

`updatePackages` resolves the `latest` dist-tag for every unpinned `@platforma-sdk/*` and `@milaboratories/*` entry in the catalog by fetching `registry.npmjs.org`. Several tests use catalogs carrying such an entry, so they went to the network. CI measured 5007ms against vitest's 5s default; locally the same call takes 3ms, which is why it only ever shows up on the runner.

## Fix

`updatePackages` gains an optional second parameter, a `LatestVersionResolver`, defaulting to the existing live lookup. Production callers are unchanged. All nine tests pass a stub.

## Verification

- 9/9 pass, suite time 5.4s down to 16ms
- with the real `getLatestVersion` rigged to throw, all nine still pass, so no test path reaches the registry
- typecheck and lint clean


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces dependency injection for npm `latest`-version resolution and updates the test suite to use a deterministic local resolver instead of contacting npmjs.org.

**Important touched terms**
- **`LatestVersionResolver`** — An asynchronous function mapping a package name to its `latest` version. This PR introduces and exports the type as the registry-lookup abstraction.
- **`updatePackages`** — The workspace-catalog rewriting operation. Its signature now accepts an optional second resolver parameter while retaining the live npm lookup as the production default.
- **`resolveLatestVersion`** — The injected resolver used by `updatePackages` for unpinned Platforma and MiLaboratories SDK packages. It replaces the previously hard-coded call to `getLatestVersion`.
- **`fakeLatest`** — A test-only resolver factory. It replaces real registry requests with configured versions or the fallback version `9.9.9`.
- **`latest` dist-tag** — npm’s designation for a package’s current default release. Production behavior is unchanged, but lookup is now routed through the injectable resolver.
- **Changeset** — Records the new optional resolver API as a patch release for `@platforma-sdk/blocks-deps-updater`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking test-coverage gaps around the production resolver path and SDK resolver assertions.

Dependency injection removes the flaky network dependency without changing default production behavior, but all tests bypass the new default and the permissive stub can conceal incorrect package selection or version application.

**Files Needing Attention:** tools/blocks-deps-updater/src/updater.ts, tools/blocks-deps-updater/src/updater.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/blocks-deps-updater/src/updater.ts | Adds the injectable latest-version resolver and preserves live registry lookup as the default, but the new default path lacks direct test coverage. |
| tools/blocks-deps-updater/src/updater.test.ts | Removes external-network dependence from all nine tests, though the permissive stub does not verify resolver targets or applied SDK versions. |
| .changeset/blocks-deps-updater-test-registry.md | Accurately documents the optional resolver API and test isolation as a patch release. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[updatePackages] --> B{Resolver supplied?}
  B -->|Production: no| C[getLatestVersion]
  C --> D[npm registry latest dist-tag]
  B -->|Tests: yes| E[fakeLatest]
  D --> F[Rewrite SDK catalog versions]
  E --> F
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20milaboratory%2Fplatforma%20PR%20%231817%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=milaboratory%2Fplatforma&pr=1817&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Fblocks-deps-updater%2Fsrc%2Fupdater.ts%3A102%0A**Production%20resolver%20is%20untested**%0A%0AThe%20default%20resolver%20is%20the%20production%20path%20when%20%60updatePackages%28%29%60%20is%20called%20without%20arguments%2C%20but%20all%20nine%20tests%20now%20override%20it%20with%20%60fakeLatest%28%29%60.%20This%20leaves%20the%20default%20wiring%20and%20registry%20behavior%E2%80%94including%20URL%20construction%2C%20response%20parsing%2C%20and%20retries%E2%80%94without%20automated%20coverage.%20A%20mocked-fetch%20test%20should%20exercise%20%60updatePackages%60%20without%20supplying%20a%20resolver.%0A%0A%23%23%23%20Issue%202%0Atools%2Fblocks-deps-updater%2Fsrc%2Fupdater.test.ts%3A10-13%0A**Fallback%20hides%20resolver%20mistakes**%0A%0A%60fakeLatest%60%20returns%20%609.9.9%60%20for%20every%20unknown%20package%2C%20so%20unexpected%20resolver%20calls%20and%20incorrect%20SDK-package%20selection%20remain%20invisible.%20The%20fixtures%20containing%20SDK%20packages%20are%20rewritten%20with%20this%20fallback%2C%20but%20the%20tests%20assert%20neither%20the%20requested%20package%20names%20nor%20the%20resulting%20SDK%20versions.%20Make%20the%20stub%20reject%20unknown%20packages%20and%20add%20focused%20assertions%20for%20package%20selection%20and%20version%20application.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fplatforma&pr=1817&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/blocks-deps-updater/src/updater.ts:102
**Production resolver is untested**

The default resolver is the production path when `updatePackages()` is called without arguments, but all nine tests now override it with `fakeLatest()`. This leaves the default wiring and registry behavior—including URL construction, response parsing, and retries—without automated coverage. A mocked-fetch test should exercise `updatePackages` without supplying a resolver.

### Issue 2
tools/blocks-deps-updater/src/updater.test.ts:10-13
**Fallback hides resolver mistakes**

`fakeLatest` returns `9.9.9` for every unknown package, so unexpected resolver calls and incorrect SDK-package selection remain invisible. The fixtures containing SDK packages are rewritten with this fallback, but the tests assert neither the requested package names nor the resulting SDK versions. Make the stub reject unknown packages and add focused assertions for package selection and version application.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blocks-deps-updater): stop the tests..."](https://github.com/milaboratory/platforma/commit/bca302b93fee93354d308e9d7f4f28e13d7de11d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62501621)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->