### PR TITLE
fix(workflow-tengo-tests): give the scratch tests a backend that has scratch

### DIFF
--- a/.changeset/pl-client-scratch-space-capability.md
+++ b/.changeset/pl-client-scratch-space-capability.md
@@ -1,0 +1,6 @@
+---
+"@milaboratories/pl-client": patch
+---
+
+Recognise the `scratchSpace:v1` backend capability, advertised only where the deployment
+actually has scratch storage.

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -86,6 +86,10 @@ jobs:
         env:
           PL_LICENSE: ${{ secrets.MI_LICENSE }}
           MI_LICENSE: ${{ secrets.MI_LICENSE }}
+          # The local runner serves a scratch request out of the command's working directory,
+          # which is what exec.test.ts's scratch cases assert. pl #2192 made that opt-in, so
+          # without this the backend advertises no scratch and those tests skip themselves.
+          PL_HAS_SCRATCH_SPACE: "true"
         with:
           pl-docker-registry: ${{ format('{0}/{1}', steps.ecr-login.outputs.registry, 'pl') }}
           pl-docker-tag: main

--- a/lib/node/pl-client/src/core/capabilities.ts
+++ b/lib/node/pl-client/src/core/capabilities.ts
@@ -18,6 +18,10 @@ export type BackendCapability =
   | "auth:v2"
   | "treeFilter:v2"
   | "wasm:v1"
+  // Advertised only where the deployment actually has scratch storage, not merely where the
+  // build understands a 'scratchFreeSpace' request: a client that sees this stops arranging
+  // its own temporary storage. Off unless pl was started with --has-scratch-space.
+  | "scratchSpace:v1"
   // Project-sharing capability tokens.
   | "crossTreeRefs:v1" // cross-color field attach (accept a foreign-colored shared envelope)
   | "userListing:v1" // list users for the recipient picker

--- a/tests/workflow-tengo/src/exec/exec.test.ts
+++ b/tests/workflow-tengo/src/exec/exec.test.ts
@@ -80,16 +80,20 @@ tplTest.concurrent.for([{ gpuMemory: "16GiB" }])(
  * the whole path — builder, quota, compute allocation, driver — rather than being dropped in
  * the middle.
  *
- * A local backend has no dedicated scratch device, so the path it reports is the command's
- * working directory. That is the documented promise for a runner that cannot do better, and
- * asserting it here keeps the "always a usable location" guarantee honest.
+ * Needs a deployment that actually has scratch storage. Since pl #2192 that is opt-in
+ * (`--has-scratch-space`), and without it `{system.scratch.*}` has nothing to resolve to and
+ * the render fails outright, so the test self-skips on a backend that advertises no scratch.
  */
 // The size is deliberately small: this test is about the request reaching the command, not
 // about how much can be allocated. Once the backend plans real storage capacity, a test that
 // asks for hundreds of gigabytes would start failing on whichever runner happens to be smaller.
 tplTest.concurrent.for([{ scratchFreeSpace: "1GiB", expectedGiB: "1" }])(
   "scratch-space (scratchFreeSpace=$scratchFreeSpace)",
-  async ({ scratchFreeSpace, expectedGiB }, { helper, expect }) => {
+  async ({ scratchFreeSpace, expectedGiB }, { helper, pl, expect, skip }) => {
+    if (!pl.hasCapability("scratchSpace:v1")) {
+      skip("deployment has no scratch storage (pl started without --has-scratch-space)");
+    }
+
     const result = await helper.renderTemplate(
       false,
       "exec.run.scratch_space",
@@ -132,7 +136,11 @@ tplTest.concurrent.for([
   { withFallback: false, expectedGiB: "2" },
 ])(
   "scratch-formula (withFallback=$withFallback)",
-  async ({ withFallback, expectedGiB }, { helper, expect }) => {
+  async ({ withFallback, expectedGiB }, { helper, pl, expect, skip }) => {
+    if (!pl.hasCapability("scratchSpace:v1")) {
+      skip("deployment has no scratch storage (pl started without --has-scratch-space)");
+    }
+
     const result = await helper.renderTemplate(
       false,
       "exec.run.scratch_formula",


### PR DESCRIPTION
Three tests in `tests/workflow-tengo/src/exec/exec.test.ts` — `scratch-space` and both `scratch-formula` cases — fail on every PR whose `workflow-tengo-tests#test` task actually runs instead of hitting the turbo cache:

```
wrong argument 3: cannot evaluate expression: "system.scratch.gib": cannot fetch gib from <nil>
wrong argument 4: cannot evaluate expression: "system.scratch.path": cannot fetch path from <nil>
```

## Cause

pl **#2192** (MILAB-6871, merged 2026-09-08) made scratch storage opt-in behind `--has-scratch-space` / `PL_HAS_SCRATCH_SPACE`. Without it the backend drops the `scratchSpace:v1` client capability and leaves the `scratchSpace` workflow feature flag off, so `{system.scratch.*}` has nothing to resolve to and reading it fails the whole render.

`.github/workflows/_test.yaml` pins `pl-docker-tag: main`, so CI picked this up as soon as that image was rebuilt, and nothing here passed the flag.

## Change

Two halves, so the tests assert where they can and skip where they cannot:

1. **CI gets a backend that has scratch.** `_test.yaml` sets `PL_HAS_SCRATCH_SPACE: "true"` on the `Start Platforma Docker` step. That is honest for the local runner: it serves a scratch request out of the command's working directory, which is exactly what these tests assert and what passed for as long as they have existed.
2. **The tests skip where the capability is absent.** `pl.hasCapability("scratchSpace:v1")` gates both, matching the existing `pl.hasCapability("wasm:v1")` and `pl.supportsWritableWorkdirFiles` skips in this suite. So a run against a plain backend reports a skip with a reason instead of a render failure.

`scratchSpace:v1` is added to `BackendCapability` in `pl-client`, whose token list is documented as needing to track the backend's advertised set.

## Depends on

Half 1 is inert until **milaboratory/github-ci#205** lands — `pl-compose`'s compose file has an explicit `environment:` allowlist, so the variable does not currently reach the container. Half 2 makes this PR green either way: before #205 the three tests skip, after it they run and assert.

## Open question for MILAB-6871

Whether `PL_HAS_SCRATCH_SPACE: "true"` is the right call for CI depends on whether a working-directory fallback counts as "the deployment has scratch storage". pl #2192's rule is "enable it only where scratch storage really exists". If the intent is that the fallback does *not* count, drop the `_test.yaml` line and keep only the skip — the tests then stay permanently skipped in CI, and the coverage needs a runner with real scratch storage to come back.
