### PR TITLE
chore(ci): checkout to v5 to clear its Node 20 deprecation warning

### DIFF
--- a/.github/workflows/_check-changesets.yaml
+++ b/.github/workflows/_check-changesets.yaml
@@ -13,12 +13,17 @@ jobs:
     outputs:
       has-pending: ${{ steps.check.outputs.has-pending }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       # hz-ubuntu-dind has Node baked in the hostedtoolcache but not on PATH;
       # set it up (cache hit on the baked 22.x) so `npx` is available.
+      #
+      # Pinned to v4 deliberately. v5 acts on the "packageManager": "pnpm@..." field
+      # in package.json and then fails with "Unable to locate executable file: pnpm",
+      # because this runner has no pnpm and this job does not need one - it only wants
+      # npx. Moving to v5 means installing pnpm here purely to satisfy the detection.
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -7,7 +7,7 @@ jobs:
   check-pnpm-consistency:
     runs-on: hz-ubuntu-dind
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -19,12 +19,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,12 +64,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0


### PR DESCRIPTION
Every workflow run logs:

> Node 20 is being deprecated. This workflow is running with Node 24 by default.

GitHub already substitutes Node 24, so today this is noise; it breaks when the fallback is withdrawn. This clears the part of it that can be cleared from this repo.

| Action | Change | Clears the warning? |
| --- | --- | --- |
| `actions/checkout` | v4 → v5 | **yes**, verified |
| `actions/create-github-app-token` | v1 → v2 | **no** — v2 is still Node 20; kept as a currency bump only |

Touches `_check.yaml`, `_check-changesets.yaml`, `_test.yaml`, `main.yaml`. No input changes.

## Measured, not assumed

I ran the workflow and counted which actions still emit the notice (18 occurrences across the job). `actions/checkout` no longer appears. These still do:

```
actions/create-github-app-token@v2              (bumped here, still node20)
actions/setup-node@v4                           (see below)
actions/github-script@60a0d83…                  (pinned SHA)
aws-actions/configure-aws-credentials@v4
docker/login-action@v3
mike-ainsel/turborepo-remote-cache-gh-action@v3-beta
milaboratory/github-ci/actions/post/shell@v4
milaboratory/github-ci/actions/post/artifact@v4
```

So the notice will **still appear after this merges**. Fully clearing it needs a `github-ci` change on its own promotion track, plus upstream releases for the third-party actions. Worth a follow-up ticket rather than stretching this PR.

## `actions/setup-node` stays on v4, deliberately

Bumping it to v5 broke `check-changesets`:

```
node: v22.23.2
##[error]Unable to locate executable file: pnpm. Please verify either the file path exists
or the file can be found within a directory specified by the PATH environment variable.
```

v5 acts on `"packageManager": "pnpm@9.14.4"` in `package.json` and looks for pnpm, which `hz-ubuntu-dind` does not have. That job only needs `npx`. Moving to v5 would mean installing pnpm purely to satisfy the detection, so it is pinned to v4 with a comment recording why — revisit when the runner image gains pnpm.

## CI state

`test / test` fails on `scratch-space (scratchFreeSpace='1GiB')` and `scratch-formula (withFallback=true)`. Both fail on `main` as well (run 34432143945) and are being addressed on `fix/scratch-tests-gate-on-backend` — unrelated to this change. Everything else passes.

## Note

Split out of #1819 (recovery tests), where the notice was spotted. Unrelated to that change, kept separate so the feature review stays clean.
