### PR TITLE
MILAB-6902: discover columns above the given ones via a new `leaves` option

### DIFF
--- a/.changeset/reverse-linker-discovery.md
+++ b/.changeset/reverse-linker-discovery.md
@@ -6,13 +6,13 @@
 
 Column discovery can now walk linkers up the hierarchy: pass `leaves` instead of `anchors` to find what contains the given columns
 
-Discovery only ever walked down — anchored on `sample`, it reached `cell`, but there was no way to go from `cell` to the `sample`-level columns above it. The direction is now expressed by which key you fill in, so there is no new flag:
+Discovery only ever walked down — anchored on `sample`, it reached `cell`, but there was no way to go from `cell` to the `sample`-level columns above it. Which key you fill in says where the anchors sit, so there is no direction flag anywhere:
 
 ```ts
 collection.discover({ anchors: { s: sampleRef }, maxHops: 4 }); // down to what they contain
 collection.discover({ leaves: { c: cellRef }, maxHops: 4 }); // up to what contains them
 ```
 
-The two keys are mutually exclusive; `resolveAnchorSide` resolves them into the request's `anchorsAre` discriminator. Only the traversal rule changes — linker columns are still read as-is, so results stay correct against the real linkers. `leaves` is not part of the `.filter()` surface, which pins `maxHops: 0`.
+`DiscoverColumnsOptions` is now a union of `RootAnchoredOptions | LeafAnchoredOptions`, so the two keys exclude each other at compile time; `resolveAnchorSide` resolves them at runtime and names the request arm (`axes` vs `leafAxes`) the anchors belong in. Only the traversal rule changes — linker columns are still read as-is, so results stay correct against the real linkers. `leaves` is not part of the `.filter()` surface, which pins `maxHops: 0`.
 
 Existing `anchors` calls are unchanged, down to a byte-identical request. Requires the engine support from platforma-open/pframes-rs#295.

--- a/.changeset/reverse-linker-discovery.md
+++ b/.changeset/reverse-linker-discovery.md
@@ -1,0 +1,11 @@
+---
+"@milaboratories/pl-model-common": minor
+"@milaboratories/pl-model-middle-layer": minor
+"@milaboratories/columns-collection-driver": minor
+---
+
+Add `reverseLinkers` to column discovery, to walk linkers fine → coarse and find the roots above the anchors instead of the leaves below them
+
+Discovery entered linkers on the many-side and exited on the one-side (e.g. `sample` → `cell`). `DiscoverColumnsOptions.reverseLinkers` flips the entry side so the traversal walks `cell` → `sample`. Only the traversal rule is reversed — linker columns are still read as-is, so results stay correct against the real linkers.
+
+The flag is optional and omitted from the request when false, so existing discovery calls are unchanged. It is traversal scope, so — like `mode` and `maxHops` — it is not part of the `.filter()` surface. Requires the pframes-rs engine support from platforma-open/pframes-rs#295.

--- a/.changeset/reverse-linker-discovery.md
+++ b/.changeset/reverse-linker-discovery.md
@@ -4,8 +4,15 @@
 "@milaboratories/columns-collection-driver": minor
 ---
 
-Add `reverseLinkers` to column discovery, to walk linkers fine → coarse and find the roots above the anchors instead of the leaves below them
+Column discovery can now walk linkers up the hierarchy: pass `leaves` instead of `anchors` to find what contains the given columns
 
-Discovery entered linkers on the many-side and exited on the one-side (e.g. `sample` → `cell`). `DiscoverColumnsOptions.reverseLinkers` flips the entry side so the traversal walks `cell` → `sample`. Only the traversal rule is reversed — linker columns are still read as-is, so results stay correct against the real linkers.
+Discovery only ever walked down — anchored on `sample`, it reached `cell`, but there was no way to go from `cell` to the `sample`-level columns above it. The direction is now expressed by which key you fill in, so there is no new flag:
 
-The flag is optional and omitted from the request when false, so existing discovery calls are unchanged. It is traversal scope, so — like `mode` and `maxHops` — it is not part of the `.filter()` surface. Requires the pframes-rs engine support from platforma-open/pframes-rs#295.
+```ts
+collection.discover({ anchors: { s: sampleRef }, maxHops: 4 }); // down to what they contain
+collection.discover({ leaves: { c: cellRef }, maxHops: 4 }); // up to what contains them
+```
+
+The two keys are mutually exclusive; `resolveAnchorSide` resolves them into the request's `anchorsAre` discriminator. Only the traversal rule changes — linker columns are still read as-is, so results stay correct against the real linkers. `leaves` is not part of the `.filter()` surface, which pins `maxHops: 0`.
+
+Existing `anchors` calls are unchanged, down to a byte-identical request. Requires the engine support from platforma-open/pframes-rs#295.

--- a/lib/model/columns-collection-driver/src/driver.ts
+++ b/lib/model/columns-collection-driver/src/driver.ts
@@ -286,7 +286,7 @@ export class ColumnsCollectionDriverImpl<A extends AccessorLike<A> = AccessorLik
       excludeColumns: options.exclude
         ? convertColumnSelectorToMultiColumnSelector(options.exclude)
         : undefined,
-      constraints: matchingModeToConstraints(options.mode ?? "enrichment"),
+      constraints: matchingModeToConstraints(options.mode ?? "enrichment", options.reverseLinkers),
       maxHops: options.maxHops ?? (hasAnchors ? 4 : 0),
       axes: anchorsList.map((anchorId) => {
         const spec =

--- a/lib/model/columns-collection-driver/src/driver.ts
+++ b/lib/model/columns-collection-driver/src/driver.ts
@@ -37,6 +37,7 @@ import {
   isPlRef,
   isEmptySpecDelta,
   matchingModeToConstraints,
+  resolveAnchorSide,
   reconstructSpecFromId,
   stringifyColumnDiscoveredId,
 } from "@milaboratories/pl-model-common";
@@ -267,7 +268,9 @@ export class ColumnsCollectionDriverImpl<A extends AccessorLike<A> = AccessorLik
       specMap.set(id, reconstructSpecFromId(spec, id));
     }
 
-    const anchors = options.anchors;
+    // Which key the caller used says where the given columns sit in the
+    // hierarchy, which is what fixes the linker traversal direction.
+    const { anchors, anchorsAre } = resolveAnchorSide(options);
     const hasAnchors = anchors !== undefined && Object.keys(anchors).length > 0;
     const anchorsRec = hasAnchors ? resolveAnchors(anchors, specMap, specDriver) : undefined;
     const anchorsList = anchorsRec ? Object.values(anchorsRec) : [];
@@ -286,7 +289,7 @@ export class ColumnsCollectionDriverImpl<A extends AccessorLike<A> = AccessorLik
       excludeColumns: options.exclude
         ? convertColumnSelectorToMultiColumnSelector(options.exclude)
         : undefined,
-      constraints: matchingModeToConstraints(options.mode ?? "enrichment", options.reverseLinkers),
+      constraints: matchingModeToConstraints(options.mode ?? "enrichment", anchorsAre),
       maxHops: options.maxHops ?? (hasAnchors ? 4 : 0),
       axes: anchorsList.map((anchorId) => {
         const spec =

--- a/lib/model/columns-collection-driver/src/driver.ts
+++ b/lib/model/columns-collection-driver/src/driver.ts
@@ -269,8 +269,8 @@ export class ColumnsCollectionDriverImpl<A extends AccessorLike<A> = AccessorLik
     }
 
     // Which key the caller used says where the given columns sit in the
-    // hierarchy, which is what fixes the linker traversal direction.
-    const { anchors, anchorsAre } = resolveAnchorSide(options);
+    // hierarchy, and it is carried down as the shape of the request.
+    const { anchors, axesKey } = resolveAnchorSide(options);
     const hasAnchors = anchors !== undefined && Object.keys(anchors).length > 0;
     const anchorsRec = hasAnchors ? resolveAnchors(anchors, specMap, specDriver) : undefined;
     const anchorsList = anchorsRec ? Object.values(anchorsRec) : [];
@@ -289,9 +289,9 @@ export class ColumnsCollectionDriverImpl<A extends AccessorLike<A> = AccessorLik
       excludeColumns: options.exclude
         ? convertColumnSelectorToMultiColumnSelector(options.exclude)
         : undefined,
-      constraints: matchingModeToConstraints(options.mode ?? "enrichment", anchorsAre),
+      constraints: matchingModeToConstraints(options.mode ?? "enrichment"),
       maxHops: options.maxHops ?? (hasAnchors ? 4 : 0),
-      axes: anchorsList.map((anchorId) => {
+      [axesKey]: anchorsList.map((anchorId) => {
         const spec =
           specMap.get(anchorId) ??
           throwError(`ColumnsCollectionDriverImpl: anchor "${anchorId}" lost from effective specs`);

--- a/lib/model/common/src/drivers/columns/discover_columns_options.test.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.test.ts
@@ -9,35 +9,23 @@ import {
 const MODES: MatchingMode[] = ["enrichment", "related", "exact"];
 
 describe("matchingModeToConstraints", () => {
-  test.each(MODES)("omits anchorsAre entirely for mode %s at the default", (mode) => {
-    for (const constraints of [
-      matchingModeToConstraints(mode),
-      matchingModeToConstraints(mode, undefined),
-      matchingModeToConstraints(mode, "roots"),
-    ]) {
-      // Absent, not `"roots"` — the engine defaults to root anchors, and omitting
-      // the key keeps the request wire-identical to what existing callers produce.
-      expect("anchorsAre" in constraints).toBe(false);
-    }
+  test.each(MODES)("mode %s yields only axes-matching flags", (mode) => {
+    // Where the anchors sit is carried by the request shape, so nothing about
+    // it may leak back into the constraints object.
+    expect(Object.keys(matchingModeToConstraints(mode)).sort()).toStrictEqual([
+      "allowFloatingHitAxes",
+      "allowFloatingSourceAxes",
+      "allowHitQualifications",
+      "allowSourceQualifications",
+    ]);
   });
 
-  test.each(MODES)("sets anchorsAre for mode %s when the anchors are leaves", (mode) => {
-    expect(matchingModeToConstraints(mode, "leaves").anchorsAre).toBe("leaves");
-  });
-
-  test.each(MODES)("anchor position is orthogonal to the axes flags of mode %s", (mode) => {
-    const { anchorsAre: _omitted, ...axesFlags } = matchingModeToConstraints(mode, "leaves");
-    // Moving the anchors must not disturb any axes-matching flag.
-    expect(axesFlags).toStrictEqual(matchingModeToConstraints(mode));
-  });
-
-  test("mode still drives the axes flags independently of anchor position", () => {
-    expect(matchingModeToConstraints("exact", "leaves")).toStrictEqual({
+  test("mode drives the flags", () => {
+    expect(matchingModeToConstraints("exact")).toStrictEqual({
       allowFloatingSourceAxes: false,
       allowFloatingHitAxes: false,
       allowSourceQualifications: false,
       allowHitQualifications: false,
-      anchorsAre: "leaves",
     });
     expect(matchingModeToConstraints("enrichment")).toStrictEqual({
       allowFloatingSourceAxes: true,
@@ -51,22 +39,22 @@ describe("matchingModeToConstraints", () => {
 describe("resolveAnchorSide", () => {
   const given: Record<string, AnchorEntry> = { a: "anchor-id" as AnchorEntry };
 
-  test("anchors are roots — discovery walks down to what they contain", () => {
+  test("anchors go into the request's `axes` arm — walk down to what they contain", () => {
     expect(resolveAnchorSide({ anchors: given })).toStrictEqual({
       anchors: given,
-      anchorsAre: "roots",
+      axesKey: "axes",
     });
   });
 
-  test("leaves are the fine end — discovery walks up to what contains them", () => {
+  test("leaves go into the `leafAxes` arm — walk up to what contains them", () => {
     expect(resolveAnchorSide({ leaves: given })).toStrictEqual({
       anchors: given,
-      anchorsAre: "leaves",
+      axesKey: "leafAxes",
     });
   });
 
-  test("neither key given still reports the default side", () => {
-    expect(resolveAnchorSide({})).toStrictEqual({ anchors: undefined, anchorsAre: "roots" });
+  test("neither key given still names the default arm", () => {
+    expect(resolveAnchorSide({})).toStrictEqual({ anchors: undefined, axesKey: "axes" });
   });
 
   test("the two keys are mutually exclusive", () => {

--- a/lib/model/common/src/drivers/columns/discover_columns_options.test.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "vitest";
+import { matchingModeToConstraints, type MatchingMode } from "./discover_columns_options";
+
+const MODES: MatchingMode[] = ["enrichment", "related", "exact"];
+
+describe("matchingModeToConstraints", () => {
+  test.each(MODES)("omits reverseLinkers entirely for mode %s when not requested", (mode) => {
+    for (const constraints of [
+      matchingModeToConstraints(mode),
+      matchingModeToConstraints(mode, false),
+      matchingModeToConstraints(mode, undefined),
+    ]) {
+      // Absent, not `false` — the engine defaults to forward, and omitting the
+      // key keeps the request wire-identical to what existing callers produce.
+      expect("reverseLinkers" in constraints).toBe(false);
+    }
+  });
+
+  test.each(MODES)("sets reverseLinkers for mode %s when requested", (mode) => {
+    expect(matchingModeToConstraints(mode, true).reverseLinkers).toBe(true);
+  });
+
+  test.each(MODES)("direction is orthogonal to the axes flags of mode %s", (mode) => {
+    const { reverseLinkers: _omitted, ...forward } = matchingModeToConstraints(mode, true);
+    // Flipping the direction must not disturb any axes-matching flag.
+    expect(forward).toStrictEqual(matchingModeToConstraints(mode));
+  });
+
+  test("mode still drives the axes flags independently of direction", () => {
+    expect(matchingModeToConstraints("exact", true)).toStrictEqual({
+      allowFloatingSourceAxes: false,
+      allowFloatingHitAxes: false,
+      allowSourceQualifications: false,
+      allowHitQualifications: false,
+      reverseLinkers: true,
+    });
+    expect(matchingModeToConstraints("enrichment")).toStrictEqual({
+      allowFloatingSourceAxes: true,
+      allowFloatingHitAxes: false,
+      allowSourceQualifications: true,
+      allowHitQualifications: true,
+    });
+  });
+});

--- a/lib/model/common/src/drivers/columns/discover_columns_options.test.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.test.ts
@@ -1,38 +1,43 @@
 import { describe, test, expect } from "vitest";
-import { matchingModeToConstraints, type MatchingMode } from "./discover_columns_options";
+import {
+  matchingModeToConstraints,
+  resolveAnchorSide,
+  type AnchorEntry,
+  type MatchingMode,
+} from "./discover_columns_options";
 
 const MODES: MatchingMode[] = ["enrichment", "related", "exact"];
 
 describe("matchingModeToConstraints", () => {
-  test.each(MODES)("omits reverseLinkers entirely for mode %s when not requested", (mode) => {
+  test.each(MODES)("omits anchorsAre entirely for mode %s at the default", (mode) => {
     for (const constraints of [
       matchingModeToConstraints(mode),
-      matchingModeToConstraints(mode, false),
       matchingModeToConstraints(mode, undefined),
+      matchingModeToConstraints(mode, "roots"),
     ]) {
-      // Absent, not `false` — the engine defaults to forward, and omitting the
-      // key keeps the request wire-identical to what existing callers produce.
-      expect("reverseLinkers" in constraints).toBe(false);
+      // Absent, not `"roots"` — the engine defaults to root anchors, and omitting
+      // the key keeps the request wire-identical to what existing callers produce.
+      expect("anchorsAre" in constraints).toBe(false);
     }
   });
 
-  test.each(MODES)("sets reverseLinkers for mode %s when requested", (mode) => {
-    expect(matchingModeToConstraints(mode, true).reverseLinkers).toBe(true);
+  test.each(MODES)("sets anchorsAre for mode %s when the anchors are leaves", (mode) => {
+    expect(matchingModeToConstraints(mode, "leaves").anchorsAre).toBe("leaves");
   });
 
-  test.each(MODES)("direction is orthogonal to the axes flags of mode %s", (mode) => {
-    const { reverseLinkers: _omitted, ...forward } = matchingModeToConstraints(mode, true);
-    // Flipping the direction must not disturb any axes-matching flag.
-    expect(forward).toStrictEqual(matchingModeToConstraints(mode));
+  test.each(MODES)("anchor position is orthogonal to the axes flags of mode %s", (mode) => {
+    const { anchorsAre: _omitted, ...axesFlags } = matchingModeToConstraints(mode, "leaves");
+    // Moving the anchors must not disturb any axes-matching flag.
+    expect(axesFlags).toStrictEqual(matchingModeToConstraints(mode));
   });
 
-  test("mode still drives the axes flags independently of direction", () => {
-    expect(matchingModeToConstraints("exact", true)).toStrictEqual({
+  test("mode still drives the axes flags independently of anchor position", () => {
+    expect(matchingModeToConstraints("exact", "leaves")).toStrictEqual({
       allowFloatingSourceAxes: false,
       allowFloatingHitAxes: false,
       allowSourceQualifications: false,
       allowHitQualifications: false,
-      reverseLinkers: true,
+      anchorsAre: "leaves",
     });
     expect(matchingModeToConstraints("enrichment")).toStrictEqual({
       allowFloatingSourceAxes: true,
@@ -40,5 +45,33 @@ describe("matchingModeToConstraints", () => {
       allowSourceQualifications: true,
       allowHitQualifications: true,
     });
+  });
+});
+
+describe("resolveAnchorSide", () => {
+  const given: Record<string, AnchorEntry> = { a: "anchor-id" as AnchorEntry };
+
+  test("anchors are roots — discovery walks down to what they contain", () => {
+    expect(resolveAnchorSide({ anchors: given })).toStrictEqual({
+      anchors: given,
+      anchorsAre: "roots",
+    });
+  });
+
+  test("leaves are the fine end — discovery walks up to what contains them", () => {
+    expect(resolveAnchorSide({ leaves: given })).toStrictEqual({
+      anchors: given,
+      anchorsAre: "leaves",
+    });
+  });
+
+  test("neither key given still reports the default side", () => {
+    expect(resolveAnchorSide({})).toStrictEqual({ anchors: undefined, anchorsAre: "roots" });
+  });
+
+  test("the two keys are mutually exclusive", () => {
+    expect(() => resolveAnchorSide({ anchors: given, leaves: given })).toThrow(
+      /mutually exclusive/,
+    );
   });
 });

--- a/lib/model/common/src/drivers/columns/discover_columns_options.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.ts
@@ -85,6 +85,15 @@ export type ColumnsFilterOptions = Omit<DiscoverColumnsOptions, "mode" | "maxHop
  * Which key the caller used *is* the statement about where the given columns
  * sit in the hierarchy, so there is no separate direction option to pass.
  *
+ * Note that `leaves` are anchors too: both keys name columns that are already
+ * integrated and that discovery pins to. `anchors` in the result is therefore
+ * the general term — the returned `anchorsAre` says which end of a linker the
+ * caller put them on, and nothing but the key name is dropped here.
+ *
+ * The engine takes one axes integration plus that one discriminator, so the
+ * two keys cannot stay separate all the way down; carrying two arrays on the
+ * wire would encode a boolean as field presence and be collapsed on arrival.
+ *
  * @throws if both `anchors` and `leaves` are given.
  */
 export function resolveAnchorSide(options: Pick<DiscoverColumnsOptions, "anchors" | "leaves">): {

--- a/lib/model/common/src/drivers/columns/discover_columns_options.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.ts
@@ -31,37 +31,47 @@ export interface MatchQualifications {
 }
 
 /**
- * Options object accepted by sandbox `discoverColumns()` and by the host
- * `ColumnsCollectionDriver.discover` / `.filter` methods. Pure JSON shape —
- * no class instances, no closures.
+ * Anchors at the coarse end of the hierarchy: discovery walks down to what
+ * they contain (anchored on `sample`, reaching `cell`).
  */
-export interface DiscoverColumnsOptions {
+export interface RootAnchoredOptions {
+  // @todo: migrate to array<AnchorEntry>
+  anchors?: Record<string, AnchorEntry>;
+  leaves?: never;
+}
+
+/**
+ * Anchors at the fine end of the hierarchy: discovery walks up to what
+ * contains them (given `cell`, reaching `sample`).
+ */
+export interface LeafAnchoredOptions {
+  leaves?: Record<string, AnchorEntry>;
+  anchors?: never;
+}
+
+/** Everything about a discovery request except where the anchors sit. */
+export interface DiscoverColumnsOptionsBase {
   /** Include columns matching these selectors. If omitted, includes all. */
   include?: ColumnSelector;
   /** Exclude columns matching these selectors. */
   exclude?: ColumnSelector;
   /** Axis matching behavior. Default: 'enrichment'. Ignored if no anchors. */
   mode?: MatchingMode;
-  /**
-   * Anchors enable axis-aware discovery + linker traversal. The anchors are the
-   * coarse end of the hierarchy, so discovery walks down to what they contain
-   * (anchored on `sample`, reaching `cell`).
-   *
-   * Mutually exclusive with {@link DiscoverColumnsOptions.leaves}.
-   */
-  // @todo: migrate to array<AnchorEntry>
-  anchors?: Record<string, AnchorEntry>;
-  /**
-   * Same as {@link DiscoverColumnsOptions.anchors}, but the given columns are
-   * the fine end of the hierarchy, so discovery walks up to what contains them
-   * (given `cell`, reaching `sample`).
-   *
-   * Mutually exclusive with {@link DiscoverColumnsOptions.anchors}.
-   */
-  leaves?: Record<string, AnchorEntry>;
   /** Maximum linker hops. Default: 4 when anchors present, 0 otherwise. */
   maxHops?: number;
 }
+
+/**
+ * Options object accepted by sandbox `discoverColumns()` and by the host
+ * `ColumnsCollectionDriver.discover` / `.filter` methods. Pure JSON shape —
+ * no class instances, no closures.
+ *
+ * Anchors enable axis-aware discovery + linker traversal. Which key carries
+ * them says where they sit, and therefore which way the traversal runs; the
+ * two are mutually exclusive.
+ */
+export type DiscoverColumnsOptions = DiscoverColumnsOptionsBase &
+  (RootAnchoredOptions | LeafAnchoredOptions);
 
 /**
  * Options accepted by `ColumnsCollection.discover` / driver `.discover`.
@@ -73,32 +83,27 @@ export type ColumnsDiscoverOptions = DiscoverColumnsOptions;
 
 /**
  * Options accepted by `ColumnsCollection.filter` / driver `.filter`. Traversal
- * scope is fixed by the source collection, so `mode` / `maxHops` / `leaves` are
- * not part of the filter surface — only `include` / `exclude` / `anchors`.
+ * scope is fixed by the source collection, so `mode` / `maxHops` are not part
+ * of the filter surface, and neither is `leaves` — `.filter()` pins
+ * `maxHops: 0`, leaving no traversal for it to describe.
  */
-export type ColumnsFilterOptions = Omit<DiscoverColumnsOptions, "mode" | "maxHops" | "leaves">;
+export type ColumnsFilterOptions = Omit<DiscoverColumnsOptionsBase, "mode" | "maxHops"> &
+  RootAnchoredOptions;
 
 /**
- * Resolve the two mutually exclusive anchor keys into the single anchor record
- * the request carries, plus the `anchorsAre` discriminator the engine needs.
+ * Resolve the two mutually exclusive anchor keys into the anchors themselves
+ * plus the request arm they belong in.
  *
- * Which key the caller used *is* the statement about where the given columns
- * sit in the hierarchy, so there is no separate direction option to pass.
- *
- * Note that `leaves` are anchors too: both keys name columns that are already
- * integrated and that discovery pins to. `anchors` in the result is therefore
- * the general term — the returned `anchorsAre` says which end of a linker the
- * caller put them on, and nothing but the key name is dropped here.
- *
- * The engine takes one axes integration plus that one discriminator, so the
- * two keys cannot stay separate all the way down; carrying two arrays on the
- * wire would encode a boolean as field presence and be collapsed on arrival.
+ * Which key the caller used *is* the statement about where the anchors sit, so
+ * it is carried down as the shape of the request rather than flattened into a
+ * direction flag beside it.
  *
  * @throws if both `anchors` and `leaves` are given.
  */
 export function resolveAnchorSide(options: Pick<DiscoverColumnsOptions, "anchors" | "leaves">): {
   anchors: Record<string, AnchorEntry> | undefined;
-  anchorsAre: NonNullable<DiscoverColumnsConstraints["anchorsAre"]>;
+  /** Which key of the request the anchors' axes go into. */
+  axesKey: "axes" | "leafAxes";
 } {
   if (options.anchors !== undefined && options.leaves !== undefined) {
     throwError(
@@ -107,21 +112,12 @@ export function resolveAnchorSide(options: Pick<DiscoverColumnsOptions, "anchors
     );
   }
   return options.leaves !== undefined
-    ? { anchors: options.leaves, anchorsAre: "leaves" }
-    : { anchors: options.anchors, anchorsAre: "roots" };
+    ? { anchors: options.leaves, axesKey: "leafAxes" }
+    : { anchors: options.anchors, axesKey: "axes" };
 }
 
-/**
- * Translate a {@link MatchingMode} into the boolean-flag form the spec driver
- * consumes. `anchorsAre` is orthogonal to the mode — it says where the anchors
- * sit, not how axes are matched — so it is threaded through unchanged and
- * omitted for the default (`"roots"`).
- */
-export function matchingModeToConstraints(
-  mode: MatchingMode,
-  anchorsAre?: DiscoverColumnsConstraints["anchorsAre"],
-): DiscoverColumnsConstraints {
-  const direction = anchorsAre !== undefined && anchorsAre !== "roots" ? { anchorsAre } : {};
+/** Translate a {@link MatchingMode} into the boolean-flag form the spec driver consumes. */
+export function matchingModeToConstraints(mode: MatchingMode): DiscoverColumnsConstraints {
   switch (mode) {
     case "enrichment":
       return {
@@ -129,7 +125,6 @@ export function matchingModeToConstraints(
         allowFloatingHitAxes: false,
         allowSourceQualifications: true,
         allowHitQualifications: true,
-        ...direction,
       };
     case "related":
       return {
@@ -137,7 +132,6 @@ export function matchingModeToConstraints(
         allowFloatingHitAxes: true,
         allowSourceQualifications: true,
         allowHitQualifications: true,
-        ...direction,
       };
     case "exact":
       return {
@@ -145,7 +139,6 @@ export function matchingModeToConstraints(
         allowFloatingHitAxes: false,
         allowSourceQualifications: false,
         allowHitQualifications: false,
-        ...direction,
       };
   }
 }

--- a/lib/model/common/src/drivers/columns/discover_columns_options.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.ts
@@ -3,6 +3,7 @@ import type { PlRef } from "../../ref";
 import type { PObjectId } from "../../pool";
 import type { PColumnSpec, AxisQualification } from "../pframe/spec";
 import type { DiscoverColumnsConstraints } from "../pframe/spec_driver";
+import { throwError } from "@milaboratories/helpers";
 
 /**
  * Axis matching behaviour applied to `discover` requests.
@@ -41,17 +42,25 @@ export interface DiscoverColumnsOptions {
   exclude?: ColumnSelector;
   /** Axis matching behavior. Default: 'enrichment'. Ignored if no anchors. */
   mode?: MatchingMode;
-  /** Anchors enable axis-aware discovery + linker traversal. */
+  /**
+   * Anchors enable axis-aware discovery + linker traversal. The anchors are the
+   * coarse end of the hierarchy, so discovery walks down to what they contain
+   * (anchored on `sample`, reaching `cell`).
+   *
+   * Mutually exclusive with {@link DiscoverColumnsOptions.leaves}.
+   */
   // @todo: migrate to array<AnchorEntry>
   anchors?: Record<string, AnchorEntry>;
+  /**
+   * Same as {@link DiscoverColumnsOptions.anchors}, but the given columns are
+   * the fine end of the hierarchy, so discovery walks up to what contains them
+   * (given `cell`, reaching `sample`).
+   *
+   * Mutually exclusive with {@link DiscoverColumnsOptions.anchors}.
+   */
+  leaves?: Record<string, AnchorEntry>;
   /** Maximum linker hops. Default: 4 when anchors present, 0 otherwise. */
   maxHops?: number;
-  /**
-   * Walk linkers fine → coarse instead of coarse → fine, to discover the
-   * roots above the anchors rather than the leaves below them. Default: false.
-   * Ignored if no anchors, or when `maxHops` is 0.
-   */
-  reverseLinkers?: boolean;
 }
 
 /**
@@ -64,26 +73,46 @@ export type ColumnsDiscoverOptions = DiscoverColumnsOptions;
 
 /**
  * Options accepted by `ColumnsCollection.filter` / driver `.filter`. Traversal
- * scope is fixed by the source collection, so `mode` / `maxHops` /
- * `reverseLinkers` are not part of the filter surface — only `include` /
- * `exclude` / `anchors`.
+ * scope is fixed by the source collection, so `mode` / `maxHops` / `leaves` are
+ * not part of the filter surface — only `include` / `exclude` / `anchors`.
  */
-export type ColumnsFilterOptions = Omit<
-  DiscoverColumnsOptions,
-  "mode" | "maxHops" | "reverseLinkers"
->;
+export type ColumnsFilterOptions = Omit<DiscoverColumnsOptions, "mode" | "maxHops" | "leaves">;
+
+/**
+ * Resolve the two mutually exclusive anchor keys into the single anchor record
+ * the request carries, plus the `anchorsAre` discriminator the engine needs.
+ *
+ * Which key the caller used *is* the statement about where the given columns
+ * sit in the hierarchy, so there is no separate direction option to pass.
+ *
+ * @throws if both `anchors` and `leaves` are given.
+ */
+export function resolveAnchorSide(options: Pick<DiscoverColumnsOptions, "anchors" | "leaves">): {
+  anchors: Record<string, AnchorEntry> | undefined;
+  anchorsAre: NonNullable<DiscoverColumnsConstraints["anchorsAre"]>;
+} {
+  if (options.anchors !== undefined && options.leaves !== undefined) {
+    throwError(
+      `"anchors" and "leaves" are mutually exclusive — pass "anchors" to discover ` +
+        `what they contain, or "leaves" to discover what contains them`,
+    );
+  }
+  return options.leaves !== undefined
+    ? { anchors: options.leaves, anchorsAre: "leaves" }
+    : { anchors: options.anchors, anchorsAre: "roots" };
+}
 
 /**
  * Translate a {@link MatchingMode} into the boolean-flag form the spec driver
- * consumes. `reverseLinkers` is orthogonal to the mode — it selects the linker
- * traversal direction, not the axes matching behaviour — so it is threaded
- * through unchanged and omitted when false.
+ * consumes. `anchorsAre` is orthogonal to the mode — it says where the anchors
+ * sit, not how axes are matched — so it is threaded through unchanged and
+ * omitted for the default (`"roots"`).
  */
 export function matchingModeToConstraints(
   mode: MatchingMode,
-  reverseLinkers?: boolean,
+  anchorsAre?: DiscoverColumnsConstraints["anchorsAre"],
 ): DiscoverColumnsConstraints {
-  const direction = reverseLinkers ? { reverseLinkers: true } : {};
+  const direction = anchorsAre !== undefined && anchorsAre !== "roots" ? { anchorsAre } : {};
   switch (mode) {
     case "enrichment":
       return {

--- a/lib/model/common/src/drivers/columns/discover_columns_options.ts
+++ b/lib/model/common/src/drivers/columns/discover_columns_options.ts
@@ -46,6 +46,12 @@ export interface DiscoverColumnsOptions {
   anchors?: Record<string, AnchorEntry>;
   /** Maximum linker hops. Default: 4 when anchors present, 0 otherwise. */
   maxHops?: number;
+  /**
+   * Walk linkers fine → coarse instead of coarse → fine, to discover the
+   * roots above the anchors rather than the leaves below them. Default: false.
+   * Ignored if no anchors, or when `maxHops` is 0.
+   */
+  reverseLinkers?: boolean;
 }
 
 /**
@@ -58,13 +64,26 @@ export type ColumnsDiscoverOptions = DiscoverColumnsOptions;
 
 /**
  * Options accepted by `ColumnsCollection.filter` / driver `.filter`. Traversal
- * scope is fixed by the source collection, so `mode` / `maxHops` are not part
- * of the filter surface — only `include` / `exclude` / `anchors`.
+ * scope is fixed by the source collection, so `mode` / `maxHops` /
+ * `reverseLinkers` are not part of the filter surface — only `include` /
+ * `exclude` / `anchors`.
  */
-export type ColumnsFilterOptions = Omit<DiscoverColumnsOptions, "mode" | "maxHops">;
+export type ColumnsFilterOptions = Omit<
+  DiscoverColumnsOptions,
+  "mode" | "maxHops" | "reverseLinkers"
+>;
 
-/** Translate a {@link MatchingMode} into the boolean-flag form the spec driver consumes. */
-export function matchingModeToConstraints(mode: MatchingMode): DiscoverColumnsConstraints {
+/**
+ * Translate a {@link MatchingMode} into the boolean-flag form the spec driver
+ * consumes. `reverseLinkers` is orthogonal to the mode — it selects the linker
+ * traversal direction, not the axes matching behaviour — so it is threaded
+ * through unchanged and omitted when false.
+ */
+export function matchingModeToConstraints(
+  mode: MatchingMode,
+  reverseLinkers?: boolean,
+): DiscoverColumnsConstraints {
+  const direction = reverseLinkers ? { reverseLinkers: true } : {};
   switch (mode) {
     case "enrichment":
       return {
@@ -72,6 +91,7 @@ export function matchingModeToConstraints(mode: MatchingMode): DiscoverColumnsCo
         allowFloatingHitAxes: false,
         allowSourceQualifications: true,
         allowHitQualifications: true,
+        ...direction,
       };
     case "related":
       return {
@@ -79,6 +99,7 @@ export function matchingModeToConstraints(mode: MatchingMode): DiscoverColumnsCo
         allowFloatingHitAxes: true,
         allowSourceQualifications: true,
         allowHitQualifications: true,
+        ...direction,
       };
     case "exact":
       return {
@@ -86,6 +107,7 @@ export function matchingModeToConstraints(mode: MatchingMode): DiscoverColumnsCo
         allowFloatingHitAxes: false,
         allowSourceQualifications: false,
         allowHitQualifications: false,
+        ...direction,
       };
   }
 }

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -81,15 +81,6 @@ export interface DiscoverColumnsConstraints {
   allowSourceQualifications: boolean;
   /** Allow hit column axes to be qualified (contextDomain extended) */
   allowHitQualifications: boolean;
-  /**
-   * Where the anchors the caller supplies sit in the hierarchy a linker
-   * expresses. `"roots"` (the default) walks down to what the anchors contain;
-   * `"leaves"` walks up to what contains them.
-   *
-   * Only the traversal rule changes — linker columns themselves are read as-is.
-   * Omit for the default direction.
-   */
-  anchorsAre?: "roots" | "leaves";
 }
 
 /** Request for discovering columns compatible with a given axes integration */
@@ -98,8 +89,16 @@ export interface DiscoverColumnsRequest {
   includeColumns?: MultiColumnSelector[];
   /** Exclude columns matching these selectors (OR-ed); applied after include filter */
   excludeColumns?: MultiColumnSelector[];
-  /** Already integrated axes with qualifications */
-  axes: ColumnAxesWithQualifications[];
+  /**
+   * Anchors at the coarse end: discovery walks down to what they contain.
+   * Mutually exclusive with {@link DiscoverColumnsRequest.leafAxes}.
+   */
+  axes?: ColumnAxesWithQualifications[];
+  /**
+   * Anchors at the fine end: discovery walks up to what contains them.
+   * Mutually exclusive with {@link DiscoverColumnsRequest.axes}.
+   */
+  leafAxes?: ColumnAxesWithQualifications[];
   /** Maximum number of hops allowed between provided axes integration and returned hits (0 = direct only) */
   maxHops?: number;
   /** Constraints controlling axes matching and qualification behavior */

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -81,6 +81,19 @@ export interface DiscoverColumnsConstraints {
   allowSourceQualifications: boolean;
   /** Allow hit column axes to be qualified (contextDomain extended) */
   allowHitQualifications: boolean;
+  /**
+   * Read linker columns fine → coarse instead of coarse → fine.
+   *
+   * A linker's axes split into a one-side and a many-side. By default a
+   * traversal enters on the many-side and exits on the one-side (e.g.
+   * `sample` → `cell`), which finds the leaves below an anchor. Setting this
+   * flips the entry side, so the traversal walks `cell` → `sample` and finds
+   * the roots above the anchor instead.
+   *
+   * Only the traversal rule is reversed — linker columns themselves are read
+   * as-is. Omit or set `false` for the default direction.
+   */
+  reverseLinkers?: boolean;
 }
 
 /** Request for discovering columns compatible with a given axes integration */

--- a/lib/model/common/src/drivers/pframe/spec_driver.ts
+++ b/lib/model/common/src/drivers/pframe/spec_driver.ts
@@ -82,18 +82,14 @@ export interface DiscoverColumnsConstraints {
   /** Allow hit column axes to be qualified (contextDomain extended) */
   allowHitQualifications: boolean;
   /**
-   * Read linker columns fine → coarse instead of coarse → fine.
+   * Where the anchors the caller supplies sit in the hierarchy a linker
+   * expresses. `"roots"` (the default) walks down to what the anchors contain;
+   * `"leaves"` walks up to what contains them.
    *
-   * A linker's axes split into a one-side and a many-side. By default a
-   * traversal enters on the many-side and exits on the one-side (e.g.
-   * `sample` → `cell`), which finds the leaves below an anchor. Setting this
-   * flips the entry side, so the traversal walks `cell` → `sample` and finds
-   * the roots above the anchor instead.
-   *
-   * Only the traversal rule is reversed — linker columns themselves are read
-   * as-is. Omit or set `false` for the default direction.
+   * Only the traversal rule changes — linker columns themselves are read as-is.
+   * Omit for the default direction.
    */
-  reverseLinkers?: boolean;
+  anchorsAre?: "roots" | "leaves";
 }
 
 /** Request for discovering columns compatible with a given axes integration */

--- a/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
@@ -57,6 +57,19 @@ export interface DiscoverColumnsConstraints {
   allowSourceQualifications: boolean;
   /** Allow hit column axes to be qualified (contextDomain extended) */
   allowHitQualifications: boolean;
+  /**
+   * Read linker columns fine → coarse instead of coarse → fine.
+   *
+   * A linker's axes split into a one-side and a many-side. By default a
+   * traversal enters on the many-side and exits on the one-side (e.g.
+   * `sample` → `cell`), which finds the leaves below an anchor. Setting this
+   * flips the entry side, so the traversal walks `cell` → `sample` and finds
+   * the roots above the anchor instead.
+   *
+   * Only the traversal rule is reversed — linker columns themselves are read
+   * as-is. Omit or set `false` for the default direction.
+   */
+  reverseLinkers?: boolean;
 }
 
 /** V2 request with separate include/exclude filters */

--- a/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
@@ -58,18 +58,14 @@ export interface DiscoverColumnsConstraints {
   /** Allow hit column axes to be qualified (contextDomain extended) */
   allowHitQualifications: boolean;
   /**
-   * Read linker columns fine → coarse instead of coarse → fine.
+   * Where the anchors the caller supplies sit in the hierarchy a linker
+   * expresses. `"roots"` (the default) walks down to what the anchors contain;
+   * `"leaves"` walks up to what contains them.
    *
-   * A linker's axes split into a one-side and a many-side. By default a
-   * traversal enters on the many-side and exits on the one-side (e.g.
-   * `sample` → `cell`), which finds the leaves below an anchor. Setting this
-   * flips the entry side, so the traversal walks `cell` → `sample` and finds
-   * the roots above the anchor instead.
-   *
-   * Only the traversal rule is reversed — linker columns themselves are read
-   * as-is. Omit or set `false` for the default direction.
+   * Only the traversal rule changes — linker columns themselves are read as-is.
+   * Omit for the default direction.
    */
-  reverseLinkers?: boolean;
+  anchorsAre?: "roots" | "leaves";
 }
 
 /** V2 request with separate include/exclude filters */

--- a/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
+++ b/lib/model/middle-layer/src/pframe/internal_api/discover_columns.ts
@@ -57,15 +57,6 @@ export interface DiscoverColumnsConstraints {
   allowSourceQualifications: boolean;
   /** Allow hit column axes to be qualified (contextDomain extended) */
   allowHitQualifications: boolean;
-  /**
-   * Where the anchors the caller supplies sit in the hierarchy a linker
-   * expresses. `"roots"` (the default) walks down to what the anchors contain;
-   * `"leaves"` walks up to what contains them.
-   *
-   * Only the traversal rule changes — linker columns themselves are read as-is.
-   * Omit for the default direction.
-   */
-  anchorsAre?: "roots" | "leaves";
 }
 
 /** V2 request with separate include/exclude filters */
@@ -74,8 +65,16 @@ export interface DiscoverColumnsRequestV2 {
   includeColumns?: MultiColumnSelector[];
   /** Exclude columns matching these selectors (OR-ed); applied after include filter */
   excludeColumns?: MultiColumnSelector[];
-  /** Already integrated axes with qualifications */
-  axes: ColumnAxesWithQualifications[];
+  /**
+   * Anchors at the coarse end: discovery walks down to what they contain.
+   * Mutually exclusive with {@link DiscoverColumnsRequestV2.leafAxes}.
+   */
+  axes?: ColumnAxesWithQualifications[];
+  /**
+   * Anchors at the fine end: discovery walks up to what contains them.
+   * Mutually exclusive with {@link DiscoverColumnsRequestV2.axes}.
+   */
+  leafAxes?: ColumnAxesWithQualifications[];
   /** Maximum number of hops allowed between provided axes integration and returned hits (0 = direct only) */
   maxHops?: number;
   /** Constraints controlling axes matching and qualification behavior */

--- a/lib/node/pl-middle-layer/src/js_render/service_injectors.ts
+++ b/lib/node/pl-middle-layer/src/js_render/service_injectors.ts
@@ -2,6 +2,7 @@ import type { QuickJSHandle, VmFunctionImplementation } from "quickjs-emscripten
 import type {
   CollectionHandle,
   ColumnsCollectionDriverHost,
+  ColumnsFilterOptions,
   DiscoverColumnsOptions,
   InferServiceModel,
   PoolEntry,
@@ -264,7 +265,7 @@ export function getServiceInjectors(): ServiceInjectorMap {
             pinHandle(
               driver.filter(
                 vm.vm.getString(handle) as CollectionHandle,
-                vm.importObjectViaJson(opts) as DiscoverColumnsOptions,
+                vm.importObjectViaJson(opts) as ColumnsFilterOptions,
                 bindings,
               ),
             ),


### PR DESCRIPTION
Host-side counterpart to [platforma-open/pframes-rs#295](https://github.com/milaboratory/pframes-rs/pull/295), which teaches the discovery engine to walk linkers in either direction.

## Problem

A linker column relates two axis groups: a fine end and a coarse end (`cell` belongs to `sample`). Discovery only ever walked from coarse to fine — anchored on `sample`, it reached `cell`. There was no way to start from `cell` and ask for the `sample`-level columns above it.

## Change

The direction is expressed by **which key you fill in**. There is no direction flag anywhere in the API:

```ts
collection.discover({ anchors: { s: sampleRef }, mode: "enrichment", maxHops: 4 });
// anchors are the coarse end -> walks down to what they contain

collection.discover({ leaves: { c: cellRef }, mode: "enrichment", maxHops: 4 });
// the given columns are the fine end -> walks up to what contains them
```

Earlier revisions of this branch did add a flag — first `reverseLinkers`, then `anchorsAre` — and both were the mechanism leaking into the contract: the request said "here are my anchors, and separately, read them this way". Since the caller already declares the anchors, the choice of key carries it.

### Plumbing

- **`DiscoverColumnsOptions`** becomes `DiscoverColumnsOptionsBase & (RootAnchoredOptions | LeafAnchoredOptions)`, so `anchors` and `leaves` exclude each other at compile time via `?: never`. Splitting the base out also keeps `ColumnsFilterOptions` an `Omit` over an interface rather than over a union, which distributes badly.
- **`resolveAnchorSide(options)`** resolves the pair at runtime into the anchors plus the request arm they belong in, and rejects both-at-once. It lives beside the option types it governs: the rule is pure and testable there, whereas `columns-collection-driver` has no test scaffolding at all.
- **On the wire**, `DiscoverColumnsRequest` / `DiscoverColumnsRequestV2` gain a `leafAxes` arm beside `axes`, mirroring the engine, and `DiscoverColumnsConstraints` goes back to the four axes-matching flags it had before this branch. `PFrameSpecDriver.discoverColumns` forwards the request verbatim, so no conversion layer needed touching.
- **`matchingModeToConstraints`** is back to one argument — anchor position never reaches it.
- The driver spreads the resolved arm as a computed key rather than passing a discriminator.

### Scope decision: `leaves` is not on the `.filter()` surface

`ColumnsFilterOptions` is built from `RootAnchoredOptions` only, alongside dropping `mode` and `maxHops`. `.filter()` calls `runDiscovery` with `maxHops: 0` pinned, so there is no traversal for a direction to describe.

This tightening caught one real call site: `service_injectors.ts` cast the sandbox's incoming JSON to `DiscoverColumnsOptions` on **both** the `discover` and `filter` bridges. The `filter` one now casts to `ColumnsFilterOptions`, which is what that entry point actually receives.

## Backward compatibility

Existing `anchors` callers are untouched and still produce byte-identical requests. `leaves` and `leafAxes` are purely additive.

The field is additive on both sides, so this can land before or after the engine PR; until that ships, `leafAxes` is accepted and ignored.

## Verification

- Full monorepo `pnpm check` passes via the pre-push hook; 170 tests in `pl-model-common`.
- `discover_columns_options.test.ts` covers both units: `resolveAnchorSide` for each key, for neither, and for the both-at-once rejection; and `matchingModeToConstraints` yielding *only* the four axes-matching flags, so nothing about anchor position can leak back into the constraints object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
