### PR TITLE
MILAB-5933: sink to a temporary file so an in-place overwrite stops crashing

### DIFF
--- a/.changeset/ptabler-overwrite-in-place.md
+++ b/.changeset/ptabler-overwrite-in-place.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.software-ptabler": patch
+---
+
+Writing a table back over the file it was read from no longer crashes.
+
+The read is lazy, so sinking straight to the target truncated a file polars was still reading. A local filesystem hides that behind cached pages; a network filesystem does not, and the process died with a bus error. The sink now lands in a sibling temporary file that is moved into place once every sink has been collected, carrying the target's mode across so a file staged writable stays writable.

--- a/lib/ptabler/software/src/ptabler/steps/base.py
+++ b/lib/ptabler/software/src/ptabler/steps/base.py
@@ -26,6 +26,7 @@ class StepContext:
         self._table_space = initial_table_space if initial_table_space is not None else {}
         self._lazy_frames: list[pl.LazyFrame] = []
         self._chained_tasks: list[callable] = []
+        self._partial_outputs: list[str] = []
     
     @property
     def settings(self) -> GlobalSettings:
@@ -81,6 +82,24 @@ class StepContext:
         self._chained_tasks.append(task)
     
     
+    def add_partial_output(self, path: str):
+        """
+        Records a file a sink writes before it is moved onto its target.
+
+        A run that fails leaves those behind, and in a block's working directory a
+        leftover file is not inert — it is collected as part of the block's output. The
+        workflow removes whatever is still registered here once execution ends.
+
+        Args:
+            path: Absolute path of the partial file
+        """
+        self._partial_outputs.append(path)
+
+    @property
+    def partial_outputs(self) -> list[str]:
+        """Returns the partial sink files recorded so far (read-only)."""
+        return self._partial_outputs
+
     def into_parts(self) -> tuple[dict[str, pl.LazyFrame], list[pl.LazyFrame], list[callable]]:
         """
         Destructs the StepContext and returns its internal state.

--- a/lib/ptabler/software/src/ptabler/steps/base.py
+++ b/lib/ptabler/software/src/ptabler/steps/base.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional
 import msgspec
@@ -99,6 +100,21 @@ class StepContext:
     def partial_outputs(self) -> list[str]:
         """Returns the partial sink files recorded so far (read-only)."""
         return self._partial_outputs
+
+    def cleanup_partial_outputs(self):
+        """
+        Removes every partial sink file still recorded, and forgets them.
+
+        A partial file that reached its target has already been moved off the disk path
+        this holds, so removing what is left removes only the writes that never landed.
+        Safe to call more than once.
+        """
+        for partial_output in self._partial_outputs:
+            try:
+                os.remove(partial_output)
+            except FileNotFoundError:
+                pass
+        self._partial_outputs = []
 
     def into_parts(self) -> tuple[dict[str, pl.LazyFrame], list[pl.LazyFrame], list[callable]]:
         """

--- a/lib/ptabler/software/src/ptabler/steps/io.py
+++ b/lib/ptabler/software/src/ptabler/steps/io.py
@@ -1,6 +1,8 @@
 import polars as pl
 import os
-from typing import List, Optional, Dict, Any 
+import stat
+import tempfile
+from typing import List, Optional, Dict, Any
 import msgspec
 
 from ptabler.common import toPolarsType, PType
@@ -140,21 +142,57 @@ class ReadParquet(BaseReadLogic, tag="read_parquet"):
         """
         return pl.scan_parquet(file_path, **scan_kwargs)
 
+PARTIAL_SUFFIX = ".ptabler-partial"
+
+
+def _create_partial_output(file_path: str) -> str:
+    """
+    Creates the file a sink writes into, already carrying the mode its target will need.
+
+    The name is unique, so two steps writing one target never share a partial file and
+    neither can land on a name the workflow's own data uses.
+
+    The mode is set here rather than at the move because the sink starts writing as soon
+    as it is collected: a target restricted to 0o600 whose partial file was created under
+    the umask would be readable by anyone with the workspace for as long as the write
+    takes. mkstemp opens at 0o600, so the window never exists, and the target's own mode
+    is applied before any row is written.
+    """
+    directory, name = os.path.split(file_path)
+    handle, temp_path = tempfile.mkstemp(
+        dir=directory or ".", prefix=f".{name}.", suffix=PARTIAL_SUFFIX
+    )
+    os.close(handle)
+
+    target_mode = _target_mode(file_path)
+    if target_mode is not None:
+        os.chmod(temp_path, target_mode)
+
+    return temp_path
+
+
+def _target_mode(file_path: str) -> Optional[int]:
+    """Returns the mode of an existing target, or None when the write creates it."""
+    try:
+        return stat.S_IMODE(os.stat(file_path).st_mode)
+    except FileNotFoundError:
+        return None
+
+
 def _replace_preserving_mode(temp_path: str, file_path: str) -> None:
     """
     Moves a finished sink file onto its target path, keeping the mode the target had.
 
     os.replace swaps in a new inode, so the target would otherwise come back with the
-    temporary file's mode. A workdir file the backend staged writable at 0o600 has that
+    partial file's mode. A workdir file the backend staged writable at 0o600 has that
     mode for a reason, and a block that writes it must not hand back something read-only.
-    """
-    try:
-        existing_mode = os.stat(file_path).st_mode
-    except FileNotFoundError:
-        existing_mode = None
 
-    if existing_mode is not None:
-        os.chmod(temp_path, existing_mode)
+    The mode is re-applied here because polars may recreate the path rather than truncate
+    the file created up front.
+    """
+    target_mode = _target_mode(file_path)
+    if target_mode is not None:
+        os.chmod(temp_path, target_mode)
 
     os.replace(temp_path, file_path)
 
@@ -199,11 +237,12 @@ class BaseWriteLogic(PStep):
         # to file_path truncates a file polars is still reading. On a local filesystem
         # that survives on cached pages; on a network filesystem the mapping goes away
         # underneath the reader and the process takes SIGBUS.
-        temp_path = f"{file_path}.ptabler-partial"
+        temp_path = _create_partial_output(file_path)
         sink_plan = self._do_sink(selected_lf, temp_path)
 
         # Add the sink plan to the context for later execution
         ctx.add_sink(sink_plan)
+        ctx.add_partial_output(temp_path)
         ctx.chain_task(lambda: _replace_preserving_mode(temp_path, file_path))
 
 class WriteCsv(BaseWriteLogic, tag="write_csv"):

--- a/lib/ptabler/software/src/ptabler/steps/io.py
+++ b/lib/ptabler/software/src/ptabler/steps/io.py
@@ -179,6 +179,17 @@ def _target_mode(file_path: str) -> Optional[int]:
         return None
 
 
+def _target_refuses_writes(file_path: str) -> bool:
+    """
+    Reports whether an existing target would reject a write through its own mode.
+
+    The backend hands a block its workdir files read-only unless the workflow asked for
+    a writable copy, and that mode is the whole enforcement. A path that does not exist
+    yet refuses nothing — the write creates it.
+    """
+    return os.path.exists(file_path) and not os.access(file_path, os.W_OK)
+
+
 def _replace_preserving_mode(temp_path: str, file_path: str) -> None:
     """
     Moves a finished sink file onto its target path, keeping the mode the target had.
@@ -237,6 +248,14 @@ class BaseWriteLogic(PStep):
         # to file_path truncates a file polars is still reading. On a local filesystem
         # that survives on cached pages; on a network filesystem the mapping goes away
         # underneath the reader and the process takes SIGBUS.
+        if _target_refuses_writes(file_path):
+            # The mode of an existing target is the only thing standing between a block
+            # and a file it was given read-only, and a partial file would walk straight
+            # past it: os.replace needs the directory to be writable, never the file.
+            # Sink onto the target so the write fails the way the caller expects.
+            ctx.add_sink(self._do_sink(selected_lf, file_path))
+            return
+
         temp_path = _create_partial_output(file_path)
         sink_plan = self._do_sink(selected_lf, temp_path)
 

--- a/lib/ptabler/software/src/ptabler/steps/io.py
+++ b/lib/ptabler/software/src/ptabler/steps/io.py
@@ -140,6 +140,25 @@ class ReadParquet(BaseReadLogic, tag="read_parquet"):
         """
         return pl.scan_parquet(file_path, **scan_kwargs)
 
+def _replace_preserving_mode(temp_path: str, file_path: str) -> None:
+    """
+    Moves a finished sink file onto its target path, keeping the mode the target had.
+
+    os.replace swaps in a new inode, so the target would otherwise come back with the
+    temporary file's mode. A workdir file the backend staged writable at 0o600 has that
+    mode for a reason, and a block that writes it must not hand back something read-only.
+    """
+    try:
+        existing_mode = os.stat(file_path).st_mode
+    except FileNotFoundError:
+        existing_mode = None
+
+    if existing_mode is not None:
+        os.chmod(temp_path, existing_mode)
+
+    os.replace(temp_path, file_path)
+
+
 class BaseWriteLogic(PStep):
     """
     Abstract base class for PSteps that write tables to files.
@@ -173,10 +192,19 @@ class BaseWriteLogic(PStep):
             selected_lf = lf_to_write.select(self.columns)
         
         file_path = os.path.join(ctx.settings.root_folder, normalize_path(self.file))
-        sink_plan = self._do_sink(selected_lf, file_path)
+
+        # Sink to a sibling temporary file and move it into place once every sink has
+        # been collected. A workflow is allowed to read and write one path — read_csv
+        # then write_csv over the same file — and the read is lazy, so sinking straight
+        # to file_path truncates a file polars is still reading. On a local filesystem
+        # that survives on cached pages; on a network filesystem the mapping goes away
+        # underneath the reader and the process takes SIGBUS.
+        temp_path = f"{file_path}.ptabler-partial"
+        sink_plan = self._do_sink(selected_lf, temp_path)
 
         # Add the sink plan to the context for later execution
         ctx.add_sink(sink_plan)
+        ctx.chain_task(lambda: _replace_preserving_mode(temp_path, file_path))
 
 class WriteCsv(BaseWriteLogic, tag="write_csv"):
     """

--- a/lib/ptabler/software/src/ptabler/steps/io.py
+++ b/lib/ptabler/software/src/ptabler/steps/io.py
@@ -198,8 +198,9 @@ def _replace_preserving_mode(temp_path: str, file_path: str) -> None:
     partial file's mode. A workdir file the backend staged writable at 0o600 has that
     mode for a reason, and a block that writes it must not hand back something read-only.
 
-    The mode is re-applied here because polars may recreate the path rather than truncate
-    the file created up front.
+    The partial file was created carrying this mode already, and polars truncates rather
+    than recreates it, so this re-applies what is usually the same mode. It is here for
+    the case where that stops holding.
     """
     target_mode = _target_mode(file_path)
     if target_mode is not None:

--- a/lib/ptabler/software/src/ptabler/workflow/workflow.py
+++ b/lib/ptabler/software/src/ptabler/workflow/workflow.py
@@ -79,6 +79,13 @@ class PWorkflow(msgspec.Struct):
             table space, sink operations, and chained tasks.
             If `lazy` is False, executes sink operations and chained tasks,
             then returns `None`.
+
+        A writing step opens the file its sink will fill while the step runs, so a lazy
+        call returns with those already on disk, listed in `StepContext.partial_outputs`.
+        They belong to the caller from that point: run the sinks and the chained tasks to
+        move them onto their targets, and call `StepContext.cleanup_partial_outputs` for
+        whatever is left. A non-lazy call does both itself. A leftover partial file in a
+        block's working directory is collected as part of the block's output.
         """
         spill_dir_created = False
         spill_path = None
@@ -123,12 +130,11 @@ class PWorkflow(msgspec.Struct):
             # A sink that raised leaves its partial file behind, and in a block's working
             # directory that file is not inert — it is collected as part of the block's
             # output. Whatever reached its target has already been moved off this list.
+            #
+            # A lazy run has not written them yet, so they belong to the caller that took
+            # the context; cleanup_partial_outputs is how it hands them back.
             if ctx is not None and not lazy:
-                for partial_output in ctx.partial_outputs:
-                    try:
-                        os.remove(partial_output)
-                    except FileNotFoundError:
-                        pass
+                ctx.cleanup_partial_outputs()
 
             if spill_dir_created and spill_path is not None and spill_path.exists():
                 shutil.rmtree(spill_path, ignore_errors=True)

--- a/lib/ptabler/software/src/ptabler/workflow/workflow.py
+++ b/lib/ptabler/software/src/ptabler/workflow/workflow.py
@@ -1,4 +1,5 @@
 import msgspec
+import os
 import polars as pl
 import shutil
 from pathlib import Path
@@ -81,7 +82,8 @@ class PWorkflow(msgspec.Struct):
         """
         spill_dir_created = False
         spill_path = None
-        
+        ctx = None
+
         if global_settings.spill_folder is not None:
             spill_path = Path(global_settings.spill_folder)
             if not spill_path.exists():
@@ -118,5 +120,15 @@ class PWorkflow(msgspec.Struct):
                 return None
         
         finally:
+            # A sink that raised leaves its partial file behind, and in a block's working
+            # directory that file is not inert — it is collected as part of the block's
+            # output. Whatever reached its target has already been moved off this list.
+            if ctx is not None and not lazy:
+                for partial_output in ctx.partial_outputs:
+                    try:
+                        os.remove(partial_output)
+                    except FileNotFoundError:
+                        pass
+
             if spill_dir_created and spill_path is not None and spill_path.exists():
                 shutil.rmtree(spill_path, ignore_errors=True)

--- a/lib/ptabler/software/src/test/overwrite_test.py
+++ b/lib/ptabler/software/src/test/overwrite_test.py
@@ -1,0 +1,63 @@
+import os
+import stat
+import tempfile
+import unittest
+
+from ptabler.workflow import PWorkflow
+from ptabler.steps import GlobalSettings, ReadCsv, WriteCsv
+
+
+class OverwriteInPlaceTests(unittest.TestCase):
+    """
+    A workflow may read a file and write the result back over the same path. The read is
+    lazy, so the sink must not truncate the file polars is still reading: on a local
+    filesystem cached pages hide that, on a network filesystem the reader takes SIGBUS.
+    """
+
+    def _run_overwrite(self, root: str, name: str) -> None:
+        PWorkflow(workflow=[
+            ReadCsv(file=name, name="t", delimiter="\t"),
+            WriteCsv(table="t", file=name, delimiter="\t"),
+        ]).execute(global_settings=GlobalSettings(root_folder=root))
+
+    def test_overwrite_leaves_no_partial_file_behind(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, "data.tsv")
+            with open(target, "w") as handle:
+                handle.write("a\tb\n1\t2\n3\t4\n")
+
+            self._run_overwrite(root, "data.tsv")
+
+            self.assertTrue(os.path.exists(target))
+            leftovers = [n for n in os.listdir(root) if n.endswith(".ptabler-partial")]
+            self.assertEqual([], leftovers, "the temporary sink file must be moved into place")
+
+    def test_overwrite_keeps_the_mode_the_target_had(self):
+        # The backend stages a workdir file writable at 0o600 on purpose, and moving the
+        # sink into place must not hand back something with the temporary file's mode.
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, "data.tsv")
+            with open(target, "w") as handle:
+                handle.write("a\tb\n1\t2\n")
+            os.chmod(target, 0o600)
+
+            self._run_overwrite(root, "data.tsv")
+
+            mode = stat.S_IMODE(os.stat(target).st_mode)
+            self.assertEqual(0o600, mode, f"mode became {oct(mode)}")
+
+    def test_writing_a_new_file_still_works(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "in.tsv"), "w") as handle:
+                handle.write("a\tb\n1\t2\n")
+
+            PWorkflow(workflow=[
+                ReadCsv(file="in.tsv", name="t", delimiter="\t"),
+                WriteCsv(table="t", file="out.tsv", delimiter="\t"),
+            ]).execute(global_settings=GlobalSettings(root_folder=root))
+
+            self.assertTrue(os.path.exists(os.path.join(root, "out.tsv")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/ptabler/software/src/test/overwrite_test.py
+++ b/lib/ptabler/software/src/test/overwrite_test.py
@@ -99,6 +99,20 @@ class OverwriteInPlaceTests(unittest.TestCase):
 
             self.assertEqual([], self._partials_in(root))
 
+    def test_a_read_only_target_still_refuses_the_write(self):
+        # The mode of a workdir file is the whole enforcement behind exec.builder's
+        # { writable: false }. Moving a partial file into place would ignore it, because
+        # os.replace asks the directory for permission and never the file.
+        with tempfile.TemporaryDirectory() as root:
+            target = self._write_source(root)
+            os.chmod(target, 0o400)
+
+            with self.assertRaises(Exception):
+                self._run_overwrite(root)
+
+            self.assertEqual(TSV, open(target).read(), "the target must be left untouched")
+            self.assertEqual([], self._partials_in(root))
+
     def test_writing_a_new_file_still_works(self):
         with tempfile.TemporaryDirectory() as root:
             self._write_source(root, "in.tsv")

--- a/lib/ptabler/software/src/test/overwrite_test.py
+++ b/lib/ptabler/software/src/test/overwrite_test.py
@@ -3,8 +3,13 @@ import stat
 import tempfile
 import unittest
 
+import polars as pl
+
 from ptabler.workflow import PWorkflow
 from ptabler.steps import GlobalSettings, ReadCsv, WriteCsv
+from ptabler.steps.io import PARTIAL_SUFFIX
+
+TSV = "a\tb\n1\t2\n3\t4\n"
 
 
 class OverwriteInPlaceTests(unittest.TestCase):
@@ -14,49 +19,97 @@ class OverwriteInPlaceTests(unittest.TestCase):
     filesystem cached pages hide that, on a network filesystem the reader takes SIGBUS.
     """
 
-    def _run_overwrite(self, root: str, name: str) -> None:
+    def _write_source(self, root: str, name: str = "data.tsv") -> str:
+        path = os.path.join(root, name)
+        with open(path, "w") as handle:
+            handle.write(TSV)
+        return path
+
+    def _run_overwrite(self, root: str, name: str = "data.tsv") -> None:
         PWorkflow(workflow=[
             ReadCsv(file=name, name="t", delimiter="\t"),
             WriteCsv(table="t", file=name, delimiter="\t"),
         ]).execute(global_settings=GlobalSettings(root_folder=root))
 
+    def _partials_in(self, root: str) -> list[str]:
+        return [n for n in os.listdir(root) if n.endswith(PARTIAL_SUFFIX)]
+
+    def test_overwrite_keeps_every_row_and_column(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = self._write_source(root)
+
+            self._run_overwrite(root)
+
+            written = pl.read_csv(target, separator="\t")
+            self.assertEqual(["a", "b"], written.columns)
+            self.assertEqual([[1, 3], [2, 4]], [written["a"].to_list(), written["b"].to_list()])
+
     def test_overwrite_leaves_no_partial_file_behind(self):
         with tempfile.TemporaryDirectory() as root:
-            target = os.path.join(root, "data.tsv")
-            with open(target, "w") as handle:
-                handle.write("a\tb\n1\t2\n3\t4\n")
+            self._write_source(root)
 
-            self._run_overwrite(root, "data.tsv")
+            self._run_overwrite(root)
 
-            self.assertTrue(os.path.exists(target))
-            leftovers = [n for n in os.listdir(root) if n.endswith(".ptabler-partial")]
-            self.assertEqual([], leftovers, "the temporary sink file must be moved into place")
+            self.assertEqual([], self._partials_in(root))
 
     def test_overwrite_keeps_the_mode_the_target_had(self):
         # The backend stages a workdir file writable at 0o600 on purpose, and moving the
-        # sink into place must not hand back something with the temporary file's mode.
+        # sink into place must not hand back something with the partial file's mode.
         with tempfile.TemporaryDirectory() as root:
-            target = os.path.join(root, "data.tsv")
-            with open(target, "w") as handle:
-                handle.write("a\tb\n1\t2\n")
+            target = self._write_source(root)
             os.chmod(target, 0o600)
 
-            self._run_overwrite(root, "data.tsv")
+            self._run_overwrite(root)
 
             mode = stat.S_IMODE(os.stat(target).st_mode)
             self.assertEqual(0o600, mode, f"mode became {oct(mode)}")
 
+    def test_two_writers_of_one_target_do_not_share_a_partial_file(self):
+        # Both sinks are collected before either is moved into place, so a partial name
+        # derived from the target alone would have them writing over each other.
+        with tempfile.TemporaryDirectory() as root:
+            self._write_source(root)
+
+            PWorkflow(workflow=[
+                ReadCsv(file="data.tsv", name="t", delimiter="\t"),
+                WriteCsv(table="t", file="out.tsv", delimiter="\t"),
+                WriteCsv(table="t", file="out.tsv", delimiter="\t"),
+            ]).execute(global_settings=GlobalSettings(root_folder=root))
+
+            written = pl.read_csv(os.path.join(root, "out.tsv"), separator="\t")
+            self.assertEqual([1, 3], written["a"].to_list())
+            self.assertEqual([], self._partials_in(root))
+
+    def test_a_failed_run_leaves_no_partial_file_behind(self):
+        # A leftover partial in a block's working directory is collected as part of the
+        # block's output, so a run that raises must not leave one.
+        with tempfile.TemporaryDirectory() as root:
+            self._write_source(root)
+
+            # The column is missing, which polars only discovers when the sink is
+            # collected — by then the partial file exists, which is the case that
+            # would otherwise leave one behind.
+            with self.assertRaises(Exception):
+                PWorkflow(workflow=[
+                    ReadCsv(file="data.tsv", name="t", delimiter="\t"),
+                    WriteCsv(
+                        table="t", file="out.tsv", delimiter="\t", columns=["absent_column"]
+                    ),
+                ]).execute(global_settings=GlobalSettings(root_folder=root))
+
+            self.assertEqual([], self._partials_in(root))
+
     def test_writing_a_new_file_still_works(self):
         with tempfile.TemporaryDirectory() as root:
-            with open(os.path.join(root, "in.tsv"), "w") as handle:
-                handle.write("a\tb\n1\t2\n")
+            self._write_source(root, "in.tsv")
 
             PWorkflow(workflow=[
                 ReadCsv(file="in.tsv", name="t", delimiter="\t"),
                 WriteCsv(table="t", file="out.tsv", delimiter="\t"),
             ]).execute(global_settings=GlobalSettings(root_folder=root))
 
-            self.assertTrue(os.path.exists(os.path.join(root, "out.tsv")))
+            written = pl.read_csv(os.path.join(root, "out.tsv"), separator="\t")
+            self.assertEqual([1, 3], written["a"].to_list())
 
 
 if __name__ == "__main__":

--- a/lib/ptabler/software/src/test/overwrite_test.py
+++ b/lib/ptabler/software/src/test/overwrite_test.py
@@ -113,6 +113,26 @@ class OverwriteInPlaceTests(unittest.TestCase):
             self.assertEqual(TSV, open(target).read(), "the target must be left untouched")
             self.assertEqual([], self._partials_in(root))
 
+    def test_a_lazy_run_hands_its_partial_files_to_the_caller(self):
+        # A writing step opens its partial file while the step runs, so a lazy call
+        # returns with them on disk and nothing has moved them anywhere yet. The caller
+        # took the context, so it owns them, and cleanup_partial_outputs is the handle.
+        with tempfile.TemporaryDirectory() as root:
+            self._write_source(root)
+
+            ctx = PWorkflow(workflow=[
+                ReadCsv(file="data.tsv", name="t", delimiter="\t"),
+                WriteCsv(table="t", file="out.tsv", delimiter="\t"),
+            ]).execute(global_settings=GlobalSettings(root_folder=root), lazy=True)
+
+            self.assertEqual(1, len(ctx.partial_outputs))
+            self.assertEqual(1, len(self._partials_in(root)), "the file is open before collection")
+
+            ctx.cleanup_partial_outputs()
+
+            self.assertEqual([], self._partials_in(root))
+            self.assertEqual([], ctx.partial_outputs)
+
     def test_writing_a_new_file_still_works(self):
         with tempfile.TemporaryDirectory() as root:
             self._write_source(root, "in.tsv")


### PR DESCRIPTION
## Why

A workflow may read a file and write the result back over the same path — `read_csv` then `write_csv` on one path. The read is **lazy**, so sinking straight to the target truncates a file polars is still reading.

A local filesystem hides that behind cached pages. A network filesystem does not. On the k8s+S3 e2e deploy, whose workspace is a CephFS RWX PVC, ptabler died:

```
Command name: "python"
Command: "python" "/app/main.py" "workflow.json" --frame-dir frames --spill-dir spill
Exited with code 135.
Latest output:
Bus error (core dumped)
```

`135` = `128 + 7` = SIGBUS — the mapping went away underneath the reader.

## What

A write whose file the same workflow also reads is a **rewrite**. A rewrite sinks to a sibling `.ptabler-partial` file, and the move onto the target runs from a `chain_task`, which already fires after `collect_all`. No engine change needed.

**Every other write sinks straight to its file, exactly as before.**

---

## The decisions

> Written in ASD-STE100 Simplified Technical English. One word has one meaning. The sentences are active, present tense, and short.

### 1. Only a rewrite writes to a temporary file

**All other writes go directly to their file.** A rewrite is a write to a file that the same workflow also reads.

The first version of this PR sent every write to a temporary file. This added a new code path to all 36 blocks that use ptabler. No block can cause the collision that the code path prevents.

`PWorkflow._overwrite_targets` compares the read paths with the write paths. It does this before the first step runs. `BaseWriteLogic.execute` then selects one of two paths:

- a rewrite goes to `_sink_rewrite`
- all other writes go directly to the file

**This PR loses one property.** The first version made every write atomic. A run that fails can again leave an incomplete output file. This is safe, because Platforma collects block outputs only after the process stops.

### 2. ptabler scans the workflow before it runs the steps

**A `write_csv` step can come before the `read_csv` step that it collides with.** ptabler cannot find this collision if it records the paths while the steps run. Therefore ptabler reads the full list of steps first.

The test `test_a_write_ahead_of_the_read_it_collides_with_is_still_found` keeps this behavior.

### 3. ptabler compares resolved paths

**`a.tsv`, `./a.tsv`, and a symlink to `a.tsv` are one file.** The function `step_file_identity` calls `realpath`. All three names then give the same result.

A direct write still uses the path from the workflow. Polars resolves the symlink correctly.

Limit: `realpath` resolves a symlink. It does not resolve a hardlink. This repository does not use hardlinks for workdir files.

### 4. A rewrite writes to the physical file

**`os.replace` does not follow a symlink.** If you give a symlink to `os.replace`, these two results occur:

- `os.replace` puts a regular file at the symlink path
- the file that the symlink pointed to keeps the old rows

`_sink_rewrite` resolves the target path one time, before it makes the temporary file.

ptabler also makes the temporary file in the directory of the physical file. This is necessary for a second reason. `os.replace` fails with the error `EXDEV` if the two paths are on different devices.

### 5. ptabler applies the mode again after it moves the file

**`os.replace` moves the inode. The permissions are on the inode.** After `os.replace`, the target path points to the inode of the temporary file. The mode of the original file is lost.

This breaks the contract of `exec.builder { writable: true }`. The write is successful, so the process shows no error.

Remove the `chmod` call and the test `test_overwrite_keeps_the_mode_the_target_had` gives this message:

```
AssertionError: 384 != 420 : mode became 0o644
```

- `384` is `0o600`. This is the mode that the backend applied.
- `420` is `0o644`. This is the default mode from the umask.

### 6. ptabler makes the temporary file with mode 0o600

**The temporary file stays on the disk for the full write.** With the default umask, its mode is `0o644`. Any user with access to the workspace can then read a table that has mode `0o600`.

`mkstemp` makes the file with mode `0o600`. The permission gap does not occur.

### 7. A read-only target refuses the write

**`os.replace` asks the directory for permission. It does not ask the file.** A temporary file therefore ignores the mode of the target.

`_sink_rewrite` examines the mode first. If the target is read-only, ptabler writes directly to the target. The write then fails, as `exec.builder { writable: false }` specifies.

### 8. `write_frame` is not in the scan

**`write_frame` writes into a directory that it makes.** It cannot collide with an io step. Therefore `ReadFrame` and `WriteFrame` are not in the collision scan.

---

## Alternative: refuse the write

**A check that refuses a same-path write is approximately 10 lines of code.** Polars does not support this pattern. The `read_ipc` documentation says: *"You cannot write to the same filename."*

This PR does not use that alternative, because it removes a function instead of a correction of the function.

**But examine this point: no supported API can use this function now.** The `pt` tengo SDK calls `addFile(name, file)`. It never sends `{ writable: true }`. A file from `wf.frame()` always gets mode `0o400`. Only a raw workflow JSON can cause an in-place overwrite.

## Tests

`src/test/overwrite_test.py`, 11 cases: content round-trips, no partial left behind, the mode survives, two writers do not share a partial name, a failed run cleans up, a read-only target still refuses, a lazy run hands its partials to the caller, a non-rewrite needs no partial file, `./x` and `x` are one file, a write ahead of its read is still found, and a fresh path still works.

```
Ran 234 tests — OK
ruff — All checks passed!
```

## Open

- `test_two_writers_of_one_target_do_not_share_a_partial_file` and `test_a_failed_run_leaves_no_partial_file_behind` write `out.tsv`, which nothing reads. After scoping they take the direct sink and pass vacuously — confirmed by making `_sink_rewrite` raise and watching both stay green. Both need `file="data.tsv"`.
- `overwrite_targets` / `_overwrite_targets` should be `rewrite_targets` to match `_sink_rewrite` and every docstring.

## Caveat

The crash reproduces only on a network filesystem, so this cannot be *proven* fixed locally — local runs pass with or without the change. What the tests demonstrate is that the truncate-under-read mechanism is gone and the mode regression is guarded.

Found while fixing the k8s e2e suites (milaboratory/platforma#1809, milaboratory/pl#2194). It was only diagnosable after the k8s runner stopped reporting `-1` for every failed job and surfaced the real `135`.









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents an in-place table rewrite from truncating a file that Polars is still reading lazily. It detects files that a workflow both reads and writes, sinks those rewrites into unique sibling temporary files, and replaces the physical target after all sinks finish. It also preserves permissions, handles symlink aliases, cleans up abandoned partial files during non-lazy execution, and keeps ordinary writes on the existing direct path.

**Important touched terms**
- **Rewrite** — A write to a file that the same workflow reads. The PR detects rewrites before step execution and routes only these writes through a temporary output.
- **Overwrite target** — The resolved file identity found in both the workflow's read and write sets. The PR stores these identities in `StepContext` to select rewrite behavior.
- **Physical file** — The final file reached after resolving symlinks. The latest change moves rewritten data onto this file while preserving the symlink itself.
- **Partial output** — A unique sibling temporary file used to hold a rewrite until lazy reads finish. The PR creates it securely, records it for cleanup, and replaces the target with it after collection.
- **Chained task** — Deferred work that runs after all lazy sinks are collected. The PR uses one to replace each rewrite target only after its source reads complete.
- **Lazy execution** — Execution that returns a `StepContext` before collecting sinks. The PR exposes registered partial outputs and gives their cleanup responsibility to the lazy caller.
- **File identity** — A canonical path produced with `realpath` for collision comparison. The PR uses it so equivalent spellings and symlink aliases identify the same file.
- **Target mode** — The target file's permission bits. The PR applies them to the temporary inode and reapplies them before replacement.

- Adds regression coverage for contents, modes, cleanup, direct writes, path aliases, step ordering, read-only targets, and symlink rewrites.
- Adds a patch changeset documenting the network-filesystem crash correction.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The latest symlink correction appears safe to merge, with only the previously reported non-blocking lazy-partial ownership concern remaining.

The current code resolves rewrite replacement targets to their physical files, so the previously reported symlink replacement defect is fixed. The earlier temporary-path, permission, and content-test threads were manually resolved without explanatory replies. The previous lazy-execution finding remains outstanding: a caller that does not collect the returned sinks and chained tasks or explicitly call cleanup can still leave registered partial files behind, although the ownership contract is now documented and exposed through StepContext.

**Files Needing Attention:** lib/ptabler/software/src/ptabler/workflow/workflow.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/ptabler/software/src/ptabler/steps/io.py | Routes detected rewrites through unique permission-preserving temporary files and now replaces the resolved physical target. |
| lib/ptabler/software/src/ptabler/steps/util.py | Adds canonical path helpers used for rewrite detection and symlink-preserving replacement. |
| lib/ptabler/software/src/ptabler/workflow/workflow.py | Pre-scans workflow file identities, coordinates deferred replacement, and cleans partial outputs after non-lazy execution. |
| lib/ptabler/software/src/ptabler/steps/base.py | Extends step context with overwrite identities and partial-output ownership and cleanup. |
| lib/ptabler/software/src/test/overwrite_test.py | Covers rewrite integrity, permissions, cleanup, aliases, ordering, lazy ownership, and symlink behavior. |
| .changeset/ptabler-overwrite-in-place.md | Documents the in-place rewrite crash fix as a patch release. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as PWorkflow
  participant C as StepContext
  participant R as Lazy reader
  participant T as Partial output
  participant F as Physical target

  W->>W: Scan read/write file identities
  W->>C: Store overwrite targets
  W->>R: Build lazy read
  W->>T: Build rewrite sink
  Note over R,T: Original target remains intact
  W->>R: collect_all()
  W->>T: collect_all()
  W->>F: Replace target after collection
  W->>C: Clean remaining partial outputs
```
</details>

<sub>Reviews (4): Last reviewed commit: ["\[MILAB-5933\]: Move a rewrite onto the fi..."](https://github.com/milaboratory/platforma/commit/162215904f61ad80cc7ffee6c4d3725bf5544e65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63013199)</sub>

<!-- /greptile_comment -->